### PR TITLE
fix(events): claim a slot for the broadcast id instead of rolling a random one

### DIFF
--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -14,6 +14,15 @@ Terraform can't pre-provision them, so ``_ensure_broadcast_subscription``
 creates one at ``start()`` (with an ``expiration_policy`` backstop) and
 deletes it at ``stop()``.
 
+That per-process id is a claimed *slot* (see ``_claim_broadcast_slot``),
+not a random value. The distinction is the difference between a leak
+bounded by how many workers are alive and a leak bounded by how many
+workers have ever died: a SIGKILLed worker's replacement re-derives the
+same name and reuses the subscription, where a random name orphans one
+per death for a full ``BROADCAST_SUBSCRIPTION_TTL_SECONDS``. Deletion at
+``stop()`` is still load-bearing and is NOT made redundant by this — the
+two cover different exits. See ``release_broadcast_subscriptions``.
+
 Import is lazy so `common.events` can be imported in OSS standalone
 installs that don't have `google-cloud-pubsub` installed.
 
@@ -38,11 +47,16 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import functools
 import json
 import logging
+import os
+import tempfile
+import threading
 import uuid
 from collections import defaultdict
+from pathlib import Path
 from typing import Any
 
 from pydantic import ValidationError
@@ -82,6 +96,238 @@ BROADCAST_SUBSCRIPTION_TTL_SECONDS = 86400
 # for a fast one — which is the entire point. Prefer failing fast and leaving
 # the TTL to clean up over blocking a shutdown that has nine seconds to live.
 BROADCAST_RELEASE_TIMEOUT_SECONDS = 2.0
