### PR TITLE
fix(core-api): raise the uvicorn worker healthcheck timeout to 30s

### DIFF
--- a/common/serve.py
+++ b/common/serve.py
@@ -21,7 +21,8 @@ workers. The supervisor lines then emit as structured JSON with ``status:info``.
 Usage (see each service's Dockerfile ``CMD``)::
 
     python -m common.serve <app_import> --settings <settings_import> \
-        --port <port> [--host H] [--workers N] [--timeout-keep-alive S]
+        --port <port> [--host H] [--workers N] [--timeout-keep-alive S] \
+        [--timeout-worker-healthcheck S]
 
 ``<app_import>`` is an ASGI import string (``core_api.app:app``); it is passed
 to uvicorn as a string so the workers can re-import it. ``<settings_import>`` is
@@ -70,6 +71,23 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--timeout-keep-alive", type=int, default=65, dest="timeout_keep_alive"
     )
+    # uvicorn's multiprocess supervisor pings each worker every 0.5s and
+    # SIGKILLs one that has not answered within this many seconds, then
+    # respawns it. A SIGKILLed worker never runs lifespan shutdown, so
+    # whatever its shutdown hooks release stays leaked. Exposed here because
+    # the value was previously unreachable: this parser rejects unknown
+    # flags, so putting --timeout-worker-healthcheck in a service CMD made
+    # argparse exit 2 and the container never started.
+    #
+    # Defaulted to uvicorn's own 5 rather than an opinion of ours: this file
+    # is vendored byte-for-byte into the enterprise repo, so the per-service
+    # value belongs in that service's CMD, next to its --workers.
+    p.add_argument(
+        "--timeout-worker-healthcheck",
+        type=int,
+        default=5,
+        dest="timeout_worker_healthcheck",
+    )
     return p
 
 
@@ -98,6 +116,7 @@ def main(argv: list[str] | None = None) -> None:
         port=args.port,
         workers=args.workers,
         timeout_keep_alive=args.timeout_keep_alive,
+        timeout_worker_healthcheck=args.timeout_worker_healthcheck,
         log_config=None,
     )
 

--- a/core-api/Dockerfile
+++ b/core-api/Dockerfile
@@ -127,4 +127,16 @@ ENTRYPOINT ["/app/docker-entrypoint.sh"]
 # supervisor/parent configures structlog before starting — otherwise its
 # lifecycle lines ("Started parent process", "Received SIGTERM", ...) bypass
 # the JSON pipeline and land in Datadog as status:error. See common/serve.py.
