### PR TITLE
fix: the four P1 behavior defects from the sunset report

### DIFF
--- a/clients/python/src/caura_client/interviewer/installer.py
+++ b/clients/python/src/caura_client/interviewer/installer.py
@@ -1,4 +1,4 @@
-"""Cron scheduling helper for ``memclaw-interviewer install`` / ``uninstall``.
+"""Cron scheduling helper for ``caura-interviewer install`` / ``uninstall``.
 
 `pip install` cannot register a cron (wheels run no install-time code), and
 silently scheduling a job that reads transcripts and phones home would be the
@@ -6,7 +6,7 @@ wrong consent posture anyway. So scheduling is one explicit command that
 writes:
 
 - a **crontab line** (idempotent — keyed by a marker comment) invoking
-  ``memclaw-interviewer run`` on an interval; and
+  ``caura-interviewer run`` on an interval; and
 - a **0600 env file** the cron line sources, because cron does NOT inherit
   the user's shell environment — the connection identity (base URL, key,
   tenant) would otherwise be absent when the job fires.
@@ -82,13 +82,16 @@ def interval_to_cron(interval: str) -> str:
 def resolve_cmd() -> str:
     """Absolute invocation for the CLI, resilient to how it was installed.
 
-    Prefer the console-script on PATH; fall back to ``<python> -m`` so a
-    venv/editable install still schedules a working command. Each path
+    Prefer the current console-script on PATH, then the legacy one (rule 3 —
+    a pre-rename install ships only that name); fall back to ``<python> -m``
+    so a venv/editable install still schedules a working command. Each path
     component is shell-quoted here (NOT the whole string — the fallback is
     two words and quoting it wholesale would make sh treat it as one
     command name).
     """
-    exe = shutil.which("memclaw-interviewer")
+    exe = shutil.which("caura-interviewer")
+    if not exe:
+        exe = shutil.which("memclaw-interviewer")  # legacy-name-ok: rule 3 — pre-rename installs ship only the old console script
     if exe:
         return shlex.quote(exe)
     return f"{shlex.quote(sys.executable)} -m caura_client.interviewer.cli"
@@ -131,7 +134,7 @@ def merge_crontab(existing: str, new_line: Optional[str]) -> str:
 
 def render_env_file(env: dict[str, str]) -> str:
     """Shell-sourceable ``export`` lines for the set connection vars only."""
-    lines = ["# Written by `memclaw-interviewer install` — sourced by the cron job.", ""]
+    lines = ["# Written by `caura-interviewer install` — sourced by the cron job.", ""]
     for k in _ENV_KEYS:
         v = env.get(k)
         if v:

--- a/clients/python/tests/test_interviewer_installer.py
+++ b/clients/python/tests/test_interviewer_installer.py
@@ -1,4 +1,4 @@
-"""Tests for `memclaw-interviewer install` / `uninstall` (cron scheduling)."""
+"""Tests for `caura-interviewer install` / `uninstall` (cron scheduling)."""
 
 from __future__ import annotations
 
@@ -85,6 +85,34 @@ def test_build_run_command_all_projects_flag(tmp_path):
     assert "--harness claude-code --all-projects" in cmd
 
 
+def test_resolve_cmd_prefers_current_console_script(monkeypatch):
+    """When both console scripts are on PATH, the cron line must invoke the
+    CURRENT one — not schedule the legacy name into a fresh install."""
+    paths = {
+        "caura-interviewer": "/usr/local/bin/caura-interviewer",
+        "memclaw-interviewer": "/usr/local/bin/memclaw-interviewer",  # legacy-name-ok: the legacy script the current one must outrank
+    }
+    monkeypatch.setattr(installer.shutil, "which", lambda name: paths.get(name))
+    assert installer.resolve_cmd() == "/usr/local/bin/caura-interviewer"
+
+
+def test_resolve_cmd_falls_back_to_legacy_script(monkeypatch):
+    """Rule 3: a pre-rename install ships only the old console script — it
+    must still resolve rather than falling through to `python -m`."""
+    legacy = "/usr/local/bin/memclaw-interviewer"  # legacy-name-ok: rule 3 — pre-rename installs ship only the old console script
+    monkeypatch.setattr(
+        installer.shutil,
+        "which",
+        lambda name: legacy if name == "memclaw-interviewer" else None,  # legacy-name-ok: rule 3 — pre-rename installs ship only the old console script
+    )
+    assert installer.resolve_cmd() == legacy
+
+
+def test_resolve_cmd_module_fallback_when_no_script(monkeypatch):
+    monkeypatch.setattr(installer.shutil, "which", lambda name: None)
+    assert installer.resolve_cmd().endswith(" -m caura_client.interviewer.cli")
+
+
 def test_render_env_file_only_set_keys_and_quotes():
     out = render_env_file({
         "CAURA_BASE_URL": "https://caura.corp.internal",
@@ -93,6 +121,7 @@ def test_render_env_file_only_set_keys_and_quotes():
         "CAURA_AGENT_ID": "",          # falsy → omitted
         "CAURA_INTERVIEWER_PROJECTS": "app-*,foo",
     })
