### PR TITLE
fix(llm): cap complete_json output and surface max-tokens truncation clearly

### DIFF
--- a/common/llm/constants.py
+++ b/common/llm/constants.py
@@ -164,6 +164,17 @@ if _jitter_requested != LLM_RETRY_JITTER_FRACTION:
 # behaviour without a deploy.
 LLM_PROVIDER_MAX_RETRIES = read_int_env("LLM_PROVIDER_MAX_RETRIES", 0, minimum=0)
 
+# Output-token ceiling for JSON completions (``complete_json``). Legit
+# outputs are small — enrichment ~150 tokens, entity graphs a few
+# thousand — but prod 2026-08-26 saw gemini-2.5-flash-lite emit runaway
+# ~50k-token JSON that the API truncated mid-string, surfacing as a
+# JSONDecodeError deep inside a 200KB partial payload (~7% of entity
+# extractions fell back to the keyword heuristic). The cap makes a
+# runaway fail fast and cheap; the truncation itself is detected via
+# ``finish_reason`` and raised as a clear, retryable ValueError instead
+# of a parse error (see providers/_truncation.py).
+LLM_JSON_MAX_OUTPUT_TOKENS = read_int_env("LLM_JSON_MAX_OUTPUT_TOKENS", 8192)
+
 # Fallback model for OpenAI-compatible providers when the tenant's
 # configured model is not set — env-overridable so on-call can swap to
 # a cheaper / different family without a redeploy.

--- a/common/llm/providers/_truncation.py
+++ b/common/llm/providers/_truncation.py
@@ -1,0 +1,50 @@
+"""Shared max-tokens truncation detection for JSON completions.
+
+Every backend reports an output cut at the token ceiling on the first
+result's ``finish_reason``: the Gemini SDKs (``vertexai.generative_models``
+and ``google-genai``) put an enum named ``MAX_TOKENS`` on
+``candidates[0]``, the OpenAI-compatible chat API (OpenAI / Anthropic /
+OpenRouter) puts the string ``"length"`` on ``choices[0]``. A truncated
+JSON body still parses *sometimes* (when the cut lands between values)
+but usually raises a ``JSONDecodeError`` pointing at a huge character
+offset — which reads like a model-output bug rather than what it is.
+Detecting the finish reason before parsing turns that into a clear,
+retryable error.
+"""
+
+from __future__ import annotations
+
+_TRUNCATION_REASONS = ("MAX_TOKENS", "LENGTH")
+
+
+def raise_if_truncated(
+    response: object,
+    *,
+    provider: str,
+    model: str,
+    max_tokens: int,
+) -> None:
+    """Raise ``ValueError`` when *response* was cut at the output-token cap.
+
+    Duck-typed over all three SDKs' response shapes (Gemini
+    ``candidates`` / OpenAI ``choices``): any attribute missing or empty
+    means "not truncated" — never break the happy path on an SDK shape
+    change.
+    """
+    results = (
+        getattr(response, "candidates", None)
+        or getattr(response, "choices", None)
+        or []
+    )
+    if not results:
+        return
+    reason = getattr(results[0], "finish_reason", None)
+    if reason is None:
+        return
+    name = getattr(reason, "name", None) or str(reason)
+    if any(marker in name.upper() for marker in _TRUNCATION_REASONS):
+        raise ValueError(
+            f"{provider} model {model} JSON response truncated at "
+            f"max_output_tokens={max_tokens} (runaway generation); "
+            "failing fast instead of parsing partial JSON"
+        )

--- a/common/llm/providers/gemini.py
+++ b/common/llm/providers/gemini.py
@@ -16,7 +16,9 @@ import json
 import logging
 import time
 
+from common.llm.constants import LLM_JSON_MAX_OUTPUT_TOKENS
 from common.llm.providers._shape_error import ProviderResponseShapeError
+from common.llm.providers._truncation import raise_if_truncated
 from common.provider_names import ProviderName
 
 logger = logging.getLogger(__name__)
@@ -77,6 +79,9 @@ class GeminiLLMProvider:
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",
                 temperature=temperature,
+                # Runaway guard — same failure mode as the Vertex provider:
+                # an uncapped looping generation comes back as truncated JSON.
+                max_output_tokens=LLM_JSON_MAX_OUTPUT_TOKENS,
             ),
         )
         llm_ms = int((time.perf_counter() - t0) * 1000)
