### PR TITLE
docs(sunset): give "contract, not convenience" an actual test

### DIFF
--- a/docs/plans/rebrand-sunset-plan.md
+++ b/docs/plans/rebrand-sunset-plan.md
@@ -116,6 +116,30 @@ comment syntax with `legacy-name-ok:` followed by the reason. Exemptions are rep
 on every run, so a PR that adds them is visible as such to a reviewer. Use them for
 contract, not for convenience.
 
+### A mention gets reworded, a contract gets the marker
+
+That last sentence needs a test, because every line the ratchet stops looks like a
+contract to whoever is writing it.
+
+Ask what breaks if the old spelling is not on that line. If the answer is nothing — it
+is prose that happens to name the thing — **reword it off the literal and take no
+exemption.** If a reader has to type the string, or find it on disk, or a machine has to
+match it, that is a contract: **mark it, and say which.**
+
+Marking a mention is not a harmless extra. Every exemption widens the surface the gate
+no longer watches, and it spends the one annotation whose whole value is that its reasons
+are true.
+
+Which way a given sweep falls is not predictable, so measure rather than assume. Prose
+about code is mostly mention. Operator-facing documentation is mostly contract, because
+its literals are the things a reader types or goes looking for — in one docs sweep, ten
+of eleven exemptions survived this test.
+
+Two practical consequences, both cheaper to know early: re-wrapping a line that carries
+the old spelling mints new text even when the file's count *falls*, and a marker cannot
+be taken off a line without taking the literal off with it. Reword first; annotate only
+what is left.
+
 ---
 
 ## Before you change an old-brand string


### PR DESCRIPTION
Adds a test to the exemption rule the plan already states. Follow-up to #960; the
guidance comes from Lane I earning it on real cases in `caura-ops#322`.

## The gap

The plan says *"Use them for contract, not for convenience."* That has no test attached,
and **every line the ratchet stops looks like a contract to whoever is writing it** — so
in practice the marker lands on whatever tripped the gate.

The test: **ask what breaks if the old spelling is not on that line.** Nothing, and it is
prose that happens to name the thing → **reword it off the literal, take no exemption.** A
reader must type it, find it on disk, or a machine must match it → **contract, so mark it.**

## The calibration line, which matters as much as the rule

The split is **not predictable from the repo**, and assuming it is what makes this
guidance backfire. Tested against the eleven exemptions `caura-daemon#136` added:

| | count | what |
|---|---|---|
| survived the test — **contract** | **10** | pasteable commands (`memclaw policy show`, `memclaw uninstall`), real on-disk paths (`~/Library/Application Support/…`, `%APPDATA%\…`), the served mirror path, and four rule 3 alias declarations |
| failed it — **mention** | **1** | *"skips the `memclaw setup` chain"* — prose about what is skipped, which never needed the literal |

The expectation going in was that most would be rewordable. **Ten of eleven were not.** A
sweep of service code came out the opposite way, its exemptions mostly being comments that
did not need the literal.

That is the finding worth carrying: **operator-facing documentation is mostly contract,
because its literals are the things a reader types or goes looking for; prose about code is
mostly mention.** So the entry tells you to measure, and gives both ends rather than a
single expectation that will be wrong half the time.

## The two costs, both measured this week

Recorded because they make rewording cheaper than annotating, and neither is obvious:

- **Re-wrapping mints.** Two comment rewrites in #138 failed the ratchet *while the file
  count fell* — `init.go (54 -> 53)`, `handler.go (5 -> 1)` — purely from re-flowing a line
  that mentions the CLI verb.
- **Markers are self-perpetuating.** Stripping the README marker in caura-daemon#139 and
  leaving the line otherwise identical failed the gate (`58 -> 59`). A marker cannot come
  off a line without the literal coming off with it.

## Placement and gates

Directly under the sentence it sharpens, in **The two gates, and what each one misses**.
Worded around the old-brand literals, so **no new markers**.

- `legacy_name_ratchet.py` → `No new lines.`
- `do_not_touch_sentinel.py` → `All 34 protected strings survive.`

Byte-identical to the enterprise copy, opened alongside. Docs only.