### PR TITLE
feat(ratchet): a floor mention is not a compat alias — give it its own marker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,36 @@ It has to be the whole token — `legacy-name-okay` in a sentence does not exemp
 anything — but the casing is up to you, and the reason is asked for rather than
 enforced.
 
+### Two markers: which claim are you making?
+
+`legacy-name-ok` is for something new that **bears** the old name — the alias,
+the redirect, the pinned wire format above.
+
+Often the line is not declaring anything. It just **names** something the rename
+will never reach, and cannot be correct without the literal: a command a reader
+pastes, a path on disk, a mirror URL. Use `legacy-name-floor` instead:
+
+```markdown
+| macOS | `~/Library/Application Support/...` | <!-- legacy-name-floor: the app dir name -->
+```
+
+Both exempt the line identically — nothing about pass or fail changes, and
+picking the wrong one cannot turn a build red or green. They are counted apart
+so the aliases stay readable: a documentation sweep can easily add ten mentions
+around one alias, and under a single marker that alias is the eleventh line
+nobody reads.
+
+**When both are true of one line, use `legacy-name-ok`.** Some lines name a
+frozen thing and declare a dual-read at once — an image tag whose repository
+name is permanent while its version is read from either spelling. One line takes
+one marker, and the alias is the claim rule 3 wants eyes on, so it wins.
+
+There is a third case, and it takes no marker at all. Ask what breaks if the old
+spelling is not on that line. If the answer is nothing — it is prose that happens
+to name the thing — **reword it and take no exemption.** That is the test the
+floor marker's claim has to pass: reword the line, and if it is still correct,
+the marker was false.
+
 Marking a line exempt frees a slot in that file, so every new exemption is
 printed in the CI output whether the check passes or not. That is deliberate: it
 is the one move the ratchet cannot adjudicate for itself, so it is the one that

--- a/docs/plans/rebrand-sunset-plan.md
+++ b/docs/plans/rebrand-sunset-plan.md
@@ -132,6 +132,12 @@ is prose that happens to name the thing — **reword it off the literal and take
 exemption.** If a reader has to type the string, or find it on disk, or a machine has to
 match it, that is a contract: **mark it, and say which.**
 
+"Which" is a marker, not a convention in the reason text. `legacy-name-ok` is a contract
+that **bears** the old name — the alias, the redirect, the pinned wire format rule 3
+recognises. `legacy-name-floor` is one that only **names** something the rename will
+never reach. Both exempt the line identically; they are counted apart so that a sweep
+adding ten mentions cannot bury the one alias among them.
+
 Marking a mention is not a harmless extra. Every exemption widens the surface the gate
 no longer watches, and it spends the one annotation whose whole value is that its reasons
 are true.

--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -30,10 +30,44 @@ gate is pointed at. On a ``pull_request`` the checkout is already the merge
 commit, so the comparison against ``main`` is exactly this PR's contribution and
 there is nothing to maintain.
 
-**The escape hatch.** A line carrying the marker ``legacy-name-ok`` is not
-counted. Rule 3 keeps old names readable forever, so legitimate additions exist:
-a compat alias, a redirect, a test pinning the old wire format. Put the marker on
-the line with a reason and it lands in the diff where a reviewer will see it.
+**The escape hatch, and the two claims it can make.** A line carrying either
+marker is not counted. The gate cannot tell them apart — the pass/fail decision
+never reads which one is there, and nothing that failed before passes now. They
+differ only in what a reviewer has to check, which is the only thing a marker
+was ever for. Put one on the line with a reason and it lands in the diff.
+
+``legacy-name-ok`` is rule 3's hatch: something new that BEARS the old name — a
+compat alias, a redirect, a test pinning the old wire format.
+
+``legacy-name-floor`` is a line that merely NAMES something the rename will never
+reach, and cannot be correct without the literal: a pasteable command, an on-disk
+path, a served mirror path. Nothing is declared and the footprint does not grow.
+
+Why a second marker rather than a convention inside the reason text. Audited at
+full coverage across the seven repos: 622 markers — **340 aliases, 274 floor
+mentions**, and 8 on lines that should have been reworded rather than marked at
+all. Forty-four per cent of every exemption in the programme is the kind rule 3
+has nothing to say about, and the only thing separating them is prose.
+
+The two populations also grow from different work. An alias arrives when
+something is renamed. A floor mention arrives whenever a document that mentions
+the product's own name is EDITED — re-flowing a comment mints new text even as
+the file's count falls, and a marker cannot come off a line without the literal
+coming off with it. So that half of the pile is fed by maintaining documentation
+rather than by sweeping the brand, and it grows for as long as the docs are
+maintained. caura-daemon#136 is the shape of it in one PR: eleven exemptions,
+four of them aliases, and a reviewer facing eleven undifferentiated entries
+stops reading.
+
+What this is NOT is a fix for false reasons at scale. Only 11 of the 622 (1.8%)
+put alias language on a non-alias line, and 218 of the 274 floor mentions
+already say "floor", "pinned" or "frozen" in their own reason text. Authors have
+been drawing the distinction correctly all along; the gate has had nowhere to
+record it, so it could not count on it. This makes the distinction structural.
+
+Both are a claim someone has to stand behind, and a floor marker is falsifiable
+in one move: reword the line without the old name, and if it is still correct
+then the marker was false and the line should carry no marker at all.
 
 **Why the count is not the check.** A file's total is a cheap proxy for "worth
 looking at", and it is the wrong one in both directions. It fails a cross-file
@@ -85,12 +119,70 @@ from typing import NamedTuple
 # a hole in the scan.
 LEGACY_NAME = "memclaw"  # legacy-name-ok: the pattern this gate searches for
 
-# Kept deliberately ugly so it is never typed by accident and always reads as a
+# Kept deliberately ugly so they are never typed by accident and always read as a
 # decision rather than a formatting artifact.
 EXEMPT_MARKER = "legacy-name-ok"
