### PR TITLE
ci(mypy): enumerate the exempt modules instead of globbing two whole trees

### DIFF
--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -159,12 +159,50 @@ ignore_missing_imports = true
 module = "tests.*"
 ignore_errors = true
 
+# Modules not yet type-checked. Deliberately enumerated one module per line
+# rather than globbed: ``core_api.services.*`` and ``core_api.pipeline.steps.*``
+# exempted 105 modules in order to cover the 19 that actually fail. Seven of
+# the remainder were already recovered by the ``forge`` carve-out below; the
+# other 79 were ungated for no reason — and, worse, every *future* file under
+# those two trees was exempt on creation. A new ``services/_probe.py``
+# returning ``str`` from an ``-> int`` function was reported as "Success: no
+# issues found in 201 source files"; with the globs gone the same file errors.
+#
+# Enumerating the 19 gates those 79, plus ``providers.local_embedding`` which
+# was on this list despite having no errors at all — 80 modules, no code
+# change. It also makes the list a ratchet: a module becomes exempt only by
+# someone adding it here in a reviewed diff, never by being born in the right
+# directory.
+#
+# Every line below is a to-do, not a policy. Delete one, fix what mypy then
+# reports, and the gate tightens for good. That is how
+# ``core_api.services.forge.*`` was recovered: it sat inside the
+# ``core_api.services.*`` glob while ``forge/cron_handler.py`` imported
+# ``LLMRequest`` from ``common.llm`` — a name that has never existed there —
+# and the forge distill cron raised RuntimeError on every tick and had never
+# once run (#955). Being inside an exempted tree is what kept that invisible.
 [[tool.mypy.overrides]]
 module = [
-    "core_api.providers.local_embedding",
     "core_api.providers._registry",
-    "core_api.services.*",
-    "core_api.pipeline.steps.*",
+    "core_api.services.contradiction_detector",
+    "core_api.services.crystallizer_service",
+    "core_api.services.entity_extraction_worker",
+    "core_api.services.entity_service",
+    "core_api.services.evolve_service",
+    "core_api.services.governance_remediation",
+    "core_api.services.ingest_service",
+    "core_api.services.insights_service",
+    "core_api.services.interview_service",
+    "core_api.services.memory_service",
+    "core_api.services.organization_settings",
+    "core_api.services.session_trace",
+    "core_api.services.skill_promoter",
+    "core_api.services.stm_service",
+    "core_api.pipeline.steps.search.classify_query",
+    "core_api.pipeline.steps.search.load_and_serialize",
+    "core_api.pipeline.steps.search.parallel_embed_entity_boost",
+    "core_api.pipeline.steps.write.parallel_embed_enrich",
+    "core_api.pipeline.steps.write.schedule_background_tasks",
     "core_api.routes.fleet",
     "core_api.routes.memories",
     "core_api.clients.storage_client",
@@ -174,6 +212,11 @@ module = [
 ]
 ignore_errors = true
 
+# Redundant against the enumerated list above — forge is no longer inside any
+# exempted glob — and kept anyway. mypy applies the last matching override, so
+# this pins the one module whose exemption is known to have hidden a total
+# production outage, whatever a later edit does to the list above. Three lines
+# of backstop on a gate that has already failed once.
 [[tool.mypy.overrides]]
 module = "core_api.services.forge.*"
 ignore_errors = false


### PR DESCRIPTION
## What

Replaces the two globs in core-api's mypy exemption — `core_api.services.*` and `core_api.pipeline.steps.*` — with the 19 modules that actually fail, and drops `core_api.providers.local_embedding`, which was on the list despite having no errors at all.

One file changed. **No code changes.** `uv run mypy src/` reports `Success: no issues found in 200 source files` before and after.

## Why

The two globs covered **105 modules in order to exempt the 19 that fail**. The other 79 were already type-clean and ungated for no reason — any of them could regress and CI would still report success.

The open-endedness is the worse half. A file created under either tree is exempt on arrival. Measured on this branch's parent:

```
$ cat > src/core_api/services/_probe.py <<'PY'
def add_one(n: int) -> int:
    return "not an int"
PY
$ cd core-api && uv run mypy src/
Success: no issues found in 201 source files
```

With the globs replaced by the enumeration, the same file:

```
src/core_api/services/_probe.py:2: error: Incompatible return value type (got "str", expected "int")  [return-value]
Found 1 error in 1 file (checked 1 source file)
```

So the gate was not merely too wide, it was eroding: it loosened every time the service grew a file.

## What this buys

**80 modules newly type-checked** (79 under the globs + `providers.local_embedding`), at zero code cost, because they were already clean and only the glob was hiding it.

And the list becomes a ratchet in both directions:

- a module becomes exempt only when someone adds a line here in a reviewed diff — never by being born in the right directory;
- each remaining line is a to-do that can be deleted once its module's errors are fixed.

That is the path `core_api.services.forge.*` already took, and the reason it matters. Forge sat inside the `core_api.services.*` glob while `forge/cron_handler.py` imported `LLMRequest` from `common.llm` — a name that has never existed there. The distill cron raised `RuntimeError` on every tick and had never once run (#955), and its error blamed a missing provider chain, so it read as a misconfiguration.

## Scope

The **355 errors across those 26 modules are untouched and stay hidden.** Triaging them is per-module work and a 355-error diff is not reviewable. This PR only stops the exempted set from growing while that happens.

For context on the residual, two-thirds of it is two files (190 in `mcp_server.py`, 75 in `services/memory_service.py`), and it is a mypy figure rather than a bug count — most is annotation drift. The exemption has already yielded one real 500 (#996) from reading its error list.

The now-redundant `core_api.services.forge.*` carve-out is deliberately kept, with a comment saying so. mypy applies the last matching override, so it pins the one module whose exemption is known to have hidden a total production outage, whatever a later edit does to the list above it.

## Verification

| check | result |
|---|---|
| `cd core-api && uv run mypy src/` | `Success: no issues found in 200 source files` |
| `cd core-storage-api && uv run mypy src/` | `Success` (83 files) |
| `cd core-operations && uv run mypy src/` | `Success` (5 files) |
| `cd core-worker && uv run mypy src/` | `Success` (11 files) |
| mypy `common/` | `Success` (97 files) |
| `ruff check core-api/src/` | `All checks passed!` |
| `ruff format --check core-api/src/` | `200 files already formatted` |
| `pytest tests/ --collect-only` | 5314 collected, 16 deselected — pytest config intact |
| `pytest tests/test_patch_null_non_nullable.py tests/test_forge_distill.py` | `95 passed` |
| ratchet behaviour | demonstrated above: caught with the change, missed without it |

`core-api/uv.lock` hash verified unchanged at every step.

Nothing in the repo parses this override list — the only other references to `ignore_errors` are docstrings in `tests/test_forge_distill.py` and `tests/test_patch_null_non_nullable.py`, both of which describe modules whose exemption state this PR does not change.