@@ -89,6 +94,12 @@ class GeminiLLMProvider:
             ) from exc
         if not text:
             raise ValueError(f"Gemini returned empty content for model {self._model}")
+        raise_if_truncated(
+            response,
+            provider="Gemini",
+            model=self._model,
+            max_tokens=LLM_JSON_MAX_OUTPUT_TOKENS,
+        )
         parsed = json.loads(text)
         if not isinstance(parsed, dict):
             raise GeminiResponseShapeError(text, type(parsed).__name__)

--- a/common/llm/providers/openai.py
+++ b/common/llm/providers/openai.py
@@ -24,6 +24,7 @@ import openai
 
 from common.llm.call_context import llm_call_label
 from common.llm.constants import (
+    LLM_JSON_MAX_OUTPUT_TOKENS,
     LLM_PROVIDER_MAX_RETRIES,
     OPENAI_CHAT_BASE_URL,
     OPENAI_HTTPX_CONNECT_TIMEOUT_SECONDS,
@@ -33,6 +34,7 @@ from common.llm.constants import (
     OPENAI_REQUEST_TIMEOUT_SECONDS,
 )
 from common.llm.providers._shape_error import ProviderResponseShapeError
+from common.llm.providers._truncation import raise_if_truncated
 
 logger = logging.getLogger(__name__)
 
@@ -240,6 +242,10 @@ class OpenAILLMProvider:
             "messages": [{"role": "user", "content": prompt}],
             "response_format": response_format,
             "temperature": temperature,
+            # Runaway guard — same failure mode as the Gemini-backed
+            # providers: an uncapped looping generation comes back as
+            # truncated JSON (finish_reason="length").
+            "max_completion_tokens": LLM_JSON_MAX_OUTPUT_TOKENS,
         }
         if seed is not None:
             create_kwargs["seed"] = seed
@@ -269,6 +275,12 @@ class OpenAILLMProvider:
         content = response.choices[0].message.content
         if not content:
             raise ValueError(f"OpenAI returned empty content for model {self._model}")
+        raise_if_truncated(
+            response,
+            provider="OpenAI-compatible",
+            model=self._model,
+            max_tokens=LLM_JSON_MAX_OUTPUT_TOKENS,
+        )
         parsed = json.loads(content)
         if not isinstance(parsed, dict):
             raise OpenAIResponseShapeError(content, type(parsed).__name__)

--- a/common/llm/providers/vertex.py
+++ b/common/llm/providers/vertex.py
@@ -38,7 +38,9 @@ import json
 import logging
 import time
 
+from common.llm.constants import LLM_JSON_MAX_OUTPUT_TOKENS
 from common.llm.providers._shape_error import ProviderResponseShapeError
+from common.llm.providers._truncation import raise_if_truncated
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +112,10 @@ class VertexLLMProvider:
             generation_config=GenerationConfig(
                 response_mime_type="application/json",
                 temperature=temperature,
+                # Runaway guard: without a ceiling, a looping generation
+                # runs to the model's own output limit and comes back as
+                # truncated JSON (~200KB partials seen on prod 2026-08-26).
+                max_output_tokens=LLM_JSON_MAX_OUTPUT_TOKENS,
             ),
         )
         llm_ms = int((time.perf_counter() - t0) * 1000)
@@ -127,6 +133,12 @@ class VertexLLMProvider:
             ) from exc
         if not text:
             raise ValueError(f"Vertex returned empty content for model {self._model}")
+        raise_if_truncated(
+            response,
+            provider="Vertex",
+            model=self._model,
+            max_tokens=LLM_JSON_MAX_OUTPUT_TOKENS,
+        )
         parsed = json.loads(text)
         if not isinstance(parsed, dict):
             # CAURA-651: see ``VertexResponseShapeError`` above.

