### PR TITLE
ci: check the services against common/ instead of against Any

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,32 @@ jobs:
             exit 1
           fi
 
+      # The four steps below check each service against common/ as well as
+      # against its own src/, because every service pyproject now carries
+      # ``mypy_path = "src:.."`` — ``..`` being the repo root, where common/
+      # lives. Before that, ``common.*`` resolved to nothing, and
+      # ``ignore_missing_imports = true`` (which every service sets, and needs)
+      # turned that silence into Any rather than an error. So the step below was
+      # a gate over 200 files that could not see a single one of the ~40
+      # common/ symbols they import.
+      #
+      # What it cost: ``core_api.services.forge.*`` is deliberately opted back
+      # IN to the type gate (``ignore_errors = false``, one of few carve-outs
+      # from the broad ``core_api.services.*`` exemption), and this step still
+      # reported "no issues found in 200 source files" while
+      # ``forge/cron_handler.py`` imported ``LLMRequest`` from ``common.llm`` —
+      # a name that has never existed there — and called ``call_with_fallback``
+      # with a signature it has never had. The forge distill cron raised
+      # RuntimeError on every tick and had never once run; the error blamed a
+      # missing provider chain, so it read as a misconfiguration. Repaired in
+      # #955. Being inside a gated tree proved nothing, and that is the
+      # assumption worth distrusting.
+      #
+      # The setting is in each pyproject rather than an env var here on purpose:
+      # a ``MYPYPATH`` set only on these steps would leave the local
+      # ``mypy src/``, the contributor's IDE, and any future pre-commit hook
+      # disagreeing with the gate — which is the shape of the failure this
+      # closes, not a fix for it.
       - name: Run mypy (core-api)
         run: cd core-api && uv run mypy src/
 
@@ -279,14 +305,20 @@ jobs:
 
       - name: Run mypy (common/)
         # common/ was type-checked by NOTHING before this step. Each mypy step
-        # above ``cd``s into one service and checks that service's own src/, so
-        # no invocation's path ever resolved to common/ — while 40 files under
-        # core-api/src alone import it. Those imports were not caught either:
+        # above ``cd``s into one service and, until ``mypy_path = "src:.."``
+        # landed, checked only that service's own src/ — so no invocation's path
+        # ever resolved to common/, while 40 files under core-api/src alone
+        # import it. Those imports were not caught either:
         # ``ignore_missing_imports = true`` (every service sets it) plus a
-        # ``mypy_path`` of just that service's src/ means an unresolved
-        # ``common.*`` import degrades to Any in silence rather than failing.
+        # ``mypy_path`` of just that service's src/ meant an unresolved
+        # ``common.*`` import degraded to Any in silence rather than failing.
         # ``cd core-api && mypy src/`` reported 199 files and none of them were
         # common/'s 94.
+        #
+        # This step is still the one that OWNS common/. The service steps reach
+        # it only through the imports they happen to follow, so a common/ module
+        # no service imports — or a branch of one none of them exercises — is
+        # covered here and nowhere else. Keep it.
         #
         # Nor did the hook cover it: .pre-commit-config.yaml deliberately runs no
         # mypy, deferring to "CI is the authoritative type-check" — which pointed

--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -138,7 +138,15 @@ indent-style = "space"
 
 [tool.mypy]
 python_version = "3.12"
-mypy_path = "src"
+# ``..`` is the repo root, where ``common/`` lives. common/ is not an installed
+# distribution — it is PYTHONPATH-mounted (the Dockerfile COPYs it to
+# /app/common), so without the repo root here every ``common.*`` import degrades
+# to Any under ``ignore_missing_imports`` and this service's use of the shared
+# library is checked by nothing. That is what let ``from common.llm import
+# LLMRequest`` — a name that has never existed there — ship in the forge cron and
+# raise on every tick (#955) while ``mypy src/`` reported no issues in 200 files.
+# Relative to this file, so CI, a local ``mypy src/`` and an IDE all agree.
+mypy_path = "src:.."
 explicit_package_bases = true
 warn_return_any = false
 warn_unused_ignores = false

--- a/core-operations/pyproject.toml
+++ b/core-operations/pyproject.toml
@@ -76,7 +76,15 @@ indent-style = "space"
 
 [tool.mypy]
 python_version = "3.12"
