### PR TITLE
fix(recall): surface the answer, not the reasoning scaffold (WT-1)

### DIFF
--- a/core-api/src/core_api/services/recall_service.py
+++ b/core-api/src/core_api/services/recall_service.py
@@ -2,6 +2,7 @@
 
 import json as _json
 import logging
+import re
 import time
 from datetime import UTC, datetime
 
@@ -36,12 +37,59 @@ not paraphrase inside quotes.
 than supplying one. If they don't contain enough to answer at all, say so plainly. Do not \
 infer beyond the evidence.
 
+After your step-by-step reasoning, end your reply with one final line formatted exactly:
+**Answer:** <your answer>
+This line must contain the complete answer on its own.
+
 Memories:
 
 {memories}
 
 {reference_date_line}Question: {query}
 Answer (step by step):"""
+
+# WT-1 — the prompt above deliberately elicits step-by-step reasoning before the
+# answer (it is load-bearing for recall accuracy on LoCoMo/LongMemEval), but the
+# raw completion used to be surfaced as ``summary`` unfiltered: callers paid ~5x
+# the tokens and had to string-parse for the trailing "**Answer:**" line
+# themselves. The marker is now extracted server-side; the reasoning scaffold
+# stays in the completion (and in ``diagnostic.recall_raw``), never in ``summary``.
+#
+# Tolerant of the variants models actually emit: ``**Answer:**`` / ``**Answer**:``
+# anywhere in the text, or a plain ``Answer:`` at the start of a line. The plain
+# form is line-anchored so prose like "the answer: ..." inside the reasoning
+# cannot false-positive mid-sentence.
+_ANSWER_MARKER = re.compile(
+    r"""
+    (?:
+        \*\*[ \t]*Answer[ \t]*:[ \t]*\*\*     # **Answer:**
+      | \*\*[ \t]*Answer[ \t]*\*\*[ \t]*:     # **Answer**:
+      | ^[ \t]*Answer[ \t]*:                  # Answer: at line start
+    )
+    [ \t]*
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+
+
+def _extract_final_answer(completion: str) -> str:
+    """Return the text after the LAST answer marker, stripped.
+
+    Fail open: with no marker (older prompt in flight, a model that ignored the
+    format instruction, the ``_fake_recall`` fallback, or a completion truncated
+    by ``MEMORY_RECALL_SUMMARY_MAX_TOKENS`` before the marker was emitted) the
+    full completion is returned unchanged — a verbose summary beats an empty or
+    mangled one. Ditto when the marker is the last thing in the completion and
+    nothing follows it.
+
+    LAST occurrence, not first: the reasoning steps may legitimately quote or
+    rehearse an "Answer:" line before committing to the final one.
+    """
+    matches = list(_ANSWER_MARKER.finditer(completion))
+    if not matches:
+        return completion
+    answer = completion[matches[-1].end() :].strip()
+    return answer or completion
 
 
 def _format_memories_for_prompt(memories: list) -> str:
