### PR TITLE
fix(entities): one subject, one entity — canonical match on resolve + link dedup (WT-2)

### DIFF
--- a/common/entity_naming.py
+++ b/common/entity_naming.py
@@ -1,0 +1,73 @@
+"""Conservative entity-name normalisation for canonical resolution (WT-2).
+
+Wet-test defect WT-2: extraction canonicalised ONE real-world subject as TWO
+entity rows — ``new analytics service`` (memory: "…PostgreSQL 16 … for the
+new analytics service") and ``analytics service`` (memory: "We migrated the
+analytics service …"). A split subject splits the knowledge graph and makes
+entity-scoped contradiction detection structurally blind (WT-3).
+
+The rule here is deliberately SMALL and deterministic — no fuzzy matching,
+no embeddings, no substring heuristics; those merge entities that must stay
+apart. Two names refer to the same entity iff their *canonical match keys*
+are equal, where the key is computed as:
+
+1. normalise: lowercase, strip, collapse internal whitespace;
+2. iteratively strip ONE leading token at a time from a fixed set of
+   determiners / temporal qualifiers (``the a an new old current existing
+   legacy``), but ONLY while the remainder still has at least TWO tokens.
+
+The two-token guard is the safety rule for names where the "qualifier" is
+part of the name itself: ``new york`` must NOT collapse to ``york`` (nor
+``the office`` to ``office``). With the guard, ``canonical_match_key("new
+york") == "new york"`` — a one-token remainder is evidence the leading word
+is load-bearing, so it is kept. Multi-token remainders (``new analytics
+service`` → ``analytics service``) keep enough specificity that the leading
+qualifier is overwhelmingly descriptive, not nominal. The guard applies per
+strip step, so stacked qualifiers still reduce safely: ``the new analytics
+service`` → ``analytics service``, while ``the new york`` stops at
+``new york``.
+
+Symmetric by construction: an incoming ``analytics service`` matches an
+existing ``new analytics service`` and vice versa, because both map to the
+same key. Comparison is only ever key-to-key.
+
+Shared by core-api (extraction-batch dedupe in
+``entity_extraction_worker``) and core-storage-api (Phase 1.5 normalised
+match in ``entity_bulk_resolve``) so both layers agree on what "the same
+name" means.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Leading tokens that are (almost always) descriptive rather than nominal.
+# FIXED, small, and not configurable on purpose — every addition widens the
+# merge surface. See module docstring for the two-token guard that protects
+# the cases where one of these IS part of the name.
+ENTITY_NAME_QUALIFIERS: frozenset[str] = frozenset(
+    {"the", "a", "an", "new", "old", "current", "existing", "legacy"}
+)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_entity_name(name: str) -> str:
+    """Lowercase, strip, and collapse internal whitespace. Nothing else."""
+    return _WHITESPACE_RE.sub(" ", name.strip().lower())
+
+
+def canonical_match_key(name: str) -> str:
+    """Return the canonical comparison key for an entity surface form.
+
+    Two surface forms denote the same entity (for resolution purposes) iff
+    their keys are equal. See module docstring for the exact rule and its
+    safety guard.
+    """
+    tokens = normalize_entity_name(name).split(" ")
+    # Strip one leading qualifier per step, only while the remainder keeps
+    # >= 2 tokens ("new york" guard — a one-token remainder means the
+    # leading word is likely part of the name, so stop).
+    while len(tokens) >= 3 and tokens[0] in ENTITY_NAME_QUALIFIERS:
+        tokens = tokens[1:]
+    return " ".join(tokens)

--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -6,6 +6,7 @@ import re
 from uuid import UUID
 
 from common.embedding import get_embedding
+from common.entity_naming import canonical_match_key
 from core_api.clients.storage_client import get_storage_client
 from core_api.constants import (
     CROSS_LINK_MEMORY_BATCH_SIZE,
@@ -136,15 +137,24 @@ async def process_entity_extraction(
         # mentions) collapse to the FIRST occurrence here — preserves
         # today's role binding (``entity_roles[ent.canonical_name] =
         # ent.role`` in the old serial path also picked first-wins).
+        #
+        # WT-2: dedupe on ``canonical_match_key`` rather than the raw
+        # string, so one extraction that returns two surface forms of the
+        # SAME subject — ``analytics service`` twice, ``Analytics Service``
+        # vs ``analytics service``, or ``new analytics service`` alongside
+        # ``analytics service`` — mints ONE entity and ONE link instead of
+        # duplicating both. First occurrence wins (surface form, type, and
+        # role alike), same first-wins contract as before.
         filtered: list[tuple[str, str, str]] = []  # (canonical_name, entity_type, role)
         seen_names: set[str] = set()
         for ent in graph.entities:
             if not _is_valid_entity(ent.canonical_name, blocklist):
                 logger.debug("Skipping invalid entity name '%s'", ent.canonical_name)
                 continue
-            if ent.canonical_name in seen_names:
+            match_key = canonical_match_key(ent.canonical_name)
+            if match_key in seen_names:
                 continue
-            seen_names.add(ent.canonical_name)
+            seen_names.add(match_key)
             filtered.append((ent.canonical_name, ent.entity_type, ent.role))
 
         if not filtered:
@@ -364,16 +374,28 @@ async def process_entity_extraction(
             # / no entity_id) would produce non-contiguous indexes and
             # trip the 422. Use a dedicated ``link_idx`` counter so the
             # response idxs always tile the payload contiguously.
+            # WT-2 Fix A: dedupe at the write site — two DIFFERENT surface
+            # forms in one batch can resolve to the SAME entity row (via the
+            # normalised match or embedding similarity), and the same
+            # (memory, entity) pair must never be sent twice. The DB's
+            # composite PK ``(memory_id, entity_id)`` is the backstop
+            # (migration 001 — no new migration needed); this keeps the
+            # batch itself clean and the role binding first-wins.
             link_items = []
             link_idx = 0
+            linked_entity_ids: set[UUID] = set()
             for name, _et, role in filtered:
                 if name not in name_to_id:
                     continue
+                entity_id = name_to_id[name]
+                if entity_id in linked_entity_ids:
+                    continue
+                linked_entity_ids.add(entity_id)
                 link_items.append(
                     {
                         "input_idx": link_idx,
                         "memory_id": str(memory_id),
-                        "entity_id": str(name_to_id[name]),
+                        "entity_id": str(entity_id),
                         "role": role,
                     }
                 )
@@ -394,11 +416,16 @@ async def process_entity_extraction(
                         memory_id,
                     )
 
-        # Upsert relations
+        # Upsert relations. Endpoints resolve by raw name first (today's
+        # contract), then by ``canonical_match_key`` — the WT-2 dedupe above
+        # can collapse a surface form out of ``filtered`` (e.g. ``analytics
+        # service`` deduped under ``new analytics service``), and a relation
+        # that names the collapsed form must still land on the merged row.
+        key_to_id: dict[str, UUID] = {canonical_match_key(n): i for n, i in name_to_id.items()}
         rel_count = 0
         for rel in graph.relations:
-            from_id = name_to_id.get(rel.from_entity)
-            to_id = name_to_id.get(rel.to_entity)
+            from_id = name_to_id.get(rel.from_entity) or key_to_id.get(canonical_match_key(rel.from_entity))
+            to_id = name_to_id.get(rel.to_entity) or key_to_id.get(canonical_match_key(rel.to_entity))
             if from_id and to_id:
                 await upsert_relation(
                     RelationUpsert(

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -242,7 +242,8 @@ async def bulk_resolve_entities(request: Request) -> list[dict | None]:
 
     Response is a list aligned to ``input_idx``: each element is either
     ``null`` (no match) or ``{"entity_id", "canonical_name", "attributes",
-    "matched_by": "exact" | "similarity", "similarity": float}``. Callers
+    "matched_by": "exact" | "normalized" | "similarity",
+    "similarity": float}``. Callers
     use the ``matched_by`` field to decide whether to take the update path
     (with client-side attribute merge) or the create path in a follow-up
     ``/entities/bulk-upsert`` call.

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -60,6 +60,7 @@ from common.constants import (
     SEMANTIC_DEDUP_THRESHOLD,
     TYPE_DECAY_DAYS,
 )
+from common.entity_naming import canonical_match_key, normalize_entity_name
 from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
 from common.models import (
     Agent,
@@ -4897,19 +4898,22 @@ class PostgresService:
         """Bulk version of the two-phase resolution in entity_service.upsert_entity.
 
         Replicates the same precedence — Phase 1 exact match by
