### PR TITLE
ci: type-gate repo-root scripts/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,36 @@ jobs:
         # mode is a noisier gate, not an absent one. See common/mypy.ini.
         run: uv run mypy --config-file common/mypy.ini common/
 
+      - name: Run mypy (scripts/)
+        # Repo-root scripts/ was type-checked by nothing, for the same structural
+        # reason common/ was: not a service src/ tree, no pyproject.toml of its
+        # own, and no root [tool.mypy], so it appeared in no mypy scope above.
+        #
+        # It is not an idle tree. scripts/forge_dry_run.py carried the other half
+        # of the forge cron outage — the same ``from common.llm import
+        # LLMRequest`` as core-api's cron_handler, a name that has never existed
+        # there, with an ``except`` that returned a stub so the CLI had never used
+        # a real LLM either. #955 repaired both halves; #983 gated the service
+        # one. This is the same gate one layer out, and re-injecting that import
+        # confirms it fires:
+        #
+        #   scripts/forge_dry_run.py:120: error: Module "common.llm" has no
+        #   attribute "LLMRequest"  [attr-defined]
+        #
+        # MUST run from the repo root. ``mypy_path`` in scripts/mypy.ini is
+        # resolved against the CWD, not against the config file, so a step that
+        # ``cd``s into scripts/ first would silently degrade every core_api.*
+        # import to Any under ignore_missing_imports — the exact gap #983 closed
+        # for the services. ``--config-file`` is required for the usual reason
+        # (mypy resolves config from the CWD and does not walk up); without it
+        # this reports 84 errors in 38 files at bare defaults instead of the 29
+        # files it owns.
+        #
+        # Six modules are exempt BY NAME in scripts/mypy.ini, not by glob, so a
+        # new script is gated the day it lands. Shrinking that list is the
+        # backlog; the gate deliberately landed without it.
+        run: uv run mypy --config-file scripts/mypy.ini scripts/
+
       - name: Enable pgvector extension
         run: PGPASSWORD=changeme psql -h localhost -U memclaw -d memclaw -c "CREATE EXTENSION IF NOT EXISTS vector;"
 

--- a/scripts/gen_events_manifest.py
+++ b/scripts/gen_events_manifest.py
@@ -25,7 +25,7 @@ import difflib
 import json
 import sys
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 from unittest import mock
 
 from common.events import lifecycle_handlers
