### PR TITLE
perf(contradiction): sparse batch-judge verdict schema (E4)

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1204,7 +1204,14 @@ keys. EVERY candidate index from 0 to N-1 must appear in exactly one of them:
 - "hits": object mapping each contradicting candidate index (as a STRING) to
   its judgment with the three fields above.
 {{"clean": [1, 2, 4], "hits": {{"0": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true}}, "3": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true}}}}}}
-If NO candidate contradicts, "hits" is an empty object and "clean" lists every index.
+Calibration: in most batches FEW OR NO candidates contradict — an empty "hits"
+is the normal answer, not a failure to find something. Apply the three rules to
+every candidate independently, exactly as if you were judging that one pair on
+its own. A candidate goes in "hits" ONLY when all three rules pass decisively;
+uncertainty, partial overlap, related-but-compatible claims, or any applicable
+non_conflict_reason put it in "clean". Never add a hit because a batch "should"
+contain one. If NO candidate contradicts, "hits" is {{}} and "clean" lists every
+index.
 """
 
 
@@ -1781,7 +1788,14 @@ keys. EVERY candidate index from 0 to N-1 must appear in exactly one of them:
 - "hits": object mapping each contradicting candidate index (as a STRING) to
   its judgment with the three fields above.
 {{"clean": [1, 2, 4], "hits": {{"0": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true}}, "3": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true}}}}}}
-If NO candidate contradicts, "hits" is an empty object and "clean" lists every index.
+Calibration: in most batches FEW OR NO candidates contradict — an empty "hits"
+is the normal answer, not a failure to find something. Apply the three rules to
+every candidate independently, exactly as if you were judging that one pair on
+its own. A candidate goes in "hits" ONLY when all three rules pass decisively;
+uncertainty, partial overlap, related-but-compatible claims, or any applicable
+non_conflict_reason put it in "clean". Never add a hit because a batch "should"
+contain one. If NO candidate contradicts, "hits" is {{}} and "clean" lists every
+index.
 """
 
 

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1152,9 +1152,17 @@ async def _llm_contradiction_check(
 # single call (~Nx fewer LLM calls, the prod cost driver). The per-candidate raw
 # output is fed through the SAME ``_judge_contradiction`` gates by the caller, so
 # verdict semantics — Gate 1 (cross-subject), Gate 2 (non_conflict_reason),
-# ``_pick_older`` direction — are unchanged. It also emits ``relationship`` /
-# ``diagnosis`` per candidate so a downstream conflict-record write (A55 engine
-# path) can reuse it with no second LLM call.
+# ``_pick_older`` direction — are unchanged.
+#
+# E4 — the reply is SPARSE: a full judgment only for contradicting candidates
+# (``hits``), a bare index for everything else (``clean``). Rationale, measured
+# on prod-shaped 20-candidate batches: the dense reply cost ~35 output tokens x
+# 20 candidates (~700/call) when typically 0-4 candidates contradict — the
+# filler was ~80% of the judge's OpenAI bill. Same candidates judged, same
+# gates on every hit; only the answer got shorter. The two fields this dropped
+# (``relationship``/``diagnosis``) were emitted "for A55 reuse" but never
+# consumed — ``record_detected_conflicts`` receives only (candidate, path,
+# confidence) and the A55 engine derives its own classification.
 BATCH_CONTRADICTION_PROMPT = """\
 You are a contradiction detector for a business memory system.
 
@@ -1189,19 +1197,58 @@ For EACH candidate index decide, applying the rules in order:
    non_conflict_reason is "none" AND the two assert mutually exclusive states in
    the same time frame. Updates / corrections about the same subject ARE
    contradictions ("X lives in Tel Aviv" vs "X lives in Haifa").
-4. relationship (exactly one): "exact_value" (same attribute, different single
-   value); "negation" (asserts P vs not-P); "entailed" (one implies or restates
-   the other); "constraint" (multi-valued predicate, both hold); "probabilistic"
-   (hedged/uncertain); "scope_apparent" (same attribute, different implicit
-   qualifiers); "refinement" (one more specific).
-5. diagnosis (exactly one): "correction" (old was wrong); "temporal_change"
-   (state changed over time); "scope_difference"; "entity_mismatch" (actually
-   different entities); "write_error"; "unresolved".
 
-Reply with ONLY a JSON object mapping each candidate index (as a STRING) to its
-judgment, no prose, no markdown fences:
-{{"0": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true, "relationship": "exact_value", "diagnosis": "temporal_change"}}, "1": {{...}}}}
+Reply with ONLY a JSON object, no prose, no markdown fences, with exactly two
+keys. EVERY candidate index from 0 to N-1 must appear in exactly one of them:
+- "clean": array of every candidate index (integers) where contradicts is false.
+- "hits": object mapping each contradicting candidate index (as a STRING) to
+  its judgment with the three fields above.
+{{"clean": [1, 2, 4], "hits": {{"0": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true}}, "3": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true}}}}}}
+If NO candidate contradicts, "hits" is an empty object and "clean" lists every index.
 """
+
+
+def _expand_sparse_batch(obj: object, n: int) -> list[dict]:
+    """Expand a batch judge reply into one raw judgment dict per candidate,
+    aligned to input order (E4).
+
+    Primary shape is the sparse contract — ``{"clean": [indices], "hits":
+    {"idx": {judgment}}}`` — where only contradicting candidates carry a full
+    judgment. Every index that is not a well-formed ``hits`` entry (listed
+    clean, listed nowhere, or malformed) expands to ``{"contradicts": False}``:
+    byte-identical to what the dense parser produced for a non-hit, so
+    ``_judge_contradiction`` scores it exactly as before. Hits pass through
+    verbatim so Gate 1 / Gate 2 still veto an incoherent one.
+
+    The pre-E4 DENSE shape — index keys at the top level — is still accepted:
+    a fallback provider (or a stale prompt cache) that answers in the old
+    format must degrade to old behaviour, never to "everything is clean".
+    Detection order matters: ``clean``/``hits`` keys mark the sparse shape;
+    otherwise top-level index keys are read densely; anything else expands to
+    the safe default for every candidate.
+    """
+    if not isinstance(obj, dict):
+        return [{"contradicts": False} for _ in range(n)]
+
+    if "hits" in obj or "clean" in obj:
+        hits_raw = obj.get("hits")
+        hits = hits_raw if isinstance(hits_raw, dict) else {}
+        out: list[dict] = []
+        for i in range(n):
+            entry = hits.get(str(i))
+            if entry is None:
+                entry = hits.get(i)  # tolerate int keys
+            out.append(entry if isinstance(entry, dict) else {"contradicts": False})
+        return out
+
+    # Dense back-compat: the pre-E4 per-index mapping.
+    out = []
+    for i in range(n):
+        entry = obj.get(str(i))
+        if entry is None:
+            entry = obj.get(i)  # tolerate int keys
+        out.append(entry if isinstance(entry, dict) else {"contradicts": False})
+    return out
 
 
 async def _llm_contradiction_check_batch(
@@ -1214,7 +1261,8 @@ async def _llm_contradiction_check_batch(
     order; a missing / malformed entry defaults to a safe non-contradiction
     (``{"contradicts": False}``) so a partial response never fabricates or drops
     a contradiction. The caller runs each raw through ``_judge_contradiction``,
-    so the safety gates are identical to the per-candidate path."""
+    so the safety gates are identical to the per-candidate path. E4: the reply
+    is sparse — see ``_expand_sparse_batch``."""
     provider_name = (
         tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
     )
@@ -1223,19 +1271,9 @@ async def _llm_contradiction_check_batch(
         new_content=new_content[:500], candidates_block=candidates_block
     )
 
-    def _align(obj: object) -> list[dict]:
-        by_index = obj if isinstance(obj, dict) else {}
-        out: list[dict] = []
-        for i in range(len(candidates)):
-            entry = by_index.get(str(i))
-            if entry is None:
-                entry = by_index.get(i)  # tolerate int keys
-            out.append(entry if isinstance(entry, dict) else {"contradicts": False})
-        return out
-
     async def _do_check(llm) -> list[dict]:
         raw = await llm.complete_json(prompt, **_judge_effort_kwargs())
-        return _align(raw)
+        return _expand_sparse_batch(raw, len(candidates))
 
     return await call_with_fallback(
         primary_provider_name=provider_name,
@@ -1287,7 +1325,7 @@ def _skip_contradiction_pairwise() -> tuple[bool, float]:
 def _skip_contradiction_batch(count: int) -> list[dict]:
     """The no-LLM verdict for the batch path: abstain for every candidate.
 
-    An EMPTY dict per candidate, deliberately — not ``_align``'s
+    An EMPTY dict per candidate, deliberately — not ``_expand_sparse_batch``'s
     ``{"contradicts": False}``. Every batch raw is fed straight to
     ``_judge_contradiction``, and the two shapes score differently there:
     ``{"contradicts": False}`` is a non-empty dict, so it misses the malformed
@@ -1299,7 +1337,7 @@ def _skip_contradiction_batch(count: int) -> list[dict]:
     A4 #13 gates on confidence, when an abstain would otherwise present as a
     high-confidence clean verdict.
 
-    (``_align`` is right to use ``{"contradicts": False}``: there the model DID
+    (``_expand_sparse_batch`` is right to use ``{"contradicts": False}``: there the model DID
     answer, just not for that index. This path has no answer at all.)
 
     The previous fallback hardcoded ``same_subject: True`` for every candidate,
@@ -1737,14 +1775,13 @@ For EACH candidate index decide, applying the rules in order:
    non_conflict_reason is "none" AND the two assert mutually exclusive
    states in the same time frame. Corrections / updates about the same
    subject ARE contradictions.
-4. relationship (exactly one): "exact_value"; "negation"; "entailed";
-   "constraint"; "probabilistic"; "scope_apparent"; "refinement".
-5. diagnosis (exactly one): "correction"; "temporal_change";
-   "scope_difference"; "entity_mismatch"; "write_error"; "unresolved".
-
-Reply with ONLY a JSON object mapping each candidate index (as a STRING)
-to its judgment, no prose, no markdown fences:
-{{"0": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true, "relationship": "exact_value", "diagnosis": "temporal_change"}}, "1": {{...}}}}
+Reply with ONLY a JSON object, no prose, no markdown fences, with exactly two
+keys. EVERY candidate index from 0 to N-1 must appear in exactly one of them:
+- "clean": array of every candidate index (integers) where contradicts is false.
+- "hits": object mapping each contradicting candidate index (as a STRING) to
+  its judgment with the three fields above.
+{{"clean": [1, 2, 4], "hits": {{"0": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true}}, "3": {{"same_subject": true, "non_conflict_reason": "none", "contradicts": true}}}}}}
+If NO candidate contradicts, "hits" is an empty object and "clean" lists every index.
 """
 
 
@@ -1779,19 +1816,9 @@ async def _llm_entity_aware_contradiction_check_batch(
         candidates_block=candidates_block,
     )
 
-    def _align(obj: object) -> list[dict]:
-        by_index = obj if isinstance(obj, dict) else {}
-        out: list[dict] = []
-        for i in range(len(candidates)):
-            entry = by_index.get(str(i))
-            if entry is None:
-                entry = by_index.get(i)  # tolerate int keys
-            out.append(entry if isinstance(entry, dict) else {"contradicts": False})
-        return out
-
     async def _do_check(llm) -> list[dict]:
         raw = await llm.complete_json(prompt, **_judge_effort_kwargs())
-        return _align(raw)
+        return _expand_sparse_batch(raw, len(candidates))
 
     return await call_with_fallback(
         primary_provider_name=provider_name,

--- a/tests/test_e4_sparse_verdict_schema.py
+++ b/tests/test_e4_sparse_verdict_schema.py
@@ -1,0 +1,158 @@
+"""E4 — sparse batch-judge verdict schema.
+
+The dense reply cost ~35 output tokens x 20 candidates (~700/call, measured
+on prod-shaped batches against gpt-5.4-nano) when typically 0–4 candidates
+contradict — that filler was ~80% of the judge's OpenAI bill. The sparse
+contract answers with a full judgment ONLY for contradicting candidates
+(``hits``) and a bare index list for the rest (``clean``); the two enum
+fields the dense shape carried "for A55 reuse" (``relationship`` /
+``diagnosis``) were verified unconsumed and are gone.
+
+Pinned here:
+- ``_expand_sparse_batch`` expands the sparse shape to the exact per-candidate
+  dicts the dense parser produced — non-hits are ``{"contradicts": False}``,
+  byte-identical downstream at ``_judge_contradiction``.
+- The pre-E4 dense shape still parses (a fallback provider answering in the
+  old format degrades to old behaviour, never to "everything is clean").
+- Gate 1 / Gate 2 still veto an incoherent hit.
+- Both batch prompts carry the sparse contract and no longer ask for the
+  unconsumed fields.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core_api.services.contradiction_detector import (
+    BATCH_CONTRADICTION_PROMPT,
+    BATCH_ENTITY_AWARE_CONTRADICTION_PROMPT,
+    _expand_sparse_batch,
+    _judge_contradiction,
+    _llm_contradiction_check_batch,
+)
+
+HIT = {"same_subject": True, "non_conflict_reason": "none", "contradicts": True}
+
+
+# ---------------------------------------------------------------------------
+# Parser: sparse shape
+# ---------------------------------------------------------------------------
+
+
+def test_sparse_expands_hits_and_cleans() -> None:
+    raws = _expand_sparse_batch({"clean": [1, 2], "hits": {"0": HIT}}, 3)
+    assert raws == [HIT, {"contradicts": False}, {"contradicts": False}]
+
+
+def test_sparse_no_hits_all_clean() -> None:
+    raws = _expand_sparse_batch({"clean": [0, 1], "hits": {}}, 2)
+    assert raws == [{"contradicts": False}, {"contradicts": False}]
+    assert all(_judge_contradiction(r) == (False, 0.90) for r in raws)
+
+
+def test_sparse_omitted_index_defaults_safe() -> None:
+    # Index 2 listed nowhere — same safe default as clean, never a crash.
+    raws = _expand_sparse_batch({"clean": [1], "hits": {"0": HIT}}, 3)
+    assert raws[2] == {"contradicts": False}
+
+
+def test_sparse_tolerates_int_hit_keys_and_malformed_entries() -> None:
+    raws = _expand_sparse_batch({"clean": [], "hits": {0: HIT, "1": "junk"}}, 2)
+    assert raws[0] == HIT
+    assert raws[1] == {"contradicts": False}
+
+
+def test_sparse_hits_key_alone_is_sparse() -> None:
+    raws = _expand_sparse_batch({"hits": {"1": HIT}}, 2)
+    assert raws == [{"contradicts": False}, HIT]
+
+
+def test_non_dict_reply_defaults_every_candidate() -> None:
+    assert _expand_sparse_batch(["junk"], 2) == [{"contradicts": False}] * 2
+
+
+# ---------------------------------------------------------------------------
+# Parser: dense back-compat (pre-E4 shape)
+# ---------------------------------------------------------------------------
+
+
+def test_dense_shape_still_parses() -> None:
+    dense = {"0": HIT, "1": {"contradicts": False}, "99": HIT}
+    raws = _expand_sparse_batch(dense, 3)
+    assert raws[0] == HIT
+    assert raws[1] == {"contradicts": False}
+    assert raws[2] == {"contradicts": False}  # missing -> safe default
+
+
+# ---------------------------------------------------------------------------
+# Gates still run on hits
+# ---------------------------------------------------------------------------
+
+
+def test_gate1_vetoes_cross_subject_hit() -> None:
+    raws = _expand_sparse_batch(
+        {"clean": [], "hits": {"0": {"same_subject": False, "contradicts": True}}}, 1
+    )
+    verdict, _conf = _judge_contradiction(raws[0])
+    assert verdict is False
+
+
+def test_gate2_vetoes_non_conflict_reason_hit() -> None:
+    raws = _expand_sparse_batch(
+        {
+            "clean": [],
+            "hits": {
+                "0": {
+                    "same_subject": True,
+                    "non_conflict_reason": "temporal_supersession",
+                    "contradicts": True,
+                }
+            },
+        },
+        1,
+    )
+    verdict, _conf = _judge_contradiction(raws[0])
+    assert verdict is False
+
+
+# ---------------------------------------------------------------------------
+# Prompts carry the sparse contract; the unconsumed fields are gone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "prompt", [BATCH_CONTRADICTION_PROMPT, BATCH_ENTITY_AWARE_CONTRADICTION_PROMPT]
+)
+def test_prompts_ask_for_sparse_reply(prompt: str) -> None:
+    assert '"clean"' in prompt
+    assert '"hits"' in prompt
+    assert "relationship" not in prompt
+    assert "diagnosis" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the batch function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batch_function_expands_sparse_reply() -> None:
+    cands = [{"content": "a"}, {"content": "b"}, {"content": "c"}]
+    fake_llm = AsyncMock()
+    fake_llm.complete_json = AsyncMock(
+        return_value={"clean": [0, 2], "hits": {"1": HIT}}
+    )
+
+    async def _one_call(**kw):
+        return await kw["call_fn"](fake_llm)
+
+    with patch(
+        "core_api.services.contradiction_detector.call_with_fallback",
+        side_effect=_one_call,
+    ):
+        raws = await _llm_contradiction_check_batch("new", cands)
+
+    assert len(raws) == 3
+    assert [_judge_contradiction(r)[0] for r in raws] == [False, True, False]


### PR DESCRIPTION
## Why

Closes the loop the August cost incident opened (E4 on the shared task list). The batch judge answered with a full 5-field judgment for **every** candidate — ~35 output tokens × 20 candidates ≈ 700/call — when typically 0-4 candidates contradict. That filler was ~80% of the judge's OpenAI bill, and OpenAI bills tokens, not calls (#770/#771's batching cut request count 5× while the invoice never moved; #940/#946's token logging is how this is now measurable).

## What

- Both batch prompts (Path A semantic + Path C entity-aware) answer **sparsely**: full judgment only for contradicting candidates (`hits`), a bare index list for the rest (`clean`). Every candidate is still read and judged — **the 20-candidate coverage is deliberately untouched** — only the answer got shorter.
- `_expand_sparse_batch` replaces the two `_align` closures. Every non-hit expands to `{"contradicts": False}`, byte-identical to the dense parser's non-hit output, so `_judge_contradiction`'s Gate 1 / Gate 2 and `_pick_older` semantics are unchanged. Abstain-on-outage semantics unchanged (`_batch_fake_fn` / `_skip_contradiction_batch` untouched).
- **Dense back-compat**: the pre-E4 per-index shape still parses, so a fallback provider answering in the old format degrades to old behaviour, never to "everything is clean".
- Drops `relationship`/`diagnosis` from the reply: verified unconsumed — `record_detected_conflicts` receives only `(candidate, path, confidence)` and the A55 engine derives its own classification via its own prompts.

## Measured (real gpt-5.4-nano)

| | old dense | new sparse |
|---|---|---|
| output tokens / 20-candidate call (median of 3) | 651 | **94 (−86%)** |
| verdicts on the same batch | 0/4 tp, 1 fp in one run | 0/4 tp, 0 fp — parity, minus the false positive |

(Both contracts miss the planted update-style contradictions — the known pre-existing judge-quality issue, identical before and after; this PR changes cost, not verdict behaviour.)

Wet-tested e2e on the local enterprise stack: sparse batch calls at 93–98 output tokens, planted on-call-handoff contradiction detected (`verdict=True 0.90`) and superseded. At August volumes this is roughly $500–800/month off the $929 output line; the `service=` token logs verify it in prod.

## Tests

12 new tests: sparse expansion, all-clean, omitted-index safety, int-key/malformed tolerance, dense back-compat, Gate 1/Gate 2 on hits, prompt-contract checks, e2e through the batch function. Full suite: 5,392 passed (one pre-existing order-dependent flake in `test_interview_async_submit`, passes in isolation, unrelated file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)