### PR TITLE
feat(api): complete the OpenAPI spec — response schemas + servers block (C33)

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -479,6 +479,68 @@
         "title": "HTTPValidationError",
         "type": "object"
       },
+      "HealthResponse": {
+        "properties": {
+          "event_bus": {
+            "description": "ok, unhealthy, or error.",
+            "title": "Event Bus",
+            "type": "string"
+          },
+          "platform_init_errors": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Only when platform init recorded errors and all dependencies are up (status=degraded).",
+            "title": "Platform Init Errors"
+          },
+          "redis": {
+            "description": "connected, unavailable, or not configured.",
+            "title": "Redis",
+            "type": "string"
+          },
+          "status": {
+            "description": "ok, degraded, or unhealthy (unhealthy is served as 503).",
+            "title": "Status",
+            "type": "string"
+          },
+          "storage": {
+            "description": "connected or unreachable.",
+            "title": "Storage",
+            "type": "string"
+          },
+          "unhealthy_dependencies": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Only on 503: names of failing dependencies.",
+            "title": "Unhealthy Dependencies"
+          }
+        },
+        "required": [
+          "status",
+          "storage",
+          "redis",
+          "event_bus"
+        ],
+        "title": "HealthResponse",
+        "type": "object"
+      },
       "MemoryDetailResponse": {
         "description": "Full detail for one memory: row fields, entity links, embedding stats.",
         "properties": {
@@ -1721,6 +1783,19 @@
         ],
         "title": "ValidationError",
         "type": "object"
+      },
+      "VersionResponse": {
+        "properties": {
+          "version": {
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version"
+        ],
+        "title": "VersionResponse",
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -1745,7 +1820,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -2614,7 +2691,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/VersionResponse"
+                }
               }
             },
             "description": "Successful Response"

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -696,6 +696,11 @@ def _openapi_with_error_responses() -> dict:
         version=app.version,
         routes=app.routes,
         tags=OPENAPI_TAGS,