--- a/tests/test_llm_json_truncation.py
+++ b/tests/test_llm_json_truncation.py
@@ -1,0 +1,272 @@
+"""Truncation guard for JSON completions (Vertex + Gemini providers).
+
+Prod 2026-08-26 (Vertex-only cutover): gemini-2.5-flash-lite
+occasionally emitted runaway ~50k-token JSON for entity extraction; the
+API truncated it mid-string and ``complete_json`` surfaced a
+``JSONDecodeError`` at a ~200KB char offset. Two-part fix under test:
+
+* ``complete_json`` now passes ``max_output_tokens=LLM_JSON_MAX_OUTPUT_TOKENS``
+  so a runaway fails fast and cheap;
+* ``raise_if_truncated`` turns a ``finish_reason=MAX_TOKENS`` response
+  into a clear, retryable ``ValueError`` *before* JSON parsing.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from common.llm.constants import LLM_JSON_MAX_OUTPUT_TOKENS
+from common.llm.providers._truncation import raise_if_truncated
+from common.llm.providers.gemini import GeminiLLMProvider
+from common.llm.providers.vertex import VertexLLMProvider
+
+
+class _FinishReason(enum.Enum):
+    """Stand-in for both SDKs' finish-reason enums (``.name`` is what counts)."""
+
+    STOP = 1
+    MAX_TOKENS = 2
+    SAFETY = 3
+
+
+def _response(text: str, finish_reason: object | None = _FinishReason.STOP):
+    candidates = (
+        [] if finish_reason is None else [SimpleNamespace(finish_reason=finish_reason)]
+    )
+    return SimpleNamespace(text=text, candidates=candidates)
+
+
+# ---------------------------------------------------------------------------
+# raise_if_truncated — duck-typed detection
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseIfTruncated:
+    def test_max_tokens_raises_with_context(self):
+        with pytest.raises(ValueError) as exc:
+            raise_if_truncated(
+                _response('{"partial": "tru', _FinishReason.MAX_TOKENS),
+                provider="Vertex",
+                model="gemini-2.5-flash-lite",
+                max_tokens=8192,
+            )
+        msg = str(exc.value)
+        assert "truncated" in msg
+        assert "max_output_tokens=8192" in msg
+        assert "gemini-2.5-flash-lite" in msg
+
+    def test_stop_does_not_raise(self):
+        raise_if_truncated(
+            _response("{}", _FinishReason.STOP),
+            provider="Vertex",
+            model="m",
+            max_tokens=1,
+        )
+
+    def test_string_reason_matches(self):
+        # google-genai can surface the reason as a plain string.
+        raise_if_truncated(
+            _response("{}", "STOP"), provider="Gemini", model="m", max_tokens=1
+        )
+        with pytest.raises(ValueError):
+            raise_if_truncated(
+                _response("{}", "MAX_TOKENS"),
+                provider="Gemini",
+                model="m",
+                max_tokens=1,
+            )
+
+    def test_openai_choices_length_raises(self):
+        # OpenAI-compatible shape: ``choices[0].finish_reason == "length"``.
+        resp = SimpleNamespace(choices=[SimpleNamespace(finish_reason="length")])
+        with pytest.raises(ValueError, match="truncated at max_output_tokens"):
+            raise_if_truncated(
+                resp, provider="OpenAI-compatible", model="gpt-5.4-nano", max_tokens=8192
+            )
+
+    def test_openai_choices_stop_does_not_raise(self):
+        resp = SimpleNamespace(choices=[SimpleNamespace(finish_reason="stop")])
+        raise_if_truncated(resp, provider="OpenAI-compatible", model="m", max_tokens=1)
+
+    def test_missing_shapes_do_not_raise(self):
+        # No candidates / no finish_reason / no attributes at all — an SDK
+        # shape change must never break the happy path.
+        raise_if_truncated(
+            _response("{}", None), provider="Vertex", model="m", max_tokens=1
+        )
+        raise_if_truncated(object(), provider="Vertex", model="m", max_tokens=1)
+        raise_if_truncated(
+            SimpleNamespace(candidates=[SimpleNamespace()]),
+            provider="Vertex",
+            model="m",
+            max_tokens=1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# VertexLLMProvider.complete_json
+# ---------------------------------------------------------------------------
+
+
+class _FakeGenerativeModel:
+    """Captures the GenerationConfig and returns a canned response."""
+
+    last_config = None
+    canned_response = None
+
+    def __init__(self, model_name):
+        self.model_name = model_name
+
+    def generate_content(self, prompt, generation_config=None):
+        type(self).last_config = generation_config
+        return type(self).canned_response
+
+
+@pytest.fixture()
+def _patched_vertex(monkeypatch):
+    import vertexai.generative_models as gm
+
+    monkeypatch.setattr(gm, "GenerativeModel", _FakeGenerativeModel)
+    # aiplatform.init does network-free client setup, but stub it anyway
+    # so tests never touch ADC.
+    from google.cloud import aiplatform
+
+    monkeypatch.setattr(aiplatform, "init", lambda **kw: None)
+    _FakeGenerativeModel.last_config = None
+    _FakeGenerativeModel.canned_response = None
+    return _FakeGenerativeModel
+
+
+class TestVertexCompleteJson:
+    def _provider(self):
+        return VertexLLMProvider(
+            project_id="test-proj", location="us-central1", model="gemini-2.5-flash-lite"
+        )
+
+    @pytest.mark.asyncio
+    async def test_happy_path_parses_and_caps_output(self, _patched_vertex):
+        _patched_vertex.canned_response = _response(json.dumps({"ok": True}))
+        result = await self._provider().complete_json("prompt")
+        assert result == {"ok": True}
+        cfg = _patched_vertex.last_config
+        # vertexai's GenerationConfig keeps kwargs on a private raw config;
+        # to_dict() is the stable public view across SDK versions.
+        cfg_dict = cfg.to_dict() if hasattr(cfg, "to_dict") else vars(cfg)
+        assert int(cfg_dict.get("max_output_tokens", 0)) == LLM_JSON_MAX_OUTPUT_TOKENS
+
+    @pytest.mark.asyncio
+    async def test_truncated_response_raises_clear_error(self, _patched_vertex):
+        _patched_vertex.canned_response = _response(
+            '{"entities": [{"name": "tru', _FinishReason.MAX_TOKENS
+        )
+        with pytest.raises(ValueError, match="truncated at max_output_tokens"):
+            await self._provider().complete_json("prompt")
+
+    @pytest.mark.asyncio
+    async def test_untruncated_bad_json_still_json_error(self, _patched_vertex):
+        # A genuine parse failure (finish_reason=STOP) must keep raising
+        # JSONDecodeError — the truncation guard must not swallow it.
+        _patched_vertex.canned_response = _response("not-json")
+        with pytest.raises(json.JSONDecodeError):
+            await self._provider().complete_json("prompt")
+
+
+# ---------------------------------------------------------------------------
+# GeminiLLMProvider.complete_json
+# ---------------------------------------------------------------------------
+
+
+class _FakeGenaiModels:
+    def __init__(self):
+        self.last_config = None
+        self.canned_response = None
+
+    def generate_content(self, *, model, contents, config):
+        self.last_config = config
+        return self.canned_response
+
+
+class TestGeminiCompleteJson:
+    def _provider(self):
+        p = GeminiLLMProvider(api_key="AIza-test", model="gemini-2.5-flash-lite")
+        p._client = SimpleNamespace(models=_FakeGenaiModels())
+        return p
+
+    @pytest.mark.asyncio
+    async def test_happy_path_parses_and_caps_output(self):
+        p = self._provider()
+        p._client.models.canned_response = _response(json.dumps({"ok": 1}))
+        assert await p.complete_json("prompt") == {"ok": 1}
+        cfg = p._client.models.last_config
+        assert cfg.max_output_tokens == LLM_JSON_MAX_OUTPUT_TOKENS
+
+    @pytest.mark.asyncio
+    async def test_truncated_response_raises_clear_error(self):
+        p = self._provider()
+        p._client.models.canned_response = _response(
+            '{"partial": "tru', _FinishReason.MAX_TOKENS
+        )
+        with pytest.raises(ValueError, match="truncated at max_output_tokens"):
+            await p.complete_json("prompt")
+
+
+# ---------------------------------------------------------------------------
+# OpenAILLMProvider.complete_json (OpenAI / Anthropic / OpenRouter)
+# ---------------------------------------------------------------------------
+
+
+def _openai_response(content: str | None, finish_reason: str = "stop"):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason=finish_reason,
+                message=SimpleNamespace(content=content),
+            )
+        ]
+    )
+
+
+class _FakeCompletions:
+    def __init__(self):
+        self.last_kwargs = None
+        self.canned_response = None
+
+    async def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        return self.canned_response
+
+
+class TestOpenAICompleteJson:
+    def _provider(self):
+        from common.llm.providers.openai import OpenAILLMProvider
+
+        p = OpenAILLMProvider(api_key="sk-test", model="gpt-5.4-nano")
+        completions = _FakeCompletions()
+        p._client = SimpleNamespace(
+            chat=SimpleNamespace(completions=completions),
+            close=lambda: None,
+        )
+        return p, completions
+
+    @pytest.mark.asyncio
+    async def test_happy_path_parses_and_caps_output(self):
+        p, completions = self._provider()
+        completions.canned_response = _openai_response(json.dumps({"ok": 2}))
+        assert await p.complete_json("prompt") == {"ok": 2}
+        assert (
+            completions.last_kwargs["max_completion_tokens"]
+            == LLM_JSON_MAX_OUTPUT_TOKENS
+        )
+
+    @pytest.mark.asyncio
+    async def test_truncated_response_raises_clear_error(self):
+        p, completions = self._provider()
+        completions.canned_response = _openai_response(
+            '{"partial": "tru', finish_reason="length"
+        )
+        with pytest.raises(ValueError, match="truncated at max_output_tokens"):
+            await p.complete_json("prompt")