@@ -64,7 +64,12 @@ _DIRECT_SUBSCRIBES: dict[str, list[str]] = {
 # core-api registers the LLM pipeline ops; core-worker registers the SQL archive
 # ops. (In OSS-standalone/InProcess mode core-api also registers the archive ops,
 # but that path provisions no Pub/Sub subscriptions, so it is out of scope here.)
-_LIFECYCLE_HELPERS: dict[str, list[Callable[[object], None]]] = {
+# ``Callable[[Any], None]``, not ``Callable[[object], None]``: each helper takes
+# its own concrete adapter type, and Callable is CONTRAVARIANT in its argument,
+# so a ``Callable[[PipelineStorageAdapter], None]`` is not a subtype of one
+# taking ``object``. Any is the accurate description of a deliberately
+# heterogeneous registry, rather than a claim every helper accepts anything.
+_LIFECYCLE_HELPERS: dict[str, list[Callable[[Any], None]]] = {
     "core-api": [lifecycle_handlers.register_pipeline_consumers],
     "core-worker": [lifecycle_handlers.register_archive_consumers],
 }

--- a/scripts/mypy.ini
+++ b/scripts/mypy.ini
@@ -1,0 +1,109 @@
+# mypy contract for repo-root scripts/ — sibling of common/mypy.ini, same
+# reasoning, same settings block.
+#
+# WHY THIS FILE EXISTS: scripts/ was type-checked by NOTHING. It is not a
+# service src/ tree, it has no pyproject.toml of its own, and the repo has no
+# root [tool.mypy] — so it appeared in none of CI's mypy scopes. That matters
+# more here than the file count suggests: scripts/forge_dry_run.py carried the
+# other half of the forge cron outage. It had the same
+# ``from common.llm import LLMRequest`` as core-api's cron_handler — a name that
+# has never existed in common.llm — and its ``except`` returned a stub, so the
+# CLI had never once used a real LLM. Both halves were repaired in #955, and
+# #983 brought the service half under a gate that would have caught it. This is
+# that gate, one layer further out. Confirmed by re-injecting the signature:
+#
+#   scripts/forge_dry_run.py:120: error: Module "common.llm" has no attribute
+#   "LLMRequest"  [attr-defined]
+#
+# RUN IT FROM THE REPO ROOT, and pass the config explicitly:
+#
+#   mypy --config-file scripts/mypy.ini scripts/
+#
+# Both halves of that are load-bearing, in opposite directions, and each fails
+# SILENTLY rather than loudly:
+#
+#   * ``--config-file`` is required because mypy resolves config from the CWD
+#     only — it does not walk up from the files being checked the way ruff does.
+#     Drop the flag and this runs at mypy's bare defaults, which is not the same
+#     gate (check_untyped_defs off, ignore_missing_imports off).
+#   * ``mypy_path`` below is resolved relative to the CWD, NOT to this file.
+#     Measured: from the repo root, ``core-api/src`` resolves core_api.* and
+#     catches a bogus symbol imported from it; ``../core-api/src`` does not, and
+#     mypy reports success. So a ``cd scripts && mypy .`` silently degrades
+#     every core_api.* import to Any under ignore_missing_imports — which is
+#     exactly the gap #983 closed for the services. Keep the invocation at the
+#     repo root.
+#
+# WHY follow_imports = silent: without it, following imports into the service
+# trees reports THEIR errors here too — 29 of them from core-api at the time
+# this landed, in a tree that has its own gate and its own reviewed exemptions.
+# A step that fails on paths it does not own teaches people to ignore it.
+# ``silent`` still type-checks scripts/ AGAINST the real service and common/
+# types — the forge signature above is caught with it on — it just does not
+# report errors inside the modules it follows.
+#
+# The [mypy] block is the same one every service pyproject and common/mypy.ini
+# already carry, so code moving between scripts/ and a src/ tree does not change
+# how it is checked. mypy_path is the one addition, and only because scripts/
+# imports from four service trees plus common/.
+
+[mypy]
+python_version = 3.12
+mypy_path = core-api/src:core-storage-api/src:core-operations/src:core-worker/src
+explicit_package_bases = True
+warn_return_any = False
+warn_unused_ignores = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+check_untyped_defs = True
+ignore_missing_imports = True
+follow_imports = silent
+
+# ---------------------------------------------------------------------------
+# EXEMPTIONS — a ratchet, not a category.
+#
+# Six modules are listed individually below, by name. That is deliberate and it
+# is the whole design: a module becomes exempt only by someone adding it here in
+# a reviewed diff, never by being born in the right directory. #983's review
+# rejected a module-level ``ignore_errors`` for exactly this reason (it re-opens
+# the gap for any NEW error in that file), and #998 tore out two globs covering
+# 105 modules to gate the 19 that actually failed. A glob like
+# ``scripts.benchmark_*`` would have been shorter and would have silently
+# swallowed every future benchmark script.
+#
+# The 23 modules NOT listed here are gated as of this commit — including
+# forge_dry_run.py and gen_events_manifest.py, the two that import common.*,
+# which is the import shape the forge bug had.
+#
+# These 33 findings are what a tree that has never been type-checked looks like,
+# not a regression: mostly untyped-dict indexing and loop-variable reassignment
+# in throwaway benchmark/repro scripts. They are a backlog to shrink, and the
+# gate is landing without them deliberately — landing a gate together with its
+# backlog is how gates get reverted. Delete an entry once its file is clean.
+# ---------------------------------------------------------------------------
+
+# 2 errors: [index] on an untyped JSON blob, [var-annotated] on an empty dict.
+[mypy-scripts._locomo_bench]
+ignore_errors = True
+
+# 6 errors: [misc], [operator] — arithmetic over values read out of an untyped
+# results dict.
+[mypy-scripts.benchmark_nano_vs_flash]
+ignore_errors = True
+
+# 10 errors: [assignment], [index], [operator] — same shape, largest instance.
+[mypy-scripts.benchmark_openai_models]
+ignore_errors = True
+
+# 4 errors: [dict-item], [func-returns-value], [index].
+[mypy-scripts.benchmark_rerank_locomo]
+ignore_errors = True
+
+# 3 errors: [index] on an untyped response payload.
+[mypy-scripts.hyperagent_test]
+ignore_errors = True
+
+# 8 errors: [assignment], [index] — a race-reproduction script that rebinds
+# loop variables to different types on purpose.
+[mypy-scripts.repro_contradictions_race]
+ignore_errors = True


### PR DESCRIPTION
## The gap

Repo-root `scripts/` is type-checked by **nothing**, for the same structural reason `common/` was before #948: not a service `src/` tree, no `pyproject.toml` of its own, and no root `[tool.mypy]` — so it appears in none of CI's mypy scopes. The pre-commit hooks are narrower still (`files: ^(core-api|core-storage-api)/src/`) and deliberately run no mypy at all.

It is not an idle tree. **`scripts/forge_dry_run.py` carried the other half of the forge cron outage** — the same `from common.llm import LLMRequest` as core-api's `cron_handler`, a name that has never existed there, with an `except` returning a stub so that CLI had never used a real LLM either. #955 repaired both halves and #983 gated the service one. The `scripts/` half has stayed ungated since.

## The gate

`scripts/mypy.ini` + a `Run mypy (scripts/)` CI step. The `[mypy]` block is the one every service pyproject and `common/mypy.ini` already carry, so code moving between `scripts/` and a `src/` tree is checked on the same terms. Two additions, both measured:

- **`mypy_path` over the four service srcs.** Without it, `scripts/`'s ten `core_api.*` imports resolve to nothing and degrade to `Any` under `ignore_missing_imports` — the exact gap #983 closed for the services.
- **`follow_imports = silent`.** Without it the step also reports errors *inside* the service trees (29 from core-api), which have their own gate and their own reviewed exemptions. A step that fails on paths it does not own teaches people to ignore it. `silent` still checks `scripts/` against the real types.

## Is the gate load-bearing?

Clean as landed:
```
$ mypy --config-file scripts/mypy.ini scripts/
Success: no issues found in 29 source files
```

Re-inject the forge signature into `forge_dry_run.py`:
```
scripts/forge_dry_run.py:120: error: Module "common.llm" has no attribute "LLMRequest"  [attr-defined]
Found 3 errors in 1 file (checked 29 source files)
```

That is the bug class this exists for, caught.

## Exemptions

**Six modules are exempt by name, never by glob**, so a new script is gated the day it lands. That is the ratchet #998 established, and the shape #983's review rejected when a glob was proposed. The 33 remaining findings are what an unchecked tree looks like — untyped-dict indexing and loop-variable rebinding in benchmark/repro scripts — and the gate lands without them on purpose: **landing a gate together with its backlog is how gates get reverted.** Each entry carries its error count and codes; delete one once its file is clean.

`gen_events_manifest.py` is **fixed rather than exempted**, so both scripts that import `common.*` — the import shape the forge bug had — are gated from day one. Its two errors were a real contravariance mistake: `Callable[[object], None]` cannot accept a `Callable[[PipelineStorageAdapter], None]`. Annotation-only; verified the module still imports and `_LIFECYCLE_HELPERS` is unchanged.

## Two silent-failure traps, documented at both sites

Both report **success** rather than failing, which is what makes them worth writing down:

| trap | consequence |
|---|---|
| running from `scripts/` instead of the repo root | `mypy_path` resolves against the **CWD**, not the config file. Measured: `core-api/src` catches a bogus symbol imported from `core_api`; `../core-api/src` does not and mypy reports success. |
| omitting `--config-file` | mypy resolves config from the CWD and does not walk up the way ruff does. Without it this runs at bare defaults: 84 errors in 38 files instead of the 29 it owns. |

Note these are the mirror image of the ruff trap in #696 (`--config` breaks per-file-ignores, so ruff must use discovery). **mypy needs the flag; ruff must not have it.** Both are now stated at their step.

## Deliberately not included

- **Repo-root `tests/`** — 526 mypy errors across 108 files, 654 ruff. Real, and wants its own PR.
- **A ruff gate for `scripts/`** — 110 errors, 12 files needing reformat. Also its own PR. (mypy is the gate that would have caught the forge bug; ruff would not have.)

Measured here so the follow-ups are cheap. `actionlint` is clean apart from one pre-existing SC2086 also present on `origin/main`.

3 files changed.