+FLOOR_MARKER = "legacy-name-floor"
+
+
+class _Kind(NamedTuple):
+    """What the report calls one marker, and the guidance printed under it.
+
+    A NamedTuple rather than a bare pair because ``_KINDS[marker][0]`` says
+    nothing about which half it is, and the file already uses one for
+    :class:`Scan`.
+    """
+
+    label: str
+    guidance: tuple[str, ...]
+
+
+# The markers, in the order the report lists them, with what it calls each.
+# Aliases lead whether there are four of them or one: they are what rule 3 wants
+# eyes on, so their position must not depend on a tally. The label carries its
+# own ``(s)`` the way every other count in this file does.
+#
+# The gate never reads this. Both markers exempt a line identically — see
+# :func:`_kind` — and the split exists purely so the report can say "4 compat
+# aliases and 6 floor mentions" where it used to say "11 exemptions".
+#
+# **Keys must be lowercase**, or the entry is never found and its lines vanish
+# from the report while still exempting. :func:`_kind` explains why.
+#
+# **Adding a kind is not only a line here.** The failure text at the end of
+# :func:`main` is the only place the gate tells an author a marker exists at all,
+# and it is written out per kind rather than driven from this table, because it
+# is imperative advice addressed to someone whose build just went red and does
+# not fit the same mould as the report's. A new kind wants a paragraph there too;
+# omitted, it is a marker nobody discovers.
+#
+# Guidance is a tuple of already-wrapped lines rather than one string with
+# newlines in it, for the same reason this file prints its other prose a line at
+# a time: re-flowing an embedded ``\n`` is how a paragraph silently loses its
+# shape, and the first line has to be joinable to a count.
+_KINDS: dict[str, _Kind] = {
+    EXEMPT_MARKER: _Kind(
+        "compat alias(es)",
+        (
+            "rule 3's escape hatch, and what this report is for.",
+            "Check each is a compat alias, a redirect or a pinned wire format,",
+            "and not headroom for a new name:",
+        ),
+    ),
+    FLOOR_MARKER: _Kind(
+        "floor mention(s)",
+        (
+            "a permanent name in text, not a new declaration.",
+            "Check the line cannot be correct without the literal: a pasteable",
+            "command, an on-disk path, a served mirror path. If rewording it",
+            "would leave it correct, the claim is false and it should carry no",
+            "marker at all:",
+        ),
+    ),
+}
 
 # Matched as a bounded token, not a bare substring. A substring test exempts any
-# line that merely contains the marker inside a longer word — "not
+# line that merely contains a marker inside a longer word — "not
 # legacy-name-okay to leave in" would silence a real occurrence, which is a hole
 # in the gate rather than a nuisance. Case-insensitive for the same reason the
 # name match is: a marker typed ``Legacy-Name-OK`` is plainly a decision, and
@@ -103,9 +195,91 @@ EXEMPT_MARKER = "legacy-name-ok"
 # Neither boundary is a comment prefix — comment syntax differs across the file
 # types this scans, and JSON has none at all while still being somewhere an alias
 # can legitimately live.
+#
+# One pattern for both markers rather than one each, so those boundaries are
+# stated once and cannot drift apart: the lookbehind and lookahead sit outside
+# the alternation, so every marker gets both. Alternation order is not load
+# bearing here because neither marker is a prefix of the other — if a third is
+# ever added that IS a prefix of another, list the longer one first, since Python
+# takes the first alternative that matches rather than the longest.
 EXEMPT_RE = re.compile(
-    rf"(?<![\w-]){re.escape(EXEMPT_MARKER)}(?=[\s:]|$)", re.IGNORECASE
+    rf"(?<![\w-])(?P<marker>{'|'.join(re.escape(m) for m in _KINDS)})(?=[\s:]|$)",
+    re.IGNORECASE,
 )
+
+
+def _kind(text: str) -> str | None:
+    """Which marker exempts this line, or ``None`` if none does.
+
+    Returns the marker literal rather than its label, so the marker stays the one
+    identity a kind is keyed by and :data:`_KINDS` stays the only place a label
+    is written down.
+
+    The gate's decision reads only whether this is ``None``. That is what keeps
+    the two markers interchangeable at the point of failure: a line that passed
+    before passes now, and a marker a reviewer thinks is the wrong KIND is still
+    a marker, so mislabelling one can never turn a red build green or a green one
+    red. Only the report reads which.
+
+    **When both claims are true of one line, the alias wins.** This is not the
+    degenerate case it looks like: 28 lines across the fleet name a permanent
+    thing AND declare a dual-read in the same breath, e.g. an image tag whose
+    repository name is frozen while its version is read from both spellings.
+    Both claims are true, one line can only carry one marker, and picking by
+    position on the line would make the answer depend on which end the author
+    typed first.
+
+    So precedence is :data:`_KINDS` order, which puts the alias first: an alias
+    reported as a floor mention is a rule 3 decision nobody looked at, while a
+    floor mention reported as an alias is one extra line in the list that most
+    wants reading anyway. Under-counting the aliases is the expensive direction,
+    so the tie breaks away from it.
+
+    The lowercasing is what keeps the result a usable :data:`_KINDS` key, and it
+    is load bearing rather than tidiness. A kind that does not match a key is
+    still not ``None``, so the line stays exempt and the gate stays green — while
+    the report, which looks the kind up to decide which list it belongs in, finds
+    nothing and drops the line without a word. Exempt but unprinted is the one
+    outcome this report exists to prevent.
+    """
+    found = {m.group("marker").lower() for m in EXEMPT_RE.finditer(text)}
+    return next((marker for marker in _KINDS if marker in found), None)
+
+
+def _reason(text: str, kind: str) -> str:
+    """What ``kind``'s marker says on this line: the text between it and the next.
+
+    Lives beside :func:`_kind` rather than inline in the report because the two
+    have to agree about which marker owns the line, and a rule split across two
+    call sites is one that eventually disagrees with itself.
+
+    Bounded on BOTH ends, and the second bound is the one that is easy to miss.
+    Slicing to end-of-line is right for the ordinary single-marker case and wrong
+    the moment a line carries two: with the winning marker written first, the
+    tail swallows the other marker's literal AND its reason, so the report groups
+    under a key like ``dual-read alias  legacy-name-floor: the command``. That is
+    not merely ugly — the reason is the grouping key, so two lines making the
+    same claim stop collapsing together, which is the one thing the grouping is
+    for.
+
+    ``.lower()`` on both sides of the comparison: the pattern is
+    case-insensitive, so a marker typed ``Legacy-Name-OK`` matches while ``kind``
+    is always normalised. Comparing raw finds nothing and quietly degrades every
+    oddly-cased line to "(no reason given)".
+
+    Empty string when the marker is not found, which cannot happen for a line
+    that :func:`_kind` classified — the caller turns it into "(no reason given)"
+    either way.
+    """
+    matches = list(EXEMPT_RE.finditer(text))
+    here = next(
+        (i for i, m in enumerate(matches) if m.group("marker").lower() == kind), None
+    )
+    if here is None:
+        return ""
+    start = matches[here].end()
+    stop = matches[here + 1].start() if here + 1 < len(matches) else len(text)
+    return text[start:stop].lstrip(": ").strip()
 
 
 # Above this many lines sharing one reason, the list is collapsed to a count.
