### PR TITLE
docs(clients): complete python client README API coverage

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -19,23 +19,25 @@ pip install caura-client
 ```python
 from caura_client import Caura
 
-mc = Caura("mc_xxx", tenant_id="my-team", agent_id="my-agent")
+# Recommended: the client is a context manager and closes its HTTP
+# connection on exit (use close() for manual management).
+with Caura("mc_xxx", tenant_id="my-team", agent_id="my-agent") as mc:
+    # Write a memory — enriched server-side with type, title, tags, importance.
+    mc.write("Q3 revenue target is $4M, set on 2026-04-15.")
 
-# Write a memory — enriched server-side with type, title, tags, importance.
-mc.write("Q3 revenue target is $4M, set on 2026-04-15.")
+    # Search (ranked raw results)
+    for m in mc.search("Q3 revenue target", top_k=5):
+        print(m.title, "—", m.content)
 
-# Search (ranked raw results)
-for m in mc.search("Q3 revenue target", top_k=5):
-    print(m.title, "—", m.content)
-
-# Recall (LLM-synthesized context brief)
-print(mc.recall("Q3 revenue target").summary)
+    # Recall (LLM-synthesized context brief)
+    print(mc.recall("Q3 revenue target").summary)
 ```
 
 Self-hosted? Pass `base_url`:
 
 ```python
-mc = Caura("standalone", tenant_id="default", base_url="http://localhost:8000")
+with Caura("standalone", tenant_id="default", base_url="http://localhost:8000") as mc:
+    ...
 ```
 
 ## API
@@ -46,10 +48,50 @@ mc = Caura("standalone", tenant_id="default", base_url="http://localhost:8000")
 | `search(query, top_k=5, ...)` | `POST /api/v1/search` | `list[Memory]` |
 | `recall(query, top_k=5, ...)` | `POST /api/v1/recall` | `RecallResult` |
 | `health()` | `GET /api/v1/health` | `dict` |
+| `get_document(doc_id, *, collection, ...)` | `GET /api/v1/documents/{doc_id}` | `dict` |
+| `submit_interview(...)` | `POST /api/v1/interview/submit` | `dict` |
+| `close()` | — | `None` |
 
 The client is a context manager (`with Caura(...) as mc:`) and raises
 `AuthError` (401/403), `NotFoundError` (404), or `CauraAPIError` on failures.
 Every result also exposes the full API payload on `.raw`.
+
+### Fetching a document
+
+`get_document()` returns the full `DocOut` envelope — the stored record is
+nested under the `"data"` key, not returned directly. `collection` is a
+required keyword-only argument, and a missing document raises
+`NotFoundError`:
+
+```python
+with Caura("mc_xxx", tenant_id="my-team", agent_id="my-agent") as mc:
+    doc = mc.get_document("doc-123", collection="interviews")
+    record = doc["data"]       # the stored record lives under "data"
+```
+
+### Lifecycle
+
+`Caura` holds an `httpx.Client`, so prefer the `with` form above — the
+connection is closed on exit. For manual management, call `close()`
+explicitly when you are done:
+
+```python
+mc = Caura("mc_xxx", tenant_id="my-team", agent_id="my-agent")
+try:
+    mc.write("...")
+finally:
+    mc.close()
+```
+
+### `submit_interview()` is an Interviewer-internal surface
+
+`submit_interview()` is used by the `caura-interviewer` adapter below to
+submit parsed session windows to the server. It is not intended as a
+general-purpose SDK method: it calls the server synchronously (the server
+interviews the window in-line, up to a 90s budget), so its `timeout`
+defaults to 120s rather than the client-wide 30s, and the returned body
+carries an extra `"http_status"` key so callers can tell a `207` partial
+from a `200` committed. New SDK users should not need it.
 
 For credentials, scopes, and the full API surface, see the
 [Caura docs](https://caura.ai/docs). Production fleets should use


### PR DESCRIPTION
## Summary

Completes `clients/python/README.md` so it covers all seven public methods of the `Caura` client instead of four. Adds `get_document()`, `submit_interview()`, and `close()`/context-manager guidance, and switches the Quickstart examples to the recommended `with` form.

## Related Issue

Closes #974

## Type of Change

- [x] Documentation update

## What Changed

- API table gains `get_document(doc_id, *, collection, ...)`, `submit_interview(...)`, and `close()`.
- New "Fetching a document" section: `collection` is a required keyword-only argument, the return value is the full `DocOut` envelope with the record nested under `["data"]` (not the record itself), and a missing document raises `NotFoundError`.
- New "Lifecycle" section: `with Caura(...) as mc:` is the recommended default (closes the underlying `httpx.Client`); `close()` is shown for manual management. The old examples never closed the client, leaking connections in long-running processes.
- `submit_interview()` is documented as an **Interviewer-internal surface** (used by the `caura-interviewer` adapter), not a general-purpose SDK method: the server interviews synchronously (up to a 90s budget), so `timeout` defaults to 120s rather than the client-wide 30s, and the returned body carries an extra `"http_status"` key to distinguish a 207 partial from a 200 committed. Per the issue's suggestion, this explicitly documents it as internal rather than public — maintainers can weigh in if they'd prefer public treatment.
- Quickstart and self-hosted examples now use the context-manager form.

## How Has This Been Tested?

- Every claim in the new README sections was verified against `clients/python/src/caura_client/client.py` docstrings and by exercising the real client with a mock `httpx` transport: `get_document()` envelope/`["data"]` nesting, required keyword-only `collection`, `NotFoundError` on missing docs, `submit_interview()` `"http_status"` key, and context-manager/`close()` lifecycle.
- Python code blocks extracted from the README pass `compile()` syntax checks (blocks with intentional `...` placeholders excluded).
- `pytest tests/` in `clients/python`: **142 passed** (no regressions; README-only change, no code touched).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes (or explained why none are needed) — docs-only; existing suite verified green
- [x] `ruff check` and `ruff format --check` pass — not applicable to `clients/python/README.md` (no Python code changed; pre-commit hook target dirs unaffected)
- [x] `mypy` passes — not applicable (no Python code changed)
- [x] `pytest` passes locally — 142 passed
- [x] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing) — CHANGELOG is generated by release-please from Conventional Commits; `docs:` has no release impact

## Additional Notes

**AI disclosure:** This PR was authored with assistance from an AI agent (OpenClaw/メギ, operating on behalf of the GitHub user tasodoufu). The content was verified against the actual client source and behavior before submission, per the project's DCO and Conventional Commits requirements. No AI-use prohibition was found in CONTRIBUTING or repository docs.

## Unverified

- Live behavior against a running Caura deployment was not tested (no credentials/deployment here); the verification above uses a mock transport that mirrors the server contract described in the source docstrings.