-        ``(tenant_id, fleet_id, canonical_name, entity_type)``; Phase 2
-        embedding cosine similarity (top-N by distance, first ≥ threshold
-        wins) — but in one round-trip and one DB connection. Phase 1 is
-        a single batched SELECT keyed by row tuple; Phase 2 issues one
-        similarity SELECT per unresolved item with a non-null embedding,
-        all sharing the same session.
+        ``(tenant_id, fleet_id, canonical_name, entity_type)``; Phase 1.5
+        conservative normalised match (WT-2 — case/whitespace and a small
+        fixed leading-qualifier strip, see ``common.entity_naming``);
+        Phase 2 embedding cosine similarity (top-N by distance, first ≥
+        threshold wins) — but in one round-trip and one DB connection.
+        Phase 1 is a single batched SELECT keyed by row tuple; Phases 1.5
+        and 2 issue one SELECT per still-unresolved item, all sharing the
+        same session.
 
         Each input item: ``{"input_idx": int, "fleet_id": str|None,
         "canonical_name": str, "entity_type": str, "name_embedding":
         list[float]|None}``. Returns a list aligned to input order where
         each element is either ``None`` (no match) or
         ``{"entity_id", "canonical_name", "attributes", "matched_by",
-        "similarity"}`` — ``matched_by`` ∈ {"exact", "similarity"}.
+        "similarity"}`` — ``matched_by`` ∈ {"exact", "normalized",
+        "similarity"}.
 
         Threshold is required, not defaulted — the resolution rule lives
         in the core-api layer; the storage service is the executor.