+    assert out.startswith("# Written by `caura-interviewer install`")
     assert "export CAURA_BASE_URL='https://caura.corp.internal'" in out
     assert "export CAURA_API_KEY='mc_secret'" in out
     assert "export CAURA_INTERVIEWER_PROJECTS='app-*,foo'" in out
@@ -157,7 +186,7 @@ def _patch(monkeypatch, tmp_path, cron, available=True):
     monkeypatch.setattr(installer, "config_dir", lambda: tmp_path / "cfg")
     monkeypatch.setattr(installer, "env_file_path", lambda: tmp_path / "cfg" / "env")
     monkeypatch.setattr(installer, "log_file_path", lambda: tmp_path / "cfg" / "cron.log")
-    monkeypatch.setattr(installer, "resolve_cmd", lambda: "memclaw-interviewer")
+    monkeypatch.setattr(installer, "resolve_cmd", lambda: "caura-interviewer")
 
 
 def test_install_writes_cron_and_env_then_uninstall_removes(monkeypatch, tmp_path, capsys):

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -196,10 +196,19 @@ DOC_MEMORY_MAX_CHARS = MAX_CONTENT_LENGTH
 # migration 013 would reject it.)
 
 # Provenance only — written to ``memories.source_uri`` as
-# ``memclaw-doc://<collection>/<doc_id>``. Nothing queries it yet (that would
+# ``caura-doc://<collection>/<doc_id>``. Nothing queries it yet (that would
 # need a storage-side filter + index); it exists so a later reconciliation
 # mechanism has a stable key to match a doc to the memories minted from it.