+
+# Directory holding the broadcast slot-claim files. See
+# ``_claim_broadcast_slot`` for what they are and why they exist.
+#
+# **Precondition, and the only one that matters**: this directory must be
+# INSTANCE-LOCAL — shared by every worker process of one instance, and shared
+# with nothing else. On Cloud Run it is the instance's own in-memory
+# filesystem, which is exactly that: the two ``--workers 2`` children see one
+# ``/tmp``, and a different instance is a different container with a different
+# ``/tmp``. The same holds for a plain Docker container or a VM.
+#
+# If this were ever backed by a volume shared BETWEEN instances *and* that
+# volume did not enforce ``flock`` (GCS FUSE, say), two instances' slot-0
+# workers would agree on both the token and the slot, land on one subscription,
+# and broadcast would silently become load-balanced. That is the failure this
+# whole scheme exists to prevent, so do not point this at a mounted volume.
+BROADCAST_SLOT_DIR = Path(tempfile.gettempdir()) / "caura-broadcast-slots"
+
+# Ceiling on how many slots a single instance will probe.
+#
+# Deliberately larger than any real ``--workers`` count. uvicorn can exceed its
+# configured worker count transiently — ``Multiprocess.restart_all`` (SIGHUP)
+# starts a replacement and waits for it to be READY *before* retiring the
+# worker it replaces, so both are live at once — and ``handle_ttin`` (SIGTTIN)
+# raises the count outright. Sizing this to ``--workers`` exactly would push
+# those overlap workers onto the uuid4 fallback for no reason. Slots are
+# reclaimed lowest-first, so the population self-compacts back down and this is
+# a ceiling, not a steady state.
+BROADCAST_MAX_SLOTS = 16
+
+# Process-scoped memo for ``_process_broadcast_slot_id``. The identity is a
+# property of the PROCESS, not of a bus object: a start/stop/start cycle must
+# reuse the same name, or the restart mints a fresh subscription and reopens
+# the leak this exists to close.
+_slot_id: str | None = None
+# Guards the claim so two threads racing through a first ``start()`` cannot
+# each take a slot and strand one of them flocked-but-unused.
+_slot_lock = threading.Lock()
+
+
+def _instance_token(slot_dir: Path) -> str | None:
+    """Return the token shared by every worker process of THIS instance.
+
+    Distinguishes slot 0 here from slot 0 on every other instance — without it
+    two instances' slot-0 workers would land on one subscription and broadcast
+    would quietly become load-balanced.
+
+    Deliberately derived from the same directory the slot locks live in, rather
+    than from the Cloud Run metadata server. The token and the mutual exclusion
+    must describe the SAME boundary; if the token said "instance" while the
+    locks coordinated over some wider or narrower scope, the two would disagree
+    and the disagreement would show up as a silent delivery bug rather than an
+    error. One filesystem, one coordination domain, one token.
+
+    Published by hard-linking a fully-written temp file into place: the link is
+    atomic and refuses to overwrite, so a reader either sees no file or sees the
+    complete token, and the first writer's value is the one everybody gets. A
+    plain create-then-write would let a second worker read the file in the
+    window before the contents landed.
+    """
+    token_path = slot_dir / "instance"
+
+    def _read() -> str:
+        try:
+            return token_path.read_text().strip()
+        except OSError:
+            # ``OSError``, not just ``FileNotFoundError``. Missing is the
+            # ordinary case, but a ``PermissionError`` or ``IsADirectoryError``
+            # on this read is still just "no token available", and it must
+            # degrade to the same ``None`` the rest of this module returns —
+            # this runs on the service startup path, and an escape here would
+            # crash boot rather than fall back to a random id.
+            return ""
+
+    token = _read()
+    if token:
+        return token
+    # Missing (we are the first worker on this instance) — or present but
+    # empty, which this function never produces and so cannot be trusted.
+    # Either way, try to publish one; the hard link decides who wins.
+    tmp_path = slot_dir / f"instance.{os.getpid()}.tmp"
+    try:
+        tmp_path.write_text(uuid.uuid4().hex[:12])
+        # FileExistsError means a sibling published first, so the re-read
+        # below adopts that sibling's token instead of ours. The link
+        # refusing to overwrite is the point — it is what makes the first
+        # writer's value the one every worker converges on.
+        with contextlib.suppress(FileExistsError):
+            token_path.hardlink_to(tmp_path)
+    except OSError:
+        return None
+    finally:
+        tmp_path.unlink(missing_ok=True)
+    # Exactly one re-read, not a retry loop: whoever won, the token is now
+    # published, so a second publish attempt could only overwrite nothing and
+    # confuse the next reader.
+    return _read() or None
+
+
+def _claim_broadcast_slot(slot_dir: Path, max_slots: int) -> str | None:
+    """Claim a broadcast identity for this process, or None if none is free.
+
+    Returns ``"{instance_token}-{slot}"``. The identity has to satisfy three
+    properties at once, and the reason this is a lock rather than a computation
+    is that no two of them are satisfiable by the same simpler thing:
+
+    1. **Stable** across respawns of the same slot. uvicorn SIGKILLs a worker
+       that misses its healthcheck and spawns a replacement; the replacement
+       must land on its predecessor's subscription and take the ``AlreadyExists``
+       path. Otherwise every worker death orphans a subscription for the full
+       ``BROADCAST_SUBSCRIPTION_TTL_SECONDS``.
+    2. **Distinct** between workers of one instance that are live AT THE SAME
+       TIME. Two live consumers on one subscription do not both get every
+       message — Pub/Sub load-balances between them — so a broadcast silently
+       degrades to "roughly half the events each". For ``org.settings-changed``
+       that is a process serving stale org settings with nothing red anywhere.
+    3. **Distinct** across instances, via the instance token.
+
+    ``flock`` gives 1 and 2 together and gives them as a kernel guarantee, not a
+    probability. The kernel releases the lock when the holder dies *however* it
+    dies, so a SIGKILLed worker frees its slot with no cooperation from a
+    shutdown path that never ran — which is the property that makes this
+    independent of whether shutdown runs at all. And it cannot hand a slot to a
+    newcomer while the incumbent is alive, which is what keeps property 2 from
+    being traded away for property 1.
+
+    Slots are probed lowest-first so the population self-compacts after a
+    transient overlap instead of drifting upward.
+
+    The obvious alternative — have the supervisor hand each child its index —
+    is not available and is worth ruling out explicitly, because it is the
+    first thing anyone proposes. ``common/serve.py`` only calls
+    ``uvicorn.run(workers=N)``; uvicorn's own ``Multiprocess`` spawns the
+    children and passes them ``(config, sockets)``, keeping the index purely
+    in the parent's list. Reaching it would mean subclassing uvicorn
+    internals. Claiming a slot is supervisor-agnostic and survives a uvicorn
+    upgrade.
+    """
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - no flock on this platform
+        # Not Windows-specific speculation: ``None`` is this function's
+        # already-required degradation path, shared with an unwritable
+        # directory, an unreadable token and slot exhaustion below. Any
+        # environment where the claim cannot be made degrades identically.
+        return None
+    try:
+        slot_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+    token = _instance_token(slot_dir)
+    if token is None:
+        return None
+    for slot in range(max_slots):
+        try:
+            fd = os.open(slot_dir / f"slot-{slot}.lock", os.O_CREAT | os.O_RDWR, 0o600)
+        except OSError:
+            # Degrade per slot, not globally: one unopenable lock file must not
+            # abandon the usable slots after it. If every slot is unopenable the
+            # loop falls through to the same ``None`` anyway.
+            continue
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            # Held by a live sibling. Never fall through to "use it anyway":
+            # sharing a slot is the silent-delivery bug, and leaking a
+            # subscription is merely expensive.
+            os.close(fd)
+            continue
+        # ``fd`` is deliberately never closed, and there is deliberately no
+        # release path. The flock lasts exactly as long as the open file
+        # description, so holding the fd for the process's lifetime is what
+        # keeps a sibling worker off this slot while we are still consuming
+        # from its subscription; the kernel drops it at exit, however we exit.
+        # Do not "fix" the apparent leak — closing it hands a live slot away.
+        return f"{token}-{slot}"
+    return None
+
+
+def _process_broadcast_slot_id() -> str:
+    """This process's broadcast identity: a claimed slot, or a random fallback.
+
+    Always returns an id, and always the SAME id for the life of the process —
+    including on the fallback path. That matters: two buses in one process that
+    disagreed about their identity would create two subscriptions where one is
+    wanted, and the ``start()`` comment about start/stop/start reusing the same
+    names silently would not hold.
+
+    The fallback direction is the load-bearing decision here and must not be
+    inverted. When no slot can be proven ours, take a random id and accept the
+    leak; never reuse a slot we could not claim. A leak is bounded, visible in
+    quota, and reaped in a day. Two live workers on one subscription is a
+    silent halving of broadcast delivery that nothing alerts on.
+    """
+    global _slot_id
+    with _slot_lock:
+        if _slot_id is None:
+            try:
+                _slot_id = _claim_broadcast_slot(
+                    BROADCAST_SLOT_DIR, BROADCAST_MAX_SLOTS
+                )
+            except Exception:
+                # The guard belongs HERE, not at the call site in ``start()``.
+                # This function is the one that promises "always returns an
+                # id"; enforcing that where it is promised makes it true for
+                # every caller, present and future, instead of for the one
+                # call site that remembered to wrap it.
+                #
+                # Not a substitute for the specific handling in the callees —
+                # each expected failure is still caught where it happens and
+                # named there. This is the backstop for the unforeseen one, on
+                # a path where the alternative is a service that will not boot.
+                # ``Exception``, not ``BaseException``: a cancellation or a
+                # KeyboardInterrupt during startup must still propagate.
+                logger.exception(
+                    "pubsub: broadcast slot claim raised; falling back to a "
+                    "random per-process id"
+                )
+                _slot_id = None
+        if _slot_id is None:
+            logger.warning(
+                "pubsub: no broadcast slot could be claimed under %s; falling "
+                "back to a random per-process id. Delivery is unaffected, but "
+                "each unclean restart will orphan a subscription for %ds "
+                "instead of reusing this slot's.",
+                BROADCAST_SLOT_DIR,
+                BROADCAST_SUBSCRIPTION_TTL_SECONDS,
+            )
+            # Memoised like any other outcome, so the warning fires once per
+            # process rather than once per bus, and so the id stays stable.
+            _slot_id = uuid.uuid4().hex[:12]
+        return _slot_id
 
 
 class PubSubEventBus(EventBus):