@@ -155,8 +329,14 @@ def _git(args: list[str]) -> str:
     )
 
 
-def _grep(tree: str | None, pathspec: str = ":/") -> list[tuple[str, str, str, bool]]:
-    """``(path, lineno, text, exempt)`` for every matching line.
+def _grep(
+    tree: str | None, pathspec: str = ":/"
+) -> list[tuple[str, str, str, str | None]]:
+    """``(path, lineno, text, kind)`` for every matching line.
+
+    ``kind`` is the marker literal exempting the line, or ``None`` for a line
+    that carries none — see :func:`_kind`. A kind rather than a bool because the
+    report has to separate the two claims a marker can make.
 
     Exempt lines are returned rather than dropped so the caller can report what a
     change newly exempted — see :func:`main`.
@@ -181,7 +361,7 @@ def _grep(tree: str | None, pathspec: str = ":/") -> list[tuple[str, str, str, b
 
     prefix = f"{tree}:" if tree is not None else ""
 
-    out: list[tuple[str, str, str, bool]] = []
+    out: list[tuple[str, str, str, str | None]] = []
     # Records are newline-terminated (a matched line cannot contain one) and
     # their three fields are NUL-separated.
     for record in _git(args).split("\n"):
@@ -195,7 +375,7 @@ def _grep(tree: str | None, pathspec: str = ":/") -> list[tuple[str, str, str, b
             if not path.startswith(prefix):
                 continue
             path = path[len(prefix) :]
-        out.append((path, lineno, text, bool(EXEMPT_RE.search(text))))
+        out.append((path, lineno, text, _kind(text)))
     return out
 
 
@@ -327,8 +507,13 @@ def scan(tree: str | None) -> Scan:
     # while the removal report has to name the actual line, since "did this alias
     # survive the rewording" cannot be answered from a count.
     exempt_text: Counter[str] = Counter()
-    for path, _, text, is_exempt in _grep(tree):
-        if is_exempt:
+    # Neither tally is split by kind, and neither wants to be: ``exempt`` only
+    # SELECTS files for the report, which re-greps them and reads each line's
+    # kind first-hand, and ``exempt_text`` keys on text that still contains its
+    # own marker, so the kind is recoverable from the key. Splitting either would
+    # be a second definition of the same fact.
+    for path, _, text, kind in _grep(tree):
+        if kind is not None:
             exempt[path] += 1
             exempt_text[text.strip()] += 1
             continue
@@ -475,9 +660,9 @@ def _report_removed_exemptions(before: Counter[str], after: Counter[str]) -> Non
     The other half of :func:`_report_new_exemptions`, and the gap that let a
     demonstrated data-loss change pass both required gates green.
 
-    ``legacy-name-ok`` means "the ratchet may ignore this line". It has never
-    meant "this line is protected", and nothing enforced the second reading —
-    but the marker looks like protection, so lines carrying it were treated as
+    Either marker means "the ratchet may ignore this line". Neither has ever
+    meant "this line is protected", and nothing enforced that reading — but a
+    marker looks like protection, so lines carrying one were treated as
     handled. Deleting one *lowers* a file's non-exempt count, which the ratchet
     reports as progress. A sweep over two plugin files removed a dual-read alias
     that decides which ``.env`` keys survive a redeploy; ratchet and sentinel
@@ -505,10 +690,20 @@ def _report_removed_exemptions(before: Counter[str], after: Counter[str]) -> Non
         return
 
     n = sum(removed.values())
+    # Not split by kind, unlike the new-exemption report. The populations are the
+    # other way round here — seven removals across four hundred commits, against
+    # eleven new exemptions in a single PR — so the wall this list can become is
+    # hypothetical, and a split would buy nothing a reader cannot see from the
+    # marker still sitting in each printed line. The guidance covers both kinds
+    # instead, since a floor mention has no alias to survive and telling a reader
+    # to look for one would be exactly the false reason this marker split exists
+    # to stop. Worth revisiting if the removal rate ever approaches the other's.
     print(
-        f"\n{n} exempt line(s) removed by this change. ``legacy-name-ok`` marks a line\n"
-        "the ratchet ignores, NOT a line that is protected — deleting one lowers the\n"
-        "count and reads as progress. Confirm each alias still exists in some form:"
+        f"\n{n} exempt line(s) removed by this change. A marker marks a line the\n"
+        "ratchet ignores, NOT a line that is protected — deleting one lowers the\n"
+        "count and reads as progress. Confirm what each one stood for still exists\n"
+        "in some form — the alias it declared, or the text that could not be\n"
+        "correct without the name:"
     )
     for text, count in sorted(removed.items()):
         suffix = f"  (x{count})" if count > 1 else ""
@@ -561,6 +756,16 @@ def _report_new_exemptions(
 
     The tally is kept only as the fallback for when git cannot answer, since a
     selection that is too narrow beats one that is arbitrary.
+
+    **Split by kind, because one list of eleven is not a signal.** This is the
+    only place the difference between the two markers is read. Floor mentions
+    outnumber aliases because they accrue from editing documentation rather than
+    from renaming anything — caura-daemon#136 landed eleven in one PR, four of
+    them aliases — so undifferentiated they are a wall a reviewer scrolls past,
+    which is the same failure the reason-grouping below prevents, one level up.
+
+    This is a better signal, not a quieter one: nothing is dropped, the totals
+    are unchanged, and both kinds are still printed in full with their reasons.
     """
     # Files git says this change touched, narrowed to those that hold an exempt
     # line at all. The union with the risen-tally set is belt and braces: when
@@ -572,20 +777,24 @@ def _report_new_exemptions(
     if not paths:
         return
 
-    # Grouped by reason, because the wall is the failure mode. A dual-read wave
-    # exempts dozens of lines carrying one identical reason, and at that length
-    # the list stops being read — which costs exactly the thing it is for, since
-    # the swap this report exists to expose shows up as the ONE reason that does
-    # not match its neighbours. Collapsing the repeats is what makes the odd one
-    # visible instead of burying it on line forty.
-    by_reason: dict[str, list[tuple[str, str, str]]] = {}
+    # Grouped by kind, then by reason. Reason-grouping is there because the wall
+    # is the failure mode: a dual-read wave exempts dozens of lines carrying one
+    # identical reason, and at that length the list stops being read — which
+    # costs exactly the thing it is for, since the swap this report exists to
+    # expose shows up as the ONE reason that does not match its neighbours.
+    # Collapsing the repeats is what makes the odd one visible instead of burying
+    # it on line forty. Kind-grouping is the same argument one level up: a floor
+    # mention's reason never matches an alias's, so mixing them puts a permanent
+    # wall between the aliases and the reader.
+    by_kind: dict[str, dict[str, list[tuple[str, str, str]]]] = {}
     shown_total = 0
+    listed_paths: set[str] = set()
     unfiltered: list[str] = []
     for path in sorted(paths):
         here = [
-            (lineno, text.strip())
-            for _, lineno, text, exempt in _grep(None, pathspec=_literal(path))
-            if exempt
+            (lineno, text.strip(), kind)
+            for _, lineno, text, kind in _grep(None, pathspec=_literal(path))
+            if kind is not None
         ]
         if not here:
             continue
@@ -603,7 +812,7 @@ def _report_new_exemptions(
             picked = here
             unfiltered.append(path)
         else:
-            picked = [(n, t) for n, t in here if int(n) in touched]
+            picked = [(n, t, k) for n, t, k in here if int(n) in touched]
         # Empty is now a real answer rather than a failure — a file this change
         # only deleted from, or touched somewhere other than its exempt lines,
         # adds nothing and every marker it holds predates the change. Printing
@@ -612,24 +821,44 @@ def _report_new_exemptions(
         if not picked:
             continue
         shown_total += len(picked)
-        for lineno, stripped in picked:
-            match = EXEMPT_RE.search(stripped)
-            tail = stripped[match.end() :].lstrip(": ") if match else ""
-            by_reason.setdefault(tail.strip() or "(no reason given)", []).append(
-                (path, lineno, stripped)
-            )
+        listed_paths.add(path)
+        for lineno, stripped, kind in picked:
+            tail = _reason(stripped, kind)
+            by_kind.setdefault(kind, {}).setdefault(
+                tail.strip() or "(no reason given)", []
+            ).append((path, lineno, stripped))
 
     # Nothing survived the per-line filter: every candidate file holds only
     # exemptions that predate this change. Silence is right — the previous
     # version could not reach here, because a risen tally guaranteed something
     # to print.
-    if not by_reason:
+    if not by_kind:
         return
 
-    listed = len({path for lines in by_reason.values() for path, _, _ in lines})
-    print(f"{shown_total} exempt line(s) written by this change in {listed} file(s) —")
-    print("check each is a compat alias, a redirect or a pinned wire format, and not")
-    print("headroom for a new name:")
+    # Both counted while picking rather than derived from ``by_kind`` afterwards,
+    # so neither tracks the shape of that dict — and so the header stays a count
+    # of what was PICKED rather than of what was successfully classified. The two
+    # are the same number today and structurally cannot differ, since
+    # :func:`_kind` only ever returns a :data:`_KINDS` key. If they ever did, a
+    # header larger than the sections beneath it is the visible symptom, which is
+    # worth more than an agreement enforced by construction.
+    print(
+        f"{shown_total} exempt line(s) written by this change in "
+        f"{len(listed_paths)} file(s) —"
+    )
+
+    # In ``_KINDS`` order rather than by size, so aliases lead even when the
+    # mentions outnumber them — which is the usual case and the reason for the
+    # split.
+    present = [
+        (marker, sum(len(lines) for lines in by_kind[marker].values()))
+        for marker in _KINDS
+        if marker in by_kind
+    ]
+    if len(present) > 1:
+        # The line the split exists for. Skipped when only one kind is present,
+        # where it would only restate the section header underneath it.
+        print(", ".join(f"{n} {_KINDS[marker].label}" for marker, n in present) + ".")
     if unfiltered:
         named = ", ".join(unfiltered[:4]) + (
             f" (+{len(unfiltered) - 4} more)" if len(unfiltered) > 4 else ""
@@ -639,17 +868,28 @@ def _report_new_exemptions(
             "exempt line they hold is listed, so some may predate this change)"
         )
 
-    for reason, lines in sorted(by_reason.items(), key=lambda kv: (-len(kv[1]), kv[0])):
-        if len(lines) <= _EXEMPTION_GROUP_AT:
-            for path, lineno, stripped in lines:
-                print(f"  {path}:{lineno}: {stripped[:100]}")
-            continue
-        files = sorted({path for path, _, _ in lines})
-        shown = ", ".join(files[:4]) + (
-            f" (+{len(files) - 4} more)" if len(files) > 4 else ""
-        )
-        print(f"  {len(lines)}x  {reason[:80]}")
-        print(f"      in {len(files)} file(s): {shown}")
+    for marker, n in present:
+        # ``spec``, not ``kind``: ``kind`` is the marker literal a few lines up,
+        # and one name for two types inside one function costs the reader a
+        # lookup at every use.
+        spec = _KINDS[marker]
+        print(f"\n{n} {spec.label} — {spec.guidance[0]}")
+        for line in spec.guidance[1:]:
+            print(line)
+        by_reason = by_kind[marker]
+        for reason, lines in sorted(
+            by_reason.items(), key=lambda kv: (-len(kv[1]), kv[0])
+        ):
+            if len(lines) <= _EXEMPTION_GROUP_AT:
+                for path, lineno, stripped in lines:
+                    print(f"  {path}:{lineno}: {stripped[:100]}")
+                continue
+            files = sorted({path for path, _, _ in lines})
+            shown = ", ".join(files[:4]) + (
+                f" (+{len(files) - 4} more)" if len(files) > 4 else ""
+            )
+            print(f"  {len(lines)}x  {reason[:80]}")
+            print(f"      in {len(files)} file(s): {shown}")
     print()
 
 
@@ -770,8 +1010,8 @@ def main() -> int:
         added = _added_lines(args.base, path)
         candidates = [
             (lineno, text.strip())
-            for _, lineno, text, exempt in _grep(None, pathspec=_literal(path))
-            if not exempt and text.strip() in minted
+            for _, lineno, text, kind in _grep(None, pathspec=_literal(path))
+            if kind is None and text.strip() in minted
         ]
         shown = (
             candidates
@@ -810,7 +1050,13 @@ def main() -> int:
         "text this repo did not have before, so no rearrangement produced it.\n\n"
         "If the addition is deliberate — a compat alias, a redirect, a test pinning the old\n"
         f"wire format, all of which rule 3 requires — append '{EXEMPT_MARKER}: <reason>' to the\n"
-        "line. It is then exempt, and the reason is visible in the diff."
+        "line. It is then exempt, and the reason is visible in the diff.\n\n"
+        "If instead the line only NAMES something the rename will never reach, and cannot\n"
+        "be correct without the literal — a pasteable command, an on-disk path, a served\n"
+        f"mirror path — append '{FLOOR_MARKER}: <reason>' instead. Identical exemption,\n"
+        "different claim: nothing is declared there, so it is counted apart and the\n"
+        "aliases stay readable. Check the claim before you make it — if rewording the\n"
+        "line would leave it correct, reword it rather than marking it."
     )
     return 1
 

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -16,6 +16,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -193,6 +194,320 @@ def test_the_marker_exempts_only_its_own_line(repo: Path) -> None:
     offenders = result.stdout.split("adds the legacy name in", 1)[1]
     assert "OTHER" in offenders
     assert "ALIAS" not in offenders
+
+
+# ── the floor marker: same exemption, a different claim ──────────────────────
+#
+# ``legacy-name-floor`` exempts a line exactly as ``legacy-name-ok`` does. The
+# gate cannot tell them apart and no build changes colour because of which one is
+# used; only the report reads the difference. It exists because the two
+# populations grow from different work — an alias arrives when something is
+# renamed, a floor mention whenever a document mentioning the product's own name
+# is EDITED — so under one marker the mentions bury the aliases. Measured on
+# caura-daemon#136: eleven exemptions in one PR, four of them aliases.
+
+
+# One regex serves both markers, with the boundaries outside the alternation, so
+# there is no second code path for a per-marker copy of these to cover — a
+# loosened bound loosens both at once. These are parametrized rather than cloned
+# so that is what gets asserted, and so a third marker is one list entry.
+#
+# The ``legacy-name-ok`` cases above are deliberately left standing and unedited.
+# They pin that marker's own contract independently of this table, which is worth
+# keeping on a gate where the whole promise is that nothing about the existing
+# marker changed.
+class _Marker(NamedTuple):
+    """One marker and the two things a boundary test needs beside it."""
+
+    marker: str
+    near_miss: str
+    label: str
+
+
+_MARKERS = [
+    _Marker("legacy-name-ok", "legacy-name-okay", "compat alias(es)"),
+    _Marker("legacy-name-floor", "legacy-name-floored", "floor mention(s)"),
+]
+_EACH = pytest.mark.parametrize("m", _MARKERS, ids=lambda m: m.marker)
+
+# Comfortably above the script's ``_EXEMPTION_GROUP_AT``, so a list of this many
+# identical reasons is collapsed to a "Nx <reason>" header rather than printed
+# line by line.
+_GROUPED = 6
+
+
+@_EACH
+def test_every_marker_exempts_its_own_line(repo: Path, m: _Marker) -> None:
+    """The whole premise: a marker exempts, or it is not a marker."""
+    _stage(repo, "cli.md", f"    {LEGACY} setup --non-interactive  # {m.marker}: why\n")
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "No new lines" in result.stdout
+
+
+@_EACH
+def test_every_marker_needs_no_reason_to_work(repo: Path, m: _Marker) -> None:
+    """Asked for, not enforced — and end-of-line is a boundary, so a bare marker
+    still exempts rather than failing on a technicality."""
+    _stage(repo, "cli.md", f"    {LEGACY} setup  # {m.marker}\n")
+
+    assert _run(repo).returncode == 0
+
+
+@_EACH
+def test_every_marker_must_be_a_whole_token(repo: Path, m: _Marker) -> None:
+    """The right-hand bound, asserted for every marker at once.
+
+    One pattern matches them all, so a loosened lookahead silently loosens every
+    marker — which is exactly the shape of hole a per-marker test cannot see,
+    because it passes for the marker it names while the other is already open.
+    """
+    _stage(repo, "new.py", f'KEY = "{LEGACY}"  # not {m.near_miss} to leave in\n')
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "new.py" in result.stdout
+
+
+@_EACH
+def test_every_marker_must_not_be_glued_to_the_token_before_it(
+    repo: Path, m: _Marker
+) -> None:
+    """The mirror bound, and a separate check: a right-hand boundary alone stops
+    ``legacy-name-okay`` but not ``somelegacy-name-ok``."""
+    _stage(repo, "new.py", f'KEY = "{LEGACY}"  # some{m.marker}\n')
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "new.py" in result.stdout
+
+
+@_EACH
+def test_every_marker_is_classified_whatever_its_casing(repo: Path, m: _Marker) -> None:
+    """Matched case-insensitively, so a line somebody deliberately annotated is
+    never failed on its capitalisation.
+
+    The exit code is the weaker half and on its own is nearly worthless. A kind
+    that does not normalise back to a marker literal still exempts the line — it
+    is not ``None`` — so the gate stays green while the report, which looks the
+    kind up to decide which list it belongs in, finds no match and drops the line
+    silently. Exempt but invisible is the one outcome this report exists to
+    prevent, so the classification is asserted too. Parametrizing extends that
+    assertion to ``legacy-name-ok``, whose own casing test above checks only the
+    exit code.
+    """
+    _stage(repo, "cli.md", f"    {LEGACY} setup  # {m.marker.upper()}: the command\n")
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert f"1 {m.label} — " in result.stdout
+    assert "cli.md:1" in result.stdout
+
+
+@_EACH
+def test_an_oddly_cased_marker_still_yields_its_reason(repo: Path, m: _Marker) -> None:
+    """The reason is sliced off the winning marker's own match, so that match has
+    to be found under any casing.
+
+    Asserted through the GROUPED path on purpose. Below the grouping threshold
+    the report prints each line verbatim, and the line contains its own reason
+    text — so a reason that failed to parse is invisible, and an assertion there
+    passes whether the slicing works or not. Only the grouped header prints the
+    parsed reason on its own, which is where a silent degrade to
+    "(no reason given)" can actually be seen.
+    """
+    _stage(
+        repo,
+        "many.py",
+        "".join(
+            f'A{i} = "{LEGACY}_x"  # {m.marker.upper()}: a permanent name\n'
+            for i in range(_GROUPED)
+        ),
+    )
+
+    out = _run(repo).stdout
+
+    assert f"{_GROUPED}x  a permanent name" in out
+    assert "(no reason given)" not in out
+
+
+@pytest.mark.parametrize(
+    "line_suffix",
+    [
+        "# legacy-name-ok: dual-read alias  legacy-name-floor: the command",
+        "# legacy-name-floor: the command  legacy-name-ok: dual-read alias",
+    ],
+    ids=["alias-first", "floor-first"],
+)
+def test_a_doubly_marked_reason_stops_at_the_next_marker(
+    repo: Path, line_suffix: str
+) -> None:
+    """A reason is bounded by the NEXT marker, not by end of line.
+
+    Both orders, because the bug only appears in one of them: with the winning
+    marker written first, slicing to end-of-line swallows the other marker's
+    literal and its reason too. The grouped header is where that shows, so this
+    writes enough identical lines to trip the grouping — and the reason is also
+    the grouping KEY, so a polluted one stops identical claims collapsing
+    together, which is what the grouping exists to do.
+    """
+    _stage(
+        repo,
+        "many.py",
+        "".join(f'A{i} = "{LEGACY}_x"  {line_suffix}\n' for i in range(_GROUPED)),
+    )
+
+    out = _run(repo).stdout
+
+    assert f"{_GROUPED}x  dual-read alias" in out
+    # The other marker's literal must not have bled into this one's reason.
+    assert "dual-read alias  legacy-name-floor" not in out
+    assert "the command  legacy-name-ok" not in out
+
+
+def test_a_doubly_marked_line_is_filed_as_an_alias_whatever_the_order(
+    repo: Path,
+) -> None:
+    """Precedence is by table order, not by position on the line.
+
+    28 lines across the fleet make both claims at once — an image tag whose
+    repository name is frozen while its version is dual-read, say — so which
+    marker an author reaches for is a real question rather than a degenerate
+    one. Breaking the tie by whichever was typed first makes the report depend
+    on line order; breaking it toward the alias means the expensive mistake
+    (a rule 3 decision filed where nobody is looking for it) cannot happen.
+
+    The floor marker is written FIRST here deliberately: with positional
+    precedence this line files as a floor mention and the assertion below fails.
+    """
+    _stage(
+        repo,
+        "cli.md",
+        f"    {LEGACY} setup  # legacy-name-floor: command  legacy-name-ok: alias\n",
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "1 compat alias(es) — " in result.stdout
+    assert "floor mention(s)" not in result.stdout
+    # The reason quoted is the winning marker's own, not the other one's.
+    assert "alias" in result.stdout
+
+
+def test_a_floor_marker_buys_no_headroom_either(repo: Path) -> None:
+    """Rule 7 stays armed, and the new marker is not a softer way past it.
+
+    The exempt-and-add swap, run through the floor marker: mark one line, fill
+    the freed slot with a new unmarked one. It fails for the same reason the
+    older marker's version does — the text comparison charges non-exempt text the
+    repo never had, and the marker's kind is not part of that comparison.
+    """
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: the served mirror path\n'
+        f'SNUCK = "{LEGACY}-new-service"\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    offenders = result.stdout.split("adds the legacy name in", 1)[1]
+    assert "SNUCK" in offenders
+
+
+def test_the_report_counts_the_two_kinds_apart(repo: Path) -> None:
+    """The change's whole purpose, in the shape caura-daemon#136 landed.
+
+    Undifferentiated, eleven exemptions are a wall a reviewer scrolls past — the
+    same failure the reason-grouping exists to prevent, one level up. The counts
+    have to be separable at a glance or the split bought nothing.
+    """
+    _stage(
+        repo,
+        "env.md",
+        f"Also read as `{LEGACY.upper()}_HOME`.<!-- legacy-name-ok: rule 3 dual-read alias -->\n"
+        f"    {LEGACY} policy show  <!-- legacy-name-floor: the command name -->\n"
+        f"    {LEGACY} uninstall  <!-- legacy-name-floor: the command name -->\n",
+    )
+
+    out = _run(repo).stdout
+
+    # The total still counts every kind, so it can never disagree with the lists.
+    assert "3 exempt line(s) written by this change in 1 file(s)" in out
+    assert "1 compat alias(es), 2 floor mention(s)." in out
+    assert "1 compat alias(es) — rule 3's escape hatch" in out
+    assert "2 floor mention(s) — a permanent name in text" in out
+
+
+def test_aliases_are_listed_before_floor_mentions(repo: Path) -> None:
+    """Fixed order, not sorted by size.
+
+    Mentions outnumber aliases in the ordinary case — that is the whole reason
+    the split exists — so a count-ordered report would put the four lines rule 3
+    wants eyes on underneath six that it does not. Position must not depend on a
+    tally.
+    """
+    _stage(
+        repo,
+        "env.md",
+        f"Also read as `{LEGACY.upper()}_HOME`.<!-- legacy-name-ok: the one alias -->\n"
+        + "".join(
+            f"    {LEGACY} verb{i}  <!-- legacy-name-floor: a command name -->\n"
+            for i in range(3)
+        ),
+    )
+
+    out = _run(repo).stdout
+
+    assert out.index("compat alias(es) — ") < out.index("floor mention(s) — ")
+
+
+def test_one_kind_alone_gets_no_redundant_split_line(repo: Path) -> None:
+    """Most PRs write one exemption of one kind. Printing "1 compat alias(es)"
+    twice running — once as the split, once as the section header — reads as a
+    form rather than a finding, and the section header already says it."""
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-ok: gateway mirror\n',
+    )
+
+    out = _run(repo).stdout
+
+    assert "1 exempt line(s) written by this change in 1 file(s)" in out
+    assert "1 compat alias(es) — rule 3's escape hatch" in out
+    # The comma-joined split line, which only earns its place with two kinds.
+    # Matched as a WHOLE line: a substring test would separate it from the
+    # section header by nothing but the trailing "." versus " —", and would
+    # start misfiring the moment that punctuation is reworded.
+    assert "1 compat alias(es)." not in out.splitlines()
+
+
+def test_a_removed_floor_mention_is_still_reported(repo: Path) -> None:
+    """Removal is reported for both kinds, under guidance true of both.
+
+    A floor mention has no alias to survive, so the old wording — "confirm each
+    alias still exists" — would be a false instruction on a real removal, which
+    is precisely the corruption this marker split exists to stop.
+    """
+    line = f"    {LEGACY} uninstall  # legacy-name-floor: the command name\n"
+    (repo / "cli.md").write_text(line)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add a floor mention")
+    _stage(repo, "cli.md", "    caura uninstall\n")
+
+    result = _run(repo)
+
+    assert result.returncode == 0
+    assert "exempt line(s) removed" in result.stdout
+    assert "the command name" in result.stdout
 
 
 # ── what must NOT fail ───────────────────────────────────────────────────────


### PR DESCRIPTION
`legacy-name-ok` means two different things and the report cannot tell them apart:
a **compat alias**, which is what rule 3's escape hatch is for, and a **floor
mention** — a permanent name appearing in text, where nothing new is declared at all.

## Measured, fleet-wide, 100% coverage

622 markers across the seven repos:

| kind | count | share |
| --- | --- | --- |
| compat alias | 340 | 55% |
| **floor mention** | **274** | **44%** |
| should be reworded, no marker | 8 | 1% |

**44% of every exemption in the programme is a floor mention**, and today the only
thing separating them from aliases is unstructured prose in the reason text.

`caura-daemon#136` is the shape of it in a single PR: eleven exemptions, four of them
aliases. A reviewer sees eleven undifferentiated entries and stops reading.

## What this does NOT claim — please read this bit

An earlier framing of this work (mine, in the brief I was given) said the mixed marker
was producing **false justifications at scale**, citing the `#882` note about being
forced to *"write a reason that was not true, into the one annotation whose whole value
is that its reasons are true."*

**The data does not support that, and this PR should not be approved on it.** I checked
the audit myself rather than taking it secondhand:

- Only **11 of 622 markers (1.8%)** put alias language on a non-alias line.
- **218 of the 274** floor mentions already say "floor", "pinned" or "frozen" in their
  own reason text.
- Most of the 11 are `taught as legacy alias` on prose lines, which is arguably true
  anyway.

Authors have been drawing this distinction correctly all along. The gate has simply had
nowhere to record it, so it could not count on it. **This is a signal and structure
change, not a corruption fix.** The `#882` risk was real and it did not scale.

What *did* scale is 274 floor mentions filed in the same list as the aliases — because
floor mentions accrue from **editing documentation** rather than from renaming anything.
Both mechanisms re-verified against the current gate:

- **Re-wrapping mints.** Re-flowing a comment that mentions the CLI verb fails the gate
  *while the file's count falls* — the text is new even though the tally dropped.
- **Markers are self-perpetuating.** Stripping a marker and leaving the line otherwise
  identical fails: the previously-exempt text becomes non-exempt text the repo never had.

So that half of the pile grows as docs are maintained, not as the brand is swept.

## The sunset plan already asks for this

`docs/plans/rebrand-sunset-plan.md` already says *"a mention gets reworded, a contract
gets the marker … **mark it, and say which**."* Until now "which" had nowhere to live but
the reason prose. This gives that sentence a mechanism.

## The design

1. **Both markers exempt identically.** The pass/fail decision reads only whether
   `_kind()` returned `None`, never which marker it found. A mislabelled marker cannot
   turn a red build green or a green one red.
2. **Every existing `legacy-name-ok` stays valid and untouched.** No migration. The 52
   pre-existing tests pass **unedited** — the test-file diff is purely additive, zero
   deleted lines. That is the evidence, not the regex.
3. **The new marker is a falsifiable claim.** "This names something on the floor and the
   line cannot be correct without the literal" is checkable in one move: reword it, and
   if it is still correct the marker was false. "This is fine" would not have earned a
   marker.
4. **Reason text stays asked-for, not enforced**, exactly as today.

**Precedence, when both claims are true of one line.** 28 lines across the fleet name a
frozen thing and declare a dual-read at once — e.g. an image tag whose repository name is
permanent while its version is read from either spelling. One line takes one marker, so
precedence is `_KINDS` order (alias first) rather than position on the line: the answer
must not depend on which end the author typed first, and the tie breaks away from
under-counting aliases, which is the expensive direction.

One regex serves both markers with the boundaries **outside** the alternation, so the
bounded-token rule is stated once and cannot drift per marker. `_KINDS` is the single
table; a third kind is one entry plus a paragraph in the failure text (which the table's
comment says out loud).

`Scan` is untouched — `exempt` and `exempt_text` are not split, because `exempt` only
*selects* files (the report re-greps and reads kinds first-hand) and `exempt_text` keys on
text that still contains its own marker.

## What the report now prints

```
10 exempt line(s) written by this change in 3 file(s) —
4 compat alias(es), 6 floor mention(s).

4 compat alias(es) — rule 3's escape hatch, and what this report is for.
Check each is a compat alias, a redirect or a pinned wire format,
and not headroom for a new name:
  ...

6 floor mention(s) — a permanent name in text, not a new declaration.
Check the line cannot be correct without the literal: a pasteable
command, an on-disk path, a served mirror path. If rewording it
would leave it correct, the claim is false and it should carry no
marker at all:
  ...
```

The first line still counts every kind together and is byte-identical to today's. The
split line is skipped when only one kind is present, where it would just restate the
section header.

## Verification

- **70 tests pass**; the test-file diff is purely additive and the 52 pre-existing tests
  are byte-identical.
- New tests fail against the pre-change script. The boundary guards would pass vacuously
  without the feature, so each was validated by **mutating the implementation** instead:
  drop the lookahead, drop the lookbehind, break the two-marker tie by position, compare
  the winning marker's casing raw, stop normalising casing, let a floor marker excuse its
  whole file, print the split line for one kind, order sections by size. **All 8 mutations
  are detected.** Two of them caught assertions of mine that were vacuous — one only
  checked an exit code where the real failure was a line silently dropped from the report,
  and one asserted a reason that the report happened to print anyway as part of the line
  text.
- **60 real commits of `origin/main` replayed** through the old and new scripts, each in
  its own worktree against its own first parent: **exit code identical 60/60**, stdout
  byte-identical on 41. Of the 19 that differ, 18 wrote exemptions (the diff is the added
  section header — no content lost, totals unchanged) and 1 is the deliberate wording
  change in the removed-exemption report.
- Gate passes on its own source, do-not-touch sentinel still passes (34/34), `ruff check`
  and `ruff format --check` clean on both files.
- Runtime unchanged: 0.36s → 0.38s over the full tree. Subprocess and regex call counts
  are identical to before (7 and 10 on a control fixture).

## Deliberately not in this PR

- **Reclassifying the 274 existing floor mentions.** Mechanism first; a mechanism change
  plus a 274-line reclassification is unreviewable.
- **A third `deferred` kind.** 7 markers are parked on another lane's clock ("moves at the
  flip", "on its own rename schedule") and are neither rule 3 nor permanent floor. The
  table now makes adding one a small change, but 7/622 does not earn it in the same diff
  that introduces the mechanism.
- **The fence-line block marker.** `caura-daemon/specs/001-memclaw-broker/fleet-overview.md:605,672`
  carry markers that render visibly inside ```` ```bash ```` fences, and a floor-vs-alias
  marker does not help them — the marked line is a pasteable command that cannot leave the
  fence, the marker cannot be removed without tripping the gate, and the literal is the
  binary name so it cannot be reworded. Needs a fence-level mechanism.
- **Splitting the removed-exemption report by kind.** Its population is the other way round
  — seven removals across four hundred commits — so the wall is hypothetical there. Its
  guidance sentence is widened to be true of both kinds (telling a reader to confirm an
  alias survived would be a false instruction for a floor mention), but the list is not
  split. Noted in the code as worth revisiting if the rate changes.

## Porting

The seven copies are **not** byte-identical — four generations, plus one genuine fork.
`caura` is upstream and this lands here first. Plan in the lane report; the headline is
that `#944` (the removed-exemption report, written after a data-loss change passed both
required gates green) is currently in **`caura` only, 1 of 7**, and is worth landing
downstream ahead of this.