-DOC_MEMORY_URI_SCHEME = "memclaw-doc"
+DOC_MEMORY_URI_SCHEME = "caura-doc"
+
+# Rows minted before the rename carry the old scheme in ``source_uri`` and are
+# never rewritten (rule 2 — customer data is not migrated for a brand). All
+# minting uses ``DOC_MEMORY_URI_SCHEME``; anything that ever grows a
+# recognizer for doc-memory URIs (the reconciliation pass above) must accept
+# these schemes alongside it.
+LEGACY_DOC_MEMORY_URI_SCHEMES = (
+    "memclaw-doc",  # legacy-name-ok: scheme already persisted in customers' memories.source_uri
+)
 
 assert DOC_MEMORY_MAX_CHARS <= MAX_CONTENT_LENGTH, (
     "DOC_MEMORY_MAX_CHARS must not exceed MemoryCreate.content max_length "

--- a/plugin/src/context-engine.test.ts
+++ b/plugin/src/context-engine.test.ts
@@ -76,7 +76,8 @@ describe("prepareSubagentSpawn — OpenClaw's rollback contract", () => {
 });
 
 const DEFAULT_KEYWORDS = [
-  "memclaw",
+  "caura",
+  "memclaw", // legacy-name-ok: rule 3 — old name keeps triggering
   "ltm",
   "long term",
   "long-term",
@@ -292,7 +293,14 @@ describe("shouldRecall — policy=auto (the default)", () => {
     assert.equal(r.reason, "explicit-recall-trigger");
   });
 
+  test("trigger keyword 'caura' fires recall on otherwise-skip prompt", () => {
+    const r = shouldRecall(input({ prompt: "caura?" }));
+    assert.equal(r.recall, true);
+    assert.equal(r.reason, "explicit-recall-trigger");
+  });
+
   test("trigger keyword 'memclaw' fires recall on otherwise-skip prompt", () => {
+    // Rule 3: the old name keeps triggering forever.
     const r = shouldRecall(input({ prompt: "memclaw?" }));
     assert.equal(r.recall, true);
     assert.equal(r.reason, "explicit-recall-trigger");

--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -657,6 +657,35 @@ describe("writeEducationFiles", () => {
       assert.equal(readFile(bakPath), original);
     });
 
+    test("legacy section listing only pre-rename tool names is recognized and replaced", () => {
+      // Plugin 0.98.5/1.x sections on customers' disks list the tools under
+      // their OLD names — there is no `caura_` token anywhere in them. The
+      // content-shape check must accept those bodies too, or every real
+      // legacy install keeps a stale duplicate forever. (#782 rewrote the
+      // fixtures above to the new names, which is how a caura_-only gate
+      // stayed green while never matching a single real legacy section.)
+      const base = tmpBase();
+      const wsDir = join(base, "workspace");
+      mkdirSync(wsDir, { recursive: true });
+
+      const userBefore = "# Tools notes\n\nMy tools notes.\n";
+      const legacy =
+        "\n---\n\n## MemClaw — Tools Available\n\n" + // legacy-name-ok: pins the heading old plugin versions wrote to customer disks
+        "Obsolete 13-tool listing including memclaw_write_bulk and memclaw_search.\n"; // legacy-name-ok: pins content old plugin versions wrote to customer disks
+      const userAfter = "\n## Other\n\nMy other section.\n";
+      writeFileSync(join(wsDir, "TOOLS.md"), userBefore + legacy + userAfter, "utf-8");
+
+      const result = writeEducationFiles(buildToolsMd(), buildAgentsMd(), undefined, base);
+
+      assert.equal(result.toolsUpdated, 1, "a pre-rename tool listing must be recognized as our block");
+      const tools = readFile(join(wsDir, "TOOLS.md"));
+      assert.ok(!tools.includes("memclaw_write_bulk"), "stale pre-rename body must be replaced"); // legacy-name-ok: asserts the old body is gone
+      assert.match(tools, /<!-- memclaw:tools v=[a-f0-9]{8} -->/); // legacy-name-ok: the fence tag is a pinned on-disk contract
+      assert.ok(tools.startsWith(userBefore), "user content above the legacy block must be preserved");
+      assert.ok(tools.includes("## Other"), "user content below the legacy block must be preserved");
+      assert.ok(existsSync(join(wsDir, "TOOLS.md.memclaw-bak")), "one-shot backup written before the splice"); // legacy-name-ok: the backup filename is a pinned on-disk contract
+    });
+
     test("backup is not overwritten on subsequent runs", () => {
       const base = tmpBase();
       const wsDir = join(base, "workspace");

--- a/plugin/src/educate.ts
+++ b/plugin/src/educate.ts
@@ -478,9 +478,10 @@ function escapeRegex(s: string): string {
  *
  * To prevent false positives on user-authored headings that happen to
  * start with the same prefix, the splice range is additionally
- * required to contain a Caura token (default: `caura_`). If the
- * range doesn't contain it, the function returns null and the splice
- * is skipped.
+ * required to contain a tool-name prefix the plugin has ever emitted —
+ * the current one (`caura_`) or the pre-rename one that 0.98.5/1.x
+ * sections on customers' disks still carry. If the range contains
+ * neither, the function returns null and the splice is skipped.
  *
  * The range starts at one preceding `---` rule (if any blank-only lines
  * separate it from the heading) and ends at the next `## ` heading or
@@ -490,7 +491,7 @@ function escapeRegex(s: string): string {
 export function findLegacyRange(
   content: string,
   legacyHeadingPrefix: string,
-  contentMustInclude: string = "caura_",
+  contentMustIncludeOneOf: readonly string[] = ["caura_", "memclaw_"], // legacy-name-ok: recognizes section bodies old plugin versions wrote to customer disks
 ): { start: number; end: number } | null {
   // Split on LF, not CRLF: under CRLF input each `lines[i]` carries a
   // trailing `\r` and `lines[i].length + 1` (LF) sums to the correct
@@ -539,14 +540,15 @@ export function findLegacyRange(
     content.length,
   );
 
-  // Content-shape verification: the splice range MUST contain a
-  // Caura token (default `caura_`). This guards against a user
-  // heading that coincidentally starts with the same prefix but
-  // contains no MemClaw content. If the slice doesn't smell like one
-  // of our blocks, leave it alone.
-  if (contentMustInclude) {
-    const slice = content.slice(startChar, endChar);
-    if (!slice.toLowerCase().includes(contentMustInclude.toLowerCase())) {
+  // Content-shape verification: the splice range MUST contain one of
+  // the tool-name prefixes the plugin has ever emitted (current
+  // `caura_`, or the pre-rename prefix 0.98.5/1.x sections carry).
+  // This guards against a user heading that coincidentally starts
+  // with the same prefix but lists none of our tools. If the slice
+  // doesn't smell like one of our blocks, leave it alone.
+  if (contentMustIncludeOneOf.length > 0) {
+    const slice = content.slice(startChar, endChar).toLowerCase();
+    if (!contentMustIncludeOneOf.some((token) => slice.includes(token.toLowerCase()))) {
       return null;
     }
   }

--- a/plugin/src/env.ts
+++ b/plugin/src/env.ts
@@ -444,7 +444,8 @@ function _readMinPromptChars(): number {
 }
 
 const DEFAULT_TRIGGER_KEYWORDS = [
-  "memclaw",
+  "caura",
+  "memclaw", // legacy-name-ok: rule 3 — old name keeps triggering
   "ltm",
   "long term",
   "long-term",

--- a/tests/test_doc_memory_spec.py
+++ b/tests/test_doc_memory_spec.py
@@ -42,9 +42,25 @@ def test_mints_spec_for_ordinary_doc():
     spec = resolve_doc_memory("runbooks", "pg-tuning", _data(content="body text"))
     assert isinstance(spec, DocMemorySpec)
     assert "body text" in spec.content
-    assert spec.source_uri == "memclaw-doc://runbooks/pg-tuning"
+    assert spec.source_uri == "caura-doc://runbooks/pg-tuning"
     assert spec.metadata["doc_collection"] == "runbooks"
     assert spec.metadata["doc_id"] == "pg-tuning"
+
+
+def test_legacy_scheme_is_never_minted_but_stays_recognized():
+    """Erni's decision on the doc-memory URI scheme: new mints use the Caura
+    scheme; rows minted before the rename keep the old one in ``source_uri``
+    forever (rule 2 — no data rewrite). Anything that ever grows a recognizer
+    for doc-memory URIs must accept both, which this constant is the roster
+    for. Pinned here so a tidy-up cannot delete the legacy scheme out from
+    under data customers already hold.
+    """
+    from core_api.constants import DOC_MEMORY_URI_SCHEME, LEGACY_DOC_MEMORY_URI_SCHEMES
+
+    assert DOC_MEMORY_URI_SCHEME == "caura-doc"
+    assert "memclaw-doc" in LEGACY_DOC_MEMORY_URI_SCHEMES  # legacy-name-ok: pins the scheme persisted in customers' memories.source_uri
+    # Minting must never use a legacy scheme.
+    assert DOC_MEMORY_URI_SCHEME not in LEGACY_DOC_MEMORY_URI_SCHEMES
 
 
 def test_summary_is_rendered_first_as_bare_prose():

--- a/tests/test_doc_memory_sync.py
+++ b/tests/test_doc_memory_sync.py
@@ -39,7 +39,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 def _spec(content: str = "body text") -> DocMemorySpec:
     return DocMemorySpec(
         content=content,
-        source_uri="memclaw-doc://runbooks/pg-tuning",
+        source_uri="caura-doc://runbooks/pg-tuning",
         metadata={"doc_collection": "runbooks", "doc_id": "pg-tuning"},
     )
 
@@ -93,7 +93,7 @@ async def test_creates_memory_with_expected_payload(patched):
     # ``sync_doc_memory`` passes the spec's content through unchanged — the
     # render happens upstream in ``resolve_doc_memory``.
     assert payload.content == "# H\n\nrendered body"
-    assert payload.source_uri == "memclaw-doc://runbooks/pg-tuning"
+    assert payload.source_uri == "caura-doc://runbooks/pg-tuning"
     assert payload.tenant_id == "t1"
     assert payload.fleet_id == "f1"
     assert payload.agent_id == "agent-a"

--- a/tests/test_documents_rest_doc_memory.py
+++ b/tests/test_documents_rest_doc_memory.py
@@ -147,7 +147,7 @@ async def test_unindexed_branch_mints(rest_env):
     rest_env["spy"].assert_awaited_once()
     spec = rest_env["spy"].call_args.args[0]
     assert _BODY in spec.content
-    assert spec.source_uri == "memclaw-doc://runbooks/pg-tuning"
+    assert spec.source_uri == "caura-doc://runbooks/pg-tuning"
 
 
 async def test_indexed_branch_mints(rest_env, monkeypatch):

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -1253,7 +1253,7 @@ async def test_doc_write_mints_memory_for_body_bearing_doc(
     spy_doc_memory.assert_awaited_once()
     spec = spy_doc_memory.call_args.args[0]
     assert "# Vacuum\n\nRun nightly." in spec.content  # rendered, body intact
-    assert spec.source_uri == "memclaw-doc://runbooks/pg-tuning"
+    assert spec.source_uri == "caura-doc://runbooks/pg-tuning"
 
 
 async def test_doc_write_mints_on_update_too(mcp_env, monkeypatch, spy_doc_memory):


### PR DESCRIPTION
Fixes the four P1 behavior defects from the sunset report. All four are old-name leftovers that changed runtime behavior, not prose.

## P1-1 — legacy education sections never replaced
`plugin/src/educate.ts:493` — `findLegacyRange`'s content-shape check required the splice range to contain `caura_`, but the sections plugin 0.98.5/1.x actually wrote to customers' TOOLS.md/AGENTS.md list `memclaw_*` tools — so no real legacy section was ever recognized, and every pre-rename install keeps a stale duplicate. The check now accepts either tool-name prefix (`contentMustIncludeOneOf: readonly string[] = ["caura_", "memclaw_"]`; single call site used the default).

**Test coverage restored**: #782 rewrote the legacy fixtures to `caura_*`, which is why CI stayed green through the regression. A new test (`plugin/src/educate.test.ts`) pins a fixture whose body lists only `memclaw_*` tools and asserts it IS recognized, replaced, and backed up — marked `legacy-name-ok: pins content old plugin versions wrote to customer disks`.

## P1-2 — "caura" was not a recall trigger keyword
`plugin/src/env.ts:446` — `DEFAULT_TRIGGER_KEYWORDS` fed `shouldRecall` but never contained `"caura"`, so a prompt naming the product did not force recall. `"caura"` is inserted first; `"memclaw"` is kept with `// legacy-name-ok: rule 3 — old name keeps triggering`. The test copy of the array and a new `'caura' fires recall` test land in `plugin/src/context-engine.test.ts`.

## P1-3 — fresh installs scheduled the legacy cron command
`clients/python/src/caura_client/interviewer/installer.py:91` — `resolve_cmd()` preferred `shutil.which("memclaw-interviewer")`, so every `caura-interviewer install` wrote a cron line invoking the legacy script. It now tries `caura-interviewer` first and falls back to the legacy script (marked legacy-name-ok). The written env-file header (`# Written by \`caura-interviewer install\``) and the module docstring's current-tense mentions are updated. **Untouched by design** (frozen on-disk contracts, per the sentinel): `CRON_MARKER = "# memclaw-interviewer (managed)"` (:33) and `~/.config/memclaw-interviewer` (:50) — uninstall must keep finding old installs. New tests pin the resolution order and header.

## P1-4 — doc-memory URI scheme flipped (implements Erni's decision)
`core-api/src/core_api/constants.py:202` — `DOC_MEMORY_URI_SCHEME` flips `"memclaw-doc"` → `"caura-doc"`, and `LEGACY_DOC_MEMORY_URI_SCHEMES = ("memclaw-doc",)` is added with a legacy-name-ok marker: **caura-doc minted, memclaw-doc recognized forever, no data rewrite**. This supersedes the #933 floor listing for this scheme. Grepped every consumer: the only production use is the single mint site (`services/doc_indexing.py:281`); nothing recognizes/queries the scheme yet, so the legacy tuple is the roster any future recognizer (the planned reconciliation pass) must accept alongside the current scheme — pinned by a new test. All five test pins updated to the new scheme (`tests/test_mcp_doc.py`, `tests/test_documents_rest_doc_memory.py`, `tests/test_doc_memory_sync.py` x2, `tests/test_doc_memory_spec.py`).

## Gates (all run locally)
- `uv run ruff check core-api/src/ core-storage-api/src/ core-storage-api/tests/ common/ core-operations/src/ core-operations/tests/ core-worker/src/ core-worker/tests/` → **All checks passed!**
- `ruff format --check` on the CI format scope (core-api/src, core-storage-api src+tests, core-operations, core-worker; `--isolated` on the three vendored common/ files) → **324 + 3 files already formatted** (note: repo-wide `ruff format --check common/` has pre-existing failures under ruff 0.16.3 that CI deliberately does not gate)
- plugin: `npx tsc --noEmit` → clean; `npm test` → **425 pass, 0 fail**
- `python3 scripts/legacy_name_ratchet.py` → **exit 0** — "No new lines. 16 removed by this change (-16 net)"; 14 exempt lines written, each a rule-3 alias or a pinned fixture, listed in the run output
- `python3 scripts/do_not_touch_sentinel.py` → **exit 0** — "All 35 protected strings survive"
- `pytest tests/test_doc_memory_spec.py tests/test_doc_memory_sync.py tests/test_mcp_doc.py tests/test_documents_rest_doc_memory.py` → **150 passed**
- `pytest clients/python/tests/test_interviewer_installer.py` → **38 passed**; client `ruff check src tests` at the CI-pinned 0.15 line → **All checks passed!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129mDPbfSxqBrCLs5dDpcGv
