### PR TITLE
fix(search): retrieval contract for genuine contradictions — newer value wins (A34)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
+++ b/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
@@ -26,6 +26,15 @@ _SCORE_FACTORS = (
 )
 
 
+def _mem_field(memory, key: str):
+    """Field access tolerating both SimpleNamespace and dict Memory shapes."""
+    if hasattr(memory, key):
+        return getattr(memory, key)
+    if isinstance(memory, dict):
+        return memory.get(key)
+    return None
+
+
 def _score_parts(row) -> ScoreParts | None:
     """Build the D12 factor breakdown from a scored row; None when unscored.
 
@@ -105,6 +114,47 @@ class LoadAndSerialize:
                         )
                     )
                     existing_ids.add(sid)
+
+        # A34 — the retrieval contract for a genuine contradiction (ratified
+        # 2026-08-25): whenever a result set contains both a superseded row
+        # and its successor, the successor ranks IMMEDIATELY ABOVE its stale
+        # predecessor. This applies to BOTH successor arrivals:
+        #   * injected above (unscored — find_successors pulled it in), and
+        #   * organically recalled on its own merit BELOW the stale row — the
+        #     Hermes/STALE-T2 trap: a query exact-matching the OLD wording
+        #     ranks the stale conflicted row #1 (A31's exact-match exemption
+        #     keeps it un-penalized so it stays surfaced) with the correction
+        #     underneath, and the answer LLM picks the stale value. Wet-test
+        #     verified: the organic path alone reproduces the bug.
+        # A successor that already ranks ABOVE its predecessor keeps its
+        # earned position (it is reached first in the walk). Chains
+        # (C supersedes B supersedes A) resolve newest-first via recursion.
+        # No new wire fields: ``supersedes_id`` names the loser, its
+        # ``status`` says why it lost.
+        succ_of: dict[str, list] = {}
+        for row in rows:
+            sup = _mem_field(row.Memory, "supersedes_id")
+            if sup:
+                succ_of.setdefault(str(sup), []).append(row)
+        if succ_of:
+            placed: set[str] = set()
+            reordered: list = []
+
+            def _place(row) -> None:
+                rid = str(_mem_field(row.Memory, "id"))
+                if rid in placed:
+                    return
+                placed.add(rid)
+                for s in succ_of.get(rid, []):
+                    _place(s)
+                reordered.append(row)
+
+            # ``_place`` marks a row placed BEFORE recursing so a (corrupt)
+            # supersession cycle terminates instead of recursing forever;
+            # append happens after the successors so they land above.
+            for row in rows:
+                _place(row)
+            rows = reordered
 
         ctx.data["results"] = [
             _memory_to_out(

--- a/tests/test_a34_successor_contract.py
+++ b/tests/test_a34_successor_contract.py
@@ -1,0 +1,195 @@
+"""A34 — the retrieval contract for a genuine contradiction: newer value wins.
+
+When a result set contains both a superseded row and its injected successor,
+the successor ranks IMMEDIATELY ABOVE its stale predecessor — never appended
+unscored at the tail. This is the Hermes/STALE-T2 shape: a query
+exact-matching the OLD fact used to return the stale conflicted row at #1
+with the current successor dangling last, and the answer LLM picked the
+stale value.
+
+Contract carries no new wire fields: the successor's ``supersedes_id`` names
+the stale row; the stale row's ``status`` says why it lost.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search import load_and_serialize as las
+
+pytestmark = pytest.mark.unit
+
+
+def _mem_ns(mid, status="active", content="c", **score):
+    return SimpleNamespace(
+        Memory=SimpleNamespace(
+            id=mid,
+            tenant_id="t",
+            fleet_id=None,
+            agent_id="a1",
+            agent_display_name=None,
+            memory_type="fact",
+            title="row",
+            content=content,
+            weight=0.5,
+            source_uri=None,
+            run_id=None,
+            metadata_=None,
+            created_at="2026-08-25T00:00:00Z",
+            expires_at=None,
+            subject_entity_id=None,
+            predicate=None,
+            object_value=None,
+            ts_valid_start=None,
+            ts_valid_end=None,
+            status=status,
+            visibility="scope_fleet",
+            recall_count=0,
+            last_recalled_at=None,
+            supersedes_id=None,
+        ),
+        score=score.get("score", 1.0),
+        similarity=None,
+        vec_sim=score.get("vec_sim", 0.9),
+        fts_score=None,
+        freshness=None,
+        entity_boost=None,
+        recall_boost=None,
+        temporal_boost=None,
+        status_penalty=None,
+        has_embedding=True,
+        entity_links=[],
+    )
+
+
+def _successor_dict(sid, supersedes, content="the corrected fact"):
+    return {
+        "id": str(sid),
+        "tenant_id": "t",
+        "fleet_id": None,
+        "agent_id": "a1",
+        "memory_type": "fact",
+        "title": "successor",
+        "content": content,
+        "weight": 0.5,
+        "source_uri": None,
+        "run_id": None,
+        "metadata_": None,
+        "created_at": "2026-08-25T01:00:00Z",
+        "expires_at": None,
+        "subject_entity_id": None,
+        "predicate": None,
+        "object_value": None,
+        "ts_valid_start": None,
+        "ts_valid_end": None,
+        "status": "active",
+        "visibility": "scope_fleet",
+        "recall_count": 0,
+        "last_recalled_at": None,
+        "supersedes_id": str(supersedes),
+    }
+
+
+async def _run(rows, successors, monkeypatch):
+    sc = MagicMock()
+    sc.find_successors = AsyncMock(return_value=successors)
+    monkeypatch.setattr(las, "get_storage_client", lambda: sc)
+    ctx = PipelineContext(data={"filtered_rows": rows, "tenant_id": "t"})
+    await las.LoadAndSerialize().execute(ctx)
+    return ctx.data["results"]
+
+
+async def test_successor_ranks_immediately_above_stale_predecessor(monkeypatch):
+    """The Hermes shape: stale conflicted row ranked #1 → successor must land
+    at #1, stale row demoted to #2, unrelated rows keep relative order."""
+    stale_id = uuid.uuid4()
+    succ_id = uuid.uuid4()
+    other_id = uuid.uuid4()
+    rows = [
+        _mem_ns(stale_id, status="conflicted", content="the stale fact", score=1.4),
+        _mem_ns(other_id, status="active", content="unrelated", score=0.8),
+    ]
+    out = await _run(rows, [_successor_dict(succ_id, stale_id)], monkeypatch)
+    order = [str(m.id) for m in out]
+    assert order == [str(succ_id), str(stale_id), str(other_id)]
+    # the successor identifies its predecessor; the stale row says why it lost
+    assert str(out[0].supersedes_id) == str(stale_id)
+    assert out[1].status == "conflicted"
+    # injected rows were never scored (D12 contract preserved)
+    assert out[0].score is None and out[0].score_parts is None
+
+
+async def test_stale_row_mid_list_gets_successor_directly_above(monkeypatch):
+    a, stale, b = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    succ = uuid.uuid4()
+    rows = [
+        _mem_ns(a, score=2.0),
+        _mem_ns(stale, status="outdated", score=1.0),
+        _mem_ns(b, score=0.5),
+    ]
+    out = await _run(rows, [_successor_dict(succ, stale)], monkeypatch)
+    assert [str(m.id) for m in out] == [str(a), str(succ), str(stale), str(b)]
+
+
+async def test_organic_successor_above_keeps_earned_rank(monkeypatch):
+    """A successor that already out-ranks its predecessor keeps its earned
+    position — no duplication from the injection path either."""
+    stale, succ = uuid.uuid4(), uuid.uuid4()
+    succ_row = _mem_ns(succ, status="active", content="corrected", score=2.0)
+    succ_row.Memory.supersedes_id = stale
+    rows = [succ_row, _mem_ns(stale, status="conflicted", score=1.0)]
+    out = await _run(rows, [_successor_dict(succ, stale)], monkeypatch)
+    assert [str(m.id) for m in out] == [str(succ), str(stale)]
+    assert len(out) == 2
+
+
+async def test_organic_successor_below_is_promoted_above_stale(monkeypatch):
+    """The wet-test-discovered case: the correction was recalled on its own
+    merit BELOW the stale exact-match (stale un-penalized per A31) — the
+    contract promotes it to immediately above. This is the exact live Hermes
+    shape: organic recall, no injection involved."""
+    stale, succ, other = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    succ_row = _mem_ns(succ, status="confirmed", content="corrected", score=0.7)
+    succ_row.Memory.supersedes_id = stale
+    rows = [
+        _mem_ns(stale, status="conflicted", content="stale wording", score=0.8),
+        succ_row,
+        _mem_ns(other, score=0.1),
+    ]
+    out = await _run(rows, [], monkeypatch)  # no injection — purely organic
+    assert [str(m.id) for m in out] == [str(succ), str(stale), str(other)]
+    # organic successor keeps its earned score on the wire
+    assert out[0].score == 0.7
+
+
+async def test_supersession_chain_orders_newest_first(monkeypatch):
+    """C supersedes B supersedes A -> C, B, A regardless of recall order."""
+    a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    ra = _mem_ns(a, status="outdated", score=2.0)
+    rb = _mem_ns(b, status="outdated", score=1.5)
+    rb.Memory.supersedes_id = a
+    rc = _mem_ns(c, status="active", score=0.2)
+    rc.Memory.supersedes_id = b
+    out = await _run([ra, rb, rc], [], monkeypatch)
+    assert [str(m.id) for m in out] == [str(c), str(b), str(a)]
+
+
+async def test_multiple_stale_rows_each_get_their_successor(monkeypatch):
+    s1, s2 = uuid.uuid4(), uuid.uuid4()
+    n1, n2 = uuid.uuid4(), uuid.uuid4()
+    rows = [
+        _mem_ns(s1, status="outdated", score=2.0),
+        _mem_ns(s2, status="conflicted", score=1.0),
+    ]
+    out = await _run(rows, [_successor_dict(n1, s1), _successor_dict(n2, s2)], monkeypatch)
+    assert [str(m.id) for m in out] == [str(n1), str(s1), str(n2), str(s2)]
+
+
+async def test_no_successors_leaves_order_untouched(monkeypatch):
+    a, b = uuid.uuid4(), uuid.uuid4()
+    rows = [_mem_ns(a, status="conflicted"), _mem_ns(b)]
+    out = await _run(rows, [], monkeypatch)
+    assert [str(m.id) for m in out] == [str(a), str(b)]