-CMD ["python", "-m", "common.serve", "core_api.app:app", "--settings", "core_api.config:settings", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--timeout-keep-alive", "65"]
+#
+# --timeout-worker-healthcheck 30 (uvicorn's default is 5). With --workers 2
+# the supervisor pings each worker every 0.5s and SIGKILLs one that has not
+# answered in time. SIGKILL skips lifespan shutdown, so this app's ephemeral
+# Pub/Sub broadcast subscriptions are never released and hold project-wide
+# quota for 24h — a worker recycle is not free here, and 5s is a tight budget
+# for a Python worker's pong thread (a GC pause or a stalled scheduler is
+# enough). 30s is still far inside Cloud Run's 120s request timeout, so a
+# genuinely hung worker is still recycled well before a request could hang on
+# it. This is defence in depth, not the primary fix for the staging
+# crash-loop; that is the missing --no-cpu-throttling on the Cloud Run
+# service (caura-enterprise#1321).
+CMD ["python", "-m", "common.serve", "core_api.app:app", "--settings", "core_api.config:settings", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--timeout-keep-alive", "65", "--timeout-worker-healthcheck", "30"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,12 @@
 fastapi>=0.115,<1
-uvicorn[standard]>=0.34,<1
+# Floor is 0.37, not 0.34: common/serve.py passes
+# ``timeout_worker_healthcheck`` to uvicorn.run(), and that parameter landed
+# in uvicorn 0.37.0 (verified absent in 0.36.0's Config.__init__). Below the
+# floor the launcher raises TypeError on startup, so >=0.34 declared a range
+# this code cannot actually run on. Container images do not resolve from this
+# file — they install frozen from each service's uv.lock — but this is the
+# local-dev install path (AGENT-INSTALL.md) and it should not lie either.
+uvicorn[standard]>=0.37,<1
 sqlalchemy[asyncio]>=2.0,<3
 asyncpg>=0.30,<1
 pgvector>=0.3,<1

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -8,11 +8,13 @@ structlog root handler — see the module docstring in common/serve.py).
 
 from __future__ import annotations
 
+import inspect
 import json
 import types
 from unittest import mock
 
 import pytest
+import uvicorn
 
 import common.serve as serve
 
@@ -70,3 +72,68 @@ def test_main_configures_logging_from_settings_and_disables_uvicorn_log_config(
     assert kwargs["port"] == 8000
     assert kwargs["workers"] == 2
     assert kwargs["timeout_keep_alive"] == 65
+
+    # Absent from argv -> uvicorn's own default, forwarded explicitly rather
+    # than left to uvicorn so the launcher's contract is the same either way.
+    assert kwargs["timeout_worker_healthcheck"] == 5
+
+
+def test_main_forwards_timeout_worker_healthcheck(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The supervisor healthcheck timeout must be reachable from a service CMD.
+
+    Pre-this-test the parser had a fixed flag list and rejected the flag, so a
+    Dockerfile that passed it made argparse exit 2 and the container never
+    started. Raising it above uvicorn's 5s default is what keeps a slow-to-pong
+    worker from being SIGKILLed mid-lifespan, dropping its shutdown hooks (and
+    with them this service's ephemeral Pub/Sub broadcast subscriptions).
+    """
+    fake_settings = types.SimpleNamespace(
+        environment="production",
+        log_level="INFO",
+        log_format_json=True,
+        log_file="",
+    )
+    monkeypatch.setattr(serve, "_load", lambda _path: fake_settings)
+    monkeypatch.setattr(serve, "configure_logging", mock.MagicMock())
+    run = mock.MagicMock()
+    monkeypatch.setattr(serve.uvicorn, "run", run)
+
+    serve.main(
+        [
+            "core_api.app:app",
+            "--settings",
+            "core_api.config:settings",
+            "--port",
+            "8000",
+            "--workers",
+            "2",
+            "--timeout-worker-healthcheck",
+            "30",
+        ]
+    )
+
+    _args, kwargs = run.call_args
+    assert kwargs["timeout_worker_healthcheck"] == 30
+
+
+def test_uvicorn_really_accepts_the_healthcheck_kwarg() -> None:
+    """Guard the one thing the mocked tests above structurally cannot check.
+
+    Every other test here monkeypatches ``serve.uvicorn.run`` with a
+    MagicMock, and a MagicMock accepts any keyword silently. So if uvicorn
+    ever renames or drops this parameter, those tests keep passing and the
+    only place it fails is the deployed container — ``TypeError`` on every
+    startup, i.e. the service does not come up at all. Assert against the
+    real signature so that failure lands in CI instead.
+
+    ``timeout_worker_healthcheck`` landed in uvicorn 0.37.0; it is absent in
+    0.36.0. That boundary is why requirements.txt floors at >=0.37 — below it
+    the declared range would include versions common/serve.py cannot run on.
+    """
+    assert (
+        "timeout_worker_healthcheck"
+        in inspect.signature(uvicorn.Config.__init__).parameters
+    )
+    assert "timeout_worker_healthcheck" in inspect.signature(uvicorn.run).parameters


### PR DESCRIPTION
## What

- `common/serve.py`: add a `--timeout-worker-healthcheck` passthrough (default
  = uvicorn's own 5) and forward it to `uvicorn.run()`.
- `core-api/Dockerfile`: pass `--timeout-worker-healthcheck 30` in the `CMD`.
- `tests/test_serve.py`: cover both the default and the explicit value.

## Why

uvicorn's multiprocess supervisor pings each worker every 0.5s and `SIGKILL`s
one that has not answered within `timeout_worker_healthcheck`, then respawns it
(`Multiprocess.keep_subprocess_alive`). The default is **5s**. A `SIGKILL`ed
worker never runs lifespan shutdown, so `core-api`'s ephemeral Pub/Sub broadcast
subscriptions are never released and hold **project-wide** quota for 24h. On
staging that is running at ~2,560 kills/hour.

**The flag was not reachable before this change.** `common/serve.py` builds an
argparse parser with a fixed flag list, so a Dockerfile `CMD` carrying
`--timeout-worker-healthcheck` made argparse `exit 2` and **the container would
never have started**. Adding the passthrough is most of the diff. Worth knowing
for anyone who reads the one-line version of this fix and reaches for the CMD
directly.

The launcher keeps uvicorn's default of 5 rather than taking an opinion, because
it is vendored byte-for-byte into `caura-enterprise` under the `identical`
policy — the per-service value belongs next to that service's `--workers`.

30s stays far inside Cloud Run's 120s request timeout, so a genuinely hung
worker is still recycled long before a request could hang behind it.

## Why there is no version pin here — the brief's premise did not survive checking

This PR was scoped as "pin uvicorn, and/or raise the timeout." I verified the
pin half and it does not hold up. Three corrections, all checkable:

**1. `core-api/requirements.txt` does not exist.** The `uvicorn[standard]>=0.34,<1`
line is in the **root** `requirements.txt`, which is a local-dev install path
(`AGENT-INSTALL.md`) and governs no container image. `core-api/pyproject.toml:13`
is the real declaration, and it reads `>=0.51.0,<1`.

**2. uvicorn already cannot float.** Since #362 (2026-06-14) the image installs
frozen from the committed lock:

```
uv export --frozen --no-dev $EXTRAS --no-emit-project ... -o /tmp/reqs.txt
uv pip install --system --no-cache -r /tmp/reqs.txt
```

`core-api/uv.lock` pins `uvicorn 0.51.0` exactly, and the export carries
per-wheel hashes so the install runs in require-hashes mode. An `==` in
`pyproject.toml` would be belt-on-belt and would only add Dependabot noise.

**3. The healthcheck is not a new feature, so it did not arrive on a rebuild.**
It landed in uvicorn **0.37.0** (2025-09-23, *"Add `--timeout-worker-healthcheck`
option"*). Verified directly in the **0.49.0** sources — the version this repo
was locked to *before* the bump — same `timeout_worker_healthcheck: int = 5`
default, and the same body:

```python
if process.is_alive(timeout=self.config.timeout_worker_healthcheck):
    continue
process.kill()  # process is hung, kill it
```

The lock moved `0.49.0 -> 0.51.0` on 2026-07-21 (#606). The `SIGKILL` behaviour
was **already active before that bump**, so it cannot explain a subscription
baseline that moved on 2026-08-24. Something else changed then, and pinning
would have encoded the wrong cause while leaving the actual 5s sensitivity in
place.

The real exposure was never the version. It was the 5s budget. This raises it.

## Relationship to the urgent fix

This is **defence in depth, not the primary fix.** The staging crash-loop is
caused by `staging-memclaw-core-api` being the only one of its four siblings
deployed without `--no-cpu-throttling`; that is
[caura-enterprise#1321](https://github.com/caura-ai/caura-enterprise/pull/1321),
which is on a ~9-10 hour clock against a shared subscription cap and should land
first and independently.

The evidence that it is the CPU flag and not this timeout: `core-storage-writer`
and `core-storage-reader` run **this same launcher** at `--workers 2` on **this
same locked uvicorn 0.51.0**, with CPU always-allocated, and record **zero**
worker kills in an hour where `core-api` records 2,560. The kills are also
traffic-independent — an instance serving 2 requests in an hour was still killed
75 times, steadily through minutes with no requests at all.

## Checks

- `pytest tests/test_serve.py tests/test_logging.py` — 43 passed.
- **New tests confirmed failing without the fix**: reverting only `common/serve.py`
  gives `common.serve: error: unrecognized arguments: --timeout-worker-healthcheck 30`
  plus a `KeyError` on the default assertion. 2 failed / 4 passed before, 6 passed after.
- `ruff check common/` (discovery-based, from repo root, as CI runs it) — clean.
- `ruff format --check --isolated common/__init__.py common/structlog_config.py common/serve.py`
  — 3 files already formatted. This is the gate that protects the enterprise
  re-vendor; longest line in `common/serve.py` is 84 cols, under the 88 limit.
- `ruff check core-api/src/` — clean.
- `pre-commit run --files ...` — all hooks pass.
- `core-api/Dockerfile` `CMD` re-parsed as JSON: valid 16-element array.
- No `uv.lock` in this diff; all four `uv.lock` hashes byte-identical before and
  after every command run.

## Note for reviewers

`common/serve.py` is an `identical`-policy vendored file. Merging this will make
the enterprise copy drift until `revendor-common.yml` re-syncs it (6-hourly, or
on the `oss-main-pushed` dispatch). That is the designed path and it self-heals;
flagging it so the drift is expected rather than alarming.