### PR TITLE
feat(api): envelope convergence — dual-emit items + keystones envelope opt-in (C30)

### DIFF
--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -657,11 +657,18 @@ async def search_documents(
             result_count_by_tenant=counts,
             query_summary=(body.query or "")[:200],
         )
+    # C30 / wire-contract D1 (ratified 2026-08-25): ``items`` is the canonical
+    # list key everywhere — /search always used it, this route used
+    # ``results``, and the mismatch cost the SupportHive builder a
+    # zero-hit-parsing bug (FR-1, ranked #1 by time cost). Dual-emit: both
+    # keys reference the same list; ``results`` stays until a separate,
+    # announced deprecation wave.
     return JSONResponse(
         {
             "collection": body.collection,
             "count": len(items),
             "results": items,
+            "items": items,
         }
     )
 

--- a/core-api/src/core_api/routes/keystones.py
+++ b/core-api/src/core_api/routes/keystones.py
@@ -219,6 +219,14 @@ async def list_keystones(
     tenant_id: str = Query(...),
     fleet_id: str | None = Query(default=None),
     agent_id: str | None = Query(default=None),
+    envelope: bool = Query(
+        default=False,
+        description=(
+            "C30/D1 opt-in: return {count, items} instead of the bare array. "
+            "The bare array stays the default until a separate announced "
+            "deprecation wave."
+        ),
+    ),
     auth: AuthContext = Depends(get_auth_context),
 ):
     """Return scope-merged keystone rules. No trust gate — reads are
@@ -246,6 +254,11 @@ async def list_keystones(
         raise _surface_storage_error(exc) from exc
     if truncated:
         response.headers["X-Truncated"] = "true"
+    # C30 / wire-contract D1 (ratified 2026-08-25): opt-in envelope. The bare
+    # array remains the default response shape — existing consumers (plugin
+    # session-start fetch included) see zero change unless they ask.
+    if envelope:
+        return {"count": len(rows), "items": rows}
     return rows
 
 

--- a/tests/test_c30_envelope_dual_emit.py
+++ b/tests/test_c30_envelope_dual_emit.py
@@ -1,0 +1,46 @@
+"""C30 — envelope convergence per the ratified wire contract (D1).
+
+`items` is the canonical list key everywhere. /documents/search dual-emits
+`results` + `items` (same list, two keys — `results` stays until a separate
+announced deprecation wave). GET /keystones keeps the bare array as its
+default shape and gains an `envelope=1` opt-in returning {count, items}.
+
+Source-level guards (the route handlers need auth/storage to run end-to-end;
+the shapes themselves are wet-tested against the live stack).
+"""
+
+import inspect
+import pathlib
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+ROOT = pathlib.Path(__file__).resolve().parents[1] / "core-api/src/core_api/routes"
+
+
+def test_documents_search_dual_emits_items():
+    src = (ROOT / "documents.py").read_text()
+    # Anchor on the response construction (unique), not the collection key
+    # (which also appears in write payloads earlier in the file).
+    idx = src.index('"count": len(items)')
+    window = src[idx - 200 : idx + 200]
+    assert '"results": items' in window
+    assert '"items": items' in window
+
+
+def test_keystones_envelope_param_exists_and_defaults_off():
+    from core_api.routes import keystones
+
+    sig = inspect.signature(keystones.list_keystones)
+    assert "envelope" in sig.parameters
+    # FastAPI Query default: the bare array MUST stay the default shape.
+    default = sig.parameters["envelope"].default
+    assert getattr(default, "default", default) is False
+
+
+def test_keystones_envelope_shape():
+    src = (ROOT / "keystones.py").read_text()
+    assert '{"count": len(rows), "items": rows}' in src
+    # bare-array default preserved
+    assert "return rows" in src


### PR DESCRIPTION
## What

Closes canonical **C30** (register API-02) — second task off the ratified wire contract (**D1**: `items` is canonical).

- **POST /documents/search** dual-emits `results` + `items` (same array) with `count` — the items/results sibling-endpoint split was SupportHive's #1 time-cost bug. `results` is permanent until a separate announced deprecation wave.
- **GET /keystones** gains `envelope=1` opt-in → `{count, items}`; the bare array stays the byte-identical default (plugin session-start fetch unaffected).

Zero behavior change for any existing caller; both changes are additive/opt-in per the contract's rule of the page.

## Testing

- Full suite **5197 passed** (3 new source-guard tests); ruff/mypy/format clean; broker baseline unchanged.
- Wet (fresh image, live stack): documents/search returns `results == items` with coherent `count` on real hits; keystones default confirmed bare-array; `envelope=1` returns `{count, items}`. (Keystone row-seeding via a user token hits the pre-existing authoring trust gate — outside this diff, which only shapes the response after rows are fetched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)