@@ -4969,6 +4973,72 @@ class PostgresService:
                         "similarity": 1.0,
                     }
                     matched_idxs.add(idx)
+
+            # Phase 1.5 (WT-2): conservative normalised match. An extracted
+            # surface form and an existing row that differ only by case,
+            # whitespace, or a small fixed set of leading determiners /
+            # temporal qualifiers ("the new analytics service" vs
+            # "analytics service") are the SAME subject; minting a second
+            # row splits the knowledge graph and blinds entity-scoped
+            # contradiction detection (WT-3). Deterministic and symmetric:
+            # a match fires iff ``canonical_match_key`` of both names is
+            # equal (see common/entity_naming.py for the exact rule and the
+            # two-token "new york" guard — "new york" does NOT reduce to
+            # "york", in either direction). Runs BEFORE Phase 2 because a
+            # deterministic string match outranks embedding similarity.
+            # Same tenant / entity_type / fleet scoping as Phase 1.
+            for it in items:
+                idx = it["input_idx"]
+                if idx in matched_idxs:
+                    continue
+                key = canonical_match_key(it["canonical_name"])
+                if not key:
+                    continue
+                # Candidate prefetch only: lower(name) ending in the key
+                # catches both directions (existing "new analytics service"
+                # for incoming "analytics service", and existing
+                # "analytics service" for incoming "new analytics service").
+                # The DECIDER is the Python-side key equality below — the
+                # suffix LIKE can never merge on its own ("data analytics
+                # service" is prefetched but rejected: its own key differs).
+                escaped = key.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                cand_stmt = (
+                    select(Entity)
+                    .where(
+                        Entity.tenant_id == tenant_id,
+                        Entity.entity_type == it["entity_type"],
+                        func.lower(Entity.canonical_name).like(f"%{escaped}", escape="\\"),
+                    )
+                    # Deterministic candidate order; cap keeps a pathological
+                    # tenant from turning the prefetch into a seq-scan dump.
+                    # A true match beyond the cap degrades to today's
+                    # behaviour (similarity / create), never to a bad merge.
+                    .order_by(Entity.id)
+                    .limit(50)
+                )
+                if it.get("fleet_id") is not None:
+                    cand_stmt = cand_stmt.where(Entity.fleet_id == it["fleet_id"])
+                else:
+                    cand_stmt = cand_stmt.where(Entity.fleet_id.is_(None))
+
+                candidates = (await session.execute(cand_stmt)).scalars().all()
+                verified = [e for e in candidates if canonical_match_key(e.canonical_name) == key]
+                if not verified:
+                    continue
+                # Prefer a pure case/whitespace variant (no qualifier was
+                # stripped on either side) over a qualifier-stripped match;
+                # ties broken by the deterministic id ordering above.
+                norm_incoming = normalize_entity_name(it["canonical_name"])
+                exact_norm = [e for e in verified if normalize_entity_name(e.canonical_name) == norm_incoming]
+                chosen = (exact_norm or verified)[0]
+                out[idx] = {
+                    "entity_id": str(chosen.id),
+                    "canonical_name": chosen.canonical_name,
+                    "attributes": chosen.attributes or {},
+                    "matched_by": "normalized",
+                    "similarity": 1.0,
+                }
+                matched_idxs.add(idx)
 
             # Phase 2: per-unmatched-item similarity SELECT, all in this
             # session. N queries one HTTP — the win is HTTP-roundtrip

