### PR TITLE
fix(ratchet): exempt generated CHANGELOGs on release-please branches

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -71,6 +71,7 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -272,6 +273,20 @@ def _literal(path: str) -> str:
     read as pathspec magic. ``:(literal)`` disables both.
     """
     return f":(literal){path}"
+
+
+def _release_please_branch() -> bool:
+    """True when CI builds release-please's own PR branch.
+
+    release-please regenerates per-package CHANGELOGs by quoting merged PR
+    titles verbatim, so titles that legitimately carried the old brand
+    (history — rule 2 says never edit it) resurface as lines this tally
+    cannot tell from fresh minting. Only that bot's branches get the
+    exemption; a human editing a CHANGELOG still answers to the gate.
+    GITHUB_HEAD_REF is set by Actions on pull_request runs and absent
+    locally, so local runs keep full coverage.
+    """
+    return os.environ.get("GITHUB_HEAD_REF", "").startswith("release-please--")
 
 
 class Scan(NamedTuple):
@@ -690,10 +705,16 @@ def main() -> int:
 
     grown = {}
     excused: dict[str, Counter[str]] = {}
+    generated_changelogs: list[str] = []
+    release_branch = _release_please_branch()
     # Sorted: the budget is spent as files are visited, so the order decides which
     # destination is charged when one text lands in several. Arbitrary is fine;
     # unstable is not.
     for path in sorted(head):
+        if release_branch and path.rsplit("/", 1)[-1].upper().startswith("CHANGELOG"):
+            if head[path] > base.get(path, 0):
+                generated_changelogs.append(path)
+            continue
         before, n = base.get(path, 0), head[path]
         # Deliberately NOT gated on ``n > before``. A file that drops one branded
         # line and adds a different, brand-new one in the same edit comes out
@@ -708,6 +729,14 @@ def main() -> int:
             grown[path] = (before, n, minted)
 
     _report_excused_moves(excused, base_by_file, head_by_file)
+
+    if generated_changelogs:
+        print(
+            f"{len(generated_changelogs)} generated CHANGELOG file(s) exempt on this "
+            "release-please branch (titles quoted from history):"
+        )
+        for path in sorted(generated_changelogs):
+            print(f"  {path}")
 
     if not grown:
         removed = sum(max(0, c - head.get(p, 0)) for p, c in base.items())

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -12,6 +12,7 @@ case-insensitive match are all git's behaviour, not ours.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -50,13 +51,26 @@ def repo(tmp_path: Path) -> Path:
     return r
 
 
-def _run(repo: Path, *extra: str) -> subprocess.CompletedProcess:
+def _run(
+    repo: Path, *extra: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess:
+    """Run the script; ``env`` entries are merged over the inherited environment.
+
+    ``GITHUB_HEAD_REF`` is stripped from the inherited environment first. The
+    suite itself runs under Actions on pull_request builds, where that variable
+    names whatever branch the PR happens to be — including release-please's own,
+    which is exactly when its CHANGELOG exemption tests would otherwise flip.
+    Branch context is simulated explicitly via ``env``, never inherited.
+    """
+    merged = {k: v for k, v in os.environ.items() if k != "GITHUB_HEAD_REF"}
+    merged.update(env or {})
     return subprocess.run(
         [sys.executable, str(SCRIPT), "--base", "HEAD", *extra],
         cwd=repo,
         capture_output=True,
         text=True,
         check=False,  # a non-zero exit is the thing under test
+        env=merged,
     )
 
 
@@ -967,3 +981,51 @@ def test_an_untouched_exemption_is_not_reported(repo: Path) -> None:
     result = _run(repo)
 
     assert "exempt line(s) removed" not in result.stdout
+
+
+# ── release-please's own branches: generated CHANGELOGs are exempt ───────────
+#
+# release-please regenerates per-package CHANGELOGs by quoting merged PR titles
+# verbatim, so a title that legitimately carried the old brand (history — rule 2
+# says never edit it) resurfaces as a line the tally cannot tell from fresh
+# minting. The exemption is gated on GITHUB_HEAD_REF naming the bot's own
+# branch, and scoped to CHANGELOG files — nothing else on that branch, and no
+# CHANGELOG anywhere else, is excused.
+
+_RELEASE_ENV = {"GITHUB_HEAD_REF": "release-please--branches--main"}
+
+
+def test_a_changelog_passes_on_a_release_please_branch(repo: Path) -> None:
+    _stage(repo, "CHANGELOG.md", f"* fix: retire the {LEGACY} gateway (#123)\n")
+
+    result = _run(repo, env=_RELEASE_ENV)
+
+    assert result.returncode == 0, result.stdout
+    assert "1 generated CHANGELOG file(s) exempt on this" in result.stdout
+    assert "CHANGELOG.md" in result.stdout
+
+
+def test_the_same_changelog_fails_off_the_bot_branch(repo: Path) -> None:
+    """The exemption is the bot's, not the file's: a human minting the name in a
+    CHANGELOG on an ordinary branch — or locally, where GITHUB_HEAD_REF is
+    absent — still answers to the gate."""
+    _stage(repo, "CHANGELOG.md", f"* fix: retire the {LEGACY} gateway (#123)\n")
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "CHANGELOG.md" in result.stdout
+
+
+def test_the_exemption_is_path_scoped_to_changelogs(repo: Path) -> None:
+    """The bot's branch buys no headroom outside the files the bot generates: a
+    non-CHANGELOG mint on that branch fails exactly as it would anywhere."""
+    _stage(repo, "CHANGELOG.md", f"* fix: retire the {LEGACY} gateway (#123)\n")
+    _stage(repo, "new.py", f'KEY = "{LEGACY}-new-service"\n')
+
+    result = _run(repo, env=_RELEASE_ENV)
+
+    assert result.returncode == 1
+    offenders = result.stdout.split("adds the legacy name in", 1)[1]
+    assert "new.py" in offenders
+    assert "CHANGELOG.md" not in offenders


### PR DESCRIPTION
## Why

Sunset report blocker **B1**. release-please regenerates per-package `CHANGELOG*.md` files by quoting merged PR titles verbatim. Titles that legitimately carried the old brand — history, which rule 2 says never to edit — resurface in the regenerated file as lines the ratchet cannot tell from fresh minting, so the bot's own release PRs go red with nothing anyone may fix: the titles are history and the file is generated.

This is wedging the enterprise repo's release PR (caura-enterprise#924) right now — its ratchet job fails with:

```
frontend/CHANGELOG.md  (0 -> 5)
platform-admin-api/CHANGELOG.md  (0 -> 2)
platform-operations/CHANGELOG.md  (0 -> 2)
```

This repo's #898 passed only by luck of a brand-clean release window; the next release whose window contains a brand-carrying title hits the same wall here.

## What

`scripts/legacy_name_ratchet.py` now skips CHANGELOG-named files in the mint check **only** when `GITHUB_HEAD_REF` starts with `release-please--` — i.e. only on that bot's own PR branches. Three deliberate boundaries:

- **Env-gated**: `GITHUB_HEAD_REF` is set by Actions on `pull_request` runs and absent locally, so local runs keep full coverage.
- **Branch-gated**: a human editing a CHANGELOG on any other branch still answers to the gate.
- **Path-scoped**: on the bot's branch, a mint in any non-CHANGELOG file still fails.

Every exempted file is printed in the CI log rather than silently skipped.

Tests (`tests/test_legacy_name_ratchet.py`): three new cases pin the pass-on-bot-branch behavior (with the visible notice), the same change failing off the bot's branch, and the path-scoping. `_run` gained an optional `env` dict merged over the inherited environment, which now strips `GITHUB_HEAD_REF` so the suite is deterministic even when it itself runs on a release-please branch.

The two repos' ratchet copies have diverged, so this is the same hunk ported into each copy, not a file sync. Sibling PR with the identical behavior: caura-ai/caura-enterprise#1303.

## Gates run locally

- `scripts/legacy_name_ratchet.py` → `No new lines.` (exit 0)
- `scripts/do_not_touch_sentinel.py` → `All 34 protected strings survive.` (exit 0)
- `uv run pytest tests/test_legacy_name_ratchet.py` → 52 passed
- ruff: `scripts/` and root `tests/` are outside this repo's CI lint scope, so no lint step applies to the touched paths (matched CI exactly, not over-linted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129mDPbfSxqBrCLs5dDpcGv
