### PR TITLE
fix(api): /recall and /ingest/commit 500 under headers_enabled=True (D14 follow-up)

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1824,6 +1824,7 @@ async def ingest_preview_endpoint(
 async def ingest_commit_endpoint(
     request: Request,
     body: IngestCommitRequest,
+    response: Response,
     auth: AuthContext = Depends(get_auth_context),
 ):
     """Write previewed facts as memories."""
@@ -1961,6 +1962,7 @@ async def ingest_undo_endpoint(
 async def recall_endpoint(
     request: Request,
     body: SearchRequest,
+    response: Response,
     auth: AuthContext = Depends(get_auth_context),
 ):
     """Search memories and return an LLM-synthesized context summary.

--- a/tests/test_broker_ingest_stm_ownership.py
+++ b/tests/test_broker_ingest_stm_ownership.py
@@ -19,6 +19,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import Response
+
 from core_api.auth import AuthContext
 from core_api.routes import memories, stm
 from core_api.schemas import IngestCommitRequest, IngestFact
@@ -56,7 +58,9 @@ async def _drive_ingest(monkeypatch, *, agent_id, auth):
         agent_id=agent_id,
         facts=[IngestFact(content="a durable fact", suggested_type="fact")],
     )
-    await memories.ingest_commit_endpoint(SimpleNamespace(), body, auth)
+    # response arg: required since /ingest/commit grew the ``response: Response``
+    # param slowapi needs under headers_enabled=True.
+    await memories.ingest_commit_endpoint(SimpleNamespace(), body, Response(), auth)
     return captured["agent_id"], gate
 
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -226,14 +226,19 @@ async def test_every_rate_limited_route_survives_header_injection(client):
     every call 500'd on staging the moment #976 deployed (2026-08-25 17:51Z),
     while CI stayed green because conftest disables the limiter suite-wide.
 
-    One request per limited route, limiter ON: assert it doesn't 500 and that
-    the success actually carries the X-RateLimit headers D14 promised."""
+    One request per limited route, limiter ON: assert it succeeds and that
+    the success actually carries the X-RateLimit headers D14 promised. The
+    write's content is unique per run so the dedup 409 path can't mask the
+    header assertion on a reused database."""
+    import uuid
+
     key = {"x-api-key": "mc_hdr_inject_probe"}
+    nonce = uuid.uuid4().hex
 
     cases = [
         (
             "/api/v1/recall",
-            {"tenant_id": "default", "query": "header injection probe"},
+            {"tenant_id": "default", "query": f"header injection probe {nonce}"},
         ),
         (
             "/api/v1/ingest/commit",
@@ -241,7 +246,7 @@ async def test_every_rate_limited_route_survives_header_injection(client):
         ),
         (
             "/api/v1/search",
-            {"tenant_id": "default", "query": "header injection probe"},
+            {"tenant_id": "default", "query": f"header injection probe {nonce}"},
         ),
         (
             "/api/v1/memories",
@@ -249,14 +254,15 @@ async def test_every_rate_limited_route_survives_header_injection(client):
                 "tenant_id": "default",
                 "agent_id": "hdr-inject-agent",
                 "memory_type": "fact",
-                "content": "header injection probe memory",
+                "content": f"header injection probe memory {nonce}",
             },
         ),
     ]
     for path, body in cases:
         resp = await client.post(path, json=body, headers=key)
-        assert resp.status_code < 500, (
-            f"{path} must not 500 under headers_enabled=True: {resp.text}"
+        assert resp.status_code < 300, (
+            f"{path} must succeed under headers_enabled=True: "
+            f"{resp.status_code} {resp.text}"
         )
         assert "x-ratelimit-limit" in resp.headers, (
             f"{path} success must carry X-RateLimit headers (D14), "

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -213,3 +213,52 @@ async def test_search_fails_open_when_rate_limit_storage_errors(client, monkeypa
     assert resp.status_code == 200, (
         f"rate-limit storage outage must fail open, got {resp.text}"
     )
+
+
+# ── headers_enabled=True: every limited route must satisfy _inject_headers ──
+
+
+async def test_every_rate_limited_route_survives_header_injection(client):
+    """With ``headers_enabled=True`` (D14, #976) slowapi's ``_inject_headers``
+    runs on every SUCCESSFUL response of a limited route and raises unless the
+    endpoint either declares a ``response: Response`` parameter or returns a
+    ``Response`` instance. ``/recall`` and ``/ingest/commit`` declared neither —
+    every call 500'd on staging the moment #976 deployed (2026-08-25 17:51Z),
+    while CI stayed green because conftest disables the limiter suite-wide.
+
+    One request per limited route, limiter ON: assert it doesn't 500 and that
+    the success actually carries the X-RateLimit headers D14 promised."""
+    key = {"x-api-key": "mc_hdr_inject_probe"}
+
+    cases = [
+        (
+            "/api/v1/recall",
+            {"tenant_id": "default", "query": "header injection probe"},
+        ),
+        (
+            "/api/v1/ingest/commit",
+            {"tenant_id": "default", "facts": []},
+        ),
+        (
+            "/api/v1/search",
+            {"tenant_id": "default", "query": "header injection probe"},
+        ),
+        (
+            "/api/v1/memories",
+            {
+                "tenant_id": "default",
+                "agent_id": "hdr-inject-agent",
+                "memory_type": "fact",
+                "content": "header injection probe memory",
+            },
+        ),
+    ]
+    for path, body in cases:
+        resp = await client.post(path, json=body, headers=key)
+        assert resp.status_code < 500, (
+            f"{path} must not 500 under headers_enabled=True: {resp.text}"
+        )
+        assert "x-ratelimit-limit" in resp.headers, (
+            f"{path} success must carry X-RateLimit headers (D14), "
+            f"got {dict(resp.headers)}"
+        )


### PR DESCRIPTION
## What

Staging outage, live since **2026-08-25 17:51Z**: every `POST /api/v1/recall` returns 500 (9/9 requests in Cloud Run logs), and `POST /api/v1/ingest/commit` fails the same way.

```
File ".../slowapi/extension.py", line 383, in _inject_headers
Exception: parameter `response` must be an instance of starlette.responses.Response
```

## Why

#976 (D14) set `headers_enabled=True` on the Limiter, so slowapi's `_inject_headers` now runs on every **successful** response of a rate-limited route — and raises unless the endpoint declares a `response: Response` param or returns a `Response` instance. Audit of all six `@*_limit` routes:

| Route | Status |
|---|---|
| `POST /memories` (write) | ✅ has `response: Response` |
| `POST /memories/bulk` | ✅ has `response: Response` |
| `POST /search` | ✅ has `response: Response` |
| `POST /documents` | ✅ returns `JSONResponse` |
| `POST /recall` | ❌ **500s** — plain dict, no param |
| `POST /ingest/commit` | ❌ **500s** — plain dict, no param |

## Fix

Add the `response: Response` parameter to the two broken endpoints (same pattern as `search`/`write_memory`).

## Why CI never caught it

`tests/conftest.py` disables the limiter suite-wide (autouse), so `tests/test_api_mcp.py`'s existing recall-200 assertion never traverses the slowapi wrapper. New regression test in `tests/test_rate_limit.py` (the one file that re-enables the limiter) hits each limited route once and asserts: no 500, and the success carries `X-RateLimit-*` headers (the D14 behavior itself). Verified the test fails on main without the fix.

## Deployment note

**Prod is not yet exposed** (prod DD_VERSION `f41fd6d4` predates #976) — but the next prod promote ships this outage unless this lands first.
