### PR TITLE
fix(api): stm admin credential gets 400/explicit-tenant, not a false 401 (WT-4)

### DIFF
--- a/core-api/src/core_api/routes/skills_inbox.py
+++ b/core-api/src/core_api/routes/skills_inbox.py
@@ -105,13 +105,15 @@ def _require_tenant(auth: AuthContext, explicit_tenant_id: str | None = None) ->
     """
     if auth.tenant_id:
         if explicit_tenant_id is not None and explicit_tenant_id != auth.tenant_id:
+            # Neither id appears in the message — see the same guard in
+            # ``routes/stm.py`` for the full reasoning: the credential's own
+            # tenant is a binding its holder may never have been told, and
+            # the requested tenant is caller-controlled input that would be
+            # reflected into a body which also lands in logs. Clients branch
+            # on the ``TENANT_MISMATCH`` prefix, not on the prose.
             raise HTTPException(
                 status_code=403,
-                detail=(
-                    "TENANT_MISMATCH — this credential is scoped to "
-                    f"tenant {auth.tenant_id!r} and cannot act on tenant "
-                    f"{explicit_tenant_id!r}"
-                ),
+                detail="TENANT_MISMATCH — this credential is not scoped to the requested tenant.",
             )
         return auth.tenant_id
     if getattr(auth, "is_admin", False):

--- a/core-api/src/core_api/routes/stm.py
+++ b/core-api/src/core_api/routes/stm.py
@@ -51,6 +51,23 @@ _PLUGIN_ONLY = (
 )
 
 
+# Published description for the ``tenant_id`` selector every STM operation
+# now accepts. STM has no markdown page of its own — STM is dead by standing
+# decision and CAP-01 was a labelling task, so writing one would advertise it
+# further — which makes the OpenAPI parameter description the only place a
+# caller reads this. Say the whole rule there, including which credential MUST
+# pass it and what omitting it costs.
+_TENANT_SELECTOR = (
+    "Tenant to act on. A tenant-scoped credential should omit it — the "
+    "credential's own tenant is used; echoing the same value is accepted and "
+    "naming a DIFFERENT one is `403 TENANT_MISMATCH`. An **admin credential** "
+    "(`ADMIN_API_KEY`) carries no tenant of its own, so for admin callers this "
+    'parameter is REQUIRED: omitting it returns **400** ("admin credential '
+    'must name a tenant") — the credential is authenticated, so it is never a '
+    "401. A caller with neither a tenant nor admin rights still gets 401."
+)
+
+
 def _reject_reserved_memory_type(memory_type: str | None) -> None:
     """Twin of ``memories._reject_reserved_memory_type``, for the promote door.
 
@@ -93,10 +110,53 @@ def _check_stm_enabled() -> None:
         )
 
 
