### PR TITLE
fix(api): PATCH with an explicit null on a NOT NULL field is 400, not 500

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -143,6 +143,18 @@ class BlankQuery(ValueError):
     """
 
 
+# ``MemoryUpdate`` fields whose backing column on ``Memory`` is NOT NULL, so an
+# explicit ``null`` in a PATCH body has no way to be honoured. Kept as a literal
+# rather than derived from ``Memory.__table__`` at import time: the schema field
+# names and column names coincide for these five but not in general (``metadata``
+# maps to ``metadata_``), so a derivation would need its own mapping table and
+# would fail silently if that drifted. ``test_patch_null_non_nullable`` asserts
+# this tuple still matches the model, which is the check that actually holds it
+# in sync — add a NOT NULL column with a ``MemoryUpdate`` field and that test
+# fails until it is listed here.
+NON_NULLABLE_UPDATE_FIELDS = ("content", "memory_type", "weight", "status", "visibility")
+
+
 def _content_hash(tenant_id: str, fleet_id: str | None, content: str) -> str:
     return hashlib.sha256(f"{tenant_id}:{fleet_id or ''}:{content}".encode()).hexdigest()
 
@@ -3499,6 +3511,34 @@ async def update_memory(
     fields_set = data.model_fields_set
     if not fields_set:
         raise HTTPException(status_code=400, detail="No fields to update")
+
+    # Explicit ``null`` on a column the row cannot hold NULL in. Every
+    # ``MemoryUpdate`` field is typed ``X | None`` because that is how an
+    # optional PATCH field is spelled, so ``{"weight": null}`` validates and
+    # arrives here indistinguishable from a real value — the field-level
+    # constraints (``min_length``, ``ge``/``le``, ``pattern``) only bind the
+    # non-None branch of the union.
+    #
+    # Nine sibling fields DO honour null-as-clear (title, source_uri,
+    # predicate, object_value, subject_entity_id, the three timestamps,
+    # entity_links); those are nullable columns and the ``simple_fields`` loop
+    # below writes the NULL deliberately. These five are not, and left
+    # unguarded each one produced a 500 rather than a 4xx: ``content`` raised
+    # ``TypeError: 'NoneType' object is not subscriptable`` building the audit
+    # diff, and the other four reached Postgres and came back as
+    # ``NotNullViolationError``. Reachable from any caller that serialises the
+    # whole schema rather than only the fields it set — the plugin's update
+    # tool drops ``undefined`` but forwards ``null`` verbatim.
+    #
+    # 400 rather than a schema-level 422, to match ``metadata=null`` below,
+    # which is the same "this null has no valid meaning" rule and is already
+    # answered that way a hundred lines down.
+    nulled = [f for f in NON_NULLABLE_UPDATE_FIELDS if f in fields_set and getattr(data, f) is None]
+    if nulled:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{', '.join(nulled)} cannot be null; omit the field to leave it unchanged",
+        )
 
     # Snapshot old values for audit diff
     changes: dict = {}

--- a/tests/test_patch_null_non_nullable.py
+++ b/tests/test_patch_null_non_nullable.py
@@ -1,0 +1,168 @@
+"""``PATCH /memories/{id}`` with an explicit ``null`` on a NOT NULL column.
+
+Every ``MemoryUpdate`` field is typed ``X | None`` — that is how an optional
+PATCH field is spelled — so ``{"weight": null}`` passes validation and reaches
+the service indistinguishable from a real value. The field-level constraints
+(``min_length``, ``ge``/``le``, ``pattern``) bind only the non-None branch of
+the union, so none of them rejects it either.
+
+For the nine fields whose column is nullable that is a supported operation:
+null clears the column, and the ``simple_fields`` loop writes the NULL
+deliberately. For the five whose column is NOT NULL there is no way to honour
+it, and before the guard each produced a 500 rather than a 4xx:
+
+    content      TypeError: 'NoneType' object is not subscriptable
+                 (``data.content[:200]`` while building the audit diff)
+    memory_type  asyncpg NotNullViolationError
+    weight       asyncpg NotNullViolationError
+    status       asyncpg NotNullViolationError
+    visibility   asyncpg NotNullViolationError
+
+Reachable from any caller that serialises the whole schema rather than only the
+fields it set; the plugin's update tool skips ``undefined`` but forwards
+``null`` verbatim (``plugin/src/tool-definitions.ts``).
+
+Nothing reported it: mypy flags the ``content`` one as
+``Value of type "str | None" is not indexable  [index]``, but
+``core-api/pyproject.toml`` carries ``ignore_errors = true`` for
+``core_api.services.*``. The other four are runtime-only.
+"""
+
+import pytest
+
+from common.models import Memory
+from core_api.schemas import MemoryUpdate
+from core_api.services.memory_service import NON_NULLABLE_UPDATE_FIELDS
+from tests.conftest import get_test_auth, uid as _uid
+
+# ``asyncio_mode = auto`` (pytest.ini) runs the async tests below without an
+# explicit asyncio mark; adding one would also land on the sync drift test.
+pytestmark = [pytest.mark.unit]
+
+
+# Fields whose column IS nullable: an explicit null legitimately clears them and
+# must keep working, so the guard cannot simply reject every null.
+NULLABLE_UPDATE_FIELDS = (
+    "title",
+    "source_uri",
+    "subject_entity_id",
+    "predicate",
+    "object_value",
+    "ts_valid_start",
+    "ts_valid_end",
+    "expires_at",
+)
+
+
+async def _write_memory(client, tenant_id: str, headers: dict) -> dict:
+    tag = _uid()
+    resp = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "content": f"null-patch guard fixture [{tag}]",
+            "agent_id": f"npg-agent-{tag}",
+            "fleet_id": f"npg-fleet-{tag}",
+            "memory_type": "fact",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, f"seed write failed: {resp.text}"
+    return resp.json()
+
+
+@pytest.mark.parametrize("field", NON_NULLABLE_UPDATE_FIELDS)
+async def test_explicit_null_on_non_nullable_field_is_400(client, tenant_id, field):
+    """400, not a 500 and not a silent no-op.
+
+    Without the guard this does not merely return the wrong status — it raises
+    out of the handler (TypeError for ``content``, NotNullViolationError for the
+    other four), which is a 500 to the caller.
+    """
+    _, headers = get_test_auth(tenant_id)
+    mem = await _write_memory(client, tenant_id, headers)
+
+    resp = await client.patch(
+        f"/api/v1/memories/{mem['id']}?tenant_id={tenant_id}",
+        json={field: None},
+        headers=headers,
+    )
+
+    assert resp.status_code == 400, f"{field}: expected 400, got {resp.status_code} {resp.text}"
+    assert field in resp.json()["detail"], f"{field}: message should name the field — {resp.text}"
+
+
+async def test_null_on_several_non_nullable_fields_names_all_of_them(client, tenant_id):
+    """One request, one 400, every offending field named.
+
+    A caller serialising the whole schema sends every null at once; reporting
+    only the first would take them through the fix one round-trip at a time.
+    """
+    _, headers = get_test_auth(tenant_id)
+    mem = await _write_memory(client, tenant_id, headers)
+
+    resp = await client.patch(
+        f"/api/v1/memories/{mem['id']}?tenant_id={tenant_id}",
+        json={"content": None, "status": None, "weight": None},
+        headers=headers,
+    )
+
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    for field in ("content", "status", "weight"):
+        assert field in detail, f"{field} missing from {detail!r}"
+
+
+@pytest.mark.parametrize("field", NULLABLE_UPDATE_FIELDS)
+async def test_explicit_null_still_clears_a_nullable_field(client, tenant_id, field):
+    """The guard must not over-reach: null-as-clear is the contract here."""
+    _, headers = get_test_auth(tenant_id)
+    mem = await _write_memory(client, tenant_id, headers)
+
+    resp = await client.patch(
+        f"/api/v1/memories/{mem['id']}?tenant_id={tenant_id}",
+        json={field: None},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200, f"{field}: expected 200, got {resp.status_code} {resp.text}"
+    assert resp.json()[field] is None
+
+
+async def test_a_real_value_still_updates(client, tenant_id):
+    """Guard fires on null only — a normal PATCH of the same fields still works."""
+    _, headers = get_test_auth(tenant_id)
+    mem = await _write_memory(client, tenant_id, headers)
+
+    resp = await client.patch(
+        f"/api/v1/memories/{mem['id']}?tenant_id={tenant_id}",
+        json={"content": "replacement content", "weight": 0.9, "status": "active"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["content"] == "replacement content"
+    assert body["weight"] == pytest.approx(0.9)
+
+
+def test_guard_list_matches_the_model():
+    """Drift guard — the reason the list can be a literal.
+
+    Every ``MemoryUpdate`` field backed by a NOT NULL column must be listed, and
+    nothing else may be. Add a NOT NULL column with a matching update field and
+    this fails until ``NON_NULLABLE_UPDATE_FIELDS`` is extended, which is the
+    only thing keeping the two in sync.
+    """
+    columns = Memory.__table__.columns
+    expected = {
+        name
+        for name in MemoryUpdate.model_fields
+        if name in columns and not columns[name].nullable
+    }
+
+    assert set(NON_NULLABLE_UPDATE_FIELDS) == expected, (
+        "NON_NULLABLE_UPDATE_FIELDS has drifted from Memory's NOT NULL columns: "
+        f"missing={sorted(expected - set(NON_NULLABLE_UPDATE_FIELDS))} "
+        f"stale={sorted(set(NON_NULLABLE_UPDATE_FIELDS) - expected)}"
+    )


### PR DESCRIPTION
## The bug

`PATCH /api/v1/memories/{id}` with `{"content": null}` returns **500**. So do four other fields, and they fail in two different ways — which matters, because a fix that handles one failure mode does not handle the other:

| field | result before this PR |
|---|---|
| `content` | `TypeError: 'NoneType' object is not subscriptable` — `data.content[:200]` while building the audit diff, **before any query runs** |
| `memory_type` | asyncpg `NotNullViolationError` |
| `weight` | asyncpg `NotNullViolationError` |
| `status` | asyncpg `NotNullViolationError` |
| `visibility` | asyncpg `NotNullViolationError` |

Every `MemoryUpdate` field is typed `X | None`, because that is how an optional PATCH field is spelled. An explicit `null` therefore validates and reaches the service indistinguishable from a real value — `min_length`, `ge`/`le` and `pattern` bind only the non-None branch of the union — and the "No fields to update" 400 does not fire, because the field *is* set.

Reproduced at the model level:

```
>>> m = MemoryUpdate.model_validate({"content": None})
>>> m.model_fields_set, m.content
({'content'}, None)
>>> m.content[:200]
TypeError: 'NoneType' object is not subscriptable
```

## This is five fields, not one, and that changes what it is

One nullable-vs-NOT NULL mismatch is an oversight. Five, sitting alongside **nine siblings that legitimately support null-as-clear**, is a schema whose nullability was never systematically checked against the model.

- **Nullable columns — null clears them, and must keep doing so:** `title`, `source_uri`, `predicate`, `object_value`, `subject_entity_id`, `ts_valid_start`, `ts_valid_end`, `expires_at`. The `simple_fields` loop writes those NULLs deliberately.
- **`metadata`** already has its own rule — 400 in merge mode, added when null-as-clear was withdrawn there.
- **The five above** are `nullable=False` on `Memory` and got the same `X | None` treatment as the nine that aren't.

I measured this rather than reading it: every optional field was PATCHed with an explicit `null` and the status recorded. Nine returned 200, `metadata` returned 400, `metadata_mode` and `entity_links` returned 200, and five raised.

## The fix

Reject those five with a **400 naming every offending field**, placed immediately after the "no fields to update" check — so a null `content` no longer costs an embedding call and a dedup query on the way to failing.

400 rather than a schema-level 422 to match the `metadata=null` rule a hundred lines further down: same "this null has no valid meaning" decision, already answered that way in the same function.

All offending fields are named in one response. A caller serialising the whole schema sends every null at once; reporting only the first would walk them through the fix one round-trip at a time.

## Reachability

Not only hand-crafted requests. The plugin's update tool skips `undefined` but **forwards `null` verbatim** (`plugin/src/tool-definitions.ts`), so any MCP caller passing a null field reaches this. `MemoryUpdate` also has a second entry point in `mcp_server.py` besides the HTTP route — both funnel through `update_memory`, so the guard covers both.

## Why the list is a literal

`NON_NULLABLE_UPDATE_FIELDS` is written out rather than derived from `Memory.__table__` at import time: schema field names and column names coincide for these five but not in general (`metadata` maps to `metadata_`), so a derivation would need its own mapping table and would fail silently if that drifted.

`test_guard_list_matches_the_model` is what actually holds the two in sync — it asserts the tuple still equals the set of `MemoryUpdate` fields backed by a NOT NULL column. **Add a NOT NULL column with a matching update field and that test fails until it is listed.**

## Why nothing caught it

mypy reports the `content` one:

```
memory_service.py: Value of type "str | None" is not indexable  [index]
```

but `core-api/pyproject.toml` carries `[[tool.mypy.overrides]] ignore_errors = true` for `core_api.services.*`. It is one of **343** errors that exemption hides. The other four are runtime-only — no type checker would have found them, since `patch[attr_name] = None` is perfectly well-typed.

Surfaced while making `common/` visible to the service mypy runs (#983). **This is not a finding from that change** — it is reported with or without it, and is hidden purely by the services exemption.

## Tests

16 new, in `tests/test_patch_null_non_nullable.py`:

- all five rejections, parametrized, each asserting 400 *and* that the message names the field;
- a multi-field request (`content` + `status` + `weight`) naming all three;
- all eight null-as-clear siblings still returning 200 with the column cleared — the guard must not over-reach;
- a normal non-null PATCH of the same fields still working;
- the drift guard against the model.

**The six behavioural tests were confirmed to fail without the fix**, with exactly the errors in the table above — verified by removing the guard and re-running, not assumed.

## Notes for the reviewer

- The import block in the new test file trips `I001` under ruff's defaults, exactly as its sibling `tests/test_c7_metadata_mode_query_param.py` does. The repo-root `tests/` tree is outside every ruff scope (CI's, and pre-commit's `^(core-api|core-storage-api)/src/`) and carries 654 such findings; I matched the surrounding style rather than formatting one file to a config the repo doesn't apply there.
- 16 tests in `tests/` fail on my machine (search/FTS and relation-weight). They reproduce **identically on unmodified `origin/main`** and are unrelated — local Postgres text-search configuration.
- mypy green on all four services and `common/`; `ruff check` and `ruff format --check` clean on every CI scope, run separately.
