### PR TITLE
fix(contradictions): Path C preflight drops only true name collisions, fails open on canonicalisation splits (WT-3)

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1501,6 +1501,20 @@ def _format_entity_context(entities: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _normalize_subject_name(name: str | None) -> str:
+    """WT-3 — normalise a canonical subject name for the L3.4 preflight's
+    name-equality check: lowercase, collapse internal whitespace, strip.
+
+    Returns ``""`` when the name is missing or is the
+    ``_extract_subject_canonical_identity`` ``"<unknown>"`` placeholder —
+    an unresolvable name can never *establish* a collision, so callers
+    treat ``""`` as "names do not match" (fail open to the judge).
+    """
+    if not name or name == "<unknown>":
+        return ""
+    return " ".join(name.lower().split())
+
+
 def _extract_subject_canonical_identity(
     entities: list[dict],
 ) -> tuple[str, str, str] | None:
@@ -1516,10 +1530,14 @@ def _extract_subject_canonical_identity(
     see the inline TODO at the preflight site for the original
     ``priya``-collision write-up).
 
-    Identity is keyed on ``entity_id`` ONLY — two ``priya`` rows with
-    the same canonical name but different entity rows ARE distinct
-    subjects (that's the whole point). The canonical name + type are
-    returned for logging / debugging, not for equality.
+    Identity is keyed on ``entity_id`` — two ``priya`` rows with the
+    same canonical name but different entity rows ARE distinct subjects
+    (that's the whole point). WT-3: the canonical name (index 0,
+    compared via ``_normalize_subject_name``) additionally scopes the
+    preflight's drop to that same-name collision class — differing ids
+    under DIFFERING names may be a canonicalisation split of one
+    subject, and the preflight fails open there. ``entity_type`` stays
+    logging/debugging-only.
     """
     if not entities:
         return None
@@ -2310,11 +2328,25 @@ async def detect_contradictions_by_entities_async(
         # (the ``priya``-collision class from the original followup
         # TODO). Now that the contexts are fetched once above, the
         # preflight is a cheap dict lookup.
+        #
+        # WT-3 — the drop is scoped to the NAME-COLLISION class the
+        # gate was built for: same canonical subject name (under
+        # ``_normalize_subject_name``) resolving to DISTINCT entity
+        # rows ("priya" vs "priya"). When the canonical NAMES differ
+        # as well as the ids, the two rows may instead be a
+        # canonicalisation SPLIT of one real-world subject ("new
+        # analytics service" vs "analytics service" — the WT-2 class);
+        # dropping there silently eats real contradictions, so we
+        # FAIL OPEN and let the LLM judge decide. Costs judge spend on
+        # genuinely-different subjects; the judge is the correct
+        # arbiter for those, the preflight is not.
         if contexts_fetched and new_ctx:
             new_identity = _extract_subject_canonical_identity(new_ctx)
             if new_identity is not None:
                 new_eid = new_identity[2]
+                new_name = _normalize_subject_name(new_identity[0])
                 drop_ids: set[str] = set()
+                n_failopen_id_mismatch = 0
                 for c in candidates:
                     if new_subject is not None and c.get("subject_entity_id") is not None:
                         # Both sides had non-NULL subject_entity_id — A1
@@ -2324,16 +2356,36 @@ async def detect_contradictions_by_entities_async(
                     cand_identity = _extract_subject_canonical_identity(cand_ctx)
                     if cand_identity is None:
                         continue  # No subject resolved — fail open.
-                    if cand_identity[2] != new_eid:
+                    if cand_identity[2] == new_eid:
+                        continue  # Same entity row — same subject.
+                    cand_name = _normalize_subject_name(cand_identity[0])
+                    if new_name and cand_name and new_name == cand_name:
+                        # Same canonical name, distinct entity rows —
+                        # the name-collision class. Drop.
                         drop_ids.add(str(c.get("id")))
+                    else:
+                        # Names differ (or one is unresolvable) — may
+                        # be a canonicalisation split of ONE subject
+                        # (WT-3). Fail open: keep the candidate.
+                        n_failopen_id_mismatch += 1
                 if drop_ids:
                     before = len(candidates)
                     candidates = [c for c in candidates if str(c.get("id")) not in drop_ids]
                     n_entity_links_skipped = before - len(candidates)
                     logger.info(
                         "Path C entity-links preflight dropped %d candidate(s) "
-                        "for memory %s (canonical subjects differ by entity_id)",
+                        "for memory %s (same canonical subject name, entity_id "
+                        "differs — name-collision class)",
                         n_entity_links_skipped,
+                        memory_id,
+                    )
+                if n_failopen_id_mismatch:
+                    logger.info(
+                        "Path C entity-links preflight retained %d candidate(s) "
+                        "for memory %s despite entity_id mismatch (canonical "
+                        "subject names differ — possible canonicalisation "
+                        "split; failing open to the LLM judge)",
+                        n_failopen_id_mismatch,
                         memory_id,
                     )
 

--- a/tests/test_caura_130_path_c_safety.py
+++ b/tests/test_caura_130_path_c_safety.py
@@ -17,6 +17,7 @@ is locked in by tests in ``tests/test_a4_13_path_c_retraction.py``.
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -217,9 +218,19 @@ def _make_new_memory(mid, *, subject_entity_id=None) -> dict:
 
 
 def _sc_for_forward_path(
-    new_mem: dict, candidates: list[dict], links_by_mem: dict[str, list[dict]]
+    new_mem: dict,
+    candidates: list[dict],
+    links_by_mem: dict[str, list[dict]],
+    entities: dict[str, dict] | None = None,
 ) -> AsyncMock:
-    """Build a mock storage client for the forward Path C path."""
+    """Build a mock storage client for the forward Path C path.
+
+    ``entities`` (optional) maps entity_id → explicit entity row, for
+    tests that need the canonical_name decoupled from the entity_id
+    (WT-3: same canonical name under DIFFERENT entity_ids, and vice
+    versa). Ids absent from the map fall back to the legacy synthesis
+    (canonical_name derived from the ``ent:<name>`` id).
+    """
     sc = AsyncMock()
 
     async def get_memory(mid: str):
@@ -236,6 +247,8 @@ def _sc_for_forward_path(
     sc.get_entity_links_for_memories = AsyncMock(return_value=links_by_mem)
 
     async def get_entity(eid: str):
+        if entities is not None and eid in entities:
+            return entities[eid]
         # Synthesize a minimal entity row keyed by id; tests pass the
         # canonical_name they want here via the links_by_mem structure
         # (we encode it in the link by using entity_id == "ent:<name>").
@@ -264,12 +277,27 @@ async def test_forward_preflight_drops_collision_when_subject_entity_id_null():
     new_mem = _make_new_memory(new_id, subject_entity_id=None)
     cand = _make_candidate(cand_id, subject_entity_id=None)
     # Same canonical name ("Priya"), different entity_ids → distinct
-    # real-world subjects → preflight must drop.
+    # real-world subjects → preflight must drop. WT-3 scoped the drop
+    # to this same-NAME collision class, so the entity rows must carry
+    # the SAME canonical_name under DIFFERENT ids (the legacy id-derived
+    # synthesis would have given them different names too).
     links = {
         str(new_id): [{"entity_id": "ent:priya-A", "role": "subject"}],
         str(cand_id): [{"entity_id": "ent:priya-B", "role": "subject"}],
     }
-    sc = _sc_for_forward_path(new_mem, [cand], links)
+    entities = {
+        "ent:priya-A": {
+            "id": "ent:priya-A",
+            "canonical_name": "Priya",
+            "entity_type": "person",
+        },
+        "ent:priya-B": {
+            "id": "ent:priya-B",
+            "canonical_name": "Priya",
+            "entity_type": "person",
+        },
+    }
+    sc = _sc_for_forward_path(new_mem, [cand], links, entities=entities)
     judge = AsyncMock(return_value=(True, 0.95))
 
     with (
@@ -525,3 +553,159 @@ async def test_forward_preflight_caps_fallthrough_set_at_max():
         f"expected the batched base call to cover {len(cands)} candidates, "
         f"got {len(judge_batch.call_args.args[1])}"
     )
+
+
+# ---------------------------------------------------------------------------
+# WT-3 — the L3.4 drop is scoped to the same-NAME collision class;
+# differing names + differing ids (a possible canonicalisation split of
+# ONE subject) must fail open to the LLM judge.
+# ---------------------------------------------------------------------------
+
+
+def _wt3_patches(sc, base_judge, entity_aware_judge):
+    """One combined context manager for the standard WT-3 patch set."""
+    stack = ExitStack()
+    for p in (
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_contradiction_check",
+            base_judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._llm_entity_aware_contradiction_check",
+            entity_aware_judge,
+        ),
+        patch(
+            "core_api.services.contradiction_detector.resolve_config",
+            new_callable=AsyncMock,
+            return_value=None,
+            create=True,
+        ),
+        patch(
+            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        stack.enter_context(p)
+    return stack
+
+
+@pytest.mark.asyncio
+async def test_wt3_preflight_fails_open_when_names_and_ids_both_differ():
+    """WT-3 regression — entity canonicalisation split ONE real-world
+    subject into two entity rows with DIFFERENT canonical names ("new
+    analytics service" vs "analytics service"). The L3.4 preflight
+    previously dropped on the id mismatch alone, silently eating the
+    real contradiction (wet-test: candidates_initial=1 → n_conflicts=0).
+    Differing names cannot be the priya name-collision class, so the
+    candidate must SURVIVE the preflight and reach the judge."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    new_mem = _make_new_memory(new_id, subject_entity_id=None)
+    cand = _make_candidate(cand_id, subject_entity_id=None)
+    links = {
+        str(new_id): [{"entity_id": "ent:svc-A", "role": "subject"}],
+        str(cand_id): [{"entity_id": "ent:svc-B", "role": "subject"}],
+    }
+    entities = {
+        "ent:svc-A": {
+            "id": "ent:svc-A",
+            "canonical_name": "new analytics service",
+            "entity_type": "project",
+        },
+        "ent:svc-B": {
+            "id": "ent:svc-B",
+            "canonical_name": "analytics service",
+            "entity_type": "project",
+        },
+    }
+    sc = _sc_for_forward_path(new_mem, [cand], links, entities=entities)
+    base_judge = AsyncMock(return_value=(False, 0.95))
+    entity_aware_judge = AsyncMock(return_value=(False, 0.95))
+
+    with _wt3_patches(sc, base_judge, entity_aware_judge):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    # Fail open: the candidate reaches the judge (entity-aware, since
+    # both contexts are populated — CAURA-131 wiring).
+    entity_aware_judge.assert_called_once()
+    base_judge.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wt3_preflight_still_drops_same_name_collision_after_normalisation():
+    """The priya guard — SAME canonical subject name (up to the WT-3
+    normalisation: case + whitespace) under DIFFERENT entity_ids is the
+    name-collision class the gate was built for and must STILL drop."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    new_mem = _make_new_memory(new_id, subject_entity_id=None)
+    cand = _make_candidate(cand_id, subject_entity_id=None)
+    links = {
+        str(new_id): [{"entity_id": "ent:priya-1", "role": "subject"}],
+        str(cand_id): [{"entity_id": "ent:priya-2", "role": "subject"}],
+    }
+    entities = {
+        "ent:priya-1": {
+            "id": "ent:priya-1",
+            "canonical_name": "Priya  Sharma",
+            "entity_type": "person",
+        },
+        "ent:priya-2": {
+            "id": "ent:priya-2",
+            "canonical_name": "priya sharma",
+            "entity_type": "person",
+        },
+    }
+    sc = _sc_for_forward_path(new_mem, [cand], links, entities=entities)
+    base_judge = AsyncMock(return_value=(True, 0.95))
+    entity_aware_judge = AsyncMock(return_value=(True, 0.95))
+
+    with _wt3_patches(sc, base_judge, entity_aware_judge):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    entity_aware_judge.assert_not_called()
+    base_judge.assert_not_called()
+    assert sc.update_memory_status.call_args_list == [], (
+        "same-canonical-name collision must still be dropped by the "
+        "L3.4 preflight after the WT-3 fail-open change"
+    )
+
+
+@pytest.mark.asyncio
+async def test_wt3_preflight_null_identity_side_still_fails_open():
+    """A candidate whose entity_links resolve NO subject-role entity has
+    no identity to compare — the preflight must keep failing open (the
+    pre-WT-3 behaviour) and let the judge decide."""
+    from core_api.services.contradiction_detector import (
+        detect_contradictions_by_entities_async,
+    )
+
+    new_id, cand_id = uuid4(), uuid4()
+    new_mem = _make_new_memory(new_id, subject_entity_id=None)
+    cand = _make_candidate(cand_id, subject_entity_id=None)
+    links = {
+        str(new_id): [{"entity_id": "ent:svc-A", "role": "subject"}],
+        # Object-role only — _extract_subject_canonical_identity → None.
+        str(cand_id): [{"entity_id": "ent:svc-A", "role": "object"}],
+    }
+    sc = _sc_for_forward_path(new_mem, [cand], links)
+    base_judge = AsyncMock(return_value=(False, 0.95))
+    entity_aware_judge = AsyncMock(return_value=(False, 0.95))
+
+    with _wt3_patches(sc, base_judge, entity_aware_judge):
+        await detect_contradictions_by_entities_async(new_id, "t1", "f1")
+
+    # Kept: judge runs (entity-aware — both contexts non-empty).
+    entity_aware_judge.assert_called_once()
+    base_judge.assert_not_called()

--- a/tests/test_caura_131_entity_aware_path_c_detection.py
+++ b/tests/test_caura_131_entity_aware_path_c_detection.py
@@ -68,7 +68,10 @@ def _make_new_memory(
 
 
 def _sc(
-    new_mem: dict, candidates: list[dict], links_by_mem: dict[str, list[dict]]
+    new_mem: dict,
+    candidates: list[dict],
+    links_by_mem: dict[str, list[dict]],
+    entities: dict[str, dict] | None = None,
 ) -> AsyncMock:
     sc = AsyncMock()
 
@@ -86,6 +89,11 @@ def _sc(
     sc.get_entity_links_for_memories = AsyncMock(return_value=links_by_mem)
 
     async def get_entity(eid: str):
+        # ``entities`` decouples canonical_name from entity_id (WT-3:
+        # the L3.4 drop is now scoped to SAME-name/different-id, so
+        # collision tests must pin the name explicitly).
+        if entities is not None and eid in entities:
+            return entities[eid]
         return {
             "id": eid,
             "canonical_name": eid.split(":", 1)[-1] if ":" in eid else eid,
@@ -801,12 +809,27 @@ async def test_l34_preflight_still_drops_collision_after_refactor():
     new_id, cand_id = uuid4(), uuid4()
     new_mem = _make_new_memory(new_id, subject_entity_id=None)
     cand = _make_candidate(cand_id, subject_entity_id=None)
-    # Distinct entity_ids → preflight drops.
+    # SAME canonical name under DISTINCT entity_ids → preflight drops.
+    # (WT-3 scoped the drop to this name-collision class, so the name
+    # must be pinned explicitly — the id-derived synthesis would give
+    # the two rows different names and fail open instead.)
     links = {
         str(new_id): [{"entity_id": "ent:priya-A", "role": "subject"}],
         str(cand_id): [{"entity_id": "ent:priya-B", "role": "subject"}],
     }
-    sc = _sc(new_mem, [cand], links)
+    entities = {
+        "ent:priya-A": {
+            "id": "ent:priya-A",
+            "canonical_name": "priya",
+            "entity_type": "person",
+        },
+        "ent:priya-B": {
+            "id": "ent:priya-B",
+            "canonical_name": "priya",
+            "entity_type": "person",
+        },
+    }
+    sc = _sc(new_mem, [cand], links, entities=entities)
     base_judge = AsyncMock(return_value=(True, 0.95))
     entity_aware_judge = AsyncMock(return_value=(True, 0.95))
 


### PR DESCRIPTION
## What

Scopes the Path C L3.4 entity-links preflight (CAURA-130) so it only drops candidates in the **name-collision** class it was built for — same canonical subject name (lowercased, whitespace-collapsed) resolving to **distinct** entity rows. When the canonical **names differ as well as the ids**, the split may be an entity-canonicalisation miss (one real-world subject split into two entity rows — the WT-2 class), so the preflight now **fails open** and lets the LLM judge decide. NULL-identity sides keep failing open exactly as before.

Closes wet-test defect **WT-3**. The canonicalisation split itself (root cause) is WT-2 and is being fixed separately; this PR stops the detector from silently eating real contradictions while splits exist.

## Why — wet-test evidence (live stack, real LLM)

Two memories about the same service:

> wrote: "We decided to use PostgreSQL 16 instead of MySQL for the new analytics service."
> then: "We migrated the analytics service from PostgreSQL 16 to MySQL after all."

Canonicalisation split the subject into two entity rows ("new analytics service" vs "analytics service"), and the preflight hard-dropped the only candidate:

```
PATH_C_DETECTION entry ... candidates_initial=1
Path C entity-links preflight dropped 1 candidate(s) ... (canonical subjects differ by entity_id)
path_c_completed ... n_conflicts=0
```

`memory_conflicts`: 0 rows — a **silent false negative**, indistinguishable from "no contradiction exists".

## Collision vs split — the distinction

| canonical names | entity ids | class | action |
|---|---|---|---|
| match (normalised) | differ | name collision (two real "priya"s) — what the gate was built for (`followup-path-c-judge-first-name-collisions`) | **drop** (unchanged) |
| differ | differ | possible canonicalisation split of ONE subject (WT-2/WT-3) | **fail open → LLM judge** (new) |
| unresolvable on either side | — | no identity to compare | fail open (unchanged) |

## Fail-open rationale / judge-spend tradeoff

Dropping is only safe when we can positively establish the collision class; an id mismatch alone cannot distinguish "two different subjects" from "one subject split in two". Failing open costs one judge call per retained candidate on subjects that genuinely differ by name — bounded by the existing fall-through cap (`_ENTITY_LINKS_PREFLIGHT_MAX_CANDIDATES`) and the A61 batched judge (at most one extra batched call). A false negative here is silent and permanent; extra judge spend is visible and bounded. The judge is the correct arbiter for name-differing pairs — that is exactly what its entity-aware prompt exists for.

## Logging

The two outcomes are now distinguishable, with counts:

- dropped: `Path C entity-links preflight dropped N candidate(s) for memory M (same canonical subject name, entity_id differs — name-collision class)`
- retained: `Path C entity-links preflight retained N candidate(s) for memory M despite entity_id mismatch (canonical subject names differ — possible canonicalisation split; failing open to the LLM judge)`

No sentinel-pinned log string was touched (`scripts/do_not_touch_sentinel.py` passes; none of its 34 pinned strings live in this path).

## Residual risk (follow-up, not in this PR)

The earlier **A1 #17** id-only gate still hard-drops when BOTH sides carry non-NULL differing `subject_entity_id` — a canonicalisation split that populates `subject_entity_id` on both memories is still silently dropped there. A follow-up could apply the same name-aware rule at that gate once entity contexts are cheap at that point in the flow (today they are only fetched after A1 #17).

## Tests

- `test_wt3_preflight_fails_open_when_names_and_ids_both_differ` — WT-3 regression: different ids AND different canonical names ("new analytics service" vs "analytics service") → candidate survives the preflight and reaches the judge. **Proven to fail on unfixed origin/main** (src stashed → fails with the exact wet-test signature `preflight dropped 1 candidate(s) → n_conflicts=0` → unstashed) .
- `test_wt3_preflight_still_drops_same_name_collision_after_normalisation` — priya guard: same normalised name ("Priya  Sharma" vs "priya sharma"), different ids → still dropped, no judge call.
- `test_wt3_preflight_null_identity_side_still_fails_open` — no subject-role entity on one side → kept, judge runs.
- The two pre-existing collision tests (CAURA-130/131) encoded "same canonical name" via an id-derived mock synthesis that actually produced different names ("priya-A"/"priya-B"); they now pin the canonical name explicitly through a new optional `entities` map on the mock storage helpers, preserving their documented intent.

Full contradiction-detector suites (169 tests) pass; full `tests/` run has 16 failures that reproduce identically on clean origin/main (pre-existing search/embedding environment noise, untouched by this change). CI ruff invocations, `legacy_name_ratchet.py`, and `do_not_touch_sentinel.py` all pass.