-def _require_tenant(auth: AuthContext) -> str:
-    if not auth.tenant_id:
-        raise HTTPException(status_code=401, detail="Tenant context required")
-    return auth.tenant_id
+def _require_tenant(auth: AuthContext, explicit_tenant_id: str | None = None) -> str:
+    """Twin of ``skills_inbox._require_tenant`` — the other half of WT-4.
+
+    Every STM endpoint needs a concrete tenant. ``AuthContext.tenant_id``
+    is typed ``str | None`` because some bootstrap paths land there
+    pre-auth — but so does the OSS admin path (auth Path 1), which
+    deliberately builds ``AuthContext(tenant_id=None, is_admin=True)``.
+    Treating BOTH as "missing tenant → 401" told the most privileged
+    credential it did not authenticate. #987 fixed that on the
+    skills-inbox routes and left this copy of the same helper out of
+    scope; this closes it.
+
+    Resolution order (identical to the inbox twin):
+
+    - Tenant-scoped credential (``auth.tenant_id`` set): the key's own
+      tenant wins. A conflicting explicit ``?tenant_id=`` is a 403 —
+      a tenant key must not act on another tenant.
+    - Admin credential (no tenant of its own): acts on the tenant it
+      names via ``?tenant_id=``. Naming none is a 400 (a REQUEST
+      problem — the credential IS authenticated, so never 401).
+    - Neither: genuinely unauthenticated bootstrap context → 401.
+
+    Returning the narrowed ``str`` lets mypy verify the downstream
+    calls without litter ``cast``s.
+    """
+    if auth.tenant_id:
+        if explicit_tenant_id is not None and explicit_tenant_id != auth.tenant_id:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "TENANT_MISMATCH — this credential is scoped to "
+                    f"tenant {auth.tenant_id!r} and cannot act on tenant "
+                    f"{explicit_tenant_id!r}"
+                ),
+            )
+        return auth.tenant_id
+    if getattr(auth, "is_admin", False):
+        if explicit_tenant_id:
+            return explicit_tenant_id
+        raise HTTPException(
+            status_code=400,
+            detail="admin credential must name a tenant — pass ?tenant_id=",
+        )
+    raise HTTPException(
+        status_code=401,
+        detail="UNAUTHENTICATED — auth context has no tenant_id",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -108,10 +168,16 @@ def _require_tenant(auth: AuthContext) -> str:
 async def get_notes(
     auth: AuthContext = Depends(get_auth_context),
     agent_id: str = Query(...),
+    # Tenant selector for ADMIN credentials (auth Path 1 carries no
+    # tenant of its own — see _require_tenant / WT-4). Tenant-scoped
+    # keys may omit it (their own tenant wins) or echo it; a
+    # conflicting value is a 403. Notes are named by ``agent_id``
+    # alone, so there was no other way for an admin to say WHOSE.
+    tenant_id: str | None = Query(None, description=_TENANT_SELECTOR),
     limit: int = Query(default=50, ge=1, le=200),
 ):
     _check_stm_enabled()
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     # Authenticated agent identity (gateway X-Agent-ID) takes precedence over the
     # caller-supplied query param. Notes are per-agent PRIVATE (see the section
     # header), so an agent credential must not read a peer's by naming it.
@@ -139,10 +205,12 @@ async def get_notes(
 async def clear_notes(
     auth: AuthContext = Depends(get_auth_context),
     agent_id: str = Query(...),
+    # Tenant selector for admin credentials — see get_notes / WT-4.
+    tenant_id: str | None = Query(None, description=_TENANT_SELECTOR),
 ):
     _check_stm_enabled()
     auth.enforce_read_only()
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     # Authenticated agent identity (gateway X-Agent-ID) takes precedence —
     # an agent credential must not clear a peer agent's notes by naming it.
     if auth.agent_id and agent_id != auth.agent_id:
@@ -165,10 +233,14 @@ async def clear_notes(
 async def get_bulletin(
     auth: AuthContext = Depends(get_auth_context),
     fleet_id: str = Query(...),
+    # Tenant selector for admin credentials — see get_notes / WT-4.
+    # ``fleet_id`` names a fleet, not a tenant, and fleet ids are only
+    # unique WITHIN a tenant, so it cannot stand in for one.
+    tenant_id: str | None = Query(None, description=_TENANT_SELECTOR),
     limit: int = Query(default=100, ge=1, le=500),
 ):
     _check_stm_enabled()
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     from core_api.services.stm_service import read_bulletin
 
     entries = await read_bulletin(tenant_id, fleet_id, limit=limit)
@@ -184,10 +256,12 @@ async def get_bulletin(
 async def clear_bulletin(
     auth: AuthContext = Depends(get_auth_context),
     fleet_id: str = Query(...),
+    # Tenant selector for admin credentials — see get_notes / WT-4.
+    tenant_id: str | None = Query(None, description=_TENANT_SELECTOR),
 ):
     _check_stm_enabled()
     auth.enforce_read_only()
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     from core_api.services.stm_service import clear_bulletin
 
     await clear_bulletin(tenant_id, fleet_id)
@@ -211,11 +285,19 @@ class PromoteRequest(BaseModel):
 async def promote_stm(
     body: PromoteRequest,
     auth: AuthContext = Depends(get_auth_context),
+    # Tenant selector for admin credentials — see get_notes / WT-4.
+    # A query param rather than a ``PromoteRequest`` field on purpose:
+    # the body has no tenant_id today, and adding one would start
+    # honouring the value ``StandaloneTenantMiddleware`` already
+    # injects into every JSON body (pydantic drops it as an unknown
+    # field right now). Query keeps the selector identical across all
+    # five STM endpoints and leaves the request schema alone.
+    tenant_id: str | None = Query(None, description=_TENANT_SELECTOR),
 ):
     _check_stm_enabled()
     auth.enforce_read_only()
     auth.enforce_usage_limits()
-    tenant_id = _require_tenant(auth)
+    tenant_id = _require_tenant(auth, tenant_id)
     # A promote IS an LTM write, so it owes the same gates as POST /memories.
     # It reached LTM having paid only the two above, which meant the STM door
     # into long-term memory was cheaper than the front door.
@@ -257,7 +339,12 @@ async def promote_stm(
     # actually land in rather than against None.
     if not body.fleet_id and agent.get("fleet_id"):
         body.fleet_id = agent["fleet_id"]
-    if auth.tenant_id:  # skip enforcement + metering for admin, as POST /memories does
+    # Skip enforcement + metering for admin, as POST /memories does. Note this
+    # branch was DEAD before the WT-4 fix above: an admin credential (tenant_id
+    # None) never got past ``_require_tenant``. It is deliberately still keyed
+    # on ``auth.tenant_id`` and not on the resolved ``tenant_id``, which is now
+    # set for admins too.
+    if auth.tenant_id:
         await enforce_fleet_write(tenant_id, body.agent_id, body.fleet_id)
         # Metering, distinct from ``enforce_usage_limits`` above: that one
         # refuses a write when the org is ALREADY over its plan cap, this one is

--- a/core-api/src/core_api/routes/stm.py
+++ b/core-api/src/core_api/routes/stm.py
@@ -57,14 +57,19 @@ _PLUGIN_ONLY = (
 # further — which makes the OpenAPI parameter description the only place a
 # caller reads this. Say the whole rule there, including which credential MUST
 # pass it and what omitting it costs.
+#
+# It deliberately does NOT name the env var behind the admin credential. The
+# capability (an admin credential reaches any tenant it names) is inherent to
+# the design and belongs in the spec; the server-side setting that grants it is
+# operator configuration no API caller can act on, and this spec is published.
 _TENANT_SELECTOR = (
     "Tenant to act on. A tenant-scoped credential should omit it — the "
     "credential's own tenant is used; echoing the same value is accepted and "
     "naming a DIFFERENT one is `403 TENANT_MISMATCH`. An **admin credential** "
-    "(`ADMIN_API_KEY`) carries no tenant of its own, so for admin callers this "
-    'parameter is REQUIRED: omitting it returns **400** ("admin credential '
-    'must name a tenant") — the credential is authenticated, so it is never a '
-    "401. A caller with neither a tenant nor admin rights still gets 401."
+    "carries no tenant of its own, so for admin callers this parameter is "
+    'REQUIRED: omitting it returns **400** ("admin credential must name a '
+    'tenant") — the credential is authenticated, so it is never a 401. A '
+    "caller with neither a tenant nor admin rights still gets 401."
 )
 
 
@@ -132,18 +137,28 @@ def _require_tenant(auth: AuthContext, explicit_tenant_id: str | None = None) ->
       problem — the credential IS authenticated, so never 401).
     - Neither: genuinely unauthenticated bootstrap context → 401.
 
+    The mismatch comparison happens BEFORE any lookup, on the two
+    strings alone, so a caller cannot use the 403/404 split to learn
+    whether a named tenant exists.
+
     Returning the narrowed ``str`` lets mypy verify the downstream
     calls without litter ``cast``s.
     """
     if auth.tenant_id:
         if explicit_tenant_id is not None and explicit_tenant_id != auth.tenant_id:
+            # Neither id appears in the message, deliberately. The
+            # credential's own tenant is a binding its holder was not
+            # necessarily told (embedded and shared keys), so echoing it
+            # discloses it to anyone holding the key; the requested tenant
+            # is caller-controlled input, and reflecting it into a body
+            # that also lands in logs is a log-injection surface (and a
+            # stored-XSS one wherever an operator UI renders a detail
+            # string). ``!r`` quotes, it does not sanitize. Neither value
+            # is actionable anyway — clients branch on the machine-readable
+            # ``TENANT_MISMATCH`` prefix, not on the prose.
             raise HTTPException(
                 status_code=403,
-                detail=(
-                    "TENANT_MISMATCH — this credential is scoped to "
-                    f"tenant {auth.tenant_id!r} and cannot act on tenant "
-                    f"{explicit_tenant_id!r}"
-                ),
+                detail="TENANT_MISMATCH — this credential is not scoped to the requested tenant.",
             )
         return auth.tenant_id
     if getattr(auth, "is_admin", False):

--- a/tests/test_broker_ingest_stm_ownership.py
+++ b/tests/test_broker_ingest_stm_ownership.py
@@ -102,7 +102,11 @@ async def _drive_stm(monkeypatch, *, agent_id, auth):
 
     monkeypatch.setattr("core_api.services.stm_service.promote", _promote)
     body = stm.PromoteRequest(agent_id=agent_id, content="a durable note")
-    await stm.promote_stm(body, auth)
+    # ``tenant_id=None`` explicitly: the route is called directly here, not
+    # through FastAPI, so the parameter default would be the ``Query(None)``
+    # marker object rather than None — and a non-None explicit tenant reads
+    # as a cross-tenant request to ``_require_tenant`` (403).
+    await stm.promote_stm(body, auth, tenant_id=None)
     return captured["agent_id"], gate
 
 

--- a/tests/test_route_authz_gaps.py
+++ b/tests/test_route_authz_gaps.py
@@ -17,8 +17,15 @@
 NOTE: requests in these tests pass explicit ``tenant_id`` in JSON bodies
 where applicable — ``StandaloneTenantMiddleware`` otherwise injects the
 standalone tenant into body/query, which would mask the cross-tenant
-scenarios. Agent rows are seeded via the storage client (``sc``), not the
-rolled-back ``db`` fixture, so the in-process storage app can see them.
+scenarios. The STM requests now pass it in the QUERY STRING for the same
+reason: since the WT-4 fix those routes declare a ``tenant_id`` selector,
+so the injected standalone tenant would be read as a caller-supplied
+cross-tenant request against these fabricated ``as_auth`` tenants and
+answered with 403 TENANT_MISMATCH — an artifact of the fixture, not of
+the routes (in a real standalone deployment every auth path resolves to
+the standalone tenant, so the injected value always matches). Agent rows
+are seeded via the storage client (``sc``), not the rolled-back ``db``
+fixture, so the in-process storage app can see them.
 """
 
 from __future__ import annotations
@@ -203,20 +210,24 @@ def _stm_enabled(monkeypatch):
 
 async def test_stm_clear_notes_blocked_for_read_only(client, as_auth, _stm_enabled):
     as_auth("tenant-ro", capabilities={"read"})
-    resp = await client.delete("/api/v1/stm/notes?agent_id=any-agent")
+    resp = await client.delete(
+        "/api/v1/stm/notes?agent_id=any-agent&tenant_id=tenant-ro"
+    )
     assert resp.status_code == 403
 
 
 async def test_stm_clear_bulletin_blocked_for_read_only(client, as_auth, _stm_enabled):
     as_auth("tenant-ro", capabilities={"read"})
-    resp = await client.delete("/api/v1/stm/bulletin?fleet_id=any-fleet")
+    resp = await client.delete(
+        "/api/v1/stm/bulletin?fleet_id=any-fleet&tenant_id=tenant-ro"
+    )
     assert resp.status_code == 403
 
 
 async def test_stm_promote_blocked_for_read_only(client, as_auth, _stm_enabled):
     as_auth("tenant-ro", capabilities={"read"})
     resp = await client.post(
-        "/api/v1/stm/promote",
+        "/api/v1/stm/promote?tenant_id=tenant-ro",
         json={"agent_id": "any-agent", "content": "should not persist"},
     )
     assert resp.status_code == 403
@@ -224,14 +235,14 @@ async def test_stm_promote_blocked_for_read_only(client, as_auth, _stm_enabled):
 
 async def test_stm_clear_notes_rejects_peer_agent(client, as_auth, _stm_enabled):
     as_auth("tenant-a", agent_id="agent-1")
-    resp = await client.delete("/api/v1/stm/notes?agent_id=agent-2")
+    resp = await client.delete("/api/v1/stm/notes?agent_id=agent-2&tenant_id=tenant-a")
     assert resp.status_code == 403
 
 
 async def test_stm_promote_rejects_peer_agent(client, as_auth, _stm_enabled):
     as_auth("tenant-a", agent_id="agent-1")
     resp = await client.post(
-        "/api/v1/stm/promote",
+        "/api/v1/stm/promote?tenant_id=tenant-a",
         json={"agent_id": "agent-2", "content": "on behalf of a peer"},
     )
     assert resp.status_code == 403
@@ -467,7 +478,7 @@ async def test_stm_notes_of_a_peer_agent_cannot_be_read(client, as_auth, _stm_en
     """
     tenant = f"tenant-{_uid()}"
     as_auth(tenant, agent_id="agent-a")
-    resp = await client.get("/api/v1/stm/notes?agent_id=agent-b")
+    resp = await client.get(f"/api/v1/stm/notes?agent_id=agent-b&tenant_id={tenant}")
     assert resp.status_code == 403, resp.text
 
 
@@ -475,7 +486,7 @@ async def test_stm_notes_of_own_agent_are_still_readable(client, as_auth, _stm_e
     """The guard must not break an agent reading its OWN notes."""
     tenant = f"tenant-{_uid()}"
     as_auth(tenant, agent_id="agent-a")
-    resp = await client.get("/api/v1/stm/notes?agent_id=agent-a")
+    resp = await client.get(f"/api/v1/stm/notes?agent_id=agent-a&tenant_id={tenant}")
     assert resp.status_code == 200, resp.text
     assert resp.json()["agent_id"] == "agent-a"
 
@@ -561,7 +572,7 @@ async def test_promote_rejects_a_server_reserved_memory_type(
 
     as_auth(tenant, agent_id="agent-a")
     resp = await client.post(
-        "/api/v1/stm/promote",
+        f"/api/v1/stm/promote?tenant_id={tenant}",
         json={
             "agent_id": "agent-a",
             "content": "promoted",
@@ -579,7 +590,7 @@ async def test_promote_refuses_a_quarantined_agent(client, as_auth, sc, _stm_ena
 
     as_auth(tenant, agent_id="agent-q")
     resp = await client.post(
-        "/api/v1/stm/promote",
+        f"/api/v1/stm/promote?tenant_id={tenant}",
         json={"agent_id": "agent-q", "content": "promoted"},
     )
     assert resp.status_code == 403, resp.text

--- a/tests/test_skills_inbox_routes.py
+++ b/tests/test_skills_inbox_routes.py
@@ -518,8 +518,17 @@ async def test_tenant_key_with_conflicting_tenant_is_403(storage, settings, side
         r_list = await client.get(f"{BASE}?tenant_id=t-other")
         r_action = await client.post(f"{BASE}/{SLUG}/defer?tenant_id=t-other", json=None)
     assert r_list.status_code == 403, r_list.text
-    assert r_list.json()["detail"].startswith("TENANT_MISMATCH")
     assert r_action.status_code == 403, r_action.text
+    for r in (r_list, r_action):
+        detail = r.json()["detail"]
+        # The machine-readable prefix is the contract clients branch on.
+        assert detail.startswith("TENANT_MISMATCH")
+        # The prose discloses NEITHER id: not the credential's own tenant
+        # (a binding an embedded/shared key's holder may never have been
+        # told) and not the caller-supplied one (attacker-controlled input
+        # reflected into a body that also lands in logs).
+        assert TENANT not in detail, detail
+        assert "t-other" not in detail, detail
     assert storage.upserts == []
 
 

--- a/tests/test_stm_admin_tenant.py
+++ b/tests/test_stm_admin_tenant.py
@@ -1,0 +1,316 @@
+"""WT-4, second half — tenant resolution on the STM routes.
+
+``core_api.routes.stm`` carried its own private ``_require_tenant``, a
+copy of the skills-inbox helper with the same flaw: every
+``AuthContext`` without a ``tenant_id`` was treated as unauthenticated.
+The OSS admin path (``core_api.auth`` Path 1) deliberately builds
+``AuthContext(tenant_id=None, is_admin=True)`` — so all five STM
+operations answered the **admin API key** with a 401, and any
+``?tenant_id=`` the operator passed was silently dropped because no STM
+route declared the parameter.
+
+#987 fixed the inbox copy and left this one out of scope. These tests
+pin the same three-case resolution here:
+
+- tenant-scoped credential → its own tenant; a conflicting explicit
+  tenant is 403 ``TENANT_MISMATCH``;
+- admin credential → the tenant it names; naming none is **400**, never
+  401;
+- neither → the original 401.
+
+Pure unit tests: the app is the STM router alone (no
+``StandaloneTenantMiddleware``, which would otherwise inject a
+``tenant_id`` into the query string of every request and mask the
+admin-without-a-tenant case), and the STM service + write-path seams
+are patched at the module boundary. No DB.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from core_api.auth import AuthContext, get_auth_context
+from core_api.routes import stm
+
+pytestmark = pytest.mark.unit
+
+TENANT = "t-acme"
+OTHER = "t-other"
+AGENT = "agent-1"
+FLEET = "fleet-1"
+
+
+@pytest.fixture
+def stm_on(monkeypatch):
+    """Enable STM. Every route calls ``_check_stm_enabled`` first, and it
+    422s by default — so without this the tenant branch is unreachable."""
+    from core_api.config import settings
+
+    monkeypatch.setattr(settings, "use_stm", True)
+
+
+class Seams:
+    """Records what the routes asked the service layer to do."""
+
+    def __init__(self):
+        self.read_notes: list[tuple] = []
+        self.clear_notes: list[tuple] = []
+        self.read_bulletin: list[tuple] = []
+        self.clear_bulletin: list[tuple] = []
+        self.promoted: list[dict] = []
+        self.fleet_writes: list[tuple] = []
+        self.metered: list[tuple] = []
+
+
+@pytest.fixture
+def seams(monkeypatch):
+    s = Seams()
+
+    async def _read_notes(tenant_id, agent_id, limit=50):
+        s.read_notes.append((tenant_id, agent_id))
+        return [{"content": "a note"}]
+
+    async def _clear_notes(tenant_id, agent_id):
+        s.clear_notes.append((tenant_id, agent_id))
+
+    async def _read_bulletin(tenant_id, fleet_id, limit=100):
+        s.read_bulletin.append((tenant_id, fleet_id))
+        return [{"content": "an entry"}]
+
+    async def _clear_bulletin(tenant_id, fleet_id):
+        s.clear_bulletin.append((tenant_id, fleet_id))
+
+    async def _promote(**kwargs):
+        s.promoted.append(kwargs)
+        return {"id": "m-1"}
+
+    monkeypatch.setattr("core_api.services.stm_service.read_notes", _read_notes)
+    monkeypatch.setattr("core_api.services.stm_service.clear_notes", _clear_notes)
+    monkeypatch.setattr("core_api.services.stm_service.read_bulletin", _read_bulletin)
+    monkeypatch.setattr("core_api.services.stm_service.clear_bulletin", _clear_bulletin)
+    monkeypatch.setattr("core_api.services.stm_service.promote", _promote)
+
+    # Promote's LTM write path (parity with POST /memories).
+    class _Config:
+        require_agent_approval = False
+
+    async def _resolve_config(tenant_id):
+        return _Config()
+
+    async def _resolve_write_agent(chosen_agent_id, tenant_id, fleet_id, **kwargs):
+        return {"trust_level": 2, "fleet_id": fleet_id}, chosen_agent_id
+
+    async def _enforce_fleet_write(tenant_id, agent_id, fleet_id):
+        s.fleet_writes.append((tenant_id, agent_id, fleet_id))
+
+    async def _check_and_increment(tenant_id, kind):
+        s.metered.append((tenant_id, kind))
+
+    monkeypatch.setattr(
+        "core_api.services.organization_settings.resolve_config", _resolve_config
+    )
+    monkeypatch.setattr(stm, "resolve_write_agent", _resolve_write_agent)
+    monkeypatch.setattr(stm, "enforce_fleet_write", _enforce_fleet_write)
+    monkeypatch.setattr(stm, "check_and_increment", _check_and_increment)
+    return s
+
+
+def make_client(
+    *,
+    # ``tenant_id=None`` + ``is_admin=True`` reproduces the OSS admin
+    # credential (auth Path 1) — the WT-4 shape.
+    tenant_id: str | None = TENANT,
+    is_admin: bool = False,
+) -> AsyncClient:
+    app = FastAPI()
+    app.include_router(stm.router, prefix="/api/v1")
+    auth = AuthContext(tenant_id=tenant_id, is_admin=is_admin)
+
+    async def _auth_dep():
+        return auth
+
+    app.dependency_overrides[get_auth_context] = _auth_dep
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def admin_client() -> AsyncClient:
+    return make_client(tenant_id=None, is_admin=True)
+
+
+PROMOTE_BODY = {"agent_id": AGENT, "content": "a durable note"}
+
+
+# ---------------------------------------------------------------------------
+# Admin credential + an explicit tenant — the operation it was refused
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_key_with_explicit_tenant_reads(stm_on, seams):
+    async with admin_client() as client:
+        notes = await client.get(
+            "/api/v1/stm/notes", params={"agent_id": AGENT, "tenant_id": TENANT}
+        )
+        bulletin = await client.get(
+            "/api/v1/stm/bulletin", params={"fleet_id": FLEET, "tenant_id": TENANT}
+        )
+    assert notes.status_code == 200, notes.text
+    assert notes.json()["tenant_id"] == TENANT
+    assert bulletin.status_code == 200, bulletin.text
+    assert bulletin.json()["tenant_id"] == TENANT
+    assert seams.read_notes == [(TENANT, AGENT)]
+    assert seams.read_bulletin == [(TENANT, FLEET)]
+
+
+async def test_admin_key_with_explicit_tenant_can_clear(stm_on, seams):
+    async with admin_client() as client:
+        notes = await client.delete(
+            "/api/v1/stm/notes", params={"agent_id": AGENT, "tenant_id": TENANT}
+        )
+        bulletin = await client.delete(
+            "/api/v1/stm/bulletin", params={"fleet_id": FLEET, "tenant_id": TENANT}
+        )
+    assert notes.status_code == 200, notes.text
+    assert bulletin.status_code == 200, bulletin.text
+    assert seams.clear_notes == [(TENANT, AGENT)]
+    assert seams.clear_bulletin == [(TENANT, FLEET)]
+
+
+async def test_admin_key_with_explicit_tenant_can_promote(stm_on, seams):
+    async with admin_client() as client:
+        r = await client.post(
+            "/api/v1/stm/promote",
+            params={"tenant_id": TENANT},
+            json=PROMOTE_BODY,
+        )
+    assert r.status_code == 200, r.text
+    assert seams.promoted[0]["tenant_id"] == TENANT
+    # The admin carve-out below the resolution (``if auth.tenant_id:``) was
+    # dead code until now: fleet-write enforcement and metering stay off for
+    # an admin credential, exactly as POST /memories does.
+    assert seams.fleet_writes == []
+    assert seams.metered == []
+
+
+# ---------------------------------------------------------------------------
+# Admin credential naming no tenant — 400, never 401
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_key_without_tenant_is_400_not_401(stm_on, seams):
+    """The WT-4 regression proper: the admin key IS authenticated, so
+    failing to say WHICH tenant is a request problem (400)."""
+    async with admin_client() as client:
+        responses = {
+            "get_notes": await client.get(
+                "/api/v1/stm/notes", params={"agent_id": AGENT}
+            ),
+            "clear_notes": await client.delete(
+                "/api/v1/stm/notes", params={"agent_id": AGENT}
+            ),
+            "get_bulletin": await client.get(
+                "/api/v1/stm/bulletin", params={"fleet_id": FLEET}
+            ),
+            "clear_bulletin": await client.delete(
+                "/api/v1/stm/bulletin", params={"fleet_id": FLEET}
+            ),
+            "promote": await client.post("/api/v1/stm/promote", json=PROMOTE_BODY),
+        }
+    for name, r in responses.items():
+        assert r.status_code == 400, f"{name}: {r.status_code} {r.text}"
+        assert "tenant" in r.json()["detail"], name
+    # Nothing reached the service layer.
+    assert seams.read_notes == seams.clear_notes == []
+    assert seams.read_bulletin == seams.clear_bulletin == []
+    assert seams.promoted == []
+
+
+# ---------------------------------------------------------------------------
+# Tenant-scoped credential
+# ---------------------------------------------------------------------------
+
+
+async def test_tenant_key_with_conflicting_tenant_is_403(stm_on, seams):
+    """A tenant-scoped key must not act on ANOTHER tenant via ?tenant_id=."""
+    async with make_client() as client:
+        read = await client.get(
+            "/api/v1/stm/notes", params={"agent_id": AGENT, "tenant_id": OTHER}
+        )
+        clear = await client.delete(
+            "/api/v1/stm/bulletin", params={"fleet_id": FLEET, "tenant_id": OTHER}
+        )
+        promote = await client.post(
+            "/api/v1/stm/promote", params={"tenant_id": OTHER}, json=PROMOTE_BODY
+        )
+    for r in (read, clear, promote):
+        assert r.status_code == 403, r.text
+        assert r.json()["detail"].startswith("TENANT_MISMATCH")
+    assert seams.read_notes == []
+    assert seams.clear_bulletin == []
+    assert seams.promoted == []
+
+
+async def test_tenant_key_with_matching_tenant_still_works(stm_on, seams):
+    async with make_client() as client:
+        r = await client.get(
+            "/api/v1/stm/notes", params={"agent_id": AGENT, "tenant_id": TENANT}
+        )
+    assert r.status_code == 200, r.text
+    assert seams.read_notes == [(TENANT, AGENT)]
+
+
+async def test_tenant_key_without_param_unchanged(stm_on, seams):
+    """No ?tenant_id= → the key's own tenant wins, exactly as before."""
+    async with make_client() as client:
+        read = await client.get("/api/v1/stm/notes", params={"agent_id": AGENT})
+        promote = await client.post("/api/v1/stm/promote", json=PROMOTE_BODY)
+    assert read.status_code == 200, read.text
+    assert read.json()["tenant_id"] == TENANT
+    assert promote.status_code == 200, promote.text
+    assert seams.promoted[0]["tenant_id"] == TENANT
+    # A tenant-scoped credential still pays fleet enforcement + metering.
+    assert seams.fleet_writes == [(TENANT, AGENT, None)]
+    assert seams.metered == [(TENANT, "write")]
+
+
+# ---------------------------------------------------------------------------
+# Neither — the 401 that was always correct
+# ---------------------------------------------------------------------------
+
+
+async def test_no_tenant_and_no_admin_still_401(stm_on, seams):
+    """Genuinely unauthenticated bootstrap context keeps the 401."""
+    async with make_client(tenant_id=None, is_admin=False) as client:
+        read = await client.get("/api/v1/stm/notes", params={"agent_id": AGENT})
+        promote = await client.post("/api/v1/stm/promote", json=PROMOTE_BODY)
+    for r in (read, promote):
+        assert r.status_code == 401, r.text
+        assert r.json()["detail"].startswith("UNAUTHENTICATED")
+
+
+# ---------------------------------------------------------------------------
+# The published contract — the parameter description is the only doc a
+# caller gets (STM has no markdown page by standing decision).
+# ---------------------------------------------------------------------------
+
+
+async def test_tenant_selector_is_documented_on_every_stm_operation():
+    from core_api.app import app
+
+    schema = app.openapi()
+    operations = [
+        (path, method, op)
+        for path, item in schema["paths"].items()
+        if path.startswith("/api/v1/stm/")
+        for method, op in item.items()
+    ]
+    assert operations, "no STM operations in the schema — did the routes move?"
+    for path, method, op in operations:
+        params = {p["name"]: p for p in op.get("parameters", [])}
+        assert "tenant_id" in params, f"{method.upper()} {path} has no tenant selector"
+        description = (params["tenant_id"].get("description") or "").lower()
+        # An admin caller must learn from the docs BOTH that the parameter
+        # is theirs to pass and what omitting it costs.
+        assert "admin" in description, f"{method.upper()} {path}"
+        assert "400" in description, f"{method.upper()} {path}"

--- a/tests/test_stm_admin_tenant.py
+++ b/tests/test_stm_admin_tenant.py
@@ -245,7 +245,15 @@ async def test_tenant_key_with_conflicting_tenant_is_403(stm_on, seams):
         )
     for r in (read, clear, promote):
         assert r.status_code == 403, r.text
-        assert r.json()["detail"].startswith("TENANT_MISMATCH")
+        detail = r.json()["detail"]
+        # The machine-readable prefix is the contract clients branch on.
+        assert detail.startswith("TENANT_MISMATCH")
+        # The prose discloses NEITHER id: not the credential's own tenant
+        # (a binding an embedded/shared key's holder may never have been
+        # told) and not the caller-supplied one (attacker-controlled input
+        # reflected into a body that also lands in logs).
+        assert TENANT not in detail, detail
+        assert OTHER not in detail, detail
     assert seams.read_notes == []
     assert seams.clear_bulletin == []
     assert seams.promoted == []


### PR DESCRIPTION
Completes wet-test defect **WT-4** — the twin [#987](https://github.com/caura-ai/caura/pull/987) found and deliberately left out of scope.

It also fixes a disclosure in the 403 detail string on **both** surfaces — the new STM copy and the already-merged skills-inbox one. See *Tenant-mismatch 403 discloses neither id* below.

## What

`core-api/src/core_api/routes/stm.py` carried its own private `_require_tenant`, a copy of the skills-inbox helper with the same flaw:

```python
def _require_tenant(auth: AuthContext) -> str:
    if not auth.tenant_id:
        raise HTTPException(status_code=401, detail="Tenant context required")
```

The OSS admin path (`core_api/auth.py` Path 1) deliberately builds `AuthContext(tenant_id=None, is_admin=True)`. So all **five** STM operations — `GET`/`DELETE /stm/notes`, `GET`/`DELETE /stm/bulletin`, `POST /stm/promote` — answered the **admin API key** with a 401, and any `?tenant_id=` the operator passed was silently dropped because no STM route declared the parameter.

The most privileged credential was told it did not authenticate.

## Why this shape

Identical to #987, deliberately — the two helpers should not drift:

- **Tenant-scoped credential**: its own tenant wins; a *conflicting* explicit tenant is **403 `TENANT_MISMATCH`**; matching or absent → unchanged behavior.
- **Admin credential**: acts on the tenant it names; naming none is **400** (`admin credential must name a tenant — pass ?tenant_id=`), never 401 — the credential IS authenticated, so the failure is a *request* problem.
- **Neither**: the **401** stays for genuinely unauthenticated bootstrap contexts.

Two notes on scope:

- The 401's message is unified with the inbox twin (`UNAUTHENTICATED — auth context has no tenant_id`, was `Tenant context required`). The status and the derived wire code (`errors.STATUS_TO_CODE`) are unchanged; nothing in the repo asserted on the old string.
- STM has **no admin gate** equivalent to `_require_inbox_admin` — there is nothing here to pass. The per-agent-privacy checks (`auth.agent_id and agent_id != auth.agent_id`) are unaffected: an admin credential carries no `agent_id`, so it passes them as before.

## Tenant-mismatch 403 discloses neither id (both surfaces)

Review follow-up. The detail string the resolution raised on a conflicting tenant was:

```
TENANT_MISMATCH — this credential is scoped to tenant {auth.tenant_id!r} and cannot act on tenant {explicit_tenant_id!r}
```

Two problems. It **echoes the caller's own tenant id**, disclosing the key's tenant binding to anyone holding the key — gratuitous, and wrong for an embedded or shared credential whose holder was never meant to know it. And it **reflects attacker-controlled input** (`explicit_tenant_id`) verbatim into a client-visible body that also lands in logs: a log-injection surface, and a stored-XSS surface if that detail is ever rendered in an operator UI. `!r` quotes but does not sanitize. Neither value is actionable for a legitimate caller, because clients branch on the machine-readable `TENANT_MISMATCH` code, not the prose.

It is now:

```
TENANT_MISMATCH — this credential is not scoped to the requested tenant.
```

**Applied to both copies**: the STM helper added in this PR *and* `core-api/src/core_api/routes/skills_inbox.py`, which has carried the identical string since #987 merged. Three lines, same defect class — leaving the merged copy echoing would have been inconsistent.

Unchanged, deliberately: the `TENANT_MISMATCH` prefix (so the derived wire code and the pinned-prefix assertions still hold), the resolution order, and the status codes. Also unchanged is the property that makes this safe — the comparison runs on the two strings **before any lookup**, so there is no tenant-existence oracle in the 403/404 split. A comment in `stm.py` records that, and both surfaces' tests now assert the 403 body contains **neither** id.

## Per-endpoint tenant source

I checked every STM endpoint for an existing way to name a tenant before adding a parameter. **None had one**, so all five take `tenant_id: str | None = Query(None)`:

| Endpoint | Existing tenant source? | Decision |
|---|---|---|
| `GET /stm/notes` | No — `agent_id` names an agent, not a tenant | add `?tenant_id=` |
| `DELETE /stm/notes` | No — same | add `?tenant_id=` |
| `GET /stm/bulletin` | No — `fleet_id` names a fleet, and fleet ids are unique only *within* a tenant | add `?tenant_id=` |
| `DELETE /stm/bulletin` | No — same | add `?tenant_id=` |
| `POST /stm/promote` | **Body**, but no tenant field: `PromoteRequest` is `agent_id` / `content` / `fleet_id` / `memory_type` / `visibility` | add `?tenant_id=`, **not** a body field |

The promote case is the one worth a sentence. Adding `tenant_id` to `PromoteRequest` would have made the route start honouring a value it does not receive from the caller: `StandaloneTenantMiddleware` injects `tenant_id` into every JSON body, and pydantic drops it today as an unknown field. A query param keeps the selector identical across all five operations and leaves the request schema alone.

`promote`'s `if auth.tenant_id:` carve-out (skip fleet-write enforcement + metering for admin, as `POST /memories` does) was **dead code** until this fix — an admin never got past `_require_tenant` to reach it. It stays keyed on `auth.tenant_id`, not on the resolved `tenant_id`, and a test now pins that.

## Docs

STM has no markdown page anywhere in the repo (grepped `docs/`, all `*.md`, `plugin/`, `static/`, `clients/`, `e2e/`, and the MCP tool descriptions in `mcp_server.py` — STM is not on the MCP surface and is not in the README endpoint tables). Writing one would cut against the standing CAP-01 decision to *label* STM rather than advertise it. So the OpenAPI parameter description is the only doc a caller gets, and it carries the whole rule:

> Tenant to act on. A tenant-scoped credential should omit it — the credential's own tenant is used; echoing the same value is accepted and naming a DIFFERENT one is `403 TENANT_MISMATCH`. An **admin credential** carries no tenant of its own, so for admin callers this parameter is REQUIRED: omitting it returns **400** ("admin credential must name a tenant") — the credential is authenticated, so it is never a 401. A caller with neither a tenant nor admin rights still gets 401.

It says "an admin credential" and **does not name `ADMIN_API_KEY`** — a judgement call worth stating. The *capability* (an admin credential reaches any tenant it names) is inherent to the design, is what a caller needs in order to use the parameter correctly, and stays in the spec. The *env var* is the server-side setting that grants it: operator configuration, not something any API caller can act on, and this spec is published. Naming it buys a reader nothing and hands an attacker enumerating the deployment a specific configuration key, so it is out.

A test asserts every STM operation in the live schema publishes that parameter with both "admin" and "400" in its description, so the docs cannot drift from the code. The `_PLUGIN_ONLY` operation descriptions and the `stm` OpenAPI tag are untouched — neither says anything about tenants, and F6's labelling tests still pass.

Files whose documentation changed: `core-api/src/core_api/routes/stm.py` (the published `_TENANT_SELECTOR` parameter description, the `_require_tenant` docstring, the per-endpoint comments) and `tests/test_route_authz_gaps.py` (module docstring — see below). No `.md` file documents these routes.

*Adjacent gap, not fixed here:* `docs/skills-inbox-api.md` has an "Auth & prerequisites" section that was not updated when #987 added `?tenant_id=` to the six inbox endpoints. Same story, different surface — worth a follow-up.

## Call-site fix (signature change)

`tests/test_broker_ingest_stm_ownership.py` calls `stm.promote_stm(body, auth)` **directly**, not through FastAPI, so the new parameter's default would be the `Query(None)` marker object rather than `None` — which `_require_tenant` reads as a cross-tenant request and answers 403. The call now passes `tenant_id=None` explicitly, with a comment saying why. Grepped the whole repo for direct calls to the other four handlers: the only other `stm.get_notes` / `stm.clear_notes` / `stm.get_bulletin` / `stm.clear_bulletin` call sites are on the STM **provider/service**, not the route module, and are untouched.

## Test evidence

New suite `tests/test_stm_admin_tenant.py` (9 tests), mirroring #987's set — admin + explicit tenant reads / clears / promotes; admin without a tenant → 400 not 401 (all five endpoints); tenant credential + conflicting explicit tenant → 403 (and nothing reaches the service layer); tenant credential with matching / absent param unchanged (and still pays fleet enforcement + metering); bootstrap context still 401; plus the published-description test above. Like #987's, the app under test is the STM router alone — the full app's `StandaloneTenantMiddleware` injects a `tenant_id` into every query string, which would mask the admin-without-a-tenant case.

**Proof the tests bite.** With both route files reverted to `origin/main` (`git checkout origin/main -- routes/stm.py routes/skills_inbox.py`) and the new tests left in place:

```
FAILED tests/test_stm_admin_tenant.py::test_admin_key_with_explicit_tenant_reads
FAILED tests/test_stm_admin_tenant.py::test_admin_key_with_explicit_tenant_can_clear
FAILED tests/test_stm_admin_tenant.py::test_admin_key_with_explicit_tenant_can_promote
FAILED tests/test_stm_admin_tenant.py::test_admin_key_without_tenant_is_400_not_401
FAILED tests/test_stm_admin_tenant.py::test_tenant_key_with_conflicting_tenant_is_403
FAILED tests/test_stm_admin_tenant.py::test_no_tenant_and_no_admin_still_401
FAILED tests/test_stm_admin_tenant.py::test_tenant_selector_is_documented_on_every_stm_operation
FAILED tests/test_skills_inbox_routes.py::test_tenant_key_with_conflicting_tenant_is_403
8 failed, 68 passed
```

`test_admin_key_without_tenant_is_400_not_401` is the WT-4 regression proper: pre-fix it gets 401 on every one of the five endpoints. (`test_no_tenant_and_no_admin_still_401` fails pre-fix only on the unified message — the status was already 401 there.) The last line is the **twin** proof: the inbox non-disclosure assertion fails against the merged #987 string and passes with the three-line fix in this PR. Restored, all 9 + 67 pass.

**Existing STM route tests.** `tests/test_route_authz_gaps.py` drives the real app, where the standalone middleware injects `tenant_id` into the query string of every request — which the STM routes now read. Against the fabricated cross-tenant `as_auth` contexts that file builds, the injected value is a mismatch and three tests started 403-ing. The requests now pass an explicit matching `tenant_id` in the query, exactly the convention that file's own docstring already documents for JSON bodies, and the docstring is extended to say so. This is a fixture artifact, not a route regression: in a real standalone deployment every auth path (Path 2's standalone branch, Path 3) resolves to the standalone tenant, so the injected value always matches, and Path 4 is unreachable while standalone. Two tests in that file were also passing for the *wrong* reason (403 for tenant mismatch instead of the peer-agent / read-only rule they claim to pin); they now test what they say.

**Runs.**

- STM- and inbox-touching suites (`test_stm_admin_tenant`, `test_stm`, `test_f6_stm_labelled_plugin_only`, `test_broker_ingest_stm_ownership`, `test_route_authz_gaps`, `test_provider_protocols`, `test_skills_inbox_routes`, `test_org_role_plumb`, `test_mcp_doc`, `test_c32_coded_auth_errors`): **303 passed**.
- Full `tests/`: **5304 passed, 4 skipped, 1 xfailed**; the 16 failures are pre-existing local embedding/ranking noise — the failure set is byte-identical on unmodified `origin/main` in the same environment (verified by stashing and re-running those five files).
- CI-exact ruff: all six `check` scopes and all six `format --check` scopes (including the `--isolated` vendored `common/` files) clean.
- `cd core-api && mypy src/`: no issues in 200 source files.
- `scripts/legacy_name_ratchet.py`: no new lines. `scripts/do_not_touch_sentinel.py`: all 34 protected strings survive.
- Broker OpenAPI baseline `--check`: up to date (STM is not a broker operation).