+        servers=(
+            [{"url": app_settings.public_api_url.rstrip("/")}]
+            if app_settings.public_api_url
+            else None
+        ),
     )
     schema.setdefault("components", {}).setdefault("schemas", {})[_ERROR_ENVELOPE_REF] = (
         _ERROR_ENVELOPE_SCHEMA

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -696,11 +696,7 @@ def _openapi_with_error_responses() -> dict:
         version=app.version,
         routes=app.routes,
         tags=OPENAPI_TAGS,
-        servers=(
-            [{"url": app_settings.public_api_url.rstrip("/")}]
-            if app_settings.public_api_url
-            else None
-        ),
+        servers=([{"url": app_settings.public_api_url.rstrip("/")}] if app_settings.public_api_url else None),
     )
     schema.setdefault("components", {}).setdefault("schemas", {})[_ERROR_ENVELOPE_REF] = (
         _ERROR_ENVELOPE_SCHEMA

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -344,6 +344,10 @@ class Settings(BaseSettings):
     # routes GET + tagged-read POST calls here instead of ``core_storage_api_url``;
     # empty keeps today's single-service behaviour (OSS + pre-split deploys).
     core_storage_read_url: str = ""
+    # Public base URL of THIS API as callers reach it (e.g. https://memclaw.dev).
+    # When set, the OpenAPI spec gains a ``servers`` block so generated clients
+    # and agents resolve relative paths correctly; empty emits no servers block.
+    public_api_url: str = ""
     settings_encryption_key: str = ""  # Required in production (Fernet key)
     jwt_secret: str = "change-me-in-production"  # Required in production
     paddle_client_token: str | None = None

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -344,7 +344,7 @@ class Settings(BaseSettings):
     # routes GET + tagged-read POST calls here instead of ``core_storage_api_url``;
     # empty keeps today's single-service behaviour (OSS + pre-split deploys).
     core_storage_read_url: str = ""
-    # Public base URL of THIS API as callers reach it (e.g. https://memclaw.dev).
+    # Public base URL of THIS API as callers reach it (e.g. https://api.caura.ai).
     # When set, the OpenAPI spec gains a ``servers`` block so generated clients
     # and agents resolve relative paths correctly; empty emits no servers block.
     public_api_url: str = ""

--- a/core-api/src/core_api/openapi_responses.py
+++ b/core-api/src/core_api/openapi_responses.py
@@ -1,0 +1,534 @@
+"""Spec-only response models for C33 (OpenAPI completeness).
+
+These models document success-response shapes in the generated OpenAPI spec
+via ``responses={200: {"model": ...}}`` on the route decorators. They are
+deliberately NOT passed as ``response_model=``: attaching them there would
+route every response through Pydantic serialization (coercing values and
+dropping undeclared keys), which is a runtime behavior change this task must
+not make. Spec-only attachment documents the shape and changes nothing on
+the wire.
+
+Consequence: nothing enforces these models at runtime. When a handler's
+return shape changes, the matching model here must change in the same PR —
+``tests/test_c33_openapi_completeness.py`` ratchets the count of
+undocumented success responses so new routes can't ship blank, and the
+wet-test checklist for schema-touching PRs includes diffing a live response
+against its model here.
+
+Conditional keys (present only under a documented condition) are declared
+Optional with a ``description`` saying when they appear; JSON-mapping values
+use ``dict[str, int]``-style types rather than named models.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from core_api.schemas import MemoryOut
+
+# --------------------------------------------------------------------------
+# memories / recall / health / version
+# --------------------------------------------------------------------------
+
+
+class MemoryStatsResponse(BaseModel):
+    total: int = Field(description="Live (non-deleted) memory count in scope.")
+    by_type: dict[str, int]
+    by_agent: dict[str, int]
+    by_status: dict[str, int]
+    by_tenant: dict[str, int] | None = Field(
+        default=None,
+        description="Only for cross-tenant reads spanning more than one tenant.",
+    )
+    deleted: int | None = Field(default=None, description="Only when include_deleted=true.")
+    total_including_deleted: int | None = Field(default=None, description="Only when include_deleted=true.")
+
+
+class MemoryCountResponse(BaseModel):
+    count: int
+
+
+class BulkDeleteResponse(BaseModel):
+    deleted: int = Field(description="Number of memories soft-deleted.")
+
+
+class SupersessionPeer(BaseModel):
+    id: str
+    content_preview: str = Field(description="First 200 characters of content.")
+    status: str
+    created_at: str
+
+
+class ContradictionEntry(BaseModel):
+    memory_id: str
+    status: str
+    reason: str = Field(description="One of rdf_conflict, semantic_conflict, unknown.")
+    content_preview: str
+    direction: str = Field(description="superseded_by or supersedes.")
+    created_at: str
+
+
+class MemoryContradictionsResponse(BaseModel):
+    memory_id: str
+    status: str | None
+    superseded_by: SupersessionPeer | None = Field(
+        description="The newer memory that superseded this one; null when none is live."
+    )
+    superseded_memories: list[SupersessionPeer]
+    detection_status: str = Field(description="completed or pending.")
+    contradictions: list[ContradictionEntry]
+
+
+class MemoryStatusPatchResponse(BaseModel):
+    memory_id: str
+    old_status: str | None
+    new_status: str
+
+
+class RecallDiagnostic(BaseModel):
+    recall_prompt: str | None
+    recall_model: str | None
+    recall_provider: str | None
+    all_candidates: list
+    top_k_used: int | None
+    retrieval_strategy: str | None
+    search_params: dict
+
+
+class RecallResponse(BaseModel):
+    query: str
+    summary: str
+    memory_count: int
+    memories: list[MemoryOut]
+    items: list[MemoryOut] = Field(
+        description="Alias of memories (canonical list key per the wire contract)."
+    )
+    recall_ms: int
+    diagnostic: RecallDiagnostic | None = Field(
+        default=None, description="Only when the request sets diagnostic=true."
+    )
+
+
+class VersionResponse(BaseModel):
+    version: str
+
+
+# --------------------------------------------------------------------------
+# documents / keystones / evolve / entities / graph
+# --------------------------------------------------------------------------
+
+
+class DocumentSearchItem(BaseModel):
+    collection: str
+    doc_id: str
+    data: dict = Field(description="Arbitrary caller-supplied document body.")
+    similarity: float
+
+
+class DocumentSearchResponse(BaseModel):
+    collection: str | None = Field(
+        description="Echo of the requested collection; null for cross-collection search."
+    )
+    count: int
+    results: list[DocumentSearchItem] = Field(description="Deprecated alias of items (wire contract D1).")
+    items: list[DocumentSearchItem]
+
+
+class DocumentCollectionInfo(BaseModel):
+    name: str
+    count: int = Field(description="Documents in this collection.")
+
+
+class DocumentCollectionsResponse(BaseModel):
+    collections: list[DocumentCollectionInfo]
+    count: int = Field(description="Number of collections, not total documents.")
+
+
+class KeystoneData(BaseModel):
+    title: str
+    content: str
+    weight: int = Field(
+        description="Priority bucket 25, 50, or 100 (request labels low/med/high are converted)."
+    )
+    scope: str = Field(description="tenant, fleet, or agent.")
+    agent_id: str | None = Field(default=None, description="Only when scope=agent.")
+    author_user_id: str | None = Field(default=None, description="Only when supplied at write time.")
+
+
+class KeystoneDoc(BaseModel):
+    id: str
+    tenant_id: str
+    fleet_id: str | None = Field(description="Null for tenant-scope rules.")
+    collection: str = Field(description='Always "_keystones".')
+    doc_id: str
+    data: KeystoneData
+    created_at: str
+    updated_at: str
+
+
+class KeystonesEnvelope(BaseModel):
+    count: int
+    items: list[KeystoneDoc]
+
+
+class KeystoneDeleteResponse(BaseModel):
+    deleted: bool
+    doc_id: str
+
+
+class WeightAdjustment(BaseModel):
+    memory_id: str
+    old_weight: float
+    new_weight: float
+    delta: float
+
+
+class GeneratedRule(BaseModel):
+    rule_memory_id: str
+    condition: str
+    action: str
+    confidence: float
+
+
+class EvolveReportResponse(BaseModel):
+    outcome_id: str
+    outcome_type: str = Field(description="success, failure, or partial.")
+    scope: str = Field(description="agent, fleet, or all.")
+    weight_adjustments: list[WeightAdjustment]
+    rules_generated: list[GeneratedRule] = Field(
+        description="At most one element; empty unless a rule persisted."
+    )
+    rule_skipped_reason: str | None = Field(
+        description="Slug explaining why no rule was generated; null when one was."
+    )
+    weight_adjustment_skipped_reason: str | None = Field(
+        description="Slug explaining why no weights moved; null when at least one did."
+    )
+    out_of_scope_count: int
+    evolve_ms: int
+
+
+class EntityListItem(BaseModel):
+    id: str
+    tenant_id: str | None
+    fleet_id: str | None
+    entity_type: str | None
+    canonical_name: str | None
+    attributes: dict | None
+    memory_count: int
+
+
+class GraphNode(BaseModel):
+    id: str
+    label: str | None = Field(description="Entity canonical_name.")
+    type: str | None = Field(description="Entity entity_type.")
+    fleet_id: str | None
+    attributes: dict | None
+    memory_count: int
+
+
+class GraphEdge(BaseModel):
+    id: str
+    source: str
+    target: str
+    relation_type: str | None
+    weight: float
+    evidence_memory_id: str | None
+
+
+class GraphResponse(BaseModel):
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+
+
+# --------------------------------------------------------------------------
+# settings / tenants / fleets / tool-descriptions
+# --------------------------------------------------------------------------
+
+
+class ProviderModelChoice(BaseModel):
+    provider: str | None
+    model: str | None
+
+
+class ProviderModelToggle(ProviderModelChoice):
+    enabled: bool | None
+
+
+class SearchSettings(BaseModel):
+    recall_boost: bool | None
+    graph_retrieval: bool | None
+    entity_retrieval: bool | None
+    default_profile: dict = Field(
+        description="Open knob map (min_similarity, top_k, freshness_floor, score_formula, ...)."
+    )
+
+
+class WriteSettings(BaseModel):
+    default_write_mode: str | None = Field(description="fast or strong; null means fast.")
+    triple_emission_enabled: bool | None
+    retraction_enabled: bool | None
+
+
+class SettingsResponse(BaseModel):
+    """Full effective settings tree: DEFAULT_SETTINGS deep-merged with tenant
+    overrides — every section always present. Deep operational blobs are left
+    as open objects here; their authoritative key sets live in
+    ``services/organization_settings.py::DEFAULT_SETTINGS``."""
+
+    enrichment: ProviderModelToggle
+    recall: ProviderModelToggle
+    embedding: ProviderModelChoice
+    entity_extraction: ProviderModelToggle
+    fallback_llm: ProviderModelChoice
+    agent_digest: dict
+    search: SearchSettings
+    crystallizer: dict
+    dedup: dict
+    lifecycle: dict
+    entity_linking: dict
+    insights: dict
+    observability: dict
+    chunking: dict
+    write: WriteSettings
+    agents: dict
+    memclaw: dict
+    security_audit: dict
+    skills_factory: dict
+    interviewer: dict
+    entity_blocklist: list[str]
+    governance: dict
+    api_keys: dict = Field(description="Per-tenant provider key overrides (open object).")
+
+
+class FleetDistributionItem(BaseModel):
+    fleet_id: str
+    memory_count: int
+    agent_count: int
+
+
+class ToolDescriptionEnriched(BaseModel):
+    description: str
+    stm_only: bool
+
+
+# --------------------------------------------------------------------------
+# fleet / agents
+# --------------------------------------------------------------------------
+
+
+class FleetCreateResponse(BaseModel):
+    ok: bool
+    fleet_id: str
+    tenant_id: str
+
+
+class FleetListItem(BaseModel):
+    fleet_id: str | None
+    node_count: int
+    last_heartbeat: str | None
+    status: str = Field(description="online or offline.")
+
+
+class FleetPurgeResponse(BaseModel):
+    ok: bool
+    tenant_id: str
+    fleet_id: str
+    deleted: dict[str, int] = Field(
+        description="Rows deleted per table (fleet_commands, memories, entities, ...)."
+    )
+
+
+class HeartbeatCommand(BaseModel):
+    id: str
+    command: str | None
+    payload: dict | None
+
+
+class HeartbeatResponse(BaseModel):
+    ok: bool
+    node_id: str
+    commands: list[HeartbeatCommand] = Field(description="Pending commands, acked on delivery.")
+
+
+class CommandCreateResponse(BaseModel):
+    id: str
+    status: str
+
+
+class FleetCommand(BaseModel):
+    id: str
+    node_id: str
+    command: str | None
+    payload: dict | None
+    status: str = Field(description="pending, acked, done, or failed.")
+    result: dict | None
+    created_at: str
+    acked_at: str | None
+    completed_at: str | None
+
+
+class OkResponse(BaseModel):
+    ok: bool
+
+
+class FleetNode(BaseModel):
+    node_id: str
+    node_name: str
+    fleet_id: str | None
+    hostname: str | None
+    ip: str | None
+    openclaw_version: str | None
+    plugin_version: str | None
+    plugin_hash: str | None
+    os_info: str | None
+    status: str = Field(description="online, stale, or offline.")
+    agents: list | None
+    tools: list | None
+    channels: list | None
+    metadata: dict | None = Field(
+        description="Open object; may carry recall_metrics, reconcile, deploy_blocked_until, sentinel markers."
+    )
+    last_heartbeat: str | None
+    created_at: str | None
+
+
+class FleetAgentStats(BaseModel):
+    agent_id: str
+    trust_level: int
+    total_memories: int
+    last_write_at: str | None
+    total_recalls: int
+    last_recall_at: str | None
+    active_24h: bool
+    stale: bool
+
+
+class FleetSummary(BaseModel):
+    total_agents: int
+    active_agents_24h: int
+    memories_24h: int
+    stale_agents: int
+    total_memories: int
+    conflicted_memories: int
+    outdated_memories: int
+    deleted_memories: int
+    recalled_memories_24h: int
+
+
+class FleetStatsResponse(BaseModel):
+    agents: list[FleetAgentStats]
+    fleet_summary: FleetSummary
+
+
+class AgentFleetPatchResponse(BaseModel):
+    agent_id: str
+    old_fleet_id: str | None
+    new_fleet_id: str
+
+
+# --------------------------------------------------------------------------
+# ingest / crystallize / insights
+# --------------------------------------------------------------------------
+
+
+class IngestFact(BaseModel):
+    content: str
+    suggested_type: str
+    source_uri: str | None = None
+    salience: float | None = Field(default=None, description="Only when the extractor emitted one.")
+
+
+class IngestPreviewResponse(BaseModel):
+    """Covers all four branches: cache hit (cached+run_id), too-short
+    (skipped_reason), zero-section, and the normal LLM path."""
+
+    url: str | None
+    content_length: int
+    facts: list[IngestFact]
+    chunk_ms: int
+    doc_hash: str | None = Field(default=None, description="Absent on cache-hit and too-short branches.")
+    sections: int | None = Field(default=None, description="Absent on cache-hit and too-short branches.")
+    cached: bool | None = Field(default=None, description="Only on a doc-hash cache hit.")
+    run_id: str | None = Field(default=None, description="Only on a cache hit: the prior run's id.")
+    skipped_reason: str | None = Field(default=None, description="Only when skipped (content_too_short).")
+
+
+class IngestCommitResponse(BaseModel):
+    url: str | None
+    facts_extracted: int
+    memories_created: int
+    skipped_duplicates: int
+    errored: int
+    run_id: str
+    ingest_ms: int
+
+
+class IngestUndoResponse(BaseModel):
+    deleted: int
+    run_id: str
+
+
+class CrystallizeReport(BaseModel):
+    """Nested blobs are open objects; authoritative sub-shapes live in
+    ``services/crystallizer_service.py`` (each may be ``{"error": true}``
+    when its check failed)."""
+
+    id: str
+    tenant_id: str | None
+    fleet_id: str | None
+    trigger: str | None
+    status: str | None = Field(description="running, completed, or failed.")
+    started_at: str | None
+    completed_at: str | None
+    duration_ms: int | None
+    summary: dict = Field(description="overall_score / critical / warning / info counts.")
+    hygiene: dict = Field(
+        description="Seven checks (orphaned_entities, near_duplicates, ...), each with count and affected ids."
+    )
+    health: dict
+    usage_data: dict
+    issues: list[dict] = Field(
+        description="Each: severity, category, code, title, description, count, affected_ids."
+    )
+    crystallization: dict
+
+
+class InsightFinding(BaseModel):
+    type: str
+    headline: str
+    what_happened: str
+    why_it_matters: str
+    recommended_action: str
+    confidence: float
+    related_memory_ids: list[str]
+    title: str = Field(description="Legacy mirror of headline.")
+    description: str = Field(description="Legacy mirror of what_happened + why_it_matters.")
+    recommendation: str = Field(description="Legacy mirror of recommended_action.")
+    insight_memory_id: str | None = Field(description="Null when persisting this finding failed.")
+
+
+class InsightsResponse(BaseModel):
+    focus: str
+    scope: str
+    memories_analyzed: int
+    findings: list[InsightFinding]
+    summary: str
+    insight_memory_ids: list[str]
+    gate_rejected: int
+    insights_ms: int
+
+
+class HealthResponse(BaseModel):
+    status: str = Field(description="ok, degraded, or unhealthy (unhealthy is served as 503).")
+    storage: str = Field(description="connected or unreachable.")
+    redis: str = Field(description="connected, unavailable, or not configured.")
+    event_bus: str = Field(description="ok, unhealthy, or error.")
+    platform_init_errors: list[str] | None = Field(
+        default=None,
+        description="Only when platform init recorded errors and all dependencies are up (status=degraded).",
+    )
+    unhealthy_dependencies: list[str] | None = Field(
+        default=None,
+        description="Only on 503: names of failing dependencies.",
+    )

--- a/core-api/src/core_api/openapi_responses.py
+++ b/core-api/src/core_api/openapi_responses.py
@@ -292,7 +292,7 @@ class SettingsResponse(BaseModel):
     chunking: dict
     write: WriteSettings
     agents: dict
-    memclaw: dict
+    memclaw: dict  # legacy-name-ok: documents the existing settings wire key
     security_audit: dict
     skills_factory: dict
     interviewer: dict

--- a/core-api/src/core_api/routes/agents.py
+++ b/core-api/src/core_api/routes/agents.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
 from core_api.schemas import AgentOut, AgentTrustUpdate, SearchProfileUpdate
@@ -69,7 +70,10 @@ async def patch_agent_trust(
     return AgentOut.model_validate(agent)
 
 
-@router.patch("/agents/{agent_id}/fleet")
+@router.patch(
+    "/agents/{agent_id}/fleet",
+    responses={200: {"model": _oar.AgentFleetPatchResponse}},
+)
 async def update_agent_fleet(
     agent_id: str,
     body: dict,

--- a/core-api/src/core_api/routes/crystallizer.py
+++ b/core-api/src/core_api/routes/crystallizer.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
 from core_api.schemas import STRICT_WRITE_BODY
@@ -125,7 +126,10 @@ async def list_reports(
     ]
 
 
-@router.get("/crystallize/reports/{report_id}")
+@router.get(
+    "/crystallize/reports/{report_id}",
+    responses={200: {"model": _oar.CrystallizeReport}},
+)
 async def get_report(
     report_id: UUID,
     auth: AuthContext = Depends(get_auth_context),
@@ -163,7 +167,10 @@ async def get_report(
     }
 
 
-@router.get("/crystallize/latest")
+@router.get(
+    "/crystallize/latest",
+    responses={200: {"model": _oar.CrystallizeReport | None}},
+)
 async def get_latest_report(
     tenant_id: str = Query(...),
     auth: AuthContext = Depends(get_auth_context),

--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from common.embedding import get_embedding
+from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
 from core_api.middleware.idempotency import IDEMPOTENCY_HEADER, idempotency_for
@@ -403,7 +404,10 @@ async def upsert_document(
 # because FastAPI matches in declaration order — without this ordering,
 # `GET /documents/collections` would match `/documents/{doc_id}` with
 # doc_id="collections" and require the `collection=` query param, returning 422.
-@router.get("/documents/collections")
+@router.get(
+    "/documents/collections",
+    responses={200: {"model": _oar.DocumentCollectionsResponse}},
+)
 async def list_collections(
     tenant_id: str = Query(...),
     fleet_id: str | None = Query(default=None),
@@ -433,7 +437,7 @@ async def list_collections(
     )
 
 
-@router.get("/documents/{doc_id}")
+@router.get("/documents/{doc_id}", responses={200: {"model": DocOut}})
 async def get_document(
     doc_id: str,
     tenant_id: str = Query(...),
@@ -454,7 +458,7 @@ async def get_document(
     return _dict_to_out(doc)
 
 
-@router.post("/documents/query")
+@router.post("/documents/query", responses={200: {"model": list[DocOut]}})
 async def query_documents(
     body: DocQueryRequest,
     auth: AuthContext = Depends(get_auth_context),
@@ -484,7 +488,7 @@ async def query_documents(
     return [_dict_to_out(d) for d in docs]
 
 
-@router.post("/skills/installable")
+@router.post("/skills/installable", responses={200: {"model": list[DocOut]}})
 async def installable_skills(
     body: InstallableSkillsRequest,
     auth: AuthContext = Depends(get_auth_context),
@@ -548,7 +552,7 @@ async def installable_skills(
     return [_dict_to_out(d) for d in docs]
 
 
-@router.get("/documents")
+@router.get("/documents", responses={200: {"model": list[DocOut]}})
 async def list_documents(
     tenant_id: str = Query(...),
     collection: str = Query(...),
@@ -607,7 +611,7 @@ async def delete_document(
 # See docs/api-surfaces.md for surface ownership rationale.
 
 
-@router.post("/documents/search")
+@router.post("/documents/search", responses={200: {"model": _oar.DocumentSearchResponse}})
 async def search_documents(
     body: DocSearchRequest,
     auth: AuthContext = Depends(get_auth_context),

--- a/core-api/src/core_api/routes/entities.py
+++ b/core-api/src/core_api/routes/entities.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
+from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
 from core_api.constants import DEFAULT_ENTITY_LIMIT, MAX_LIST_LIMIT
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Knowledge Graph"])
 
 
-@router.get("/entities")
+@router.get("/entities", responses={200: {"model": list[_oar.EntityListItem]}})
 async def list_entities(
     tenant_id: str = Query(...),
     fleet_id: str | None = Query(default=None),
@@ -80,7 +81,7 @@ async def list_entities(
     ]
 
 
-@router.get("/graph")
+@router.get("/graph", responses={200: {"model": _oar.GraphResponse}})
 async def get_graph(
     tenant_id: str = Query(...),
     fleet_id: str | None = Query(default=None),

--- a/core-api/src/core_api/routes/evolve.py
+++ b/core-api/src/core_api/routes/evolve.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.constants import EVOLVE_OUTCOME_TYPES, VALID_SCOPES
 from core_api.schemas import STRICT_WRITE_BODY
@@ -84,7 +85,7 @@ class EvolveRequest(BaseModel):
 # ── Routes ──
 
 
-@router.post("/evolve/report")
+@router.post("/evolve/report", responses={200: {"model": _oar.EvolveReportResponse}})
 async def report_outcome_endpoint(
     body: EvolveRequest,
     auth: AuthContext = Depends(get_auth_context),

--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, field_validator
 
 logger = logging.getLogger(__name__)
 
+from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
 from core_api.constants import NODE_OFFLINE_SECONDS, NODE_STALE_SECONDS
@@ -239,7 +240,11 @@ class CommandResultIn(BaseModel):
 # ── Fleet CRUD ──
 
 
-@router.post("/fleet", status_code=201)
+@router.post(
+    "/fleet",
+    status_code=201,
+    responses={201: {"model": _oar.FleetCreateResponse}},
+)
 async def create_fleet(
     body: FleetCreateIn,
     auth: AuthContext = Depends(get_auth_context),
@@ -281,7 +286,7 @@ async def create_fleet(
     return {"ok": True, "fleet_id": body.fleet_id, "tenant_id": body.tenant_id}
 
 
-@router.get("/fleet")
+@router.get("/fleet", responses={200: {"model": list[_oar.FleetListItem]}})
 async def list_fleets(
     tenant_id: str = Query(...),
     auth: AuthContext = Depends(get_auth_context),
@@ -332,7 +337,7 @@ async def delete_fleet(
     )
 
 
-@router.post("/fleet/{fleet_id}/purge")
+@router.post("/fleet/{fleet_id}/purge", responses={200: {"model": _oar.FleetPurgeResponse}})
 async def purge_fleet(
     fleet_id: str,
     tenant_id: str = Query(...),
@@ -640,7 +645,7 @@ async def _maybe_queue_auto_upgrade(
         return False
 
 
-@router.post("/fleet/heartbeat")
+@router.post("/fleet/heartbeat", responses={200: {"model": _oar.HeartbeatResponse}})
 async def heartbeat(
     body: HeartbeatIn,
     auth: AuthContext = Depends(get_auth_context),
@@ -862,7 +867,10 @@ async def heartbeat(
 # ── Command result ──
 
 
-@router.post("/fleet/commands/{command_id}/result")
+@router.post(
+    "/fleet/commands/{command_id}/result",
+    responses={200: {"model": _oar.OkResponse}},
+)
 async def command_result(
     command_id: UUID,
     body: CommandResultIn,
@@ -892,7 +900,7 @@ async def command_result(
 # ── Fleet nodes (frontend reads) ──
 
 
-@router.get("/fleet/nodes")
+@router.get("/fleet/nodes", responses={200: {"model": list[_oar.FleetNode]}})
 async def list_nodes(
     tenant_id: str = Query(...),
     fleet_id: str | None = Query(default=None),
@@ -953,7 +961,7 @@ async def list_nodes(
 # ── Fleet & agent stats ──
 
 
-@router.get("/fleet/stats")
+@router.get("/fleet/stats", responses={200: {"model": _oar.FleetStatsResponse}})
 async def fleet_stats(
     tenant_id: str = Query(...),
     fleet_id: str | None = Query(default=None),
@@ -968,7 +976,11 @@ async def fleet_stats(
 # ── Queue command (frontend posts) ──
 
 
-@router.post("/fleet/commands", status_code=201)
+@router.post(
+    "/fleet/commands",
+    status_code=201,
+    responses={201: {"model": _oar.CommandCreateResponse}},
+)
 async def create_command(
     body: CommandIn,
     auth: AuthContext = Depends(get_auth_context),
@@ -1001,7 +1013,7 @@ async def create_command(
 # ── Command history ──
 
 
-@router.get("/fleet/commands")
+@router.get("/fleet/commands", responses={200: {"model": list[_oar.FleetCommand]}})
 async def list_commands(
     tenant_id: str = Query(...),
     node_id: UUID | None = Query(default=None),

--- a/core-api/src/core_api/routes/health.py
+++ b/core-api/src/core_api/routes/health.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request, Response
 from starlette.status import HTTP_503_SERVICE_UNAVAILABLE
 
 from common.events.factory import get_event_bus
+from core_api import openapi_responses as _oar
 from core_api.cache import redis_healthy
 from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
@@ -24,7 +25,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["System"])
 
 
-@router.get("/version")
+@router.get("/version", responses={200: {"model": _oar.VersionResponse}})
 async def version():
     return {"version": VERSION}
 
@@ -93,7 +94,10 @@ async def whoami(request: Request) -> dict:
     }
 
 
-@router.get("/tool-descriptions")
+@router.get(
+    "/tool-descriptions",
+    responses={200: {"model": dict[str, str] | dict[str, _oar.ToolDescriptionEnriched]}},
+)
 async def tool_descriptions(enriched: bool = False):
     """Return tool descriptions, derived from the SoT registry.
 
@@ -171,7 +175,7 @@ async def _probe_dependencies() -> tuple[dict[str, Any], list[str]]:
     return result, unhealthy
 
 
-@router.get("/health")
+@router.get("/health", responses={200: {"model": _oar.HealthResponse}})
 async def health(response: Response):
     """Liveness + readiness probe.
 

--- a/core-api/src/core_api/routes/insights.py
+++ b/core-api/src/core_api/routes/insights.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.constants import INSIGHTS_FOCUS_MODES, VALID_SCOPES
 from core_api.schemas import STRICT_WRITE_BODY
@@ -63,7 +64,7 @@ class InsightsRequest(BaseModel):
 # ── Routes ──
 
 
-@router.post("/insights/generate")
+@router.post("/insights/generate", responses={200: {"model": _oar.InsightsResponse}})
 async def generate_insights_endpoint(
     body: InsightsRequest,
     auth: AuthContext = Depends(get_auth_context),

--- a/core-api/src/core_api/routes/keystones.py
+++ b/core-api/src/core_api/routes/keystones.py
@@ -52,6 +52,7 @@ import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Response
 from pydantic import BaseModel, Field
 
+from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import KeystoneUpsertPayload, get_storage_client
 from core_api.config import settings as app_settings
@@ -251,7 +252,10 @@ def _surface_storage_error(exc: httpx.HTTPStatusError) -> HTTPException:
 # ── Routes ──
 
 
-@router.get("")
+@router.get(
+    "",
+    responses={200: {"model": list[_oar.KeystoneDoc] | _oar.KeystonesEnvelope}},
+)
 async def list_keystones(
     response: Response,
     tenant_id: str = Query(...),
@@ -300,7 +304,7 @@ async def list_keystones(
     return rows
 
 
-@router.post("")
+@router.post("", responses={200: {"model": _oar.KeystoneDoc}})
 async def upsert_keystone(
     body: KeystoneSetRequest,
     x_agent_id: str | None = Header(default=None, alias="X-Agent-ID"),
@@ -433,7 +437,7 @@ async def upsert_keystone(
     return doc
 
 
-@router.delete("/{doc_id}")
+@router.delete("/{doc_id}", responses={200: {"model": _oar.KeystoneDeleteResponse}})
 async def delete_keystone(
     # Enforce the slug shape at the path-parameter layer — without this
     # an unvalidated ``doc_id`` flows straight into ``storage_client``'s

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -23,6 +23,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from common.enrichment.constants import SERVER_RESERVED_MEMORY_TYPES
+from core_api import openapi_responses as _oar
 from core_api.agent_ids import DEFAULT_AGENT_ID
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
@@ -159,7 +160,7 @@ def _missing_agent_id_error() -> RequestValidationError:
     )
 
 
-@router.get("/tenants")
+@router.get("/tenants", responses={200: {"model": list[str]}})
 async def list_tenants(
     auth: AuthContext = Depends(get_auth_context),
 ):
@@ -168,7 +169,7 @@ async def list_tenants(
     return sorted(await get_storage_client().list_active_tenants())
 
 
-@router.get("/fleets")
+@router.get("/fleets", responses={200: {"model": list[_oar.FleetDistributionItem]}})
 async def list_fleets(
     tenant_id: str | None = Query(default=None),
     auth: AuthContext = Depends(get_auth_context),
@@ -462,7 +463,7 @@ async def list_memories(
     return PaginatedMemoryResponse(items=items, next_cursor=next_cursor)
 
 
-@router.get("/memories/stats")
+@router.get("/memories/stats", responses={200: {"model": _oar.MemoryStatsResponse}})
 async def memory_stats(
     tenant_id: str | None = Query(default=None),
     fleet_id: str | None = Query(default=None),
@@ -555,7 +556,7 @@ async def memory_stats(
     )
 
 
-@router.get("/memories/count")
+@router.get("/memories/count", responses={200: {"model": _oar.MemoryCountResponse}})
 async def memory_count(
     tenant_id: str | None = Query(default=None),
     fleet_id: str | None = Query(default=None),
@@ -740,7 +741,7 @@ async def delete_all_memories(
     )
 
 
-@router.post("/memories/bulk-delete")
+@router.post("/memories/bulk-delete", responses={200: {"model": _oar.BulkDeleteResponse}})
 async def bulk_delete_by_ids(
     body: dict = Body(...),
     auth: AuthContext = Depends(get_auth_context),
@@ -874,7 +875,10 @@ async def get_memory(
     }
 
 
-@router.get("/memories/{memory_id}/contradictions")
+@router.get(
+    "/memories/{memory_id}/contradictions",
+    responses={200: {"model": _oar.MemoryContradictionsResponse}},
+)
 async def get_contradictions(
     memory_id: UUID,
     tenant_id: str = Query(...),
@@ -1529,7 +1533,10 @@ async def delete_memory(
     )
 
 
-@router.patch("/memories/{memory_id}/status")
+@router.patch(
+    "/memories/{memory_id}/status",
+    responses={200: {"model": _oar.MemoryStatusPatchResponse}},
+)
 async def update_memory_status(
     memory_id: UUID,
     body: dict,
@@ -1804,7 +1811,7 @@ async def _search_inner(
     )
 
 
-@router.post("/ingest/preview")
+@router.post("/ingest/preview", responses={200: {"model": _oar.IngestPreviewResponse}})
 async def ingest_preview_endpoint(
     body: IngestRequest,
     auth: AuthContext = Depends(get_auth_context),
@@ -1819,7 +1826,7 @@ async def ingest_preview_endpoint(
     return await ingest_preview(body)
 
 
-@router.post("/ingest/commit")
+@router.post("/ingest/commit", responses={200: {"model": _oar.IngestCommitResponse}})
 @write_limit
 async def ingest_commit_endpoint(
     request: Request,
@@ -1842,7 +1849,7 @@ async def ingest_commit_endpoint(
     return await ingest_commit(body)
 
 
-@router.post("/ingest/file")
+@router.post("/ingest/file", responses={200: {"model": _oar.IngestPreviewResponse}})
 async def ingest_file_endpoint(
     file: UploadFile = File(...),
     tenant_id: str = Form(...),
@@ -1902,7 +1909,7 @@ async def ingest_file_endpoint(
     return await ingest_preview(req)
 
 
-@router.post("/ingest/undo/{run_id}")
+@router.post("/ingest/undo/{run_id}", responses={200: {"model": _oar.IngestUndoResponse}})
 async def ingest_undo_endpoint(
     run_id: str,
     tenant_id: str = Query(...),
@@ -1957,7 +1964,7 @@ async def ingest_undo_endpoint(
     return {"deleted": deleted_count, "run_id": run_id}
 
 
-@router.post("/recall")
+@router.post("/recall", responses={200: {"model": _oar.RecallResponse}})
 @search_limit
 async def recall_endpoint(
     request: Request,

--- a/core-api/src/core_api/routes/settings.py
+++ b/core-api/src/core_api/routes/settings.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 
+from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.services.organization_settings import (
     PROVIDER_OPTIONS,
@@ -22,7 +23,7 @@ def _resolve_tenant(auth: AuthContext, tenant_id: str | None) -> str:
     raise HTTPException(status_code=400, detail="tenant_id required")
 
 
-@router.get("/settings")
+@router.get("/settings", responses={200: {"model": _oar.SettingsResponse}})
 async def get_tenant_settings(
     tenant_id: str | None = None,
     auth: AuthContext = Depends(get_auth_context),
@@ -32,7 +33,7 @@ async def get_tenant_settings(
     return await get_settings_for_display(tid)
 
 
-@router.put("/settings")
+@router.put("/settings", responses={200: {"model": _oar.SettingsResponse}})
 async def update_tenant_settings(
     body: dict,
     tenant_id: str | None = None,
@@ -73,7 +74,10 @@ async def update_tenant_settings(
         raise HTTPException(status_code=422, detail=str(e)) from e
 
 
-@router.get("/settings/providers")
+@router.get(
+    "/settings/providers",
+    responses={200: {"model": dict[str, dict[str, list[str]]]}},
+)
 async def list_providers():
     """List available LLM providers and models for each function."""
     return PROVIDER_OPTIONS

--- a/tests/test_broker_contract.py
+++ b/tests/test_broker_contract.py
@@ -28,18 +28,14 @@ _METHODS = ("get", "post", "patch", "delete", "put")
 # with the reason. Adding an entry is a conscious decision to leave a response
 # shape unguarded — that is the point of listing them here.
 #
-#   GET /health, GET /version   — liveness/handshake payloads with no
-#       response_model on the route; trivial, stable shapes.
-#
 # ``GET /memories/{memory_id}`` was listed here until its handler stopped returning
 # a ``JSONResponse`` (FastAPI skips response validation for a Response object, so a
 # ``response_model`` alongside one documents a guarantee the code does not make).
 # It now returns a dict against ``MemoryDetailResponse`` and is genuinely typed —
 # and the assertion below FAILS on a stale entry, which is what removed it.
-_UNTYPED_200 = {
-    ("get", "/api/v1/health"),
-    ("get", "/api/v1/version"),
-}
+# ``GET /health`` and ``GET /version`` came off the list when C33 gave them
+# documented schemas (spec-only ``responses=`` in ``openapi_responses.py``).
+_UNTYPED_200: set[tuple[str, str]] = set()
 
 
 def _baseline() -> dict:

--- a/tests/test_c33_openapi_completeness.py
+++ b/tests/test_c33_openapi_completeness.py
@@ -128,6 +128,6 @@ def test_servers_block_absent_by_default(monkeypatch):
 def test_servers_block_present_when_configured(monkeypatch):
     from core_api.config import settings
 
-    monkeypatch.setattr(settings, "public_api_url", "https://memclaw.dev/")
+    monkeypatch.setattr(settings, "public_api_url", "https://api.caura.ai/")
     spec = _fresh_spec()
-    assert spec.get("servers") == [{"url": "https://memclaw.dev"}]
+    assert spec.get("servers") == [{"url": "https://api.caura.ai"}]

--- a/tests/test_c33_openapi_completeness.py
+++ b/tests/test_c33_openapi_completeness.py
@@ -1,0 +1,133 @@
+"""C33 — OpenAPI completeness guarantees.
+
+Three invariants:
+
+1. Every endpoint annotated via ``openapi_responses`` actually surfaces a
+   non-empty success schema in the generated spec (the ``responses=``
+   attachment is easy to typo into a no-op).
+2. The number of success responses WITHOUT a documented schema only goes
+   down — a ratchet, so new routes can't ship blank and regressions on
+   annotated routes are caught. Lower the ceiling when you document more.
+3. The ``servers`` block is driven by ``public_api_url``: absent when the
+   setting is empty (OSS default — spec byte-identical to pre-C33), present
+   with the trailing-slash-normalized URL when set.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Success responses (200/201 on get/put/post/patch/delete ops) still lacking
+# a real schema. 66 before C33. Deliberately undocumented for now: STM (dead
+# feature), plugin/skill delivery (script/text payloads), and admin
+# internals. Lower this as any of them get documented.
+EMPTY_SUCCESS_CEILING = 23
+
+ANNOTATED = [
+    ("get", "/api/v1/memories/stats"),
+    ("get", "/api/v1/memories/count"),
+    ("post", "/api/v1/memories/bulk-delete"),
+    ("get", "/api/v1/memories/{memory_id}/contradictions"),
+    ("patch", "/api/v1/memories/{memory_id}/status"),
+    ("post", "/api/v1/recall"),
+    ("get", "/api/v1/version"),
+    ("get", "/api/v1/health"),
+    ("post", "/api/v1/documents/search"),
+    ("get", "/api/v1/documents"),
+    ("get", "/api/v1/documents/{doc_id}"),
+    ("get", "/api/v1/documents/collections"),
+    ("post", "/api/v1/documents/query"),
+    ("post", "/api/v1/skills/installable"),
+    ("get", "/api/v1/keystones"),
+    ("post", "/api/v1/keystones"),
+    ("delete", "/api/v1/keystones/{doc_id}"),
+    ("post", "/api/v1/evolve/report"),
+    ("get", "/api/v1/entities"),
+    ("get", "/api/v1/graph"),
+    ("get", "/api/v1/settings"),
+    ("put", "/api/v1/settings"),
+    ("get", "/api/v1/settings/providers"),
+    ("get", "/api/v1/tenants"),
+    ("get", "/api/v1/fleets"),
+    ("get", "/api/v1/tool-descriptions"),
+]
+
+
+def _fresh_spec():
+    from core_api.app import app
+
+    app.openapi_schema = None  # bust the cache; other tests may have filled it
+    try:
+        return app.openapi()
+    finally:
+        app.openapi_schema = None
+
+
+def _success_schema(spec, method, path):
+    op = spec["paths"][path][method]
+    for code in ("200", "201"):
+        if code in op["responses"]:
+            content = op["responses"][code].get("content", {})
+            return content.get("application/json", {}).get("schema")
+    return None
+
+
+def _is_empty(schema) -> bool:
+    if not schema:
+        return True
+    keys = set(schema.keys())
+    return keys <= {"title", "type"} and schema.get("type") in (None, "object")
+
+
+def test_annotated_endpoints_have_real_schemas():
+    spec = _fresh_spec()
+    blank = [
+        f"{m.upper()} {p}"
+        for m, p in ANNOTATED
+        if _is_empty(_success_schema(spec, m, p))
+    ]
+    assert not blank, f"annotated but schema still empty: {blank}"
+
+
+def test_empty_success_schema_ratchet():
+    spec = _fresh_spec()
+    empty = []
+    for path, ops in spec["paths"].items():
+        for method, op in ops.items():
+            if method not in ("get", "put", "post", "delete", "patch"):
+                continue
+            found = False
+            for code in ("200", "201"):
+                if code in op.get("responses", {}):
+                    found = True
+                    if _is_empty(
+                        op["responses"][code]
+                        .get("content", {})
+                        .get("application/json", {})
+                        .get("schema")
+                    ):
+                        empty.append(f"{method.upper()} {path}")
+                    break
+            del found
+    assert len(empty) <= EMPTY_SUCCESS_CEILING, (
+        f"{len(empty)} success responses lack a schema "
+        f"(ceiling {EMPTY_SUCCESS_CEILING}). New/regressed: document them in "
+        f"core_api/openapi_responses.py or raise the ceiling with justification. "
+        f"Full list: {empty}"
+    )
+
+
+def test_servers_block_absent_by_default(monkeypatch):
+    from core_api.config import settings
+
+    monkeypatch.setattr(settings, "public_api_url", "")
+    spec = _fresh_spec()
+    assert "servers" not in spec or not spec.get("servers")
+
+
+def test_servers_block_present_when_configured(monkeypatch):
+    from core_api.config import settings
+
+    monkeypatch.setattr(settings, "public_api_url", "https://memclaw.dev/")
+    spec = _fresh_spec()
+    assert spec.get("servers") == [{"url": "https://memclaw.dev"}]

--- a/tests/test_d13_recall_metering.py
+++ b/tests/test_d13_recall_metering.py
@@ -37,7 +37,6 @@ async def test_operation_reaches_the_usage_hook(monkeypatch):
 
     async def fake_hook(*, tenant_id, operation, count):
         seen["operation"] = operation
-        return None
 
     class Hooks:
         usage_meter = staticmethod(fake_hook)
@@ -63,8 +62,10 @@ def test_no_bare_search_literal_left_on_recall_sites():
 
     root = pathlib.Path(__file__).resolve().parents[1] / "core-api" / "src" / "core_api"
     recall_route = (root / "routes" / "memories.py").read_text()
-    # the /recall endpoint body sits between its decorator and the next route
-    recall_section = recall_route.split('@router.post("/recall")')[1].split("@router.post")[0]
+    # the /recall endpoint body sits between its decorator and the next route;
+    # anchor on the path literal only so decorator kwargs (e.g. C33's
+    # ``responses=``) don't break the split
+    recall_section = recall_route.split('@router.post("/recall"')[1].split("@router.post")[0]
     assert 'check_and_increment(body.tenant_id, recall_operation())' in recall_section
     assert 'check_and_increment(body.tenant_id, "search")' not in recall_section
 


### PR DESCRIPTION
## Summary

C33 (register API-10), OSS half. Before: **66 of 104** success responses in `/api/openapi.json` were empty `{}` schemas and the spec had no `servers` block — agents and generated clients got zero response shapes. After: **23 remain**, all deliberate skips (STM routes — dead feature; plugin/skill delivery payloads — script/text; admin internals).

## What changed

- **`core_api/openapi_responses.py`** — 44 spec-only response models attached to 43 endpoints via `responses={200: {"model": ...}}`. Deliberately **not** `response_model=`: that would route responses through Pydantic serialization (coercing values, dropping undeclared keys) — a runtime behavior change. Spec-only attachment moves only the spec; the wire is untouched. Shapes were extracted from the handlers and their storage calls, not guessed; conditional keys carry when-they-appear descriptions (e.g. ingest/preview's four branches, health's degraded/unhealthy keys, keystone `data.agent_id` only when scope=agent).
- **`servers` block** — new `public_api_url` setting (`PUBLIC_API_URL`). Empty (OSS default): no servers block, spec byte-identical to before. Set (`https://memclaw.dev`): spec gains `servers=[{url}]`. The enterprise deploy env rides the C33 enterprise PR.
- **Guards** — `tests/test_c33_openapi_completeness.py`: every annotated endpoint must surface a real schema; empty-success-schema count **ratcheted at ≤23** (new routes can't ship blank); servers behavior asserted both ways.
- **Broker baseline** regenerated — additive only (`HealthResponse`/`VersionResponse` now typed on the two broker-set ops); their `_UNTYPED_200` allowlist entries removed, which that guard itself demanded.

## Testing

- Full root suite: **5252 passed**; mypy/ruff clean.
- **Live wet sweep** on the local enterprise compose stack (fresh image, fresh tenant): 22 endpoints exercised end-to-end — each live JSON response `model_validate`d against its model **and** checked for undocumented top-level keys (the docs must not lie by omission). All PASS. Live spec: exactly 23 empty schemas; no servers block without the env (unit tests cover the env-set path both ways).
- Wet testing this slice also caught the `POST /documents` D14 500 fixed in #985.

Found & filed along the way: **C36 (High)** — `GET/PUT /settings` returns `api_keys` verbatim while the docstring claims masking (separate task, not touched here).

Refs: canonical C33 / register API-10. Enterprise half (bare `/openapi.json` redirect, llms-full.txt renderer, `PUBLIC_API_URL` env, refreshed `openapi.snapshot.json`) follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)