### PR DESCRIPTION
## Summary

Implements the A34 retrieval contract (first slice of MEM-04): **whenever a result set contains both a superseded row and its successor, the successor ranks immediately above its stale predecessor** — never below it, never dangling unscored at the tail.

This closes the live Hermes/STALE-T2 trap: a query exact-matching the OLD wording ranks the stale `conflicted` row #1 (A31's exact-match exemption deliberately keeps it surfaced/un-penalized) with the correction underneath — and the answer LLM picks the stale value.

## What changed

One reorder pass in `LoadAndSerialize` (`load_and_serialize.py`), covering **both** successor arrival paths:

- **Injected** successors (pulled in by `find_successors`, unscored) — previously appended at the tail; now placed directly above their stale predecessor.
- **Organically recalled** successors that ranked *below* their predecessor — promoted to directly above it. Wet-testing showed this path alone reproduces the bug.

Contract details:
- A successor that already out-ranks its predecessor keeps its earned position.
- Chains (C supersedes B supersedes A) resolve newest-first via recursion; a corrupt supersession *cycle* terminates (placed-before-recurse guard).
- **No new wire fields**: the successor's `supersedes_id` names the loser; the stale row's `status` says why it lost. Injected rows stay unscored (`score`/`score_parts` null — D12 contract preserved).

## Testing

- 7 new regression tests in `tests/test_a34_successor_contract.py` (injected above / mid-list / organic-above keeps rank / organic-below promoted / chain newest-first / multiple stale rows / no-op without successors). Full suite: **5225 passed**.
- **Live wet test** on the local enterprise compose stack (fresh core-api image): seeded the exact evolving-profile pair that failed pre-fix — post-fix the correction ranks #1 directly above the stale exact-match (raw score 0.71 vs 0.80).
- **67-question regression bench** (strong mode, d=0, golden-baseline compare): single-session-user, temporal-reasoning, knowledge-update exactly at baseline; multi-session within thresholds; recall unchanged everywhere. One initial single-session-preference accuracy dip was diagnosed as answer-LLM flake — all 3 failing questions had perfect recall and **zero supersession pairs in their K=20 sets** (the reorder provably never fired), and an immediate same-build re-run scored **12/12 (100%)** at baseline recall (0.9722).

Refs: canonical A34 / MEM-04; ratified wire-contract page (no new fields needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)