@@ -254,9 +500,9 @@ class PubSubEventBus(EventBus):
         # Topics registered with ``broadcast=True`` get a PER-PROCESS
         # subscription so every process receives every message (fan-out),
         # instead of the shared per-service subscription that delivers each
-        # message to a single consumer. ``_instance_id`` makes this process's
-        # subscription name unique; ``_broadcast_sub_paths`` records the ones
-        # this process created so ``stop()`` can delete them.
+        # message to a single consumer. ``_broadcast_slot_id`` makes this
+        # process's subscription name unique; ``_broadcast_sub_paths`` records
+        # the ones this process created so ``stop()`` can delete them.
         self._broadcast_topics: set[str] = set()
         self._broadcast_sub_paths: list[str] = []
         # Short names of subscriptions THIS bus deliberately deleted, so a pull
@@ -266,7 +512,12 @@ class PubSubEventBus(EventBus):
         # halting-the-loop log. Short names because that is what ``_pull_loop``
         # is given — ``_broadcast_sub_paths`` holds full resource paths.
         self._released_subscriptions: set[str] = set()
-        self._instance_id = uuid.uuid4().hex[:12]
+        # Resolved lazily in ``start()``, and only when a broadcast topic is
+        # actually registered — claiming a slot touches the filesystem, and a
+        # publisher-only bus would pay for an identity it never puts in a name.
+        # ``_process_broadcast_slot_id`` memoises per process, so resolving it
+        # late costs nothing and keeps the id stable across a restart.
+        self._broadcast_slot_id: str | None = None
 
     def _spawn_background_task(self, coro: Any) -> asyncio.Task[Any]:
         """Schedule a fire-and-forget task; see ``_background_tasks`` for why."""
@@ -579,9 +830,9 @@ class PubSubEventBus(EventBus):
             logger.warning("PubSubEventBus.start() called more than once; ignoring")
             return
         # Clear the released-subscription record. Names are deterministic in
-        # ``_instance_id``, which is per-object, so a start/stop/start cycle
-        # recreates the SAME names — a leftover entry here would silence a
-        # genuine NotFound on the second run, turning this suppression into
+        # ``_broadcast_slot_id``, which is per-PROCESS, so a start/stop/start
+        # cycle recreates the SAME names — a leftover entry here would silence
+        # a genuine NotFound on the second run, turning this suppression into
         # the blind spot it was written to avoid.
         self._released_subscriptions.clear()
         pubsub_v1 = self._ensure_pubsub_sdk()
