### PR TITLE
docs(sunset): record the broker's cloud host as a sequenced cutover

### DIFF
--- a/docs/plans/rebrand-sunset-plan.md
+++ b/docs/plans/rebrand-sunset-plan.md
@@ -66,6 +66,12 @@ migrated, each by a sequence that is deliberate rather than optional:
   itself is a single short window. The old role is kept.
 - **Cloud Run** — the services are being decoupled from build-time configuration
   first, so that a rename is a deploy rather than a rebuild.
+- **The broker's default cloud host** — the compile-time default in the daemon and
+  the release mirror derived from it move together, and only once the gateway serves
+  the new host. The mirror is the auto-updater's only source for a broker that never
+  registered, so flipping before the new host serves `/…/latest.txt` and `/…/<tag>/`
+  breaks update for exactly the installs with no other way to recover. Carried in the
+  daemon as the repository's only `TODO(rebrand cutover)`.
 
 If you are about to change one of these, the sequence matters more than the change.
 


### PR DESCRIPTION
Docs-only. One bullet in *What is not frozen*, beside Pub/Sub, the database and Cloud Run.

## Why it needs recording

`caura-daemon/internal/cloud/client.go` carries the repository's **only** `TODO(rebrand cutover)` — the compile-time default cloud host, to be flipped once the gateway serves the new one.

Nothing in the plan mentioned it. So to anyone grepping that file it reads as an unswept string in a repo that has just been swept — **the shape most likely to be "tidied" by the next pass.** The plan's job is to make that mistake hard, and it currently doesn't cover this one.

It is not debt. It is the same class as the three items already listed: an external precondition that has to land before the change is safe.

## What makes the ordering load-bearing

`update.go` derives the **release mirror** from this same constant, and that mirror is the auto-updater's only binary source for a broker that never registered with a cloud.

So flipping the host before the new one serves `/…/latest.txt` and `/…/<tag>/` breaks `update` for exactly the installs with no other recovery path — the ones whose owners are least likely to be watching. That's the detail worth carrying into the plan, because the flip looks like a one-constant change and isn't.

## Gates

- `Legacy-name ratchet` — no new lines, no new exemptions (worded around the literals)
- `Do-not-touch sentinel` — 34/34