### PR DESCRIPTION
## Problem

After the Vertex-only cutover ([caura-enterprise#1300](https://github.com/caura-ai/caura-enterprise/pull/1300)), prod entity extraction showed a **~7% total-failure rate** (9 of ~130 in the first 50 minutes): `gemini-2.5-flash-lite` occasionally emits a runaway ~50k-token JSON that the API truncates mid-string. `complete_json` then fails with a `JSONDecodeError` pointing at a ~200KB char offset — a misleading symptom — and the caller falls back to the keyword heuristic (writes unaffected, entity-graph quality degraded).

Prod evidence (core-api, 2026-08-26 08:12–08:32 UTC):
```
entity-extraction-primary attempt 1/2 failed (JSONDecodeError: Unterminated string starting at: line 8851 column 7 (char 203549))
```

## Fix (all three chat providers — no path keeps the gap)

Applies to `VertexLLMProvider`, `GeminiLLMProvider`, **and `OpenAILLMProvider`** (the OpenAI-compatible path serving OpenAI / Anthropic / OpenRouter — same uncapped-JSON gap, added for parity per review):

1. **Cap the output**: `complete_json` now passes an output-token ceiling — `max_output_tokens=LLM_JSON_MAX_OUTPUT_TOKENS` on the Gemini SDKs, `max_completion_tokens` on the OpenAI-compatible API (the same param `complete_text` already uses there). Default **8192**, env-overridable. Legit outputs are far smaller (enrichment ~150 tokens, entity graphs a few thousand), so a runaway now fails fast and cheap instead of burning ~50k output tokens per attempt.
2. **Name the failure**: a shared `raise_if_truncated()` checks the truncation finish reason (Gemini `candidates[0].finish_reason=MAX_TOKENS` / OpenAI `choices[0].finish_reason="length"`) *before* parsing and raises a clear, retryable `ValueError` (provider, model, cap) instead of a parse error deep inside a partial payload. Duck-typed over all three SDKs' response shapes — any missing attribute means "not truncated", so an SDK shape change can never break the happy path.

Genuine parse failures (`finish_reason=STOP`, malformed body) still raise `JSONDecodeError` unchanged, and `call_with_retry`'s existing retry behavior is preserved — a truncated attempt retries the same as before, just with an accurate log line and a fraction of the token spend.

## Testing

- `tests/test_llm_json_truncation.py` (13 tests): truncation raises with context for all three response shapes (Gemini enum, string reason, OpenAI `"length"`), STOP/missing-shape cases don't, all three providers pass the cap into their request config (verified via captured config/kwargs), happy-path parse, and untruncated-bad-JSON still raises `JSONDecodeError`.
- Adjacent suites green: `test_gemini_provider.py`, `test_platform_providers.py`, `test_provider_protocols.py` (125 passed) plus the OpenAI-kwargs-sensitive suites `test_a5a_seed_and_canonical.py`, `test_a5b_prompt_and_schema.py`, `test_credential_bridge.py`, `test_e3_judge_token_cost.py`, `test_extraction_partial_parse.py`, `test_audit_s6_c1_events.py` (62 passed). Ruff clean.

## Notes

- This addresses the truncation symptom; the deeper follow-ups remain open: honoring `model_override` on the platform-singleton path (so e.g. entity extraction can use a stronger model than enrichment) and migrating off the deprecated `vertexai` SDK to google-genai (unlocks gemini-3.x on v1beta1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)