### PR TITLE
fix(logging): route warnings through logging so they stop counting as errors

### DIFF
--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import logging
 import sys
 import threading
+import warnings
 from typing import Any
 
 import structlog
@@ -96,6 +97,9 @@ _configured_log_file: str | None = None
 # or a library that ran before us.
 _installed_handler: logging.Handler | None = None
 _installed_file_handler: logging.Handler | None = None
+# True only when this module changed warning capture from disabled to enabled.
+# A caller that enabled capture before us still owns that process-global state.
+_installed_warning_capture = False
 # RLock so a custom `warnings.showwarning` hook that re-enters
 # `configure_logging` on the same thread won't deadlock. The mismatch
 # warning below is the only user-visible call site that could plausibly
@@ -441,8 +445,6 @@ def configure_logging(
                 or json_logs != _configured_json_logs
                 or log_file != _configured_log_file
             ):
-                import warnings
-
                 warnings.warn(
                     f"configure_logging re-called with different arguments: "
                     f"({environment!r}, {log_level!r}, json_logs={json_logs!r}, "
@@ -608,7 +610,7 @@ def _reset_for_testing() -> None:
     """
     global _configured, _configured_environment, _configured_log_level
     global _configured_json_logs, _configured_log_file
-    global _installed_handler, _installed_file_handler
+    global _installed_handler, _installed_file_handler, _installed_warning_capture
     with _configure_lock:
         structlog.reset_defaults()
         # Drop any bound contextvars so test fixtures don't leak request-scoped
@@ -630,6 +632,10 @@ def _reset_for_testing() -> None:
         _installed_handler = None
         _installed_file_handler = None
         root.setLevel(logging.WARNING)
+        # Undo only the process-global warning capture installed by this module.
+        if _installed_warning_capture:
+            logging.captureWarnings(False)
+        _installed_warning_capture = False
         # Clear the per-logger WARNING overrides that _configure_logging_impl
         # installs at INFO level. Without this, a test that reconfigures at
         # DEBUG would see root at DEBUG but these four stuck at WARNING —
@@ -746,7 +752,7 @@ def _configure_logging_impl(
             foreign_renderer,
         ],
     )
-    global _installed_handler, _installed_file_handler
+    global _installed_handler, _installed_file_handler, _installed_warning_capture
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
     root = logging.getLogger()
@@ -818,6 +824,32 @@ def _configure_logging_impl(
                 )
 
     root.setLevel(min_level)
+
+    # Route `warnings.warn()` through logging instead of letting it write
+    # straight to stderr. Cloud Run derives a log's status from the stream it
+    # arrived on, so a bare stderr warning lands in Datadog as
+    # ``status:error`` — same false-error mechanism this module's header
+    # describes for uvicorn's supervisor lines, reaching Datadog by a
+    # different route.
+    #
+    # Measured before this: 1,543 of 1,550 error-status logs from staging
+    # core-api over 6h (99.5%) were one third-party DeprecationWarning-class
+    # warning, at ~257/hour. Error rate and Error Tracking for that service
+    # were almost entirely this.
+    #
+    # captureWarnings sends them to the `py.warnings` logger, which has no
+    # handler of its own and propagates to the root handler installed above —
+    # so they emit as JSON at WARNING, and stay visible without counting as
+    # errors.
+    #
+    # Only warnings raised AFTER this call are captured, which makes the
+    # import order in each service's app.py load-bearing: configure_logging()
+    # runs before the heavyweight imports, so warnings raised while those
+    # modules are defined are caught. Moving an import above that call would
+    # silently send its warnings back to stderr.
+    previous_showwarning = warnings.showwarning
+    logging.captureWarnings(True)
+    _installed_warning_capture = warnings.showwarning is not previous_showwarning
 
     # Silence noisy dependency loggers so INFO traffic from httpx's
     # per-request lines and google-auth token refreshes doesn't drown the

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import warnings
 
 import pytest
 
@@ -634,7 +635,105 @@ def test_uvicorn_error_lifecycle_line_emits_info_status(_json_log_buffer) -> Non
     # Filter on the quoted message so only the JSON handler's line matches — the
     # buffer also holds pytest's plain-format capture-handler copies (same
     # buffer, swapped by the fixture), which lack the surrounding quotes.
-    records = [json.loads(line) for line in lines if '"Started parent process [8]"' in line]
+    records = [
+        json.loads(line) for line in lines if '"Started parent process [8]"' in line
+    ]
     assert len(records) == 1, f"expected one uvicorn.error JSON record, got: {lines}"
     assert records[0]["severity"] == "INFO"
     assert records[0]["status"] == "info"
+
+
+def test_configure_logging_captures_warnings(_json_log_buffer) -> None:
+    """``configure_logging()`` must route ``warnings.warn()`` into logging.
+
+    Cloud Run derives a log's status from the stream it arrived on, so a bare
+    stderr warning lands in Datadog as ``status:error``. Measured before this:
+    1,543 of 1,550 error-status logs from staging core-api over 6h (99.5%)
+    were one third-party warning about an unresolved forward reference in a
+    pydantic-settings model — that service's error rate was almost entirely
+    this, and the same false-error mechanism as the uvicorn supervisor lines
+    above, arriving by a different route.
+
+    Asserted on logging's capture flag rather than by raising a warning:
+    pytest's own warnings plugin wraps each test in a recorder that replaces
+    ``warnings.showwarning``, so a ``warnings.warn()`` here would be swallowed
+    by the plugin and never reach ``py.warnings``, and ``showwarning`` itself
+    reads as the recorder's rather than logging's. Re-enabling capture inside
+    the test to work around that would only assert that the test called
+    ``captureWarnings`` — vacuous. The rendering half is covered by
+    ``test_py_warnings_logger_emits_warning_status``.
+
+    ``logging._warnings_showwarning`` is private, but it is the flag
+    ``captureWarnings`` actually toggles (it holds the displaced
+    ``showwarning`` while capture is on) and the recorder does not save or
+    restore it. If a future CPython renames it this fails with AttributeError
+    — loudly, which is the right failure for a test whose job is to notice.
+    """
+    assert logging._warnings_showwarning is not None, (
+        "configure_logging() must call logging.captureWarnings(True), or "
+        "warnings go to stderr and Datadog files them as errors"
+    )
+
+
+def test_py_warnings_logger_emits_warning_status(_json_log_buffer) -> None:
+    """A captured warning must render as ``status:warning``, never error.
+
+    The pairing to the test above: that one pins that warnings are routed
+    into logging, this one pins where they land once they are. Driven through
+    the ``py.warnings`` logger directly — the same approach as the
+    ``uvicorn.error`` test above — so it exercises our pipeline without
+    depending on the interpreter's warning filters or pytest's capture.
+    """
+    logging.getLogger("py.warnings").warning(
+        "cfg.py:47: UserWarning: stand-in for the pydantic-settings warning"
+    )
+
+    lines = _json_log_buffer.getvalue().strip().splitlines()
+    # Filter on the quoted text so only the JSON handler's line matches — the
+    # buffer also holds pytest's plain-format capture-handler copies.
+    needle = '"cfg.py:47: UserWarning: stand-in for the pydantic-settings warning"'
+    records = [json.loads(line) for line in lines if needle in line]
+    assert len(records) == 1, f"expected one py.warnings JSON record, got: {lines}"
+    assert records[0]["status"] == "warning", "a warning must not count as an error"
+    assert records[0]["severity"] == "WARNING"
+
+
+def test_reset_for_testing_undoes_warning_capture() -> None:
+    """A reset must undo warning capture installed by ``configure_logging``.
+
+    Deliberately does not use ``_json_log_buffer``: that fixture resets on the
+    way in and out, which is the very behaviour under test.
+    """
+    _reset_for_testing()
+    logging.captureWarnings(False)
+    previous_showwarning = warnings.showwarning
+    configure_logging(environment="test", log_level="INFO", json_logs=True)
+    try:
+        assert warnings.showwarning is not previous_showwarning, "capture should be on"
+
+        _reset_for_testing()
+
+        assert warnings.showwarning is previous_showwarning, (
+            "_reset_for_testing() must call logging.captureWarnings(False), or "
+            "warning routing leaks past the reset that claims to undo it"
+        )
+    finally:
+        _reset_for_testing()
+        logging.captureWarnings(False)
+
+
+def test_reset_for_testing_preserves_preexisting_warning_capture() -> None:
+    """A reset must not disable warning capture owned by another caller."""
+    _reset_for_testing()
+    logging.captureWarnings(False)
+    logging.captureWarnings(True)
+    captured_showwarning = warnings.showwarning
+    try:
+        configure_logging(environment="test", log_level="INFO", json_logs=True)
+
+        _reset_for_testing()
+
+        assert warnings.showwarning is captured_showwarning
+    finally:
+        _reset_for_testing()
+        logging.captureWarnings(False)


### PR DESCRIPTION
## Problem

`warnings.warn()` writes straight to stderr, bypassing structlog entirely. Cloud Run derives a log's status from the stream it arrived on, so every Python warning reaches Datadog as **`status:error`**.

**Measured: 1,543 of 1,550 error-status logs from staging core-api over 6h — 99.5% — were a single warning**, at ~257/hour. That service's error rate, Error Tracking, and anything keyed on either were reporting essentially one warning.

This is the same false-error mechanism `common/structlog_config.py`'s own header already documents for uvicorn's supervisor lines, arriving by a different route. That one was fixed by keeping `uvicorn.*` propagating to the structlog root handler — warnings never went through `logging` at all, so they were untouched by it.

## Fix

`logging.captureWarnings(True)` in `configure_logging()`. Warnings go to the `py.warnings` logger, which has no handler of its own and propagates to the root handler configured there — so they emit as JSON at WARNING. **They stay visible; they stop counting as errors.**

Verified by capture rather than by reasoning:

| | stderr | stdout |
|---|---|---|
| without the call | 54 bytes (→ `status:error`) | 0 bytes |
| with it | 0 bytes | JSON, `level: warning`, `logger: py.warnings` |

## The warning itself is not ours to fix

Worth stating plainly, since it's the whole volume: it comes from `mcp.server.fastmcp.server.Settings.lifespan` (mcp 1.28.1), annotated `Callable[[FastMCP[LifespanResultT]], ...]` — a generic forward reference pydantic-settings 2.15.0 can't resolve. We can't fix the annotation from here, so reclassifying it is the fix available to us. It also stays queryable as `status:warning` rather than disappearing.

## An ordering precondition worth knowing about

Only warnings raised **after** `configure_logging()` are captured, which makes each service's `app.py` import order load-bearing. core-api calls `configure_logging()` at `app.py:22` and the mcp import lands at `:38`, so warnings raised while those modules are defined are caught. Moving an import above that call would silently send its warnings back to stderr. Called out in the comment at the call site.

## Tests

Two, and the split is deliberate:

- **`test_configure_logging_captures_warnings`** pins that the call happens. It asserts on `logging._warnings_showwarning` rather than raising a warning, because pytest's warnings plugin wraps each test in a recorder that replaces `warnings.showwarning` — so a `warnings.warn()` in a test is swallowed by the plugin, and `showwarning` reads as the recorder's rather than logging's. Re-enabling capture inside the test to dodge that would only assert that the test called `captureWarnings` — vacuous. **Confirmed to fail without the fix.**
- **`test_py_warnings_logger_emits_warning_status`** covers the other half — that a `py.warnings` record renders as `status:warning` — driven through the logger directly, the same approach as the neighbouring `uvicorn.error` test. This one passes either way by design; it pins the destination, not the routing.

The private-attribute reliance is intentional and documented: it's the flag `captureWarnings` actually toggles, the recorder doesn't save or restore it, and a CPython rename would fail loudly with `AttributeError` rather than silently passing.

## ⚠️ Merge order — this must land BEFORE the enterprise PR

`common/structlog_config.py` is an `identical`-policy vendored file in caura-memclaw-enterprise, whose CI runs `check_vendored_drift.py` against OSS **`main`** demanding byte equality.

- The matching enterprise PR's CI **cannot go green** until this is on OSS `main`.
- In the window between the two merges, **every open enterprise PR fails the drift gate**.

So: merge this, then the enterprise PR immediately after. I've verified the enterprise copy is byte-identical to this branch's and that `check_vendored_drift.py` reports `OK: 12 vendored files checked` against it.

## Verification

- `39 passed` in `tests/test_logging.py`; **`5204 passed`, 4 skipped, 1 xfailed** on the full repo-root suite
- `ruff check common/` clean; `ruff format --check --isolated common/__init__.py common/structlog_config.py common/serve.py` clean (the 88-col vendoring gate)
- `mypy --config-file common/mypy.ini common/` — only two pre-existing `dateutil` stub errors in `common/enrichment/service.py`, none in changed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)