### PR TITLE
fix(worker,storage): enrichment completion observable in the C25 view (B7)

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -3069,7 +3069,7 @@ async def _enrich_memory_background(
             patch["status"] = enrichment.status
 
         meta.pop("enrichment_pending", None)
-        # B7×C25 — this path REPLACES metadata wholesale, so clear the
+        # B7 x C25 — this path REPLACES metadata wholesale, so clear the
         # namespaced copy too or the C25 read view stays pending forever.
         if isinstance(meta.get("_system"), dict):
             meta["_system"].pop("enrichment_pending", None)

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -3069,6 +3069,10 @@ async def _enrich_memory_background(
             patch["status"] = enrichment.status
 
         meta.pop("enrichment_pending", None)
+        # B7×C25 — this path REPLACES metadata wholesale, so clear the
+        # namespaced copy too or the C25 read view stays pending forever.
+        if isinstance(meta.get("_system"), dict):
+            meta["_system"].pop("enrichment_pending", None)
         patch["metadata_"] = meta
 
         # Apply patch via storage client -- use update_memory_status for status

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1080,13 +1080,33 @@ class PostgresService:
                 # ``deleted_at IS NULL`` guard mirrors the column-set
                 # branch above so a PATCH never resurrects a deleted
                 # row via the metadata-merge path either.
-                await session.execute(
-                    text(
-                        "UPDATE memories "
-                        "SET metadata = COALESCE(metadata::jsonb, '{}'::jsonb) || (:patch)::jsonb "
-                        "WHERE id = :id AND tenant_id = :tenant_id AND deleted_at IS NULL"
-                    ).bindparams(patch=json.dumps(metadata_patch), id=memory_id, tenant_id=tenant_id),
-                )
+                if "_system" in metadata_patch:
+                    # B7 x C25 — ``||`` is a SHALLOW merge: a patch carrying the
+                    # ``_system`` namespace would REPLACE the stored sub-object,
+                    # clobbering sibling platform keys (write_latency_ms,
+                    # write_mode, …) whenever the worker clears a *_pending
+                    # flag. Deep-merge that one level: top-level keys merge as
+                    # before, then ``_system`` is re-set to old||new.
+                    await session.execute(
+                        text(
+                            "UPDATE memories "
+                            "SET metadata = jsonb_set("
+                            "  COALESCE(metadata::jsonb, '{}'::jsonb) || (:patch)::jsonb, "
+                            "  '{_system}', "
+                            "  COALESCE(metadata::jsonb -> '_system', '{}'::jsonb) "
+                            "    || COALESCE((:patch)::jsonb -> '_system', '{}'::jsonb)"
+                            ") "
+                            "WHERE id = :id AND tenant_id = :tenant_id AND deleted_at IS NULL"
+                        ).bindparams(patch=json.dumps(metadata_patch), id=memory_id, tenant_id=tenant_id),
+                    )
+                else:
+                    await session.execute(
+                        text(
+                            "UPDATE memories "
+                            "SET metadata = COALESCE(metadata::jsonb, '{}'::jsonb) || (:patch)::jsonb "
+                            "WHERE id = :id AND tenant_id = :tenant_id AND deleted_at IS NULL"
+                        ).bindparams(patch=json.dumps(metadata_patch), id=memory_id, tenant_id=tenant_id),
+                    )
         return True
 
     async def memory_update_status(

--- a/core-storage-api/tests/test_b7_system_deep_merge.py
+++ b/core-storage-api/tests/test_b7_system_deep_merge.py
@@ -1,0 +1,86 @@
+"""B7 x C25 — the metadata_patch JSONB merge deep-merges the ``_system``
+namespace instead of replacing it.
+
+``||`` is shallow: a worker patch carrying ``_system: {enrichment_pending:
+false}`` would otherwise REPLACE the stored sub-object, clobbering sibling
+platform keys (write_latency_ms, write_mode, …) every time a *_pending flag
+clears. Runs against the real Postgres fixture — jsonb_set semantics are the
+thing under test.
+"""
+
+import uuid
+
+import pytest
+
+from core_storage_api.services.postgres_service import PostgresService, get_session
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _insert_memory(svc: PostgresService, tenant: str, metadata: dict):
+    row = await svc.memory_add(
+        {
+            "tenant_id": tenant,
+            "agent_id": "b7-tester",
+            "content": f"b7 canary {uuid.uuid4()}",
+            "memory_type": "fact",
+            "weight": 0.5,
+            "metadata_": metadata,
+            "status": "active",
+            "visibility": "scope_team",
+        }
+    )
+    return row
+
+
+async def _get_metadata(memory_id, tenant):
+    from sqlalchemy import text
+
+    async with get_session() as s:
+        res = await s.execute(
+            text("SELECT metadata FROM memories WHERE id = :i AND tenant_id = :t"),
+            {"i": str(memory_id), "t": tenant},
+        )
+        return res.scalar_one()
+
+
+async def test_system_namespace_deep_merges():
+    svc = PostgresService()
+    tenant = f"b7-{uuid.uuid4().hex[:8]}"
+    stored = {
+        "write_mode": "fast",
+        "enrichment_pending": True,
+        "_system": {
+            "write_mode": "fast",
+            "enrichment_pending": True,
+            "write_latency_ms": 123,
+        },
+        "caller_key": "kept",
+    }
+    row = await _insert_memory(svc, tenant, stored)
+
+    ok = await svc.memory_update(
+        row.id,
+        tenant,
+        {"metadata_patch": {"enrichment_pending": False, "_system": {"enrichment_pending": False}}},
+    )
+    assert ok
+
+    md = await _get_metadata(row.id, tenant)
+    assert md["enrichment_pending"] is False
+    sysm = md["_system"]
+    assert sysm["enrichment_pending"] is False  # cleared
+    assert sysm["write_latency_ms"] == 123  # sibling SURVIVED (the deep-merge point)
+    assert sysm["write_mode"] == "fast"
+    assert md["caller_key"] == "kept"
+
+
+async def test_patch_without_system_keeps_shallow_behavior():
+    svc = PostgresService()
+    tenant = f"b7-{uuid.uuid4().hex[:8]}"
+    row = await _insert_memory(svc, tenant, {"a": 1})
+    ok = await svc.memory_update(row.id, tenant, {"metadata_patch": {"b": 2}})
+    assert ok
+    md = await _get_metadata(row.id, tenant)
+    assert md == {"a": 1, "b": 2}
+    assert "_system" not in md  # no phantom namespace injected

--- a/core-worker/src/core_worker/clients/storage_client.py
+++ b/core-worker/src/core_worker/clients/storage_client.py
@@ -225,7 +225,10 @@ async def update_memory_embedding(
     body: dict = {
         "tenant_id": tenant_id,
         "embedding": embedding,
-        "metadata_patch": {"embedding_pending": False},
+        # B7 x C25 — clear BOTH homes: the C25 read view gives ``_system``
+        # precedence, so legacy-only clearing would leave
+        # ``system_metadata.embedding_pending`` True forever.
+        "metadata_patch": {"embedding_pending": False, "_system": {"embedding_pending": False}},
     }
     if embedded_content_hash is not None:
         body["embedded_content_hash"] = embedded_content_hash

--- a/core-worker/src/core_worker/consumer.py
+++ b/core-worker/src/core_worker/consumer.py
@@ -485,7 +485,14 @@ def _build_patch(
     # — without it, a fallback redelivery would silently keep the row
     # marked pending forever). Storage's JSONB ``||`` merge overwrites
     # a prior ``True`` with ``False`` cleanly.
-    metadata_patch: dict = {"enrichment_pending": False}
+    # B7 x C25 — clear the flag in BOTH homes. The C25 boundary gives the
+    # ``_system`` namespace precedence on the read side
+    # (``extract_system_metadata``: nested wins over legacy), so clearing only
+    # the legacy top-level key would leave ``system_metadata.enrichment_pending``
+    # True FOREVER on fast-mode rows — polling would never observe completion.
+    # Storage deep-merges the ``_system`` sub-object (one level) when present
+    # in the patch, so sibling ``_system`` keys survive.
+    metadata_patch: dict = {"enrichment_pending": False, "_system": {"enrichment_pending": False}}
     for field in _ENRICHMENT_METADATA_FIELDS:
         if field in skip:
             continue
@@ -503,6 +510,7 @@ def _build_patch(
             # ``llm_ms=0`` so the proxy is reliable.
             if result.llm_ms > 0 and value is not None:
                 metadata_patch[field] = value
+                metadata_patch["_system"][field] = value
             continue
         # Other metadata fields: drop the specific defaults that carry
         # no information — heuristic-fallback ``"summary": ""``,
@@ -512,6 +520,7 @@ def _build_patch(
         if value is None or value in (False, 0, "", []):
             continue
         metadata_patch[field] = value
+        metadata_patch["_system"][field] = value
     if metadata_patch:
         patch["metadata_patch"] = metadata_patch
 

--- a/core-worker/tests/test_b7_pending_clears_both_homes.py
+++ b/core-worker/tests/test_b7_pending_clears_both_homes.py
@@ -1,0 +1,56 @@
+"""B7 x C25 — the worker's enrichment PATCH must clear the pending flag in
+BOTH metadata homes.
+
+C25 gave the ``_system`` namespace read-side precedence
+(``extract_system_metadata``: nested wins over legacy), so a patch that
+clears only the legacy top-level ``enrichment_pending`` leaves
+``system_metadata.enrichment_pending`` True forever — polling would never
+observe completion on fast-mode rows. The patch also mirrors the enrichment
+metadata fields into ``_system`` so async-enriched rows carry the same
+namespaced view strong-mode rows get at write time.
+"""
+
+from common.enrichment.schema import EnrichmentResult
+from core_worker.consumer import _build_patch
+
+
+def _result(**over):
+    base = {
+        "memory_type": "fact",
+        "weight": 0.5,
+        "title": "t",
+        "summary": "platform summary",
+        "tags": ["a"],
+        "contains_pii": False,
+        "pii_types": [],
+        "retrieval_hint": "hint",
+        "llm_ms": 42,
+    }
+    base.update(over)
+    return EnrichmentResult(**base)
+
+
+def test_pending_cleared_in_both_homes():
+    patch = _build_patch(_result())
+    mp = patch["metadata_patch"]
+    assert mp["enrichment_pending"] is False
+    assert mp["_system"]["enrichment_pending"] is False
+
+
+def test_metadata_fields_mirrored_into_system():
+    patch = _build_patch(_result())
+    mp = patch["metadata_patch"]
+    assert mp["summary"] == "platform summary"
+    assert mp["_system"]["summary"] == "platform summary"
+    assert mp["llm_ms"] == 42
+    assert mp["_system"]["llm_ms"] == 42
+
+
+def test_heuristic_fallback_still_clears_both_homes():
+    # llm_ms=0 → every metadata field skips, but the pending clear must
+    # still go out in both homes (the original regression, extended to C25).
+    heuristic = _result(summary="", tags=[], retrieval_hint="", llm_ms=0, title="")
+    patch = _build_patch(heuristic)
+    mp = patch["metadata_patch"]
+    assert mp["enrichment_pending"] is False
+    assert mp["_system"] == {"enrichment_pending": False}

--- a/core-worker/tests/test_consumer.py
+++ b/core-worker/tests/test_consumer.py
@@ -221,7 +221,7 @@ async def test_update_memory_embedding_clears_embedding_pending_flag():
     body = client.patch.await_args.kwargs["json"]
     assert body["embedding"] == [0.1] * 768
     assert body["tenant_id"] == "tenant-A"
-    assert body["metadata_patch"] == {"embedding_pending": False}
+    assert body["metadata_patch"] == {"embedding_pending": False, "_system": {"embedding_pending": False}}
 
 
 @pytest.mark.asyncio
@@ -383,7 +383,7 @@ async def test_update_memory_embedding_sends_provenance_key():
     assert body["embedded_content_hash"] == "h1"
     assert "content_hash" not in body, body
     # The metadata merge must survive alongside it.
-    assert body["metadata_patch"] == {"embedding_pending": False}
+    assert body["metadata_patch"] == {"embedding_pending": False, "_system": {"embedding_pending": False}}
 
 
 @pytest.mark.asyncio

--- a/core-worker/tests/test_consumer_enrich.py
+++ b/core-worker/tests/test_consumer_enrich.py
@@ -444,7 +444,9 @@ async def test_enrichment_pending_cleared_even_with_heuristic_fallback(monkeypat
 
     fields = patch_call.await_args.kwargs["fields"]
     mp = fields["metadata_patch"]
-    assert mp == {"enrichment_pending": False}, "heuristic fallback PATCH must still clear enrichment_pending"
+    assert mp == {"enrichment_pending": False, "_system": {"enrichment_pending": False}}, (
+        "heuristic fallback PATCH must still clear enrichment_pending in both homes"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Closes canonical **B7** (register PERF-02): fast mode's `enrichment_pending` is the pollable completion signal — but the async completion paths cleared only the legacy top-level key, and the C25 read view gives `metadata._system` precedence, so `system_metadata.enrichment_pending` stayed **True forever** on fast-mode rows. Polling could never observe completion; same for `embedding_pending`.

- **Worker enrichment PATCH**: dual-home flag clear + mirrors enrichment fields into `_system` (async-enriched rows now match strong-mode rows' namespaced view). Heuristic-fallback redeliveries keep the both-homes clear.
- **Worker embed PATCH**: dual-home `embedding_pending` clear.
- **core-api async-apply path** (wholesale metadata replace): pops from `_system` too.
- **Storage `metadata_patch` merge**: deep-merges `_system` one level (`jsonb_set` old||new) — the shallow `||` would let any flag-clear REPLACE the stored `_system`, clobbering siblings (`write_latency_ms`, `write_mode`, …). Patches without `_system` keep the exact prior statement.

With this, the fast-mode contract is complete: write returns `system_metadata.enrichment_pending: true` → poll GET/search until it flips false with `summary`/`tags` populated. (The push-event companion is API-15, product-scoped.)

## Testing

- Worker **75 passed** (3 new: dual-home clear, `_system` mirroring, heuristic-fallback both-homes; 3 existing exact-shape assertions updated to the intended new patch shape). Storage **156 passed** incl. 2 new deep-merge tests **against real Postgres** — sibling `_system` keys survive the clear; no phantom namespace on plain patches. Root suite **5217 passed**; ruff/mypy clean across all three services.
- Local stack runs no core-worker, so the full async round-trip can't wet-test locally; the storage deep-merge (the risky part) is verified against the real compose Postgres, and the write-side flag was wet-verified in C25's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)