### PR TITLE
fix(api): admin credential gets 400/explicit-tenant on skills-inbox, not 401 (WT-4)

### DIFF
--- a/core-api/src/core_api/routes/skills_inbox.py
+++ b/core-api/src/core_api/routes/skills_inbox.py
@@ -82,19 +82,49 @@ async def _require_skills_factory_enabled(tenant_id: str) -> dict:
     return await get_settings_for_display(tenant_id)
 
 
-def _require_tenant(auth: AuthContext) -> str:
+def _require_tenant(auth: AuthContext, explicit_tenant_id: str | None = None) -> str:
     """Every inbox endpoint needs a concrete tenant. ``AuthContext.tenant_id``
     is typed ``str | None`` because some bootstrap paths land there
-    pre-auth; the inbox is an authenticated route, so a missing tenant
-    is a 401. Returning the narrowed ``str`` lets mypy verify the
-    downstream calls without litter ``cast``s.
+    pre-auth — but so does the OSS admin path (auth Path 1), which
+    deliberately builds ``AuthContext(tenant_id=None, is_admin=True)``.
+    Wet-test defect WT-4: treating BOTH as "missing tenant → 401" told
+    the most privileged credential it did not authenticate.
+
+    Resolution order:
+
+    - Tenant-scoped credential (``auth.tenant_id`` set): the key's own
+      tenant wins. A conflicting explicit ``?tenant_id=`` is a 403 —
+      a tenant key must not act on another tenant.
+    - Admin credential (no tenant of its own): acts on the tenant it
+      names via ``?tenant_id=``. Naming none is a 400 (a REQUEST
+      problem — the credential IS authenticated, so never 401).
+    - Neither: genuinely unauthenticated bootstrap context → 401.
+
+    Returning the narrowed ``str`` lets mypy verify the downstream
+    calls without litter ``cast``s.
     """
-    if not auth.tenant_id:
+    if auth.tenant_id:
+        if explicit_tenant_id is not None and explicit_tenant_id != auth.tenant_id:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "TENANT_MISMATCH — this credential is scoped to "
+                    f"tenant {auth.tenant_id!r} and cannot act on tenant "
+                    f"{explicit_tenant_id!r}"
+                ),
+            )
+        return auth.tenant_id
+    if getattr(auth, "is_admin", False):
+        if explicit_tenant_id:
+            return explicit_tenant_id
         raise HTTPException(
-            status_code=401,
-            detail="UNAUTHENTICATED — auth context has no tenant_id",
+            status_code=400,
+            detail="admin credential must name a tenant — pass ?tenant_id=",
         )
-    return auth.tenant_id
+    raise HTTPException(
+        status_code=401,
+        detail="UNAUTHENTICATED — auth context has no tenant_id",
+    )
 
 
 def _require_inbox_admin(auth: AuthContext) -> None:
@@ -474,6 +504,11 @@ async def _persist_status_transition(
 @router.get("/", response_model=InboxListResponse, include_in_schema=False)
 async def list_inbox(
     fleet_id: str | None = None,
+    # Tenant selector for ADMIN credentials (auth Path 1 carries no
+    # tenant of its own — see _require_tenant / WT-4). Tenant-scoped
+    # keys may omit it (their own tenant wins) or echo it; a
+    # conflicting value is a 403.
+    tenant_id: str | None = Query(None),
     # Validated at the FastAPI layer: 1 ≤ limit ≤ 200. A bare ``int=50``
     # default would 200 on any non-negative input — including ``limit=0``
     # (silently empty list) and ``limit=10_000`` (DoS via wide query).
@@ -489,7 +524,7 @@ async def list_inbox(
     beyond that, auto-defer is the relief valve (Phase 2 worker
     enforces).
     """
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     settings = await _require_skills_factory_enabled(tenant_id)
     max_pending = (
         ((settings.get("skills_factory") or {}).get("inbox_max_pending"))
@@ -592,13 +627,15 @@ async def list_inbox(
 @router.post("/{slug:path}/approve", response_model=ActionResponse)
 async def approve(
     slug: str,
+    # Tenant selector for admin credentials — see list_inbox / WT-4.
+    tenant_id: str | None = Query(None),
     auth: AuthContext = Depends(get_auth_context),
 ) -> ActionResponse:
     """Promote ``staged → active``. Pre-apply rescan via Sentinel
     blocks the transition if the doc became unsafe between propose
     and apply.
     """
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     settings = await _require_skills_factory_enabled(tenant_id)
     _require_inbox_admin(auth)
     sf = (settings or {}).get("skills_factory") if isinstance(settings, dict) else {}
@@ -726,6 +763,8 @@ async def approve(
 async def reject(
     slug: str,
     body: RejectRequest,
+    # Tenant selector for admin credentials — see list_inbox / WT-4.
+    tenant_id: str | None = Query(None),
     auth: AuthContext = Depends(get_auth_context),
 ) -> ActionResponse:
     """Reject ``staged → rejected`` and write the cluster fingerprint
@@ -738,7 +777,7 @@ async def reject(
     depends on ``get_db`` (the settings gate + audit log already ignore
     their ``db`` arg and route through storage).
     """
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     settings = await _require_skills_factory_enabled(tenant_id)
     _require_inbox_admin(auth)
     sf = (settings or {}).get("skills_factory") if isinstance(settings, dict) else {}
@@ -882,13 +921,15 @@ async def reject(
 async def quarantine(
     slug: str,
     body: QuarantineRequest,
+    # Tenant selector for admin credentials — see list_inbox / WT-4.
+    tenant_id: str | None = Query(None),
     auth: AuthContext = Depends(get_auth_context),
 ) -> ActionResponse:
     """Move to ``quarantined`` for security review. Does NOT touch the
     poison table — quarantine is reversible by a security admin; only
     Reject crystallizes a poison row.
     """
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     await _require_skills_factory_enabled(tenant_id)
     _require_inbox_admin(auth)
     doc = await _load_doc_or_404(tenant_id=tenant_id, slug=slug)
@@ -940,13 +981,15 @@ async def defer(
     # ``POST`` (curl operators, the documented "empty body" contract)
     # must not 422 on the envelope itself.
     body: DeferRequest | None = None,
+    # Tenant selector for admin credentials — see list_inbox / WT-4.
+    tenant_id: str | None = Query(None),
     auth: AuthContext = Depends(get_auth_context),
 ) -> ActionResponse:
     """Defer — leaves the doc in ``staged`` so Forge can revise it on
     the next run. Stamps ``deferred_at`` so the inbox can sort
     deferred items to the bottom + show "deferred N days ago".
     """
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     await _require_skills_factory_enabled(tenant_id)
     _require_inbox_admin(auth)
     doc = await _load_doc_or_404(tenant_id=tenant_id, slug=slug)
@@ -1007,6 +1050,8 @@ async def defer(
 async def edit(
     slug: str,
     body: EditRequest,
+    # Tenant selector for admin credentials — see list_inbox / WT-4.
+    tenant_id: str | None = Query(None),
     auth: AuthContext = Depends(get_auth_context),
 ) -> ActionResponse:
     """Edit content / description / summary, then rehash + rescan.
@@ -1016,7 +1061,7 @@ async def edit(
 
     Raw markdown only (per OQ-D — no WYSIWYG in MVP).
     """
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     settings = await _require_skills_factory_enabled(tenant_id)
     _require_inbox_admin(auth)
     sf = (settings or {}).get("skills_factory") if isinstance(settings, dict) else {}

--- a/tests/test_skills_inbox_routes.py
+++ b/tests/test_skills_inbox_routes.py
@@ -246,11 +246,16 @@ def side_effects(monkeypatch):
 
 
 def make_client(
-    *, org_role: str | None = "admin", is_admin: bool = False
+    *,
+    org_role: str | None = "admin",
+    is_admin: bool = False,
+    # ``tenant_id=None`` + ``is_admin=True`` reproduces the OSS admin
+    # credential (auth Path 1) — the WT-4 shape.
+    tenant_id: str | None = TENANT,
 ) -> AsyncClient:
     app = FastAPI()
     app.include_router(si.router, prefix="/api/v1")
-    auth = AuthContext(tenant_id=TENANT, org_role=org_role, is_admin=is_admin)
+    auth = AuthContext(tenant_id=tenant_id, org_role=org_role, is_admin=is_admin)
 
     async def _auth_dep():
         return auth
@@ -466,6 +471,83 @@ async def test_action_on_missing_doc_404(storage, settings, side_effects):
     async with make_client() as client:
         r = await client.post(f"{BASE}/forge/nope/approve")
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tenant resolution — WT-4 (admin credential vs ?tenant_id=)
+# ---------------------------------------------------------------------------
+# The OSS admin key (auth Path 1) deliberately builds
+# ``AuthContext(tenant_id=None, is_admin=True)``. Pre-fix,
+# ``_require_tenant`` answered it with "401 UNAUTHENTICATED — auth
+# context has no tenant_id" on every inbox endpoint — the most
+# privileged credential told it did not authenticate — and the
+# ``?tenant_id=`` the operator passed was silently ignored because no
+# route declared it.
+
+
+async def test_admin_key_with_explicit_tenant_lists(storage, settings):
+    storage.query_rows = [forge_doc()]
+    async with make_client(tenant_id=None, org_role=None, is_admin=True) as client:
+        r = await client.get(f"{BASE}?tenant_id={TENANT}")
+    assert r.status_code == 200, r.text
+    assert r.json()["tenant_id"] == TENANT
+
+
+async def test_admin_key_with_explicit_tenant_can_act(storage, settings, side_effects):
+    storage.seed(forge_doc())
+    async with make_client(tenant_id=None, org_role=None, is_admin=True) as client:
+        r = await client.post(f"{BASE}/{SLUG}/defer?tenant_id={TENANT}", json=None)
+    assert r.status_code == 200, r.text
+
+
+async def test_admin_key_without_tenant_is_400_not_401(storage, settings, side_effects):
+    """WT-4 regression: the admin key IS authenticated — omitting the
+    tenant selector is a request problem (400), never a 401."""
+    async with make_client(tenant_id=None, org_role=None, is_admin=True) as client:
+        r_list = await client.get(BASE)
+        r_action = await client.post(f"{BASE}/{SLUG}/defer", json=None)
+    assert r_list.status_code == 400, r_list.text
+    assert "tenant" in r_list.json()["detail"]
+    assert r_action.status_code == 400, r_action.text
+
+
+async def test_tenant_key_with_conflicting_tenant_is_403(storage, settings, side_effects):
+    """A tenant-scoped key cannot act on ANOTHER tenant via ?tenant_id=."""
+    storage.seed(forge_doc())
+    async with make_client() as client:
+        r_list = await client.get(f"{BASE}?tenant_id=t-other")
+        r_action = await client.post(f"{BASE}/{SLUG}/defer?tenant_id=t-other", json=None)
+    assert r_list.status_code == 403, r_list.text
+    assert r_list.json()["detail"].startswith("TENANT_MISMATCH")
+    assert r_action.status_code == 403, r_action.text
+    assert storage.upserts == []
+
+
+async def test_tenant_key_with_matching_tenant_still_works(storage, settings):
+    storage.query_rows = [forge_doc()]
+    async with make_client() as client:
+        r = await client.get(f"{BASE}?tenant_id={TENANT}")
+    assert r.status_code == 200, r.text
+
+
+async def test_tenant_key_without_param_unchanged(storage, settings, side_effects):
+    """No ?tenant_id= → the key's own tenant wins, exactly as before."""
+    storage.seed(forge_doc())
+    storage.query_rows = [forge_doc()]
+    async with make_client() as client:
+        r_list = await client.get(BASE)
+        r_action = await client.post(f"{BASE}/{SLUG}/defer", json=None)
+    assert r_list.status_code == 200, r_list.text
+    assert r_list.json()["tenant_id"] == TENANT
+    assert r_action.status_code == 200, r_action.text
+
+
+async def test_no_tenant_and_no_admin_still_401(storage, settings):
+    """Genuinely unauthenticated bootstrap context keeps the 401."""
+    async with make_client(tenant_id=None, org_role=None, is_admin=False) as client:
+        r = await client.get(BASE)
+    assert r.status_code == 401, r.text
+    assert r.json()["detail"].startswith("UNAUTHENTICATED")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes wet-test defect **WT-4**.

## What

`_require_tenant` in `core-api/src/core_api/routes/skills_inbox.py` treated every `AuthContext` without a `tenant_id` as unauthenticated. But the OSS admin path (`core_api/auth.py` Path 1) deliberately builds `AuthContext(tenant_id=None, is_admin=True)` — so every skills-inbox endpoint answered the **admin API key** with:

```
401 UNAUTHENTICATED — auth context has no tenant_id
```

Wet-test repro (against pre-fix code): `GET /api/v1/skills-inbox?tenant_id=T` with the admin key → 401; the `?tenant_id=` query param was silently ignored because no inbox route declared it. All six inbox endpoints were affected (list, approve, reject, quarantine, defer, edit).

## Why this shape

The admin key IS authenticated — the failure is a *request* problem (which tenant's inbox?), not a credential problem. So:

- **Tenant-scoped key**: its own tenant wins; a *conflicting* `?tenant_id=` is a **403** (a tenant key cannot act on another tenant); matching or absent param → unchanged behavior.
- **Admin key**: acts on the tenant named via `?tenant_id=`; naming none is a **400** ("admin credential must name a tenant — pass ?tenant_id="), never a 401.
- **Neither**: the existing **401** stays for genuinely unauthenticated bootstrap contexts.

All six endpoints now declare `tenant_id: str | None = Query(None)` and pass it through to `_require_tenant`. `_require_inbox_admin` already honors the `is_admin` flag, so the admin key passes the mutating-action gate with no change there.

## Evidence

- New regression tests in `tests/test_skills_inbox_routes.py`: admin + `?tenant_id=T` succeeds (list and defer), admin without tenant → **400 not 401**, tenant key + conflicting `?tenant_id=` → 403, tenant key with matching/absent param unchanged, bootstrap context keeps 401.
- **Proof the tests bite**: with the src change stashed (i.e., against unfixed `origin/main` route code), exactly the four fix-dependent tests fail — `test_admin_key_with_explicit_tenant_lists`, `test_admin_key_with_explicit_tenant_can_act`, `test_admin_key_without_tenant_is_400_not_401`, `test_tenant_key_with_conflicting_tenant_is_403` (`4 failed, 63 passed`); unstashed, all 67 pass.
- Suites touching skills_inbox (`test_skills_inbox_routes.py`, `test_org_role_plumb.py`, `test_mcp_doc.py`): **156 passed**.
- Full `tests/` run: 5220 passed; the 16 failures are pre-existing local embedding/ranking noise — the failure set is byte-identical on unmodified `origin/main` in the same environment.
- CI-exact ruff check/format (all six check scopes + five format scopes + isolated common files): clean. `legacy_name_ratchet.py` and `do_not_touch_sentinel.py`: pass.

Note: the production repro quoted above was taken against pre-fix code.
