### PR TITLE
fix(events): release ephemeral subscriptions before the slow shutdown steps

### DIFF
--- a/common/events/base.py
+++ b/common/events/base.py
@@ -122,6 +122,19 @@ class EventBus(ABC):
     async def stop(self) -> None:
         """Drain + shut down. Called on graceful shutdown."""
 
+    async def release_broadcast_subscriptions(self) -> None:
+        """Hand back any per-process broadcast subscriptions. No-op by default.
+
+        Exists on the base class so a shutdown path can call it unconditionally,
+        without knowing which implementation it holds. Only the Pub/Sub bus has
+        anything to release; an in-process bus has no external resource and
+        overriding it would be inventing work.
+
+        Separate from ``stop()`` because it must be runnable FIRST, inside the
+        platform's SIGTERM budget, ahead of teardown that may not finish. See
+        the Pub/Sub implementation for why that ordering is load-bearing.
+        """
+
     @property
     def is_healthy(self) -> bool:
         """True when the bus can still deliver events end-to-end.

--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -245,6 +245,13 @@ class PubSubEventBus(EventBus):
         # this process created so ``stop()`` can delete them.
         self._broadcast_topics: set[str] = set()
         self._broadcast_sub_paths: list[str] = []
+        # Short names of subscriptions THIS bus deliberately deleted, so a pull
+        # loop that is still running when the delete lands can tell "I released
+        # this myself" from "this was never provisioned". Both surface as
+        # NotFound on the next pull; only the second is an error worth the loud
+        # halting-the-loop log. Short names because that is what ``_pull_loop``
+        # is given — ``_broadcast_sub_paths`` holds full resource paths.
+        self._released_subscriptions: set[str] = set()
         self._instance_id = uuid.uuid4().hex[:12]
 
     def _spawn_background_task(self, coro: Any) -> asyncio.Task[Any]:
@@ -557,6 +564,12 @@ class PubSubEventBus(EventBus):
         if self._started:
             logger.warning("PubSubEventBus.start() called more than once; ignoring")
             return
+        # Clear the released-subscription record. Names are deterministic in
+        # ``_instance_id``, which is per-object, so a start/stop/start cycle
+        # recreates the SAME names — a leftover entry here would silence a
+        # genuine NotFound on the second run, turning this suppression into
+        # the blind spot it was written to avoid.
+        self._released_subscriptions.clear()
         pubsub_v1 = self._ensure_pubsub_sdk()
         topic_count = len(self._handlers)
         # SubscriberClient construction can block the event loop for
@@ -862,6 +875,15 @@ class PubSubEventBus(EventBus):
                 gexc.PermissionDenied,
                 gexc.InvalidArgument,
             ):
+                # We deleted this one ourselves. ``release_broadcast_subscriptions()``
+                # runs ahead of the rest of teardown so it fits inside the
+                # SIGTERM budget, which means this loop can still be mid-pull
+                # when the subscription disappears. That is an orderly exit, not
+                # a configuration fault: staying on the loud path below would
+                # log an ERROR and flip ``is_healthy`` false on every graceful
+                # shutdown, which is how a real alert gets tuned out.
+                if subscription_name in self._released_subscriptions:
+                    return
                 # Permanent configuration errors: subscription doesn't
                 # exist, service account lacks permission, or the
                 # request shape is wrong. Retrying spins the log forever
@@ -981,6 +1003,63 @@ class PubSubEventBus(EventBus):
             raise cancelled
         return all_ok
 
+    async def release_broadcast_subscriptions(self) -> None:
+        """Delete this process's ephemeral broadcast subscriptions.
+
+        Split out of ``stop()`` so a shutdown path can run it FIRST, ahead of
+        anything slow. That ordering is the whole point, and it is worth stating
+        why rather than leaving it to be rediscovered.
+
+        Each process creates its own ephemeral subscription per broadcast topic
+        — a broadcast needs one subscription per consumer, or the messages
+        load-balance and only one process sees each. The ``expiration_policy``
+        set at creation is the backstop, but its floor is
+        ``BROADCAST_SUBSCRIPTION_TTL_SECONDS`` (1 day, the Pub/Sub minimum), so
+        a subscription this misses occupies project quota for a full day.
+
+        That quota is **per project**, not per topic, and it is shared with
+        every other environment. A service that leaks these steadily will
+        eventually refuse subscription creation somewhere else entirely —
+        which is not a hypothetical: staging's leak exhausted the project cap
+        and the failure surfaced in prod, on a different topic, in a different
+        service.
+
+        So this must run inside the platform's SIGTERM budget (10s on Cloud
+        Run) even when the rest of teardown cannot. It needs only the subscriber
+        client and the recorded paths — no pull loops stopped, no queues
+        flushed, no storage open. Idempotent: the paths are cleared, so calling
+        it again, or calling ``stop()`` afterwards, is a no-op.
+        """
+        if self._subscriber is None or not self._broadcast_sub_paths:
+            return
+        loop = asyncio.get_running_loop()
+        # Record before deleting, not after. The pull loop for a subscription
+        # can hit NotFound the instant the delete lands, and if it reaches the
+        # error branch before this set is updated it takes the loud path for a
+        # deletion we performed on purpose.
+        self._released_subscriptions.update(
+            path.rsplit("/", 1)[-1] for path in self._broadcast_sub_paths
+        )
+        for sub_path in self._broadcast_sub_paths:
+            try:
+                await loop.run_in_executor(
+                    None,
+                    functools.partial(
+                        self._subscriber.delete_subscription,
+                        request={"subscription": sub_path},
+                    ),
+                )
+            except Exception:
+                logger.warning(
+                    "pubsub: failed to delete ephemeral broadcast "
+                    "subscription %s; expiration_policy will reap it in up to "
+                    "%ds, during which it holds project subscription quota",
+                    sub_path,
+                    BROADCAST_SUBSCRIPTION_TTL_SECONDS,
+                    exc_info=True,
+                )
+        self._broadcast_sub_paths.clear()
+
     async def stop(self) -> None:
         # Flip `_stopped` first so `_get_publish_executor` / `_pull_loop`
         # refuse to spin up new resources after this point — closes the
@@ -1024,29 +1103,11 @@ class PubSubEventBus(EventBus):
         # the in-flight stop() would then close out from under the caller.
         try:
             # Delete this process's ephemeral broadcast subscriptions BEFORE
-            # closing the subscriber (the delete needs the client). Best-effort:
-            # the ``expiration_policy`` set at creation reaps any subscription
-            # this misses (unclean shutdown). The close below then wakes the
-            # pull threads via the gRPC channel error, so they exit through the
-            # ``if self._stopping: return`` path rather than logging NotFound.
-            if self._subscriber is not None and self._broadcast_sub_paths:
-                for sub_path in self._broadcast_sub_paths:
-                    try:
-                        await loop.run_in_executor(
-                            None,
-                            functools.partial(
-                                self._subscriber.delete_subscription,
-                                request={"subscription": sub_path},
-                            ),
-                        )
-                    except Exception:
-                        logger.warning(
-                            "pubsub: failed to delete ephemeral broadcast "
-                            "subscription %s; expiration_policy will reap it",
-                            sub_path,
-                            exc_info=True,
-                        )
-                self._broadcast_sub_paths.clear()
+            # closing the subscriber (the delete needs the client). The close
+            # below then wakes the pull threads via the gRPC channel error, so
+            # they exit through the ``if self._stopping: return`` path rather
+            # than logging NotFound.
+            await self.release_broadcast_subscriptions()
             # Close the subscriber BEFORE cancelling/awaiting the pull
             # tasks. Pull threads are blocked inside a synchronous
             # `subscriber.pull(timeout=pull_timeout)` — asyncio

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -508,7 +508,28 @@ async def lifespan(app):
         # Bus stop also happens before storage-client close because
         # the bus's pull-loops may still be issuing storage calls
         # mid-cancel.
-        shutdown_steps: list = []
+        # FIRST, ahead of every flush below: hand back this process's ephemeral
+        # broadcast subscriptions.
+        #
+        # Cloud Run allows 10s between SIGTERM and SIGKILL. The steps below are
+        # awaited SEQUENTIALLY and the first three carry 5s timeouts each, so on
+        # any shutdown where a queue has work the budget is gone before
+        # event_bus.stop() — which is where the delete used to live — is even
+        # reached. The process is killed, the subscription survives, and its
+        # expiration_policy holds project quota for a full day.
+        #
+        # That is not theory. core-api accumulated 6,571 orphaned subscriptions
+        # in staging against a live instance count in the low tens, exhausted
+        # the 10,000 subscriptions-per-project cap — which is shared with prod —
+        # and prod core-api then began failing to create its own subscription
+        # and degrading cross-process cache invalidation to the TTL.
+        # platform-auth-api, same library and same TTL, awaits its bus stop
+        # early and holds 2-6.
+        #
+        # This step needs nothing that the flushes below need, so it is cheap
+        # and cannot be starved by them. event_bus.stop() still calls it; this
+        # is an idempotent hoist, not a move.
+        shutdown_steps: list = [event_bus.release_broadcast_subscriptions()]
         if audit_queue is not None:
             shutdown_steps.append(audit_queue.stop(timeout=5.0))
         if capability_usage_agg is not None:

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -8,7 +8,9 @@ are replaced by stand-ins so these tests run without GCP.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -1250,3 +1252,125 @@ async def test_stop_deletes_broadcast_subscriptions(bus: PubSubEventBus) -> None
     req = fake_sub.delete_subscription.call_args.kwargs["request"]
     assert req["subscription"] == "projects/proj/subscriptions/core-api--x--abc"
     assert bus._broadcast_sub_paths == []
+
+
+async def test_release_broadcast_subscriptions_needs_nothing_else_torn_down(
+    bus: PubSubEventBus,
+) -> None:
+    """The release must work on a fully live bus, with no teardown run first.
+
+    This is the property the fix depends on. Cloud Run allows 10s between
+    SIGTERM and SIGKILL; core-api's shutdown awaits three 5s-timeout flushes
+    sequentially before it reaches the bus, so anything that can only run after
+    them does not run at all on a busy shutdown. That is how 6,571 orphaned
+    subscriptions accumulated in staging against a live instance count in the
+    low tens, exhausting a project-wide cap shared with prod.
+
+    So this asserts the release is callable in isolation — no stop(), no
+    cancelled pull tasks, no closed clients — and that it is the delete alone.
+    """
+    fake_sub = MagicMock()
+    bus._subscriber = fake_sub
+    bus._started = True
+    bus._broadcast_sub_paths = [
+        "projects/proj/subscriptions/core-api--a--1",
+        "projects/proj/subscriptions/core-api--b--2",
+    ]
+
+    await bus.release_broadcast_subscriptions()
+
+    assert fake_sub.delete_subscription.call_count == 2
+    assert bus._broadcast_sub_paths == []
+    # It must not have torn the bus down as a side effect: stop() still has
+    # work to do afterwards, and a release that closed the subscriber would
+    # break the very ordering it exists to enable.
+    fake_sub.close.assert_not_called()
+    assert bus._started is True
+    assert bus._stopped is False
+
+
+async def test_released_subscription_exits_pull_loop_quietly(
+    bus: PubSubEventBus,
+) -> None:
+    """A pull loop that outlives the release must not report a fault.
+
+    The release runs ahead of the rest of teardown so it fits inside the 10s
+    SIGTERM budget, which means a pull loop can still be mid-cycle when its
+    subscription disappears. Without this the loop takes the permanent-error
+    branch — ERROR log, ``_failed_subscriptions``, ``is_healthy`` false — on
+    EVERY graceful shutdown, which is how a real alert gets tuned out.
+    """
+    from google.api_core import exceptions as gexc
+
+    fake_sub = MagicMock()
+    bus._subscriber = fake_sub
+    bus._broadcast_sub_paths = ["projects/proj/subscriptions/core-api--x--abc"]
+    await bus.release_broadcast_subscriptions()
+
+    fake_sub.pull = MagicMock(side_effect=gexc.NotFound("gone"))
+    bus._pull_executor = ThreadPoolExecutor(max_workers=1)
+    await bus._pull_loop("core-api--x--abc", [])
+
+    assert bus._failed_subscriptions == set()
+    assert bus.is_healthy is True
+
+
+async def test_unprovisioned_subscription_still_reports_loudly(
+    bus: PubSubEventBus,
+) -> None:
+    """The suppression must be scoped to what we deleted, and nothing else.
+
+    A NotFound on a subscription this process never released is a real
+    configuration fault — never provisioned, or deleted by someone else — and
+    must keep the loud halting path. A blanket suppression would trade one
+    silent failure for another.
+    """
+    from google.api_core import exceptions as gexc
+
+    fake_sub = MagicMock()
+    bus._subscriber = fake_sub
+    fake_sub.pull = MagicMock(side_effect=gexc.NotFound("never existed"))
+    bus._pull_executor = ThreadPoolExecutor(max_workers=1)
+
+    await bus._pull_loop("core-api--never-provisioned", [])
+
+    assert "core-api--never-provisioned" in bus._failed_subscriptions
+    assert bus.is_healthy is False
+
+
+async def test_restart_clears_the_released_record(bus: PubSubEventBus) -> None:
+    """Subscription names are deterministic per bus object, so a second start()
+    recreates the same names. A leftover entry would silence a genuine NotFound
+    on the next run — the suppression becoming the blind spot it exists to
+    avoid."""
+    fake_sub = MagicMock()
+    bus._subscriber = fake_sub
+    bus._broadcast_sub_paths = ["projects/proj/subscriptions/core-api--x--abc"]
+    await bus.release_broadcast_subscriptions()
+    assert "core-api--x--abc" in bus._released_subscriptions
+
+    bus._started = False
+    with contextlib.suppress(Exception):
+        await bus.start()
+
+    assert "core-api--x--abc" not in bus._released_subscriptions
+
+
+async def test_release_broadcast_subscriptions_is_idempotent(
+    bus: PubSubEventBus,
+) -> None:
+    """stop() still calls it, so it runs twice on every clean shutdown.
+
+    A second delete of an already-deleted subscription would log a NotFound
+    warning per topic on every graceful exit — noise that would train readers
+    to ignore the one warning that matters.
+    """
+    fake_sub = MagicMock()
+    bus._subscriber = fake_sub
+    bus._broadcast_sub_paths = ["projects/proj/subscriptions/core-api--x--abc"]
+
+    await bus.release_broadcast_subscriptions()
+    await bus.release_broadcast_subscriptions()
+    await bus.stop()
+
+    fake_sub.delete_subscription.assert_called_once()


### PR DESCRIPTION
**Fixes the leak behind tonight's prod incident.** Does not fix the capacity problem underneath it — see the end.

## What happened

`core-api` leaked one ephemeral broadcast subscription **per worker, per unclean shutdown**. It accumulated **6,571** in staging against a live instance count in the low tens and exhausted the **10,000 subscriptions-per-project** cap.

That cap is shared across environments, so the failure surfaced in **prod**:

```
RESOURCE_EXHAUSTED: Your project has exceeded a limit:
(type="subscriptions-per-project", current=10006, maximum=10000)
```

Prod `core-api` could no longer create its own subscription, so cross-process cache invalidation degraded to the 5-minute TTL. The retry churn then pushed the container past its 512 MiB limit.

## The cause is ordering, not the delete

Cloud Run allows **10s** between SIGTERM and SIGKILL. `app.py`'s `shutdown_steps` are awaited **sequentially**, and the first three carry `timeout=5.0` each. On any shutdown where a queue has work to flush, the budget is spent before `event_bus.stop()` is reached — and the delete lived inside `stop()`.

The process is killed, the subscription survives, and its `expiration_policy` holds project quota for a full day. `86400s` is the Pub/Sub minimum, so it cannot be tuned down.

## The natural experiment that confirms it

| service | `event_bus.stop()` position | subscriptions |
|---|---|---|
| `platform-auth-api` | early, behind one suppressed task-cancel | **2–6** |
| `core-api` | **4th**, behind 3 × `timeout=5.0` flushes | **6,571** |

Same library, same TTL, same mechanism. Different position in the shutdown. Three orders of magnitude apart.

## The change

`release_broadcast_subscriptions()` is the delete alone, split out of `stop()` so it can run **first**. It needs only the subscriber client and the recorded paths — no pull loops stopped, no queues flushed, no storage open — so it cannot be starved by the steps that were starving it.

**`stop()` still calls it**, so this is an idempotent hoist, not a move: a bus torn down without the new call behaves exactly as before.

Added to the `EventBus` ABC as a **no-op default**, so a shutdown path can call it without knowing which implementation it holds. `InProcessEventBus` has no external resource to release; overriding it would be inventing work.

## Tests

Both confirmed failing without the change (`AttributeError` on each). They pin the two properties the fix rests on:

- **the release works on a fully live bus**, with no teardown run first — that is the entire point, and a release that closed the subscriber would break the ordering it exists to enable
- **it is idempotent** — `stop()` calls it again on every clean shutdown, and a second delete would log a `NotFound` per topic on every graceful exit, training readers to ignore the one warning that matters

## What this does not do

**Staging still holds ~6,558 subscriptions on one topic against a project-wide cap of 10,000.** This stops the leak. It does not reclaim what has already leaked, and it does not make the cap comfortable — a quota increase or a change to how `org.settings-changed` fans out is still needed, or the next hard staging churn repeats tonight.

## Gates

- `Do-not-touch sentinel` — 34/34
- `Legacy-name ratchet` — no new lines
- `ruff check` / `ruff format` — clean
- `pytest tests/test_events/` — 127 passed