-mypy_path = "src"
+# ``..`` is the repo root, where ``common/`` lives. common/ is not an installed
+# distribution — it is PYTHONPATH-mounted (the Dockerfile COPYs it to
+# /app/common), so without the repo root here every ``common.*`` import degrades
+# to Any under ``ignore_missing_imports`` and this service's use of the shared
+# library is checked by nothing. That is what let ``from common.llm import
+# LLMRequest`` — a name that has never existed there — ship in the forge cron and
+# raise on every tick (#955) while ``mypy src/`` reported no issues in 200 files.
+# Relative to this file, so CI, a local ``mypy src/`` and an IDE all agree.
+mypy_path = "src:.."
 explicit_package_bases = true
 warn_return_any = false
 warn_unused_ignores = false

--- a/core-storage-api/pyproject.toml
+++ b/core-storage-api/pyproject.toml
@@ -98,7 +98,15 @@ exclude = ["**/migrations/env.py"]  # late-import pattern; lint-only via per-fil
 
 [tool.mypy]
 python_version = "3.12"
-mypy_path = "src"
+# ``..`` is the repo root, where ``common/`` lives. common/ is not an installed
+# distribution — it is PYTHONPATH-mounted (the Dockerfile COPYs it to
+# /app/common), so without the repo root here every ``common.*`` import degrades
+# to Any under ``ignore_missing_imports`` and this service's use of the shared
+# library is checked by nothing. That is what let ``from common.llm import
+# LLMRequest`` — a name that has never existed there — ship in the forge cron and
+# raise on every tick (#955) while ``mypy src/`` reported no issues in 200 files.
+# Relative to this file, so CI, a local ``mypy src/`` and an IDE all agree.
+mypy_path = "src:.."
 explicit_package_bases = true
 warn_return_any = false
 warn_unused_ignores = false

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -22,7 +22,9 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import (
+    ColumnElement,
     String,
+    Table,
     and_,
     bindparam,
     case,
@@ -43,6 +45,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import load_only
+from sqlalchemy.sql.dml import ReturningInsert
 
 from common import duplicate_memory
 from common.constants import (
@@ -68,6 +71,7 @@ from common.models import (
     AuditChainHead,
     AuditLog,
     BackgroundTaskLog,
+    Base,
     CrystallizationReport,
     DedupReview,
     Document,
@@ -177,6 +181,27 @@ def _scope_sql(
         clause += f" AND {table}.fleet_id = :fleet_id"
         params["fleet_id"] = fleet_id
     return clause, params
+
+
+def _table(model: type[Base]) -> Table:
+    """The mapped ``Table`` behind a declarative model.
+
+    ``DeclarativeBase.__table__`` is annotated ``FromClause``, which has no
+    ``.delete()`` and is not accepted by ``insert()`` / ``update()`` — but every
+    mapped class here is table-mapped, so at runtime it is always a ``Table``.
+    Going through here says that once, in one place, instead of at each of the
+    seven core-statement sites that build DML from ``__table__`` directly.
+
+    ``type[Base]`` rather than ``type[Any]`` so passing something that is not a
+    mapped class is a type error here rather than an ``AttributeError`` at the
+    call site. The cost is the ignore below — the one place where the
+    ``FromClause``-is-really-a-``Table`` claim is made, which is the point of
+    having a single helper.
+
+    Nothing reported this until the services could see ``common/``: the models
+    live in ``common.models``, so every ``__table__`` here was ``Any``.
+    """
+    return model.__table__  # type: ignore[return-value]
 
 
 def _as_json_str(value: Any) -> str:
@@ -486,6 +511,11 @@ def _verify_audit_chain_rows(
                     "created_at": row.created_at.astimezone(UTC).isoformat(),
                 },
             }
+        # ``event_hash`` is ``Mapped[bytes | None]`` — the column is nullable —
+        # but a NULL one cannot reach here: the ``else`` branch above compares it
+        # against ``compute_event_hash(...)``, which returns ``bytes``, so a NULL
+        # row is reported ``event_hash_mismatch`` and returns before this line.
+        assert row.event_hash is not None  # narrow for mypy after the branch above
         expected_prev = row.event_hash
         expected_seq += 1
 
@@ -2763,7 +2793,7 @@ class PostgresService:
             )
             if node_ids:
                 cmd_result = await session.execute(
-                    FleetCommand.__table__.delete().where(FleetCommand.node_id.in_(node_ids))
+                    _table(FleetCommand).delete().where(FleetCommand.node_id.in_(node_ids))
                 )
                 counts["fleet_commands"] = cmd_result.rowcount  # type: ignore[attr-defined]
             else:
@@ -3247,7 +3277,7 @@ class PostgresService:
         shows up in operator profiles.
         """
         async with get_session() as session:
-            base_filters = [
+            base_filters: list[ColumnElement[bool]] = [
                 Memory.embedding.is_(None),
                 Memory.deleted_at.is_(None),
             ]
@@ -3918,7 +3948,10 @@ class PostgresService:
         admin ``/admin/fleets`` (``exclude_scope_agent`` False, cross-tenant
         when ``tenant_id`` is None). Read-only (reader replica).
         """
-        filters = [Memory.deleted_at.is_(None), Memory.fleet_id.isnot(None)]
+        filters: list[ColumnElement[bool]] = [
+            Memory.deleted_at.is_(None),
+            Memory.fleet_id.isnot(None),
+        ]
         if exclude_scope_agent:
             # ``Memory.visibility`` is NOT NULL with a server default, so the
             # three-valued-logic NULL pitfall doesn't apply.
@@ -4495,7 +4528,7 @@ class PostgresService:
         what it shared. Ignored when ``agent_id`` is set (that path already
         scopes visibility to the named agent).
         """
-        scope_filters = []
+        scope_filters: list[ColumnElement[bool]] = []
         if readable_tenant_ids:
             scope_filters.append(Memory.tenant_id.in_(readable_tenant_ids))
         else:
@@ -4759,7 +4792,7 @@ class PostgresService:
         (reader replica).
         """
         # ── Scope/visibility — MUST mirror memory_stats_breakdown. ──
-        scope_filters = []
+        scope_filters: list[ColumnElement[bool]] = []
         if readable_tenant_ids:
             scope_filters.append(Memory.tenant_id.in_(readable_tenant_ids))
         else:
@@ -4991,8 +5024,12 @@ class PostgresService:
                 idx = it["input_idx"]
                 if idx in matched_idxs:
                     continue
-                key = canonical_match_key(it["canonical_name"])
-                if not key:
+                # Named ``match_key``, not ``key``: ``key`` is already bound in this
+                # function to the Phase-1 lookup tuple
+                # ``(canonical_name, entity_type, fleet_id)``. Rebinding it to a str
+                # is harmless at runtime but reads as the same thing and is not.
+                match_key = canonical_match_key(it["canonical_name"])
+                if not match_key:
                     continue
                 # Candidate prefetch only: lower(name) ending in the key
                 # catches both directions (existing "new analytics service"
@@ -5001,7 +5038,7 @@ class PostgresService:
                 # The DECIDER is the Python-side key equality below — the
                 # suffix LIKE can never merge on its own ("data analytics
                 # service" is prefetched but rejected: its own key differs).
-                escaped = key.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                escaped = match_key.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
                 cand_stmt = (
                     select(Entity)
                     .where(
@@ -5022,7 +5059,7 @@ class PostgresService:
                     cand_stmt = cand_stmt.where(Entity.fleet_id.is_(None))
 
                 candidates = (await session.execute(cand_stmt)).scalars().all()
-                verified = [e for e in candidates if canonical_match_key(e.canonical_name) == key]
+                verified = [e for e in candidates if canonical_match_key(e.canonical_name) == match_key]
                 if not verified:
                     continue
                 # Prefer a pure case/whitespace variant (no qualifier was
@@ -5323,11 +5360,12 @@ class PostgresService:
                         else Entity.fleet_id.is_(None),
                     )
                 )
-                entity = result.scalar_one_or_none()
-                if entity is None:
+                winner = result.scalar_one_or_none()
+                if winner is None:
                     raise ValueError(
                         f"Entity '{data.get('canonical_name')}' conflict but re-select returned nothing"
                     )
+                entity = winner
             return entity
 
     async def entity_update(self, entity_id: UUID, data: dict) -> Entity | None:
@@ -5820,7 +5858,9 @@ class PostgresService:
                 mid = UUID(mid)
             if not isinstance(eid, UUID):
                 eid = UUID(eid)
-            ins_stmt = (
+            # Annotated because ``literal_column("xmax")`` types as ``Any``, and
+            # mypy will not infer a variable whose type is partly ``Any``.
+            ins_stmt: ReturningInsert[tuple[UUID, UUID, str, Any]] = (
                 pg_insert(MemoryEntityLink)
                 .values(memory_id=mid, entity_id=eid, role=it["role"])
                 .on_conflict_do_update(
@@ -6650,7 +6690,9 @@ class PostgresService:
                 # entities.id`` (prod 2026-06-16). ``update(Entity.__table__)`` is a
                 # plain Core executemany UPDATE that honours the custom bindparams and
                 # has no ORM bulk-by-PK or session-synchronisation behaviour at all.
-                sql_update(Entity.__table__)
+                # ``_table(Entity)`` IS ``Entity.__table__`` — it only narrows the
+                # declared type; the Core-not-ORM target above is unchanged.
+                sql_update(_table(Entity))
                 .where(
                     Entity.__table__.c.id == bindparam("eid"),
                     Entity.__table__.c.tenant_id == tenant_id,
@@ -7001,6 +7043,7 @@ class PostgresService:
         span every collection across the readable set (collections with the
         same name across multiple tenants merge into one row).
         """
+        tenant_pred: ColumnElement[bool]
         if readable_tenant_ids:
             tenant_pred = Document.tenant_id.in_(readable_tenant_ids)
         else:
@@ -7036,6 +7079,7 @@ class PostgresService:
         not advertise non-active skills in the count. ``readable_tenant_ids``
         widens to ``ANY($readable)`` over the same scope the listing used.
         """
+        tenant_pred: ColumnElement[bool]
         if readable_tenant_ids:
             tenant_pred = Document.tenant_id.in_(readable_tenant_ids)
         else:
@@ -7076,6 +7120,7 @@ class PostgresService:
         equality filter. Returns ``(Document, similarity)`` pairs where
         ``similarity = 1 - cosine_distance``.
         """
+        tenant_pred: ColumnElement[bool]
         if readable_tenant_ids:
             tenant_pred = Document.tenant_id.in_(readable_tenant_ids)
         else:
@@ -7115,6 +7160,7 @@ class PostgresService:
         sibling tenants; ``tenant_id`` stays the binding/home tenant.
         Mirrors core-api ``document_repository.get_by_doc_id``.
         """
+        tenant_pred: ColumnElement[bool]
         if readable_tenant_ids:
             tenant_pred = Document.tenant_id.in_(readable_tenant_ids)
         else:
@@ -7147,6 +7193,7 @@ class PostgresService:
         for cross-tenant credentials. Mirrors core-api
         ``document_repository.query``.
         """
+        tenant_pred: ColumnElement[bool]
         if readable_tenant_ids:
             tenant_pred = Document.tenant_id.in_(readable_tenant_ids)
         else:
@@ -8713,12 +8760,12 @@ class PostgresService:
             node_ids = list(result.scalars().all())
 
             if node_ids:
-                await session.execute(
-                    FleetCommand.__table__.delete().where(FleetCommand.node_id.in_(node_ids))
-                )
+                await session.execute(_table(FleetCommand).delete().where(FleetCommand.node_id.in_(node_ids)))
 
             await session.execute(
-                FleetNode.__table__.delete().where(
+                _table(FleetNode)
+                .delete()
+                .where(
                     FleetNode.tenant_id == tenant_id,
                     FleetNode.fleet_id == fleet_id,
                 )
@@ -8732,7 +8779,7 @@ class PostgresService:
         values: dict[str, Any],
     ) -> UUID:
         async with get_session() as session:
-            stmt = pg_insert(FleetNode.__table__).values(**values)
+            stmt = pg_insert(_table(FleetNode)).values(**values)
             stmt = stmt.on_conflict_do_update(  # type: ignore[assignment]
                 constraint="uq_fleet_nodes_tenant_node",
                 set_={k: v for k, v in values.items() if k not in ("tenant_id", "node_name")},
@@ -8990,7 +9037,7 @@ class PostgresService:
         if not node_ids:
             return
         async with get_session() as session:
-            await session.execute(FleetCommand.__table__.delete().where(FleetCommand.node_id.in_(node_ids)))
+            await session.execute(_table(FleetCommand).delete().where(FleetCommand.node_id.in_(node_ids)))
 
     # ══════════════════════════════════════════════════════════════════════
     #  AUDIT
@@ -9074,7 +9121,7 @@ class PostgresService:
             # head exists; the unconditional FOR UPDATE select below is what
             # actually serializes writers.
             await session.execute(
-                pg_insert(AuditChainHead.__table__)
+                pg_insert(_table(AuditChainHead))
                 .values(tenant_id=tenant_id, last_seq=0, last_hash=GENESIS_PREV_HASH)
                 .on_conflict_do_nothing(index_elements=["tenant_id"])
             )

--- a/core-worker/pyproject.toml
+++ b/core-worker/pyproject.toml
@@ -98,7 +98,15 @@ indent-style = "space"
 
 [tool.mypy]
 python_version = "3.12"
-mypy_path = "src"
+# ``..`` is the repo root, where ``common/`` lives. common/ is not an installed
+# distribution — it is PYTHONPATH-mounted (the Dockerfile COPYs it to
+# /app/common), so without the repo root here every ``common.*`` import degrades
+# to Any under ``ignore_missing_imports`` and this service's use of the shared
+# library is checked by nothing. That is what let ``from common.llm import
+# LLMRequest`` — a name that has never existed there — ship in the forge cron and
+# raise on every tick (#955) while ``mypy src/`` reported no issues in 200 files.
+# Relative to this file, so CI, a local ``mypy src/`` and an IDE all agree.
+mypy_path = "src:.."
 explicit_package_bases = true
 warn_return_any = false
 warn_unused_ignores = false


### PR DESCRIPTION
## What this fixes

`core_api.services.forge.*` is **deliberately opted back in** to the type gate — `ignore_errors = false`, one of few carve-outs from the broad `core_api.services.*` exemption — and `cd core-api && uv run mypy src/` still reported **"no issues found in 200 source files"** while `forge/cron_handler.py` imported `LLMRequest` from `common.llm` (a name that has never existed there) and called `call_with_fallback` with a signature it has never had.

The forge distill cron raised `RuntimeError` on every tick and **had never once run**. The error blamed a missing provider chain, so it read as a misconfiguration. Repaired in #955 — this PR is about why nothing caught it.

**No service's mypy run could see `common/`.** Each step `cd`s into one service and checks that service's own `src/`, and `mypy_path` named only that `src/`. So every `common.*` import resolved to nothing, and `ignore_missing_imports = true` — which every service sets, and needs, for its unstubbed third-party deps — turned that silence into `Any` rather than an error.

A service could sit in a gated tree, with a green gate, and have its use of the shared library checked by nothing at all. #948 put `common/` itself under the gate; this is the same gap one layer out and is not closed by it.

## The change

`mypy_path = "src"` → `mypy_path = "src:.."` in all four service pyprojects. `..` is the repo root, where `common/` lives; the path is resolved relative to the pyproject, so CI, a local `mypy src/` and an IDE all agree.

**Not a `MYPYPATH` env var on the CI steps.** That would leave the local run and the contributor's editor disagreeing with the gate — which is the shape of this failure, not a fix for it.

**Not packaging `common` as a distribution.** That is the more honest description of what `common/` is, and it stays available later; it is not what this PR buys. It would mean relocking every service, changing the Dockerfiles that `COPY` `common/` to `/app/common`, and changing how the runtime resolves the package — a production-adjacent change to obtain a type-check property that one line per service already obtains.

## Proof the gate bites

Re-inserting the historical import into `forge/cron_handler.py`:

```
src/core_api/services/forge/cron_handler.py:39: error: Module "common.llm" has no attribute "LLMRequest"  [attr-defined]
Found 1 error in 1 file (checked 200 source files)
```

Before this change the same file passed.

**And it has already earned itself once, on this branch.** Rebasing onto #989 (WT-2 entity canonicalisation, merged while this was open) surfaced two errors nothing else reported. Its new Phase-1.5 block binds `key = canonical_match_key(...)`, a `str`, inside a function where `key` is already the Phase-1 lookup tuple `(canonical_name, entity_type, fleet_id)` fifty lines up. Harmless at runtime — the earlier loop has finished — but it reads as the same thing and is not. `canonical_match_key` comes from `common/entity_naming.py`, which is new and which no service run could see. Renamed to `match_key`; that is the whole fix.

## Measured cost, before any fix

| service | today | with `common/` visible |
|---|---|---|
| core-api | 0 | 0 |
| core-storage-api | 0 | **34** |
| core-operations | 0 | 0 |
| core-worker | 0 | 0 |

All 34 were in one file — `postgres_service.py`, which imports this repo's SQLAlchemy models from `common.models`. **All are fixed here, nothing is exempted.** Every one was annotation-level; none was a defect in what the code does at runtime:

- **24** — a predicate list or variable inferred `BinaryExpression[bool]` from an `is_()` / `in_()`, then given the wider `ColumnElement[bool]` that a `== <optional>` comparison returns. Declared at the five list sites and above the five `tenant_pred` branches.
- **7** — `Model.__table__`, annotated `FromClause` by the declarative base (no `.delete()`, not accepted by `insert()` / `update()`) though every mapped class here is table-mapped, so at runtime it is always a `Table`. A `_table()` helper says that once instead of at each site. The Core-not-ORM targeting in `entity_embeddings_write_back` is unchanged — `_table(Entity)` **is** `Entity.__table__`, it only narrows the declared type.
- **2 narrowing** — `event_hash` is `Mapped[bytes | None]` (the column is nullable), but a NULL cannot reach the assignment: the branch above compares it against `compute_event_hash`'s `bytes` return, so a NULL row is reported `event_hash_mismatch` and returns first. Asserted, with that reasoning written down. And the entity dedup re-SELECT, which already raises on `None`, now binds the optional to its own name.
- **1** — `ins_stmt` annotated, because `literal_column("xmax")` types as `Any` and mypy will not infer a variable whose type is partly `Any`.

## Changed since the first revision

The first push exempted `postgres_service.py` with `ignore_errors = true` and deferred the 34 to a follow-up, reasoning that a gate arriving alongside a 34-error diff is a gate that gets reverted.

**The review was right and I've dropped that.** A module-level `ignore_errors` re-opens this exact gap for any *new* error in that file — and, as the review noted, that file has no coverage safety net either (it is in `omit`). The review suggested 34 per-line `# type: ignore` comments as the bounded alternative; fixing the underlying declarations turned out to be a **smaller** diff than 34 ignores, and leaves nothing suppressed. Nothing is exempted in this PR now, and there is no follow-up to remember.

## One thing this PR surfaces but does not report

**core-api's 0 above is not coverage.** Its `[[tool.mypy.overrides]] ignore_errors = true` covers `core_api.services.*`, `core_api.pipeline.steps.*`, `routes.fleet`, `routes.memories`, `clients.storage_client`, `mcp_server`, `app` and `auth`.

Neutralise those overrides and core-api goes from **343 errors to 355** with `common/` visible. Sixteen errors in six files that this change surfaces and the gate will not report, because they sit in modules exempt for unrelated reasons — including `services/memory_service.py`, which passes a `str` to `publish_memory_enrich_request(memory_id: UUID)`.

Forge was one of the few carve-outs back in, which is exactly why forge was the one that bit. Recorded here rather than fixed — it is a separate finding, and a separate decision about how much of `core_api.services.*` should stay exempt.

## Checks

- All four service mypy steps and the `common/` step green.
- `tests/` 5284 passed · `core-storage-api/tests/` 156 · `core-operations/tests/` 50 · `core-worker/tests/` 75.
- `ruff check` and `ruff format --check` clean, run separately and scoped.
- `actionlint` output on `.github/workflows/ci.yml` unchanged from `origin/main`.
- `pre-commit run --from-ref origin/main --to-ref HEAD` clean.
- No lockfile touched.
