### PR TITLE
fix(api): every 429 carries Retry-After (D14)

### DIFF
--- a/core-api/src/core_api/middleware/per_tenant_concurrency.py
+++ b/core-api/src/core_api/middleware/per_tenant_concurrency.py
@@ -128,6 +128,11 @@ async def per_tenant_slot(
         raise HTTPException(
             status_code=429,
             detail=f"Too many concurrent {scope} requests; retry shortly.",
+            # D14 — a 429 that says "retry shortly" must SAY how shortly. The
+            # bulkhead frees a slot as soon as any in-flight request finishes;
+            # 1s matches the acquire-timeout granularity and the per-second
+            # rate zones elsewhere on the surface.
+            headers={"Retry-After": "1"},
         )
     try:
         yield

--- a/core-api/src/core_api/middleware/rate_limit.py
+++ b/core-api/src/core_api/middleware/rate_limit.py
@@ -104,6 +104,13 @@ limiter = Limiter(
     # Redis outages degrade gracefully — requests pass through rather
     # than all rate-limited routes returning 500.
     swallow_errors=True,
+    # D14 — without this, slowapi's ``_inject_headers`` is a silent no-op
+    # (it checks ``self._headers_enabled`` first), so NO response carried
+    # X-RateLimit-* and no 429 carried Retry-After — despite app.py's 429
+    # handler dutifully calling the injector. Field-observed as "MCP feels
+    # fragile": throttled agents saw random unreliability with no back-off
+    # signal (Hermes onboarding test).
+    headers_enabled=True,
     # No default_limits — decorators are applied explicitly per-route.
     # Avoids accidentally limiting /health, /version, /mcp, etc.
 )

--- a/tests/test_d14_ratelimit_headers.py
+++ b/tests/test_d14_ratelimit_headers.py
@@ -1,0 +1,70 @@
+"""D14 — 429s (and limited routes generally) must carry back-off headers.
+
+slowapi's ``_inject_headers`` silently no-ops unless the Limiter was built
+with ``headers_enabled=True`` — which it never was, so no response carried
+``X-RateLimit-*`` and no 429 carried ``Retry-After``, even though the custom
+429 handler in app.py explicitly re-runs the injector. Hermes experienced
+this as "MCP feels fragile": throttling with no back-off signal.
+"""
+
+import pytest
+from fastapi.responses import JSONResponse
+
+from core_api.middleware.rate_limit import limiter
+
+pytestmark = pytest.mark.unit
+
+
+def test_limiter_headers_enabled():
+    # The whole fix: without this flag the injector below is a no-op.
+    # (``limiter.enabled`` is False under test settings — rate limiting is
+    # off in tests — so assert the header flag, which is what shipped.)
+    assert getattr(limiter, "_headers_enabled", False) is True
+
+
+def test_inject_headers_actually_injects(monkeypatch):
+    """Drive slowapi's injector directly with a synthetic window and assert
+    the headers land — the exact call app.py's 429 handler makes.
+    ``enabled`` is forced on for the assertion since test settings disable
+    limiting; production runs with it enabled."""
+    import time
+
+    monkeypatch.setattr(limiter, "enabled", True)
+
+    from limits import RateLimitItemPerSecond
+
+    item = RateLimitItemPerSecond(10)
+    reset_at = int(time.time()) + 1
+    response = JSONResponse({"detail": "Rate limit exceeded"}, status_code=429)
+    out = limiter._inject_headers(response, (item, [str(reset_at)]))
+    assert out.headers.get("X-RateLimit-Limit") == "10"
+    # Remaining comes from live window stats (fresh storage here) — assert
+    # presence, not a specific count.
+    assert "X-RateLimit-Remaining" in out.headers
+    assert "X-RateLimit-Reset" in out.headers or "Retry-After" in out.headers
+
+
+async def test_bulkhead_429_carries_retry_after(monkeypatch):
+    """The per-tenant concurrency bulkhead's 429 said "retry shortly" with no
+    Retry-After — the third 429 source (after nginx + slowapi) the D14 wet
+    test surfaced. FastAPI turns HTTPException.headers into response headers."""
+    import asyncio
+
+    from fastapi import HTTPException
+
+    from core_api.middleware import per_tenant_concurrency as ptc
+
+    class _NeverAcquires:
+        async def acquire(self):
+            await asyncio.sleep(3600)
+
+        def release(self):
+            pass
+
+    monkeypatch.setattr(ptc, "_get_semaphore", lambda scope, tenant_id: _NeverAcquires())
+    monkeypatch.setattr(ptc.settings, "per_tenant_acquire_timeout_seconds", 0.01)
+    with pytest.raises(HTTPException) as exc_info:
+        async with ptc.per_tenant_slot("search", "t1"):
+            pass
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers.get("Retry-After") == "1"


### PR DESCRIPTION
## What

Closes canonical **D14** (register PERF-04/N5) — app half. No 429 carried a back-off signal; Hermes experienced throttling as "MCP feels fragile".

- **slowapi**: `headers_enabled=True` on the Limiter — without it, `_inject_headers` (which the 429 handler already calls) is a silent no-op, so no response carried `X-RateLimit-*` or `Retry-After`. The in-code comment claimed otherwise; now it's true.
- **Per-tenant concurrency bulkhead**: its 429 said *"retry shortly"* with no header — a **third 429 source discovered by this task's wet test** (the audit had mapped only slowapi + nginx). `HTTPException(headers=...)` rides the canonical-envelope handler, which already propagates headers.
- Companion enterprise PR adds `Retry-After` to nginx's own `limit_req` 429s.

## Testing

- 3 unit tests (flag set; injector actually injects; bulkhead 429 carries the header). Full suite **5217 passed**; ruff/mypy clean.
- Wet, fresh images, hammering /search past all limiters: **all three 429 sources verified** — slowapi (`Retry-After: 1` + `X-RateLimit-Limit: 30`/`Remaining: 0`), bulkhead (`Retry-After: 1`), nginx (`Retry-After: 1`, via companion PR's gateway build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)