### PR TITLE
fix(events): bound and narrow the broadcast-subscription release

### DIFF
--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -69,6 +69,20 @@ SOURCE_ENV_ATTRIBUTE = "source_env"
 # Pub/Sub minimum for ``expiration_policy``.
 BROADCAST_SUBSCRIPTION_TTL_SECONDS = 86400
 
+# Per-call ceiling on the delete RPC in ``release_broadcast_subscriptions()``.
+#
+# The SDK's generated default is 60s, with a retry deadline also 60s — six times
+# Cloud Run's entire 10s SIGTERM budget for a single call. Since that method
+# exists precisely to finish inside that budget, inheriting the default defeats
+# it: one slow Pub/Sub call and the process is killed mid-release, leaking the
+# subscriptions the method was added to reclaim.
+#
+# A timed-out delete costs nothing that matters. ``expiration_policy`` still
+# reaps the subscription, so bounding the call only trades a slow failure mode
+# for a fast one — which is the entire point. Prefer failing fast and leaving
+# the TTL to clean up over blocking a shutdown that has nine seconds to live.
+BROADCAST_RELEASE_TIMEOUT_SECONDS = 2.0
+
 
 class PubSubEventBus(EventBus):
     """Pub/Sub-backed bus.
@@ -874,7 +888,7 @@ class PubSubEventBus(EventBus):
                 gexc.NotFound,
                 gexc.PermissionDenied,
                 gexc.InvalidArgument,
-            ):
+            ) as exc:
                 # We deleted this one ourselves. ``release_broadcast_subscriptions()``
                 # runs ahead of the rest of teardown so it fits inside the
                 # SIGTERM budget, which means this loop can still be mid-pull
@@ -882,7 +896,18 @@ class PubSubEventBus(EventBus):
                 # a configuration fault: staying on the loud path below would
                 # log an ERROR and flip ``is_healthy`` false on every graceful
                 # shutdown, which is how a real alert gets tuned out.
-                if subscription_name in self._released_subscriptions:
+                #
+                # NotFound ONLY, deliberately. "We deleted it" explains a
+                # subsequent NotFound and nothing else. PermissionDenied means an
+                # IAM grant changed and InvalidArgument means we built a bad
+                # request — neither becomes benign because this process happened
+                # to release that name, and both are exactly what the loud path
+                # below exists to surface. Widening this back to the whole
+                # exception group would let a real IAM regression exit silently
+                # with ``is_healthy`` still true.
+                if isinstance(exc, gexc.NotFound) and (
+                    subscription_name in self._released_subscriptions
+                ):
                     return
                 # Permanent configuration errors: subscription doesn't
                 # exist, service account lacks permission, or the
@@ -1040,13 +1065,15 @@ class PubSubEventBus(EventBus):
         self._released_subscriptions.update(
             path.rsplit("/", 1)[-1] for path in self._broadcast_sub_paths
         )
-        for sub_path in self._broadcast_sub_paths:
+
+        async def _release_one(sub_path: str) -> None:
             try:
                 await loop.run_in_executor(
                     None,
                     functools.partial(
                         self._subscriber.delete_subscription,
                         request={"subscription": sub_path},
+                        timeout=BROADCAST_RELEASE_TIMEOUT_SECONDS,
                     ),
                 )
             except Exception:
@@ -1058,6 +1085,21 @@ class PubSubEventBus(EventBus):
                     BROADCAST_SUBSCRIPTION_TTL_SECONDS,
                     exc_info=True,
                 )
+
+        # Concurrently, not sequentially. Under dual-subscribe every broadcast
+        # topic has two names, so even one topic is two deletes — and a
+        # sequential loop multiplies the per-call ceiling by the subscription
+        # count, which is how a bounded call still overruns an unbounded
+        # budget. Fanning out keeps the wall-clock at roughly one timeout no
+        # matter how many there are.
+        #
+        # ``return_exceptions=True`` because ``_release_one`` already logs and
+        # swallows; this is belt-and-braces so an unexpected escape cannot
+        # abort the remaining deletes or propagate out of a shutdown path.
+        await asyncio.gather(
+            *(_release_one(p) for p in self._broadcast_sub_paths),
+            return_exceptions=True,
+        )
         self._broadcast_sub_paths.clear()
 
     async def stop(self) -> None:

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -1338,6 +1338,96 @@ async def test_unprovisioned_subscription_still_reports_loudly(
     assert bus.is_healthy is False
 
 
+async def test_release_bounds_the_delete_rpc(bus: PubSubEventBus) -> None:
+    """The delete must carry an explicit short timeout, not the SDK default.
+
+    This method exists to finish inside Cloud Run's 10s SIGTERM budget. The
+    SDK's generated default is 60s per call with a 60s retry deadline — six
+    times the whole budget for one call — so inheriting it defeats the reason
+    the method was split out: one slow Pub/Sub call and the process is killed
+    mid-release, leaking exactly what this reclaims.
+
+    A timed-out delete costs nothing that matters; ``expiration_policy`` still
+    reaps the subscription. Bounding only trades a slow failure for a fast one.
+    """
+    from common.events.pubsub import BROADCAST_RELEASE_TIMEOUT_SECONDS
+
+    fake_sub = MagicMock()
+    bus._subscriber = fake_sub
+    bus._broadcast_sub_paths = [
+        "projects/proj/subscriptions/a--x--abc",
+        "projects/proj/subscriptions/b--x--abc",
+    ]
+
+    await bus.release_broadcast_subscriptions()
+
+    assert fake_sub.delete_subscription.call_count == 2
+    for call in fake_sub.delete_subscription.call_args_list:
+        assert call.kwargs["timeout"] == BROADCAST_RELEASE_TIMEOUT_SECONDS
+    # Small enough that even a sequential worst case fits the budget.
+    assert BROADCAST_RELEASE_TIMEOUT_SECONDS <= 5.0
+
+
+async def test_release_survives_one_failing_delete(bus: PubSubEventBus) -> None:
+    """One subscription failing must not strand the others.
+
+    The deletes are fanned out concurrently; a single raise must neither abort
+    its siblings nor escape into the shutdown path that called this.
+    """
+    fake_sub = MagicMock()
+    bus._subscriber = fake_sub
+    fake_sub.delete_subscription = MagicMock(
+        side_effect=[RuntimeError("pubsub blip"), None]
+    )
+    bus._broadcast_sub_paths = [
+        "projects/proj/subscriptions/a--x--abc",
+        "projects/proj/subscriptions/b--x--abc",
+    ]
+
+    await bus.release_broadcast_subscriptions()
+
+    assert fake_sub.delete_subscription.call_count == 2
+    # Both are recorded as released regardless: the pull loops must exit
+    # quietly either way, and the TTL reaps whatever the delete missed.
+    assert bus._released_subscriptions == {"a--x--abc", "b--x--abc"}
+    assert bus._broadcast_sub_paths == []
+
+
+@pytest.mark.parametrize("exc_name", ["PermissionDenied", "InvalidArgument"])
+async def test_released_subscription_still_reports_non_notfound_loudly(
+    bus: PubSubEventBus,
+    exc_name: str,
+) -> None:
+    """Releasing a name excuses a later NotFound on it, and nothing else.
+
+    "We deleted this one ourselves" explains a subsequent NotFound. It does not
+    explain a PermissionDenied — an IAM grant changed — or an InvalidArgument —
+    we built a malformed request. Neither becomes benign because this process
+    happened to release that name, and both are precisely what the halting path
+    exists to surface.
+
+    The original suppression sat inside the shared handler for all three, so a
+    real IAM regression against a released name would exit the loop silently with
+    ``is_healthy`` still true. ``test_unprovisioned_subscription_still_reports_loudly``
+    does NOT cover this: it varies the *name* (never released) while holding the
+    exception at NotFound, so it constrains only one of the two axes.
+    """
+    from google.api_core import exceptions as gexc
+
+    fake_sub = MagicMock()
+    bus._subscriber = fake_sub
+    bus._broadcast_sub_paths = ["projects/proj/subscriptions/core-api--x--abc"]
+    await bus.release_broadcast_subscriptions()
+    assert "core-api--x--abc" in bus._released_subscriptions
+
+    fake_sub.pull = MagicMock(side_effect=getattr(gexc, exc_name)("still a fault"))
+    bus._pull_executor = ThreadPoolExecutor(max_workers=1)
+    await bus._pull_loop("core-api--x--abc", [])
+
+    assert "core-api--x--abc" in bus._failed_subscriptions
+    assert bus.is_healthy is False
+
+
 async def test_restart_clears_the_released_record(bus: PubSubEventBus) -> None:
     """Subscription names are deterministic per bus object, so a second start()
     recreates the same names. A leftover entry would silence a genuine NotFound