@@ -113,6 +161,7 @@ async def summarize_memories(
         if diagnostic:
             resp["diagnostic"] = {
                 "recall_prompt": None,
+                "recall_raw": None,
                 "recall_model": None,
                 "recall_provider": None,
                 "all_candidates": diagnostic_ctx.get("all_candidates", []),
@@ -154,6 +203,7 @@ async def summarize_memories(
         if diagnostic:
             resp["diagnostic"] = {
                 "recall_prompt": None,
+                "recall_raw": None,
                 "recall_model": None,
                 "recall_provider": provider,
                 "all_candidates": diagnostic_ctx.get("all_candidates", []),
@@ -197,7 +247,7 @@ async def summarize_memories(
         )
 
     recall_model = getattr(config, "recall_model", None)
-    summary = await call_with_fallback(
+    completion = await call_with_fallback(
         primary_provider_name=provider,
         call_fn=_do_recall,
         fake_fn=_fake_recall,
@@ -222,6 +272,10 @@ async def summarize_memories(
         budget_s=15.0,
     )
 
+    # WT-1 — surface only the final answer as ``summary``; the step-by-step
+    # scaffold stays available under ``diagnostic.recall_raw``.
+    summary = _extract_final_answer(completion)
+
     recall_ms = int((time.perf_counter() - t0) * 1000)
 
     # C4 — materialise once; alias under both ``memories`` and ``items``.
@@ -238,6 +292,9 @@ async def summarize_memories(
     if diagnostic:
         result["diagnostic"] = {
             "recall_prompt": prompt,
+            # WT-1 — the unfiltered completion (reasoning scaffold + marker),
+            # for debugging what the extraction saw.
+            "recall_raw": completion,
             "recall_model": recall_model or "default",
             "recall_provider": provider,
             "all_candidates": diagnostic_ctx.get("all_candidates", []),

--- a/tests/test_wt1_recall_answer_extraction.py
+++ b/tests/test_wt1_recall_answer_extraction.py
@@ -1,0 +1,223 @@
+"""WT-1: ``/recall``'s ``summary`` must be the answer, not the reasoning scaffold.
+
+Wet-test defect WT-1: ``RECALL_PROMPT`` deliberately elicits step-by-step
+reasoning before the answer (load-bearing for recall accuracy on
+LoCoMo/LongMemEval — the reasoning stays), but the raw completion was surfaced
+as ``summary`` unfiltered. Callers paid ~5x the tokens and had to string-parse
+for the trailing ``**Answer:**`` line themselves.
+
+The fix: the prompt now instructs the model to end with one final
+``**Answer:** <answer>`` line, and ``_extract_final_answer`` strips everything
+up to and including the LAST such marker server-side. No marker → fail open
+(full completion unchanged), so the ``_fake_recall`` fallback, truncated
+completions, and marker-ignoring models all still surface something.
+
+Two layers:
+
+1. Unit: ``_extract_final_answer`` across marker variants and edge cases.
+2. Service: ``summarize_memories`` with the LLM call mocked to return a
+   scaffolded completion — ``summary`` must be just the answer, the response
+   SHAPE (C4 ``items`` alias included) must not change, and ``diagnostic``
+   must carry the raw completion under ``recall_raw``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import core_api.services.recall_service as rs_mod
+from core_api.services.recall_service import (
+    RECALL_PROMPT,
+    _extract_final_answer,
+    summarize_memories,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# Unit: _extract_final_answer
+# ---------------------------------------------------------------------------
+
+# The wet-test repro shape: scaffold, then a final bold marker line.
+_SCAFFOLDED = (
+    "Step 1: Extract the relevant facts.\n"
+    "- The memories state the platform database is PostgreSQL 16.\n"
+    "Step 2: Reason over the facts.\n"
+    "The question asks which database we use; the memories answer it directly.\n"
+    "\n"
+    "**Answer:** We use **PostgreSQL 16**."
+)
+
+
+def test_marker_present_returns_only_answer() -> None:
+    assert _extract_final_answer(_SCAFFOLDED) == "We use **PostgreSQL 16**."
+
+
+def test_marker_absent_fails_open_unchanged() -> None:
+    completion = "The memories do not record a completion date."
+    assert _extract_final_answer(completion) == completion
+
+
+def test_fake_fallback_text_passes_through_untouched() -> None:
+    # ``_fake_recall`` output carries no marker; it must survive verbatim.
+    completion = "(LLM unavailable; top 3 memories unsynthesized) alpha beta gamma"
+    assert _extract_final_answer(completion) == completion
+
+
+def test_multiple_markers_last_one_wins() -> None:
+    completion = (
+        "Step 1: a draft.\n"
+        "**Answer:** the draft answer\n"
+        "Wait — re-checking the dates.\n"
+        "**Answer:** the corrected answer"
+    )
+    assert _extract_final_answer(completion) == "the corrected answer"
+
+
+def test_marker_mid_text_returns_everything_after_it() -> None:
+    completion = "Step 1: reasoning. **Answer:** Anna owns the rollback plan.\n"
+    assert _extract_final_answer(completion) == "Anna owns the rollback plan."
+
+
+def test_bold_colon_outside_variant() -> None:
+    completion = "reasoning...\n**Answer**: 42"
+    assert _extract_final_answer(completion) == "42"
+
+
+def test_non_bold_line_start_variant() -> None:
+    completion = "Step 1: facts.\nStep 2: reasoning.\nAnswer: shipped on the 3rd"
+    assert _extract_final_answer(completion) == "shipped on the 3rd"
+
+
+def test_whitespace_around_marker_tolerated() -> None:
+    completion = "reasoning\n  **Answer:**   padded answer  \n"
+    assert _extract_final_answer(completion) == "padded answer"
+
+
+def test_plain_answer_mid_sentence_is_not_a_marker() -> None:
+    # Only the bold forms match mid-line; a plain "Answer:" must be
+    # line-anchored so reasoning prose can't false-positive.
+    completion = "The partial Answer: fragments were discarded during step 2."
+    assert _extract_final_answer(completion) == completion
+
+
+def test_marker_with_nothing_after_fails_open() -> None:
+    # A completion truncated right at the marker must not become an
+    # empty summary.
+    completion = "Step 1: facts.\nStep 2: reasoning.\n**Answer:**"
+    assert _extract_final_answer(completion) == completion
+
+
+def test_answer_spanning_multiple_lines_is_kept_whole() -> None:
+    completion = "reasoning\n**Answer:** line one\nline two"
+    assert _extract_final_answer(completion) == "line one\nline two"
+
+
+def test_prompt_instructs_the_marker() -> None:
+    # The extraction only works if the prompt asks for the marker; pin the
+    # instruction so a prompt edit can't silently orphan the parser.
+    assert "**Answer:**" in RECALL_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Service: summarize_memories surfaces the answer, keeps the shape
+# ---------------------------------------------------------------------------
+
+
+class _Mem(SimpleNamespace):
+    """The attribute surface ``summarize_memories`` actually touches (same
+    stand-in as ``test_no_llm_fallbacks_declare_themselves``): the prompt
+    formatter's fields, ``ts_valid_start`` for the sort, ``model_dump`` for
+    the response assembly."""
+
+    def model_dump(self, mode: str | None = None) -> dict:
+        return {"content": self.content, "memory_type": self.memory_type}
+
+
+def _mem(content: str) -> _Mem:
+    return _Mem(
+        content=content, memory_type="fact", title=None, status="active", ts_valid_start=None
+    )
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        recall_enabled=True,
+        recall_provider="openai",
+        recall_model="test-model",
+    )
+
+
+_EXPECTED_TOP_LEVEL_KEYS = {
+    "query",
+    "summary",
+    "memory_count",
+    "memories",
+    "items",
+    "recall_ms",
+}
+
+
+@pytest.mark.asyncio
+async def test_summary_is_the_answer_not_the_scaffold(monkeypatch) -> None:
+    """WT-1 regression: with a scaffolded LLM completion, ``summary`` carries
+    ONLY the text after the final ``**Answer:**`` marker.
+
+    This test FAILS on the unfixed code (summary == the full completion)."""
+    monkeypatch.setattr(
+        rs_mod, "call_with_fallback", AsyncMock(return_value=_SCAFFOLDED)
+    )
+
+    result = await summarize_memories(
+        [_mem("The platform database is PostgreSQL 16.")],
+        "which database do we use?",
+        _config(),
+    )
+
+    assert result["summary"] == "We use **PostgreSQL 16**.", (
+        f"summary must be the answer alone, got {result['summary']!r}"
+    )
+    assert "Step 1" not in result["summary"]
+    # Shape unchanged — C4 ``items`` alias and the rest of the surface intact.
+    assert _EXPECTED_TOP_LEVEL_KEYS.issubset(result.keys())
+    assert result["items"] == result["memories"]
+    assert result["memory_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_markerless_completion_surfaces_verbatim(monkeypatch) -> None:
+    """Fail open at the service level too: no marker → summary is the full
+    completion, unchanged."""
+    completion = "The memories do not contain enough to answer."
+    monkeypatch.setattr(
+        rs_mod, "call_with_fallback", AsyncMock(return_value=completion)
+    )
+
+    result = await summarize_memories([_mem("unrelated fact")], "when?", _config())
+
+    assert result["summary"] == completion
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_carries_raw_completion(monkeypatch) -> None:
+    """``diagnostic.recall_raw`` preserves the unfiltered completion next to
+    the existing ``recall_prompt``, so the scaffold stays inspectable."""
+    monkeypatch.setattr(
+        rs_mod, "call_with_fallback", AsyncMock(return_value=_SCAFFOLDED)
+    )
+
+    result = await summarize_memories(
+        [_mem("The platform database is PostgreSQL 16.")],
+        "which database do we use?",
+        _config(),
+        diagnostic=True,
+    )
+
+    assert result["summary"] == "We use **PostgreSQL 16**."
+    diag = result["diagnostic"]
+    assert diag["recall_raw"] == _SCAFFOLDED
+    assert diag["recall_prompt"] is not None


### PR DESCRIPTION
Closes wet-test defect **WT-1**.

## What

`/api/v1/recall`'s `summary` field returned the LLM's full step-by-step reasoning verbatim; the actual answer hid behind a trailing `**Answer:**` marker. The wet-test repro: `summary` carried "Step 1: … **Answer:** We use **PostgreSQL 16**." — callers paid ~5x the tokens of the answer alone and had to string-parse for the marker themselves.

The step-by-step reasoning is **deliberate and load-bearing** for recall accuracy (LoCoMo/LongMemEval) — it stays in the prompt untouched, grounding rules unchanged. Only the surfacing changes:

- **Prompt**: `RECALL_PROMPT` now instructs the model to end with one final line formatted exactly `**Answer:** <your answer>`.
- **Server-side extraction**: new pure helper `_extract_final_answer()` in `core-api/src/core_api/services/recall_service.py` finds the **last** occurrence of the marker (tolerant of `**Answer:**` / `**Answer**:` anywhere, plain `Answer:` at line start) and surfaces only the text after it, stripped.
- **Diagnostics**: `diagnostic.recall_raw` now carries the unfiltered completion next to the existing `recall_prompt`, so the scaffold stays inspectable.

## Fail-open behavior

No marker → the full completion is returned unchanged. That covers the `_fake_recall` no-LLM fallback, completions truncated by `MEMORY_RECALL_SUMMARY_MAX_TOKENS` before the marker was emitted, and models that ignore the format instruction. Marker with nothing after it also fails open — a verbose summary beats an empty one.

## Compatibility

- Response **shape** is unchanged — the C4 `items`/`memories` alias contract is intact (its tests run in the evidence below); only the `summary` text gets cleaner. Both consumers (REST `/recall`, MCP `caura_recall(include_brief=True)`) pass the `summarize_memories` dict through untouched.
- Grepped the repo for `Answer:` — nothing in `scripts/` or the benchmark harnesses parses the marker out of `/recall` responses, so no scorer breaks. A caller that string-parses for `**Answer:**` today still works: with no marker present, the whole summary *is* the answer.
- No function signatures changed; no positional callers affected.

## Token-cost impact

The scaffold in the repro is ~5x the size of the answer line. Callers consuming `summary` downstream (re-prompting an agent with it, displaying it) now pay for the answer only; the reasoning tokens are still generated (accuracy-load-bearing) but no longer ride along on every consumer hop.

## Evidence

New tests in `tests/test_wt1_recall_answer_extraction.py`: 11 unit tests for `_extract_final_answer` (marker present / absent / multiple markers → last wins / marker mid-text / bold and non-bold variants / whitespace / mid-sentence plain `Answer:` not a marker / empty-after-marker fail-open / multi-line answers) + a prompt pin + 3 service-level tests with a mocked LLM completion containing scaffolding + marker.

**Fails-without-fix proof**: stashed the `recall_service.py` change (i.e. origin/main behavior), ran the service-level regression test, then unstashed:

```
FAILED tests/..._proof::test_summary_is_the_answer_not_the_scaffold
  E  + **Answer:** We use **PostgreSQL 16**.   ← summary carried the full scaffold
FAILED tests/..._proof::test_diagnostic_carries_raw_completion
2 failed, 1 passed
```

With the fix applied, full run of the new tests + consumer-contract suites:

```
uv run pytest tests/test_wt1_recall_answer_extraction.py tests/test_c4_recall_items_alias.py \
  tests/test_mcp_recall.py tests/test_api_mcp.py tests/test_no_llm_fallbacks_declare_themselves.py \
  -q -m "not benchmark"
44 passed
```

Gates: `legacy_name_ratchet.py` ✓ ("No new lines"), `do_not_touch_sentinel.py` ✓ ("All 34 protected strings survive"). Lint: all 6 CI `ruff check` scopes + all 6 `ruff format --check` scopes pass verbatim.