--- a/tests/test_entity_naming.py
+++ b/tests/test_entity_naming.py
@@ -1,0 +1,98 @@
+"""Unit tests for ``common.entity_naming`` — the WT-2 canonical match key.
+
+The rule under test (see the module docstring for the full rationale):
+
+- normalise: lowercase, strip, collapse internal whitespace;
+- iteratively strip ONE leading determiner/temporal qualifier
+  (``the a an new old current existing legacy``) per step, ONLY while the
+  remainder keeps >= 2 tokens.
+
+The two-token guard is the safety property: ``new york`` must never reduce
+to ``york`` — in either comparison direction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from common.entity_naming import canonical_match_key, normalize_entity_name
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# normalize_entity_name — case / whitespace only
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_lowercases_and_collapses_whitespace():
+    assert normalize_entity_name("  New   Analytics\tService ") == "new analytics service"
+
+
+def test_normalize_touches_nothing_else():
+    # Punctuation and internal structure are preserved — conservative on
+    # purpose (no punctuation stripping in this fix; see PR body).
+    assert normalize_entity_name("PostgreSQL 16") == "postgresql 16"
+    assert normalize_entity_name("gpt-5.4-nano") == "gpt-5.4-nano"
+
+
+# ---------------------------------------------------------------------------
+# canonical_match_key — the WT-2 merge rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("a", "b"),
+    [
+        # The wet-test pair itself.
+        ("new analytics service", "analytics service"),
+        # Case / whitespace variants.
+        ("Analytics Service", "analytics   service"),
+        # Determiner.
+        ("the analytics service", "analytics service"),
+        # Stacked qualifiers strip one per step.
+        ("the new analytics service", "analytics service"),
+        # Other qualifiers from the fixed set.
+        ("legacy billing system", "billing system"),
+        ("current payment gateway", "payment gateway"),
+    ],
+)
+def test_same_subject_maps_to_same_key(a: str, b: str):
+    assert canonical_match_key(a) == canonical_match_key(b)
+
+
+@pytest.mark.parametrize(
+    ("a", "b"),
+    [
+        # THE guard case: stripping "new" would leave the 1-token "york".
+        ("new york", "york"),
+        # Same guard for pure determiners.
+        ("the office", "office"),
+        ("an apple", "apple"),
+        # Qualifier stacking stops at the guard: "the new york" -> "new york",
+        # which still differs from "york".
+        ("the new york", "york"),
+        # Non-qualifier leading words never strip.
+        ("data analytics service", "analytics service"),
+        # Substrings never match — no substring heuristics.
+        ("analytics", "analytics service"),
+    ],
+)
+def test_distinct_subjects_keep_distinct_keys(a: str, b: str):
+    assert canonical_match_key(a) != canonical_match_key(b)
+
+
+def test_the_new_york_reduces_to_new_york_not_york():
+    # Explicit shape check (not just inequality): the per-step guard stops
+    # exactly when the remainder would drop below two tokens.
+    assert canonical_match_key("the new york") == "new york"
+    assert canonical_match_key("new york") == "new york"
+    assert canonical_match_key("york") == "york"
+
+
+def test_symmetry_of_the_rule():
+    # The rule is key-to-key, so it cannot be asymmetric — pin that anyway.
+    a, b = "new analytics service", "analytics service"
+    assert (canonical_match_key(a) == canonical_match_key(b)) == (
+        canonical_match_key(b) == canonical_match_key(a)
+    )

--- a/tests/test_wt2_entity_canonicalisation.py
+++ b/tests/test_wt2_entity_canonicalisation.py
@@ -1,0 +1,474 @@
+"""WT-2 — one real-world subject must resolve to ONE entity, linked ONCE.
+
+Wet-test evidence (live stack, real LLM):
+
+- memory 1 ``"We decided to use PostgreSQL 16 instead of MySQL for the new
+  analytics service."`` → links: ``mysql``, ``new analytics service``,
+  ``postgresql 16``
+- memory 3 ``"We migrated the analytics service from PostgreSQL 16 to MySQL
+  after all."`` → links: ``analytics service``, ``analytics service``
+  (DUPLICATE), ``mysql``, ``postgresql 16``
+
+Two defects, two fixes, both covered here:
+
+- **Fix A (link dedup)**: the same ``(memory, entity)`` pair must never be
+  written twice from one extraction batch. Deduped at the write site in
+  ``entity_extraction_worker`` (the DB composite PK from migration 001 is
+  the backstop — no new migration).
+- **Fix B (conservative canonicalisation)**: before creating a new entity,
+  ``bulk_resolve_entities`` Phase 1.5 compares the incoming name against the
+  tenant's existing rows under ``common.entity_naming.canonical_match_key``
+  (lowercase / collapse whitespace / strip a small fixed set of leading
+  qualifiers, guarded so ``new york`` never merges with ``york``).
+
+Three families:
+
+1. Worker-level (mocked storage) — batch dedupe and link-write dedupe.
+2. Storage-level (real Postgres via the in-process ASGI bridge) — Phase 1.5
+   normalised matching and its non-merge guards.
+3. End-to-end wet-test replay — two extraction runs against real storage,
+   asserting one entity row, both memories linked, no duplicate links.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from core_api.constants import VECTOR_DIM
+from core_api.services.entity_extraction_worker import process_entity_extraction
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Shared builders (same shapes as tests/test_p1_entity_extraction_bulk.py)
+# ---------------------------------------------------------------------------
+
+
+def _config(**overrides):
+    cfg = MagicMock()
+    cfg.auto_entity_linking_enabled = False
+    cfg.entity_blocklist = frozenset()
+    cfg.entity_extraction_provider = "openai"
+    cfg.entity_extraction_model = "gpt-4o-mini"
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _entity(name: str, entity_type: str = "technology", role: str = "subject") -> MagicMock:
+    e = MagicMock()
+    e.canonical_name = name
+    e.entity_type = entity_type
+    e.role = role
+    return e
+
+
+def _graph(entities: list[MagicMock], relations: list | None = None) -> MagicMock:
+    g = MagicMock()
+    g.entities = entities
+    g.relations = relations or []
+    return g
+
+
+def _build_sc_mock(
+    *,
+    resolve_returns: list[dict | None],
+    upsert_returns: list[dict],
+) -> MagicMock:
+    sc = MagicMock()
+    sc.bulk_resolve_entities = AsyncMock(return_value=resolve_returns)
+    sc.bulk_upsert_entities = AsyncMock(return_value=upsert_returns)
+    sc.bulk_upsert_entity_links = AsyncMock(
+        return_value=[{"input_idx": i, "created": True} for i in range(len(upsert_returns))]
+    )
+    return sc
+
+
+_WORKER = "core_api.services.entity_extraction_worker"
+
+
+# ---------------------------------------------------------------------------
+# 1) Worker-level — mocked storage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@patch(f"{_WORKER}.log_action", new_callable=AsyncMock)
+@patch(f"{_WORKER}.upsert_relation", new_callable=AsyncMock)
+@patch(f"{_WORKER}.get_embedding", new_callable=AsyncMock)
+@patch(f"{_WORKER}.get_storage_client")
+@patch(f"{_WORKER}.extract_entities_from_content", new_callable=AsyncMock)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_extractor_repeating_one_entity_writes_one_link(
+    mock_cfg, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """The wet-test memory-3 shape: the extractor returns the SAME subject
+    twice (verbatim + a case variant). Exactly ONE entity is resolved /
+    upserted and exactly ONE link row is written."""
+    mock_cfg.return_value = _config()
+    mock_extract.return_value = _graph(
+        [
+            _entity("analytics service", role="subject"),
+            _entity("Analytics Service", role="mentioned"),
+        ]
+    )
+    mock_embed.return_value = None  # no similarity phase in this test
+
+    eid = str(uuid4())
+    sc = _build_sc_mock(
+        resolve_returns=[None],
+        upsert_returns=[{"input_idx": 0, "entity_id": eid, "action": "created"}],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task", side_effect=lambda coro: coro.close()):
+        await process_entity_extraction(
+            uuid4(), "t-wt2", None, "agent-1", "content", "decision"
+        )
+
+    # One resolve item, one upsert item, ONE link item.
+    resolve_items = sc.bulk_resolve_entities.call_args.kwargs["items"]
+    assert len(resolve_items) == 1
+    link_items = sc.bulk_upsert_entity_links.call_args.kwargs["items"]
+    assert len(link_items) == 1
+    assert link_items[0]["entity_id"] == eid
+    assert link_items[0]["role"] == "subject"  # first occurrence wins
+
+
+@pytest.mark.unit
+@patch(f"{_WORKER}.log_action", new_callable=AsyncMock)
+@patch(f"{_WORKER}.upsert_relation", new_callable=AsyncMock)
+@patch(f"{_WORKER}.get_embedding", new_callable=AsyncMock)
+@patch(f"{_WORKER}.get_storage_client")
+@patch(f"{_WORKER}.extract_entities_from_content", new_callable=AsyncMock)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_qualifier_variants_in_one_extraction_collapse_to_one_entity(
+    mock_cfg, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """``new analytics service`` and ``analytics service`` in ONE extraction
+    are the same subject — one entity minted, one link written."""
+    mock_cfg.return_value = _config()
+    mock_extract.return_value = _graph(
+        [
+            _entity("new analytics service"),
+            _entity("analytics service"),
+            _entity("postgresql 16"),
+        ]
+    )
+    mock_embed.return_value = None
+
+    svc_id, pg_id = str(uuid4()), str(uuid4())
+    sc = _build_sc_mock(
+        resolve_returns=[None, None],
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": svc_id, "action": "created"},
+            {"input_idx": 1, "entity_id": pg_id, "action": "created"},
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task", side_effect=lambda coro: coro.close()):
+        await process_entity_extraction(
+            uuid4(), "t-wt2", None, "agent-1", "content", "decision"
+        )
+
+    resolve_items = sc.bulk_resolve_entities.call_args.kwargs["items"]
+    assert [it["canonical_name"] for it in resolve_items] == [
+        "new analytics service",  # first surface form wins
+        "postgresql 16",
+    ]
+    link_items = sc.bulk_upsert_entity_links.call_args.kwargs["items"]
+    assert len(link_items) == 2
+    assert {it["entity_id"] for it in link_items} == {svc_id, pg_id}
+
+
+@pytest.mark.unit
+@patch(f"{_WORKER}.log_action", new_callable=AsyncMock)
+@patch(f"{_WORKER}.upsert_relation", new_callable=AsyncMock)
+@patch(f"{_WORKER}.get_embedding", new_callable=AsyncMock)
+@patch(f"{_WORKER}.get_storage_client")
+@patch(f"{_WORKER}.extract_entities_from_content", new_callable=AsyncMock)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_two_names_resolving_to_same_entity_write_one_link(
+    mock_cfg, mock_extract, mock_sc_factory, mock_embed, _rel, _log
+):
+    """Write-site dedup proper (Fix A): two names with DIFFERENT match keys
+    that storage resolution nevertheless maps to the same entity row (e.g.
+    embedding similarity) must produce ONE link item, not two."""
+    mock_cfg.return_value = _config()
+    mock_extract.return_value = _graph(
+        [
+            _entity("postgres"),
+            _entity("postgresql"),
+        ]
+    )
+    mock_embed.return_value = [0.1] * 8
+
+    shared = str(uuid4())
+    sc = _build_sc_mock(
+        resolve_returns=[
+            {"entity_id": shared, "canonical_name": "postgres", "attributes": {}, "matched_by": "similarity", "similarity": 0.97},
+            {"entity_id": shared, "canonical_name": "postgres", "attributes": {}, "matched_by": "similarity", "similarity": 0.95},
+        ],
+        upsert_returns=[
+            {"input_idx": 0, "entity_id": shared, "action": "updated"},
+            {"input_idx": 1, "entity_id": shared, "action": "updated"},
+        ],
+    )
+    mock_sc_factory.return_value = sc
+
+    memory_id = uuid4()
+    with patch("core_api.tasks.track_task", side_effect=lambda coro: coro.close()):
+        await process_entity_extraction(
+            memory_id, "t-wt2", None, "agent-1", "content", "decision"
+        )
+
+    link_items = sc.bulk_upsert_entity_links.call_args.kwargs["items"]
+    assert len(link_items) == 1, (
+        f"duplicate (memory, entity) link items written: {link_items}"
+    )
+    assert link_items[0]["memory_id"] == str(memory_id)
+    assert link_items[0]["entity_id"] == shared
+    # input_idx must still tile [0, len) for the storage-side contiguity check.
+    assert [it["input_idx"] for it in link_items] == [0]
+
+
+# ---------------------------------------------------------------------------
+# 2) Storage-level — Phase 1.5 normalised match (real Postgres)
+# ---------------------------------------------------------------------------
+
+
+def _t() -> str:
+    return f"test-tenant-wt2-{uuid4().hex[:8]}"
+
+
+async def _create_entity(sc, tenant_id: str, name: str, *, entity_type: str = "technology") -> dict:
+    return await sc.create_entity(
+        {
+            "tenant_id": tenant_id,
+            "fleet_id": None,
+            "entity_type": entity_type,
+            "canonical_name": name,
+            "attributes": {},
+            "name_embedding": None,
+        }
+    )
+
+
+def _resolve_item(name: str, *, entity_type: str = "technology") -> dict:
+    return {
+        "input_idx": 0,
+        "fleet_id": None,
+        "canonical_name": name,
+        "entity_type": entity_type,
+        "name_embedding": None,
+    }
+
+
+@pytest.mark.integration
+async def test_bulk_resolve_normalized_match_strips_leading_qualifier(sc):
+    """Incoming ``analytics service`` resolves to the existing
+    ``new analytics service`` row instead of minting a second entity."""
+    tid = _t()
+    existing = await _create_entity(sc, tid, "new analytics service")
+
+    results = await sc.bulk_resolve_entities(
+        tenant_id=tid, items=[_resolve_item("analytics service")], threshold=0.85
+    )
+    assert results[0] is not None
+    assert results[0]["entity_id"] == existing["id"]
+    assert results[0]["matched_by"] == "normalized"
+
+
+@pytest.mark.integration
+async def test_bulk_resolve_normalized_match_is_symmetric(sc):
+    """Reverse direction: incoming ``new analytics service`` resolves to an
+    existing ``analytics service`` row."""
+    tid = _t()
+    existing = await _create_entity(sc, tid, "analytics service")
+
+    results = await sc.bulk_resolve_entities(
+        tenant_id=tid, items=[_resolve_item("new analytics service")], threshold=0.85
+    )
+    assert results[0] is not None
+    assert results[0]["entity_id"] == existing["id"]
+    assert results[0]["matched_by"] == "normalized"
+
+
+@pytest.mark.integration
+async def test_bulk_resolve_normalized_match_case_and_whitespace(sc):
+    tid = _t()
+    existing = await _create_entity(sc, tid, "analytics service")
+
+    results = await sc.bulk_resolve_entities(
+        tenant_id=tid, items=[_resolve_item("Analytics  Service")], threshold=0.85
+    )
+    assert results[0] is not None
+    assert results[0]["entity_id"] == existing["id"]
+
+
+@pytest.mark.integration
+async def test_bulk_resolve_new_york_never_merges_with_york(sc):
+    """The non-merge guard, both directions. ``new york`` stripped would be
+    the 1-token ``york``, so the qualifier is treated as part of the name."""
+    tid = _t()
+    await _create_entity(sc, tid, "new york", entity_type="location")
+
+    results = await sc.bulk_resolve_entities(
+        tenant_id=tid,
+        items=[_resolve_item("york", entity_type="location")],
+        threshold=0.85,
+    )
+    assert results[0] is None, "incoming 'york' must NOT merge into 'new york'"
+
+    tid2 = _t()
+    await _create_entity(sc, tid2, "york", entity_type="location")
+    results = await sc.bulk_resolve_entities(
+        tenant_id=tid2,
+        items=[_resolve_item("new york", entity_type="location")],
+        threshold=0.85,
+    )
+    assert results[0] is None, "incoming 'new york' must NOT merge into 'york'"
+
+
+@pytest.mark.integration
+async def test_bulk_resolve_normalized_match_respects_entity_type(sc):
+    """Same scoping as Phase 1 exact: a name match across DIFFERENT
+    entity_types is not a merge."""
+    tid = _t()
+    await _create_entity(sc, tid, "new analytics service", entity_type="technology")
+
+    results = await sc.bulk_resolve_entities(
+        tenant_id=tid,
+        items=[_resolve_item("analytics service", entity_type="project")],
+        threshold=0.85,
+    )
+    assert results[0] is None
+
+
+@pytest.mark.integration
+async def test_bulk_resolve_no_substring_or_extra_word_merge(sc):
+    """Non-qualifier leading words never strip; substrings never match."""
+    tid = _t()
+    await _create_entity(sc, tid, "data analytics service")
+
+    for incoming in ("analytics service", "service", "data analytics"):
+        results = await sc.bulk_resolve_entities(
+            tenant_id=tid, items=[_resolve_item(incoming)], threshold=0.85
+        )
+        assert results[0] is None, f"'{incoming}' must not merge into 'data analytics service'"
+
+
+@pytest.mark.integration
+async def test_bulk_resolve_exact_match_still_wins_over_normalized(sc):
+    """With both ``new york`` and ``york`` present, each incoming form
+    resolves exactly to its own row."""
+    tid = _t()
+    ny = await _create_entity(sc, tid, "new york", entity_type="location")
+    y = await _create_entity(sc, tid, "york", entity_type="location")
+
+    results = await sc.bulk_resolve_entities(
+        tenant_id=tid,
+        items=[
+            {**_resolve_item("new york", entity_type="location"), "input_idx": 0},
+            {**_resolve_item("york", entity_type="location"), "input_idx": 1},
+        ],
+        threshold=0.85,
+    )
+    assert results[0]["entity_id"] == ny["id"]
+    assert results[0]["matched_by"] == "exact"
+    assert results[1]["entity_id"] == y["id"]
+    assert results[1]["matched_by"] == "exact"
+
+
+# ---------------------------------------------------------------------------
+# 3) End-to-end wet-test replay — real storage, mocked extractor output
+# ---------------------------------------------------------------------------
+
+
+async def _write_memory(sc, tenant_id: str, content: str) -> dict:
+    return await sc.create_memory(
+        {
+            "tenant_id": tenant_id,
+            "agent_id": "wt2-agent",
+            "content": content,
+            "memory_type": "decision",
+            "embedding": [0.1] * VECTOR_DIM,
+            "weight": 0.5,
+        }
+    )
+
+
+@pytest.mark.integration
+@patch(f"{_WORKER}.log_action", new_callable=AsyncMock)
+@patch(f"{_WORKER}.get_embedding", new_callable=AsyncMock)
+@patch(f"{_WORKER}.extract_entities_from_content", new_callable=AsyncMock)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_wet_test_replay_one_subject_one_entity_no_duplicate_links(
+    mock_cfg, mock_extract, mock_embed, _log, sc
+):
+    """Replays WT-2 against real storage: memory 1 extracts ``new analytics
+    service``; memory 3 extracts ``analytics service`` TWICE. Expected end
+    state: ONE entity row for the subject, both memories linked to it, one
+    link row each, and the second surface form recorded as an alias."""
+    tid = _t()
+    mock_cfg.return_value = _config()
+    mock_embed.return_value = None  # deterministic phases only (no similarity)
+
+    mem1 = await _write_memory(
+        sc, tid, "We decided to use PostgreSQL 16 instead of MySQL for the new analytics service."
+    )
+    mem3 = await _write_memory(
+        sc, tid, "We migrated the analytics service from PostgreSQL 16 to MySQL after all."
+    )
+
+    # Memory 1 extraction.
+    mock_extract.return_value = _graph(
+        [
+            _entity("postgresql 16"),
+            _entity("mysql"),
+            _entity("new analytics service"),
+        ]
+    )
+    with patch("core_api.tasks.track_task", side_effect=lambda coro: coro.close()):
+        await process_entity_extraction(
+            UUID(mem1["id"]), tid, None, "wt2-agent", mem1["content"], "decision"
+        )
+
+    # Memory 3 extraction — the same subject twice, without the qualifier.
+    mock_extract.return_value = _graph(
+        [
+            _entity("analytics service", role="subject"),
+            _entity("analytics service", role="mentioned"),
+            _entity("mysql"),
+            _entity("postgresql 16"),
+        ]
+    )
+    with patch("core_api.tasks.track_task", side_effect=lambda coro: coro.close()):
+        await process_entity_extraction(
+            UUID(mem3["id"]), tid, None, "wt2-agent", mem3["content"], "decision"
+        )
+
+    # ONE entity row for the subject: the first-seen canonical name stands,
+    # and no second row was minted for the stripped form.
+    subject = await sc.find_exact_entity(
+        tid, "new analytics service", None, entity_type="technology"
+    )
+    assert subject is not None
+    split_row = await sc.find_exact_entity(
+        tid, "analytics service", None, entity_type="technology"
+    )
+    assert split_row is None, "WT-2 regression: subject split into a second entity row"
+
+    # The memory-3 surface form is preserved as an alias.
+    assert "analytics service" in (subject.get("attributes") or {}).get("_aliases", [])
+
+    # Both memories linked to the ONE subject entity — once each.
+    result = await sc.get_entity_with_linked_memories(subject["id"])
+    linked_ids = [entry.get("memory", entry)["id"] for entry in result["linked_memories"]]
+    assert sorted(linked_ids) == sorted([mem1["id"], mem3["id"]])
+    assert len(linked_ids) == len(set(linked_ids)), "duplicate link rows"


### PR DESCRIPTION
Closes wet-test defect **WT-2**: entity extraction canonicalised one real-world subject as TWO entities, and linked one memory to the subject twice. This is also the **root cause of WT-3** (contradiction-detection false negatives) — the detector-side fix for WT-3 lands separately as defense-in-depth; with this PR the graph no longer splits in the first place.

## Wet-test evidence (live stack, real LLM)

| memory | content | links written |
|---|---|---|
| 1 | "We decided to use PostgreSQL 16 instead of MySQL for the **new analytics service**." | `mysql`, `new analytics service`, `postgresql 16` |
| 3 | "We migrated the **analytics service** from PostgreSQL 16 to MySQL after all." | `analytics service`, `analytics service` **(DUPLICATE)**, `mysql`, `postgresql 16` |

One subject ("the analytics service") became two entity rows, so entity-scoped contradiction detection never saw memories 1 and 3 on the same node.

## Fix A — link dedup at the write site

`core_api/services/entity_extraction_worker.py`:

- The per-extraction batch now dedupes entities on the **canonical match key** (below) instead of the raw string, so an extractor that returns the same subject twice — verbatim, as a case/whitespace variant, or as a qualifier variant (`new analytics service` + `analytics service`) — mints ONE entity and ONE link. First occurrence keeps its surface form, type, and role (same first-wins contract as before).
- Link items are additionally deduped by **resolved entity_id**, so two distinct surface forms that resolution maps to the same row (e.g. via embedding similarity) can never emit two `(memory, entity)` link writes from one batch.
- No new migration: the composite PK `(memory_id, entity_id)` on `memory_entity_links` (migration 001) remains the DB-level backstop; the dedup is in code, per the frozen-migrations rule.
- Relation endpoints now also fall back to the canonical match key, so a relation naming the collapsed surface form still lands on the merged row.

## Fix B — conservative canonicalisation on resolve

`bulk_resolve_entities` (storage side) gains **Phase 1.5**, between exact match and embedding similarity — deterministic string matching outranks fuzzy:

**The exact rule** (`common/entity_naming.py`, shared by both layers so they agree on "the same name"):

1. normalise: lowercase, strip, collapse internal whitespace;
2. iteratively strip ONE leading token per step from a FIXED set of determiners/temporal qualifiers — `the a an new old current existing legacy` — **only while the remainder keeps ≥ 2 tokens**.

Two names refer to the same entity iff their keys are equal, compared under the same tenant / `entity_type` / fleet scoping as Phase 1 exact match. On a match the incoming form links to the existing row and is recorded in the existing `_aliases` attribute mechanism (first-seen canonical name stands, per the established first-seen-wins contract).

**Guards / non-merge safety cases** (all pinned by tests):

- `new york` vs `york`: stripping `new` would leave the 1-token `york`, so the qualifier is treated as part of the name — **no merge, in either direction**. The per-step guard also makes stacking safe: `the new york` → `new york`, never `york`.
- `the office` / `an apple`: 2-token names whose leading word is a qualifier never strip — no merge with `office` / `apple`.
- `data analytics service` vs `analytics service`: non-qualifier leading words never strip — no merge.
- No substring matching, no fuzzy matching, no embeddings in this phase; the SQL suffix-LIKE is only a candidate prefetch, the decider is exact key equality in Python.
- Cross-`entity_type` name collisions stay separate (same conservatism as Phase 1).
- Punctuation is left untouched (deliberately conservative; can be revisited as follow-up if wet tests surface punctuation variants).

`matched_by: "normalized"` is added to the bulk-resolve response contract (`exact | normalized | similarity`); no caller branches on the value beyond non-None.

## Tests

`tests/test_entity_naming.py` (rule unit tests) + `tests/test_wt2_entity_canonicalisation.py`:

- worker-level: same subject twice in one extraction → one resolve/upsert/link; qualifier variants collapse; two names resolving to one entity → one link item;
- storage-level (real Postgres): normalised match both directions, case/whitespace, `new york`/`york` non-merge both directions, entity_type scoping, no-substring guards, exact still wins;
- end-to-end wet-test replay: memory 1 extracts `new analytics service`, memory 3 extracts `analytics service` twice → ONE entity row, both memories linked once each, surface form recorded as alias.

**Fails-without-fix proof**: with the source changes stashed (origin/main code, new tests kept), 7/27 fail — every merge/dedup assertion, including the end-to-end replay failing exactly at the "subject split into a second entity row" assertion; the non-merge guard tests pass on main as they should. All 27 pass with the fix.

Full CI-parity verification: all ruff check/format invocations, mypy (core-api, core-storage-api, common), broker OpenAPI `--check`, `legacy_name_ratchet.py --base origin/main`, `do_not_touch_sentinel.py`, root suite (5240 passed; the 16 failures in FTS/search/relation-weight files pre-exist on unmodified origin/main in this environment and are untouched by this diff), and the core-storage-api suite (156 passed).