### PR DESCRIPTION
Two defects in [#991](https://github.com/caura-ai/caura/pull/991), both mine, both already merged to `main`. Neither was found here — they were found by review on the enterprise port of the same change ([caura-enterprise#1316](https://github.com/caura-ai/caura-enterprise/pull/1316)), which is a useful argument for porting a fix rather than letting two copies drift.

## 1. The suppression was scoped too broadly

`_pull_loop` catches `NotFound`, `PermissionDenied` and `InvalidArgument` in one handler. #991 put the "we released this ourselves, exit quietly" check inside that shared handler — but the justification only holds for `NotFound`.

A genuine `PermissionDenied` (an IAM grant changed) or `InvalidArgument` (we built a malformed request) against a subscription this process happens to have released was **silently swallowed**: loop returns, no ERROR, `_failed_subscriptions` untouched, `is_healthy` still true. That defeats exactly the safety net the rest of the branch exists to provide.

Narrowed to `isinstance(exc, gexc.NotFound)`, with a comment saying why the other two are deliberately excluded.

**Why this survived review the first time**, since it's the more useful half: I argued on #991 that the suppression was "narrow rather than a blanket swallow" and cited `test_unprovisioned_subscription_still_reports_loudly` as evidence. That test varies the **name** (never released) while holding the exception at `NotFound`. It constrains one of the two axes. My claim was true along the axis I tested and false along the one I didn't — and I stated it confidently enough that the review took it.

## 2. The delete RPC was unbounded, which defeated the point of the method

`release_broadcast_subscriptions()` exists **solely** to finish inside Cloud Run's 10s SIGTERM budget. The delete inherited the SDK's generated default — `timeout=60.0`, retry deadline also 60.0, **six times the entire budget for one call** — run sequentially, once per subscription. One slow Pub/Sub call and the process is killed mid-release, leaking precisely what the method was added to reclaim. Under dual-subscribe every broadcast topic has two names, so even a single topic is two deletes.

Now `BROADCAST_RELEASE_TIMEOUT_SECONDS = 2.0` per call, **and the deletes fan out concurrently** rather than sequentially — a bounded call still overruns an unbounded budget if you multiply it by the subscription count.

A timed-out delete costs nothing that matters: `expiration_policy` still reaps the subscription. Bounding only trades a slow failure mode for a fast one, which is the whole point.

## Tests — each confirmed failing without its fix

| Test | Mutation that breaks it |
|---|---|
| `test_released_subscription_still_reports_non_notfound_loudly` (parametrized: `PermissionDenied`, `InvalidArgument`) | Restore the shared-handler check — **both** params fail |
| `test_release_bounds_the_delete_rpc` | Remove the explicit `timeout=` |
| `test_release_survives_one_failing_delete` | Fails **only** when both isolation layers go |

That last row is stated as a limitation rather than dressed up: the isolation is deliberately layered (per-call `try/except` **plus** `return_exceptions=True`), so removing either one alone leaves the test green. It's a characterization test for the behaviour, not a single-line regression guard, and pretending otherwise is how the first gap got through.

**Harness note**, carried from a sibling lane and worth knowing generally: same-byte-length mutations can reuse stale `__pycache__` bytecode and report a **false pass**. Every mutation above was run with the cache purged.

## Gates

61 tests in `tests/test_events/test_pubsub_bus.py` · mypy clean over `common/` (97 files) · ruff check and format clean on the changed source · legacy-name ratchet: no new lines · do-not-touch sentinel: 34/34 · `core-api/uv.lock` untouched (hashed before and after every `uv` command).