@@ -693,7 +944,9 @@ class PubSubEventBus(EventBus):
                     # Per-process subscription (unique suffix) for fan-out; skip
                     # the pull loop if it can't be created (see the helper — it
                     # degrades to TTL rather than crashing startup).
-                    sub_name = f"{sub_name}--{self._instance_id}"
+                    if self._broadcast_slot_id is None:
+                        self._broadcast_slot_id = _process_broadcast_slot_id()
+                    sub_name = f"{sub_name}--{self._broadcast_slot_id}"
                     if not await self._ensure_broadcast_subscription(topic, sub_name):
                         continue
                 task = asyncio.create_task(self._pull_loop(sub_name, handlers))
@@ -731,10 +984,34 @@ class PubSubEventBus(EventBus):
         try:
             await loop.run_in_executor(self._pull_executor, _create)
         except gexc.AlreadyExists:
-            # A prior unclean shutdown left this process's subscription (same
-            # _instance_id) around — reuse it. The create failed, so its
-            # expiration_policy TTL is NOT reset here; the pull loop's ongoing
-            # activity is what keeps Pub/Sub from expiring it.
+            # The predecessor in this slot left its subscription behind — reuse
+            # it. Since ``_broadcast_slot_id`` is slot-stable this is the
+            # EXPECTED path after a SIGKILLed worker is respawned, not a rare
+            # one, and it is what bounds the subscription population by live
+            # slots instead of by cumulative worker deaths.
+            #
+            # Three things it deliberately does NOT do:
+            #
+            # - **It does not reset the expiration_policy TTL.** The create
+            #   failed, so nothing was written. That is fine: the TTL measures
+            #   subscriber inactivity, and the pull loop this returns True for
+            #   is about to start pulling. Activity, not the create call, is
+            #   what keeps Pub/Sub from expiring it.
+            # - **It does not seek past the predecessor's backlog.** A reused
+            #   subscription may carry messages the dead worker never acked.
+            #   Draining them is right, not merely tolerable: handlers here are
+            #   required to be idempotent, a fresh process has an empty cache so
+            #   replayed invalidations are no-ops, and a seek would discard
+            #   exactly the ``org.settings-changed`` events whose loss is the
+            #   stale-settings bug. Under the old random naming nobody drained
+            #   that backlog at all — it sat on the orphan until the TTL.
+            # - **It does not reconcile configuration.** A reused subscription
+            #   keeps whatever ``ack_deadline_seconds`` it was created with.
+            #   Worth knowing before changing that value, and worth knowing that
+            #   a subscription ``filter`` — which the module docstring floats
+            #   for server-side ``source_env`` dropping — is IMMUTABLE in
+            #   Pub/Sub. Adding one means changing this name, not updating the
+            #   subscription in place.
             pass
         except Exception:
             logger.error(
@@ -1054,6 +1331,29 @@ class PubSubEventBus(EventBus):
         client and the recorded paths — no pull loops stopped, no queues
         flushed, no storage open. Idempotent: the paths are cleared, so calling
         it again, or calling ``stop()`` afterwards, is a no-op.
+
+        **Still worth doing now that names are slot-stable.** Slot stability
+        means a subscription survives a worker's death to be reused by that
+        slot's next occupant — but only on the SAME instance, because the
+        instance token in the name does not outlive the instance. A clean
+        shutdown is overwhelmingly an instance going away (Cloud Run scaling
+        down, a revision cutover), and that instance's token never returns, so
+        anything left behind is a pure orphan with nobody to inherit it.
+
+        So the two mechanisms cover disjoint exits and neither subsumes the
+        other: slot-stable naming handles the death where shutdown CANNOT run
+        (SIGKILL, where the process is simply gone), and this handles the exit
+        where it can and where reuse is impossible anyway. Deleting also drops
+        the backlog on a subscription no successor will ever drain.
+
+        One case sits between the two and is deliberately accepted: a single
+        worker shut down cleanly while its INSTANCE survives (uvicorn's SIGHUP
+        restart, SIGTTOU). There the delete is churn — the replacement claims
+        the freed slot and recreates the same name — and it discards a backlog
+        the successor could have drained. Cloud Run sends neither signal, so
+        this costs a pair of RPCs in a case that does not arise in the
+        deployment this is written for; special-casing it would add a branch
+        nothing exercises.
         """
         if self._subscriber is None or not self._broadcast_sub_paths:
             return

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -10,14 +10,23 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import multiprocessing
+import time
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from queue import Empty
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from common.events import Event, PubSubEventBus, Topics
-from common.events.pubsub import BROADCAST_SUBSCRIPTION_TTL_SECONDS
+from common.events.pubsub import (
+    BROADCAST_MAX_SLOTS,
+    BROADCAST_SUBSCRIPTION_TTL_SECONDS,
+    _claim_broadcast_slot,
+    _process_broadcast_slot_id,
+)
 
 
 @pytest.fixture
@@ -1464,3 +1473,276 @@ async def test_release_broadcast_subscriptions_is_idempotent(
     await bus.stop()
 
     fake_sub.delete_subscription.assert_called_once()
+
+
+# ── broadcast slot identity ──────────────────────────────────────────
+#
+# The subscription name has to satisfy three properties AT ONCE. Each test
+# below pins exactly one, because the properties trade against each other and a
+# scheme that buys one by giving up another is the failure mode to guard:
+# trading away "distinct between concurrent workers" turns a broadcast into a
+# load-balanced queue, silently.
+#
+# These use real spawned processes, matching uvicorn's own supervisor
+# (``multiprocessing.get_context("spawn")``). They have to: the property under
+# test is that the KERNEL releases a claim when a process is SIGKILLed, and a
+# mock cannot exhibit that.
+
+
+def _slot_child(slot_dir: Path, queue: Any) -> None:
+    """Claim a slot, report it, then block until killed — like a live worker."""
+    queue.put(_claim_broadcast_slot(slot_dir, BROADCAST_MAX_SLOTS))
+    time.sleep(300)
+
+
+@pytest.fixture
+def spawn_worker(tmp_path: Path) -> Any:
+    """Spawn ``_slot_child`` processes into ``tmp_path`` and reap them all."""
+    ctx = multiprocessing.get_context("spawn")
+    queue = ctx.Queue()
+    started: list[Any] = []
+
+    def _spawn() -> tuple[Any, str | None]:
+        proc = ctx.Process(target=_slot_child, args=(tmp_path, queue))
+        proc.start()
+        started.append(proc)
+        # Watch the child alongside the queue rather than just blocking on the
+        # queue. A child that dies before reporting — an import failure under
+        # spawn, an unwritable slot dir — would otherwise burn the entire
+        # timeout per spawn before surfacing as an unhelpful Empty, turning an
+        # already-failing run into a multi-minute one. A live child reports in
+        # ~100ms; the generous ceiling is only there for a cold CI box.
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            try:
+                return proc, queue.get(timeout=0.1)
+            except Empty:
+                if proc.exitcode is not None:
+                    # It may have reported and exited before we looked.
+                    with contextlib.suppress(Empty):
+                        return proc, queue.get(timeout=1)
+                    raise AssertionError(
+                        f"slot child exited {proc.exitcode} without reporting"
+                    ) from None
+        raise AssertionError("slot child never reported")
+
+    yield _spawn
+    for proc in started:
+        if proc.is_alive():
+            proc.kill()
+        proc.join(timeout=10)
+
+
+def test_broadcast_slot_is_stable_across_a_sigkilled_respawn(
+    spawn_worker: Any,
+) -> None:
+    # PROPERTY 1 — stability. uvicorn SIGKILLs a worker that misses its 5s
+    # healthcheck ping and spawns a replacement (``Multiprocess.
+    # keep_subprocess_alive``). The replacement must re-derive its
+    # predecessor's identity so ``_ensure_broadcast_subscription`` takes the
+    # AlreadyExists path instead of minting a fresh subscription that orphans
+    # the old one for a day. This is the property a random id fails, and it is
+    # the entire leak.
+    victim, first = spawn_worker()
+    assert first is not None
+
+    # Exactly what uvicorn does: SIGKILL, reap, spawn a brand-new process.
+    # No shutdown hook runs — that is the point.
+    victim.kill()
+    victim.join(timeout=10)
+    _replacement, second = spawn_worker()
+
+    assert second == first, (
+        f"respawned worker took identity {second!r}, predecessor held {first!r}; "
+        "a changed identity orphans the predecessor's subscription for "
+        f"{BROADCAST_SUBSCRIPTION_TTL_SECONDS}s"
+    )
+
+
+def test_broadcast_slot_is_distinct_between_concurrently_live_workers(
+    tmp_path: Path, spawn_worker: Any
+) -> None:
+    # PROPERTY 2 — THE TRAP. Two live workers sharing one subscription does not
+    # fail loudly: Pub/Sub load-balances between them and each sees roughly half
+    # the events. For org.settings-changed that is a process serving stale
+    # settings with nothing red anywhere. Worse than the leak, so stability must
+    # never be bought at this property's expense.
+    _first, ident_a = spawn_worker()
+    _second, ident_b = spawn_worker()
+    assert ident_a is not None and ident_b is not None
+    assert ident_a != ident_b, (
+        f"two concurrently-live workers both claimed {ident_a!r}; they would "
+        "share one subscription and each receive only part of the broadcast"
+    )
+
+    # And the stronger form: a THIRD claimant, arriving while both incumbents
+    # are still alive, must not be handed either of their identities. This is
+    # the uvicorn ``restart_all`` (SIGHUP) shape, where the replacement is
+    # started and waited on BEFORE the worker it replaces is terminated, so the
+    # configured worker count is transiently exceeded.
+    third = _claim_broadcast_slot(tmp_path, BROADCAST_MAX_SLOTS)
+    assert third not in {ident_a, ident_b}, (
+        f"overlap claimant got {third!r}, already held by a live worker"
+    )
+
+
+def test_broadcast_slot_is_distinct_across_instances(tmp_path: Path) -> None:
+    # PROPERTY 3 — cross-instance distinctness. Every instance's slot 0 is a
+    # different consumer. A bare slot index, or a bare Cloud Run instance id,
+    # each satisfies two of the three properties and fails this one or
+    # property 2; only the token+slot pair satisfies all three.
+    # Two never-used directories stand in for two instances' filesystems, so
+    # each of these is by construction the FIRST claim on its own instance —
+    # the same slot on different instances, which is exactly the colliding
+    # case. Asserted on the whole identity rather than on its parts: pinning
+    # the slot component's shape here would couple this test to the id format
+    # and make it fire for mutations that leave cross-instance distinctness
+    # perfectly intact.
+    ident_a = _claim_broadcast_slot(tmp_path / "instance-a", BROADCAST_MAX_SLOTS)
+    ident_b = _claim_broadcast_slot(tmp_path / "instance-b", BROADCAST_MAX_SLOTS)
+    assert ident_a is not None and ident_b is not None
+    assert ident_a != ident_b, (
+        f"the first slot on two separate instances both resolved to "
+        f"{ident_a!r}; those two workers would share one subscription"
+    )
+
+
+def test_broadcast_slot_falls_back_rather_than_sharing_when_exhausted(
+    tmp_path: Path,
+) -> None:
+    # The fallback DIRECTION, which must never be inverted. When no slot can be
+    # proven free, the claim fails and the caller takes a random id — accepting
+    # a bounded, quota-visible, day-lived leak. It must never wrap around and
+    # reuse a held slot, which would be the silent collision.
+    held = [_claim_broadcast_slot(tmp_path, 2) for _ in range(2)]
+    assert None not in held and len(set(held)) == 2
+    assert _claim_broadcast_slot(tmp_path, 2) is None
+
+
+def test_identity_falls_back_to_a_random_id_when_no_slot_can_be_claimed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An unclaimable slot must degrade to the pre-existing random-id behaviour,
+    # not crash a service at boot. Delivery is unaffected; only the leak returns.
+    monkeypatch.setattr("common.events.pubsub._slot_id", None)
+    monkeypatch.setattr(
+        "common.events.pubsub._claim_broadcast_slot", lambda *_a, **_k: None
+    )
+    assert len(_process_broadcast_slot_id()) == 12
+
+
+def test_identity_is_stable_per_process_even_on_the_fallback_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The fallback must be memoised, not re-rolled per caller. An unmemoised
+    # failure gives each bus in a process its OWN random id, which is exactly
+    # the per-process property the memo exists to provide — two buses would
+    # then create two subscriptions where one is wanted, and start()'s claim
+    # that a start/stop/start cycle recreates the same names would be false.
+    monkeypatch.setattr("common.events.pubsub._slot_id", None)
+    monkeypatch.setattr(
+        "common.events.pubsub._claim_broadcast_slot", lambda *_a, **_k: None
+    )
+    assert _process_broadcast_slot_id() == _process_broadcast_slot_id()
+
+
+def test_claim_returns_none_rather_than_raising_on_an_unreadable_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Pins the WIDENING specifically, at the layer where it happens. Reading
+    # the token file is the one filesystem call in this module that did not
+    # degrade to None: every other one catches OSError, while this caught only
+    # FileNotFoundError, so a PermissionError escaped the whole call chain.
+    #
+    # Deliberately asserted here rather than only through start(): the guard in
+    # _process_broadcast_slot_id also catches this, so an end-to-end test stays
+    # green with the narrow except restored and proves nothing about it. Two
+    # isolation layers, so each needs its own test or neither is really pinned.
+    real_read_text = Path.read_text
+
+    def _unreadable(self: Path, *a: Any, **k: Any) -> str:
+        if self.name == "instance":
+            raise PermissionError(13, "Permission denied")
+        return real_read_text(self, *a, **k)
+
+    monkeypatch.setattr(Path, "read_text", _unreadable)
+    assert _claim_broadcast_slot(tmp_path, BROADCAST_MAX_SLOTS) is None
+
+
+async def test_start_survives_an_unreadable_instance_token(
+    bus: PubSubEventBus, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The module's stated contract is that ANY environment where the slot
+    # cannot be claimed degrades to a random id. An unreadable token file is
+    # such an environment, and it is reachable: the slot directory lives in a
+    # shared tmpdir, so a file owned by another uid, or a directory where a
+    # regular file is expected, both surface as OSError rather than as the
+    # FileNotFoundError that the ordinary "first worker" case raises.
+    #
+    # This runs on the startup path, so the failure mode being pinned is a
+    # service that will not boot — the exact opposite of the degradation the
+    # docstring promises.
+    #
+    # A characterization test for the end-to-end contract, stated as such: two
+    # layers now prevent this (the widened except in _read, and the guard in
+    # _process_broadcast_slot_id), so it stays green if either one alone is
+    # removed. The layer-specific tests above and below are what actually pin
+    # them. Dressing this up as a regression guard for either is how the gap in
+    # #991 got through.
+    import types
+    from unittest.mock import patch
+
+    monkeypatch.setattr("common.events.pubsub._slot_id", None)
+    monkeypatch.setattr("common.events.pubsub.BROADCAST_SLOT_DIR", tmp_path)
+
+    real_read_text = Path.read_text
+
+    def _unreadable(self: Path, *a: Any, **k: Any) -> str:
+        if self.name == "instance":
+            raise PermissionError(13, "Permission denied")
+        return real_read_text(self, *a, **k)
+
+    monkeypatch.setattr(Path, "read_text", _unreadable)
+
+    class FakeSubscriberClient:
+        def subscription_path(self, proj: str, name: str) -> str:
+            return f"projects/{proj}/subscriptions/{name}"
+
+        def create_subscription(self, request: dict[str, Any]) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    async def _h(_e: Event) -> None:
+        return None
+
+    bus.subscribe(Topics.Org.SETTINGS_CHANGED, _h, broadcast=True)
+    with patch.object(
+        PubSubEventBus,
+        "_ensure_pubsub_sdk",
+        return_value=types.SimpleNamespace(SubscriberClient=FakeSubscriberClient),
+    ):
+        await bus.start()
+
+    # Booted, and with a usable identity rather than none at all.
+    assert bus._started is True
+    assert bus._broadcast_slot_id is not None
+    assert len(bus._broadcast_slot_id) == 12  # the random fallback, not a slot
+    bus._stopping = True  # keep teardown of the fake client quiet
+
+
+def test_identity_survives_an_unexpected_error_in_the_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The totality guard lives in _process_broadcast_slot_id, not at the
+    # start() call site, so it holds for every caller rather than for the one
+    # that remembered to wrap it. Pinned with an exception the callees do not
+    # anticipate at all, since the point is the unforeseen case.
+    monkeypatch.setattr("common.events.pubsub._slot_id", None)
+
+    def _boom(*_a: Any, **_k: Any) -> str:
+        raise RuntimeError("something no callee anticipated")
+
+    monkeypatch.setattr("common.events.pubsub._claim_broadcast_slot", _boom)
+    assert len(_process_broadcast_slot_id()) == 12


### PR DESCRIPTION
Makes the broadcast-subscription leak bounded by **how many workers are alive** instead of **how many workers have ever died** — without depending on shutdown running.

## The leak

`core-api` runs `uvicorn --workers 2` (`core-api/Dockerfile:130` via `common/serve.py:95`). uvicorn's supervisor pings each worker over a pipe and **SIGKILLs** any that misses `timeout_worker_healthcheck` (5s default), then spawns a replacement — `Multiprocess.keep_subprocess_alive`, uvicorn 0.51.0:

```python
if process.is_alive(timeout=self.config.timeout_worker_healthcheck):
    continue
process.kill()          # SIGKILL
process.join()
...
process = Process(self.config, self.sockets)
process.start()
self.processes[idx] = process
```

SIGKILL means no lifespan shutdown, so `release_broadcast_subscriptions()` (#991, #997) never runs. The replacement called `uuid.uuid4().hex[:12]` again and created a **brand-new** subscription, orphaning its predecessor's for the full `BROADCAST_SUBSCRIPTION_TTL_SECONDS` (86400 — the Pub/Sub `expiration_policy` minimum, not tunable).

`_ensure_broadcast_subscription` has had an `AlreadyExists` → reuse branch all along. It was **dead code**: `uuid4()` guarantees the name is never reused, so it could never fire. This makes it the expected path.

## Why this is a lock and not a computation

The identity has to satisfy three properties **at once**:

| | stable across respawn | distinct between concurrent workers | distinct across instances |
|---|---|---|---|
| `uuid4()` (today) | ❌ | ✅ | ✅ |
| pid / `SpawnProcess-N` | ❌ | ✅ | ✅ |
| Cloud Run instance id | ✅ | ❌ **the trap** | ✅ |
| bare slot index | ✅ | ✅ | ❌ |
| **flock slot + instance token** | ✅ | ✅ | ✅ |

**Property 2 is the trap.** Two concurrently-live workers on one subscription does not fail loudly — Pub/Sub load-balances between them and each sees roughly half the events. For `org.settings-changed` that is a process serving stale org settings with nothing red anywhere. That is worse than the leak, so stability must never be bought at its expense.

**There is no worker-slot identity in the environment**, so the fix constructs one:

- uvicorn 0.51.0 passes the child only `(config, sockets)` — `_subprocess.py:51`. The slot index `idx` exists solely in the parent's list and is never exported.
- Workers are `multiprocessing.get_context("spawn")` children, so `os.environ` is byte-identical to the parent's. `SpawnProcess-N` and pid both come from monotonic counters and are **never reused** — they fail stability, which is the property that matters.
- Cloud Run injects `K_SERVICE`/`K_REVISION`/`K_CONFIGURATION`, all per-instance; `CLOUD_RUN_TASK_INDEX` is Jobs-only. Nothing per-worker.

`flock` supplies properties 1 and 2 together, as a kernel guarantee rather than a probability: the kernel releases the lock when the holder dies **however** it dies, so a SIGKILLed worker frees its slot with no cooperation from a shutdown path that never ran — and it cannot hand a slot to a newcomer while the incumbent is alive. The instance token supplies property 3, and is deliberately drawn from the same directory the locks live in so the token and the mutual exclusion describe the **same** boundary.

**The fallback direction is the load-bearing decision**: when no slot can be proven ours, take a `uuid4()` and accept the leak. Never reuse a slot we could not claim. A leak is bounded, visible in quota, and reaped in a day; a collision is a silent halving of broadcast delivery.

## Tests — each confirmed failing without its fix

Real spawned processes, matching uvicorn's own supervisor. They have to be: the property under test is that the *kernel* releases a claim on SIGKILL, and a mock cannot exhibit that.

| Mutation | Test that goes red |
|---|---|
| `return f"{token}-{slot}-{os.getpid()}"` (stability removed) | `test_broadcast_slot_is_stable_across_a_sigkilled_respawn` |
| flock failure ignored instead of `continue` (concurrent distinctness removed) | `test_broadcast_slot_is_distinct_between_concurrently_live_workers` **and** `test_broadcast_slot_falls_back_rather_than_sharing_when_exhausted` |
| `return f"{slot}"` (token dropped) | `test_broadcast_slot_is_distinct_across_instances` |
| fallback returned without memoising | `test_identity_is_stable_per_process_even_on_the_fallback_path` |

Mutation 2 killing two tests is not a coupling artifact — both pin real consequences of "never reuse a held slot". `__pycache__` purged before every run.

## Two defects review caught in my own first cut

Recording these because the pattern from #997 repeated — the comment asserting a property was the thing that was wrong.

1. **A module global holding the flock fd, with a comment claiming it kept the claim open.** It did nothing: `os.open` returns a raw `int`, CPython never closes raw fds on GC, and the assignment was overwritten on every call while all the flocks stayed held. Worse than useless — the next reader either trusts a mechanism that does not exist, or deletes the global and adds the "missing" close, which would hand a live slot to a sibling. Replaced with a comment at the `return` stating the real invariant.
2. **The memo did not memoise the failure path.** On fallback, `_slot_id` stayed `None`, so every subsequent bus in the process re-ran the whole claim and minted its *own* `uuid4()` — losing the per-process property the memo exists to provide, and falsifying `start()`'s comment that a start/stop/start cycle recreates the same names. Production escaped only by the `get_event_bus()` singleton, which nothing in this file states or depends on. Reproduced, then fixed by moving the fallback into `_process_broadcast_slot_id` so there is one contract with one owner.

Also from review: the claim is now resolved lazily in `start()` and only when a broadcast topic is registered, so a publisher-only bus does no filesystem work; and one unopenable lock file degrades per-slot instead of abandoning the slots after it.

## What it does not do

- **It does not eliminate the leak, and the PR title should not be read as claiming that.** It converts "one orphan per worker *death*" into "one orphan per *instance* teardown that skips shutdown". The instance token does not outlive the instance, so instance churn still leaks. Given ~130 worker deaths per instance per 25 minutes against instance lifetimes measured in hours, that is a large reduction — but it is bounded, not zero.
- **It does not reclaim what has already leaked.**
- **It does not make `release_broadcast_subscriptions()` redundant.** The two cover disjoint exits: slot-stable naming handles the death where shutdown *cannot* run; the delete handles the exit where it can and where reuse is impossible anyway (the instance is going away and its token never returns). Deleting also drops a backlog no successor will drain.

## Notes

- **`common/events/pubsub.py` is `manual` in the enterprise vendor manifest** — the re-vendor bot will not sync it. A hand-port is needed, and it is not cosmetic: `platform-auth-api` subscribes `Topics.Fleet.POLICY_EVENTS` with `broadcast=True` and also runs `--workers 2`, so it has the identical leak shape.
- A reused subscription keeps its creation-time config. Relevant to the server-side `source_env` `filter` the module docstring floats: a Pub/Sub `filter` is **immutable**, so adding one means changing this name, not updating in place. Noted in the code.

## Gates

`pytest tests/` 5337 passed / 0 failed (`tests/test_events/` 140) · mypy `--config-file common/mypy.ini common/` clean (97 files) · `ruff check` clean on `common/`, `core-api/src/`, `core-storage-api/src/`, `core-storage-api/tests/` · `ruff format --check` clean at CI's scopes (`common/` not blanket-formatted) · do-not-touch sentinel 34/34 · legacy-name ratchet: no new lines · `core-api/uv.lock` untouched (hashed before and after every `uv` command).
