### PR TITLE
fix(api): rate-limited routes without a Response param 500 on every call

### DIFF
--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -4,7 +4,7 @@ import logging
 import re
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
@@ -192,6 +192,9 @@ def _dict_to_out(d: dict) -> DocOut:
 @write_limit
 async def upsert_document(
     request: Request,
+    # slowapi with headers_enabled needs an injectable Response to attach
+    # X-RateLimit-*/Retry-After; without this param every call 500s (D14).
+    response: Response,
     body: DocWriteRequest,
     auth: AuthContext = Depends(get_auth_context),
     idempotency_key: str | None = Header(None, alias=IDEMPOTENCY_HEADER),

--- a/tests/test_d14_rate_limited_response_param.py
+++ b/tests/test_d14_rate_limited_response_param.py
@@ -1,0 +1,80 @@
+"""D14 follow-up: every rate-limited route must inject a Response.
+
+With ``headers_enabled=True`` (D14, #976), slowapi injects
+X-RateLimit-*/Retry-After into the endpoint's ``Response``. When the handler
+signature has no ``Response``-annotated parameter, slowapi raises inside
+``_inject_headers`` and the route 500s ON EVERY CALL — not just when
+throttled. That shipped: POST /documents, POST /ingest/commit and
+POST /recall all 500'd from #976 until this guard's fix, unnoticed because
+the bench and wet tests only exercised POST /memories and POST /search
+(both of which already carried the parameter).
+
+The guard is AST-based so it catches the mistake at unit-test time, without
+booting the app or hitting a limiter.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROUTES_DIR = (
+    pathlib.Path(__file__).resolve().parents[1] / "core-api" / "src" / "core_api"
+)
+_LIMIT_DECORATORS = {"write_limit", "search_limit", "write_bulk_limit"}
+
+
+def _decorator_names(fn: ast.AsyncFunctionDef | ast.FunctionDef) -> set[str]:
+    names = set()
+    for dec in fn.decorator_list:
+        node = dec.func if isinstance(dec, ast.Call) else dec
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+    return names
+
+
+def _has_response_param(fn: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
+    for arg in [*fn.args.posonlyargs, *fn.args.args, *fn.args.kwonlyargs]:
+        ann = arg.annotation
+        if isinstance(ann, ast.Name) and ann.id == "Response":
+            return True
+        if isinstance(ann, ast.Attribute) and ann.attr == "Response":
+            return True
+    return False
+
+
+def test_every_rate_limited_route_declares_a_response_param():
+    offenders = []
+    for path in sorted(_ROUTES_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            if not (_decorator_names(node) & _LIMIT_DECORATORS):
+                continue
+            if not _has_response_param(node):
+                offenders.append(f"{path.name}:{node.lineno} {node.name}")
+    assert not offenders, (
+        "rate-limited route(s) without a Response-annotated parameter — "
+        "slowapi headers_enabled 500s these on every call: " + ", ".join(offenders)
+    )
+
+
+def test_guard_actually_sees_the_limited_routes():
+    """The guard above passes vacuously if the decorator names drift —
+    pin the number of rate-limited handlers it inspects."""
+    seen = 0
+    for path in sorted(_ROUTES_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and (
+                _decorator_names(node) & _LIMIT_DECORATORS
+            ):
+                seen += 1
+    assert seen >= 4, f"expected at least 4 rate-limited handlers, saw {seen}"

--- a/tests/test_documents_rest_doc_memory.py
+++ b/tests/test_documents_rest_doc_memory.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import pytest
-
 from core_api.services.doc_indexing import resolve_doc_memory
+from fastapi import Response
 
 pytestmark = [pytest.mark.unit]
 
@@ -50,9 +50,8 @@ def test_rule_lives_in_one_module_only():
     """Guard against a surface growing its own derivation logic."""
     import inspect
 
-    from core_api.routes import documents as rest_module
-
     from core_api import mcp_server
+    from core_api.routes import documents as rest_module
 
     for module in (rest_module, mcp_server):
         src = inspect.getsource(module)
@@ -138,6 +137,7 @@ async def test_unindexed_branch_mints(rest_env):
 
     await mod.upsert_document.__wrapped__(
         request=AsyncMock(),
+        response=Response(),
         body=_body(mod),
         auth=_auth(),
         idempotency_key=None,
@@ -158,6 +158,7 @@ async def test_indexed_branch_mints(rest_env, monkeypatch):
 
     await mod.upsert_document.__wrapped__(
         request=AsyncMock(),
+        response=Response(),
         body=_body(mod, data={"summary": "Postgres tuning.", "content": _BODY}),
         auth=_auth(),
         idempotency_key=None,
@@ -172,7 +173,11 @@ async def test_caller_agent_id_is_forwarded(rest_env):
     mod = rest_env["module"]
 
     await mod.upsert_document.__wrapped__(
-        request=AsyncMock(), body=_body(mod), auth=_auth(), idempotency_key=None
+        request=AsyncMock(),
+        response=Response(),
+        body=_body(mod),
+        auth=_auth(),
+        idempotency_key=None,
     )
 
     assert rest_env["spy"].call_args.kwargs["agent_id"] == "agent-a"
@@ -185,6 +190,7 @@ async def test_bodyless_structured_record_now_mints(rest_env):
 
     await mod.upsert_document.__wrapped__(
         request=AsyncMock(),
+        response=Response(),
         body=_body(mod, collection="customers", data={"plan": "business", "seats": 40}),
         auth=_auth(),
         idempotency_key=None,
@@ -202,6 +208,7 @@ async def test_skips_mint_for_empty_payload(rest_env):
 
     await mod.upsert_document.__wrapped__(
         request=AsyncMock(),
+        response=Response(),
         body=_body(mod, collection="customers", data={}),
         auth=_auth(),
         idempotency_key=None,
@@ -217,7 +224,11 @@ async def test_raising_mint_does_not_fail_the_doc_write(rest_env):
     rest_env["spy"].side_effect = RuntimeError("memory subsystem down")
 
     out = await mod.upsert_document.__wrapped__(
-        request=AsyncMock(), body=_body(mod), auth=_auth(), idempotency_key=None
+        request=AsyncMock(),
+        response=Response(),
+        body=_body(mod),
+        auth=_auth(),
+        idempotency_key=None,
     )
 
     rest_env["spy"].assert_awaited_once()


### PR DESCRIPTION
## Summary

**Completes the D14 headers_enabled fix**: `POST /documents` still 500s on every call on current main — the same slowapi bug #984 fixed for `/recall` and `/ingest/commit` (staging outage, live since 2026-08-25 17:51Z).

slowapi with `headers_enabled=True` (D14, #976) injects `X-RateLimit-*`/`Retry-After` into the endpoint's injectable `Response`. A rate-limited handler with no `Response`-annotated parameter raises inside `_inject_headers` on **every** request. #984 covered two of the three broken handlers; `upsert_document` is the third.

> Rebased over #984: originally this PR fixed all three; the `/recall` + `/ingest/commit` halves were dropped in favor of #984's merged fix. What remains is the `/documents` fix plus a structural guard #984's behavioral test doesn't provide.

## What changed

- `response: Response` added to `upsert_document` (with a comment explaining why it must stay).
- New guard `tests/test_d14_rate_limited_response_param.py`: AST-based — every `write_limit`/`search_limit`/`write_bulk_limit`-decorated handler must declare a `Response` param, plus a handler-count floor so a decorator rename can't make it pass vacuously. Unlike a per-endpoint behavioral test, this fails the moment any future rate-limited route ships without the param.
- `tests/test_documents_rest_doc_memory.py` direct-invocation call sites updated to pass a `Response()`.

## Testing

- Full root suite post-rebase: **5248 passed** (includes #984's `tests/test_rate_limit.py`).
- **Wet-verified** on the local enterprise compose stack: `POST /documents` 200 with `x-ratelimit-limit/remaining/reset` + `retry-after` (was 500 unconditionally).

Refs: D14 (#976) follow-up; completes #984.

🤖 Generated with [Claude Code](https://claude.com/claude-code)