### PR TITLE
chore: retire old-brand names from internal test and build identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "memclaw",
+  "name": "caura",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "memclaw",
+      "name": "caura",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "memclaw",
+  "name": "caura",
   "private": true,
   "version": "0.0.0",
   "description": "Production-grade persistent memory platform for OpenClaw agents. Agents store and retrieve memories via semantic search, with entity/relationship graphs and tenant isolation.",

--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -267,7 +267,7 @@ function _autoFixWithConfig(initial: Record<string, unknown>): {
   result: ReturnType<typeof autoFixAllowlist>;
   cleanup: () => void;
 } {
-  const tmp = mkdtempSync(join(tmpdir(), "memclaw-autofix-test-"));
+  const tmp = mkdtempSync(join(tmpdir(), "caura-autofix-test-"));
   mkdirSync(join(tmp, ".openclaw"), { recursive: true });
   const cfgPath = join(tmp, ".openclaw", "openclaw.json");
   writeFileSync(cfgPath, JSON.stringify(initial), "utf-8");
@@ -403,7 +403,7 @@ function _ensureExtraDirsWithConfig(
   result: ReturnType<typeof ensureExtraSkillDirs>;
   cleanup: () => void;
 } {
-  const tmp = mkdtempSync(join(tmpdir(), "memclaw-extradirs-test-"));
+  const tmp = mkdtempSync(join(tmpdir(), "caura-extradirs-test-"));
   mkdirSync(join(tmp, ".openclaw"), { recursive: true });
   const cfgPath = join(tmp, ".openclaw", "openclaw.json");
   if (initial !== null) {

--- a/plugin/src/heartbeat.test.ts
+++ b/plugin/src/heartbeat.test.ts
@@ -23,7 +23,7 @@ describe("deploy cooldown lifecycle", () => {
     // The cooldown / pending files live under getPluginDir() which
     // resolves from $HOME by default — point it at a clean tmp dir
     // for each test.
-    tmpHome = mkdtempSync(join(tmpdir(), "memclaw-deploy-test-"));
+    tmpHome = mkdtempSync(join(tmpdir(), "caura-deploy-test-"));
     mkdirSync(join(tmpHome, ".openclaw", "plugins", "memclaw"), {
       recursive: true,
     });
@@ -98,7 +98,7 @@ describe("deploy post-restart verification", () => {
   let prevHome: string | undefined;
 
   beforeEach(() => {
-    tmpHome = mkdtempSync(join(tmpdir(), "memclaw-deploy-test-"));
+    tmpHome = mkdtempSync(join(tmpdir(), "caura-deploy-test-"));
     mkdirSync(join(tmpHome, ".openclaw", "plugins", "memclaw"), {
       recursive: true,
     });

--- a/plugin/src/install-id.test.ts
+++ b/plugin/src/install-id.test.ts
@@ -27,7 +27,7 @@ function installFile(home: string): string {
 beforeEach(() => {
   _resetInstallIdCacheForTesting();
   _origHome = process.env.HOME;
-  _tmpHome = mkdtempSync(join(tmpdir(), "memclaw-installid-"));
+  _tmpHome = mkdtempSync(join(tmpdir(), "caura-installid-"));
   process.env.HOME = _tmpHome;
 });
 
@@ -73,7 +73,7 @@ describe("getInstallId", () => {
     const id1 = getInstallId();
     // Switch HOME to a fresh dir and clear the cache — simulates a
     // second install on the same machine in a different user's home.
-    const second = mkdtempSync(join(tmpdir(), "memclaw-installid-2-"));
+    const second = mkdtempSync(join(tmpdir(), "caura-installid-2-"));
     try {
       process.env.HOME = second;
       _resetInstallIdCacheForTesting();

--- a/plugin/src/interview-buffer.test.ts
+++ b/plugin/src/interview-buffer.test.ts
@@ -26,7 +26,7 @@ describe("interview buffer", () => {
   let bufPath: string;
 
   beforeEach(() => {
-    tmp = mkdtempSync(join(tmpdir(), "memclaw-interview-buffer-"));
+    tmp = mkdtempSync(join(tmpdir(), "caura-interview-buffer-"));
     bufPath = join(tmp, "interview-buffer.jsonl");
     __INTERVIEW_BUFFER_INTERNALS__.setPathForTests(bufPath);
   });
@@ -165,7 +165,7 @@ describe("interview buffer — wet-test regressions (task #6)", () => {
   let bufPath: string;
 
   beforeEach(() => {
-    tmp = mkdtempSync(join(tmpdir(), "memclaw-interview-wet-"));
+    tmp = mkdtempSync(join(tmpdir(), "caura-interview-wet-"));
     bufPath = join(tmp, "interview-buffer.jsonl");
     __INTERVIEW_BUFFER_INTERNALS__.setPathForTests(bufPath);
   });

--- a/plugin/src/interview-command.test.ts
+++ b/plugin/src/interview-command.test.ts
@@ -50,7 +50,7 @@ describe("interview_request command handler", () => {
   }
 
   beforeEach(() => {
-    tmp = mkdtempSync(join(tmpdir(), "memclaw-interview-cmd-"));
+    tmp = mkdtempSync(join(tmpdir(), "caura-interview-cmd-"));
     __INTERVIEW_BUFFER_INTERNALS__.setPathForTests(join(tmp, "buf.jsonl"));
     // Point the Phase-1.5 task-trail at the empty tmp dir so the handler's
     // pre-read sync can never discover a REAL ~/.openclaw task DB on the

--- a/plugin/src/task-trail.test.ts
+++ b/plugin/src/task-trail.test.ts
@@ -117,7 +117,7 @@ describe("task-trail sync", () => {
   let legacyDbPath: string;
 
   beforeEach(() => {
-    tmp = mkdtempSync(join(tmpdir(), "memclaw-task-trail-"));
+    tmp = mkdtempSync(join(tmpdir(), "caura-task-trail-"));
     __TASK_TRAIL_INTERNALS__.setBaseDirForTests(tmp);
     __TASK_TRAIL_INTERNALS__.setSidecarPathForTests(join(tmp, "sidecar.json"));
     __INTERVIEW_BUFFER_INTERNALS__.setPathForTests(join(tmp, "buf.jsonl"));

--- a/scripts/wet-test-install.sh
+++ b/scripts/wet-test-install.sh
@@ -73,7 +73,7 @@ echo "  Plugin:    $PLUGIN_DIR"
 echo ""
 
 # ── Step 1: Clone or update ──
-CLONE_DIR="/tmp/memclaw-wet-test"
+CLONE_DIR="/tmp/caura-wet-test"
 if [[ -d "$CLONE_DIR/.git" ]]; then
   echo "[1/6] Updating existing clone..."
   cd "$CLONE_DIR"
@@ -163,7 +163,7 @@ if [[ -f "$OPENCLAW_CONFIG" ]]; then
     if (!config.plugins.load.paths.includes(pluginDir)) config.plugins.load.paths.push(pluginDir);
 
     // Ensure tools are allowed.
-    // Keep in sync with MEMCLAW_TOOLS (plugin/src/tools.ts) — a missing
+    // Keep in sync with CAURA_TOOLS (plugin/src/tools.ts) — a missing
     // entry here means that tool is absent from tools.alsoAllow, so any
     // OpenClaw tools.profile (which grants core tools + alsoAllow only)
     // strips it. caura_keystones was the casualty of this drift.

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -113,7 +113,7 @@ async def test_entity_lookup(client):
         "agent_id": f"entity-agent-{tag}",
         "fleet_id": f"entity-fleet-{tag}",
         "memory_type": "fact",
-        "content": f"Alice met Bob at the MemClaw headquarters in Tel Aviv [{tag}]",
+        "content": f"Alice met Bob at the Caura headquarters in Tel Aviv [{tag}]",
     }, headers=headers)
 
     ent_resp = await client.get("/api/v1/entities", params={

--- a/tests/test_api_plugin.py
+++ b/tests/test_api_plugin.py
@@ -26,8 +26,7 @@ async def test_post_install_plugin_generates_script(client):
     assert resp.status_code == 200
     script = resp.text
     assert script.startswith("#!/usr/bin/env bash")
-    assert "CAURA_API_URL=" in script
-    assert "caura.example.com" in script
+    assert "CAURA_API_URL=https://caura.example.com" in script
     assert "CAURA_FLEET_ID=" in script
     assert "my-fleet" in script
     assert "CAURA_API_KEY=" in script

--- a/tests/test_api_plugin.py
+++ b/tests/test_api_plugin.py
@@ -17,7 +17,7 @@ async def test_post_install_plugin_generates_script(client):
         "/api/v1/install-plugin",
         json={
             "fleet_id": "my-fleet",
-            "api_url": "https://memclaw.example.com",
+            "api_url": "https://caura.example.com",
             "api_key": "sk-test-key-1234",
             "node_name": "node-alpha",
         },
@@ -27,7 +27,7 @@ async def test_post_install_plugin_generates_script(client):
     script = resp.text
     assert script.startswith("#!/usr/bin/env bash")
     assert "CAURA_API_URL=" in script
-    assert "memclaw.example.com" in script
+    assert "caura.example.com" in script
     assert "CAURA_FLEET_ID=" in script
     assert "my-fleet" in script
     assert "CAURA_API_KEY=" in script
@@ -99,7 +99,7 @@ async def test_script_has_chmod_600(client):
 
 
 async def test_script_contains_correct_env_vars(client):
-    """The .env block has all required MEMCLAW_* variables."""
+    """The .env block has all required CAURA_* variables."""
     resp = await client.post(
         "/api/v1/install-plugin",
         json={

--- a/tests/test_capability_usage.py
+++ b/tests/test_capability_usage.py
@@ -200,7 +200,7 @@ async def test_mcp_call_tool_records_capability_and_op(monkeypatch):
 
     assert len(calls) == 1
     k = calls[0]
-    assert k["capability"] == "doc"   # memclaw_ prefix stripped
+    assert k["capability"] == "doc"   # caura_ prefix stripped
     assert k["op"] == "search"
     assert k["transport"] == "mcp"
     assert k["tenant_id"] == "t-mcp"

--- a/tests/test_direct_mcp_skill.py
+++ b/tests/test_direct_mcp_skill.py
@@ -117,7 +117,7 @@ def test_documents_every_tool_by_name() -> None:
 
 def test_does_not_reintroduce_signature_cards() -> None:
     """Regression guard for the schema-deferral decision: the adapter should
-    NOT carry per-tool signature cards (``memclaw_x(arg, ...)``) that merely
+    NOT carry per-tool signature cards (``caura_x(arg, ...)``) that merely
     duplicate the always-in-context MCP tool schemas."""
     skill = _read_adapter()
     assert "`caura_recall(" not in skill and "`caura_write(" not in skill, (

--- a/tests/test_install_skill_endpoint.py
+++ b/tests/test_install_skill_endpoint.py
@@ -127,7 +127,7 @@ def test_codex_only_skips_claude_block():
 # --- skill selector (?skill=) -------------------------------------------------
 
 
-def test_default_skill_is_memclaw_and_unchanged():
+def test_default_skill_slug_unchanged():
     """No ``?skill=`` → the installer is the original default one: the same
     install paths, the same fetch URL, the 'Caura' title, and no trace of
     company-brain. Guards the 'default load is unaffected' contract."""
@@ -175,7 +175,7 @@ def test_skill_param_is_allowlisted_no_path_traversal():
 # --- /skill/{skill} serving route ---------------------------------------------
 
 
-def test_serve_memclaw_skill_still_works():
+def test_serve_default_skill_still_works():
     client = _client()
     resp = client.get("/api/v1/skill/memclaw")
     assert resp.status_code == 200

--- a/tests/test_org_role_plumb.py
+++ b/tests/test_org_role_plumb.py
@@ -71,7 +71,7 @@ async def test_path4_absent_header_is_none(monkeypatch):
     assert ctx.org_role is None
 
 
-async def test_memclaw_key_path_ignores_org_role_header(monkeypatch):
+async def test_api_key_path_ignores_org_role_header(monkeypatch):
     """Path 2 (API-key callers) must not gain a role from the header —
     approving skills stays a human decision; agent keys can't act on
     admin-only routes by self-asserting X-Org-Role."""

--- a/tests/test_plugin_source_manifest.py
+++ b/tests/test_plugin_source_manifest.py
@@ -91,12 +91,12 @@ def test_install_script_does_not_bake_a_manifest_heredoc():
 
     Origin of this guard: in 2026-05 OpenClaw upstream made
     ``contracts.tools`` strictly enforced in plugin manifests
-    (openclaw/openclaw@7641783d). caura-memclaw's
+    (openclaw/openclaw@7641783d). caura-ai/caura's
     ``plugin/openclaw.plugin.json`` was updated to declare it, but the
     install script's baked HEREDOC was left behind — so every fresh
     ``curl /api/v1/install-plugin | bash`` produced a manifest without
     ``contracts.tools``, which OpenClaw silently rejected, dropping the
-    entire MemClaw tool surface from the agent.
+    entire Caura tool surface from the agent.
 
     The structural fix was to serve the manifest via ``/plugin-source``
     (single source of truth) and have the installer fetch it. This test
@@ -192,7 +192,7 @@ def test_served_manifest_declares_contracts_tools():
     OpenClaw upstream rejects every ``api.registerTool`` call when this
     field is missing (since 2026-05-01). The plugin TS suite has its
     own drift test (tool-definitions.test.ts) that asserts the list
-    matches MEMCLAW_TOOLS exactly; this Python test only guards the
+    matches CAURA_TOOLS exactly; this Python test only guards the
     file-level invariant so a server-side test failure surfaces too
     if someone deletes the field from the manifest file.
     """
@@ -212,7 +212,7 @@ def test_served_manifest_declares_contracts_tools():
 def test_install_script_alsoAllow_lockstep():
     """The install script's hardcoded ``alsoAllow`` array MUST match
     ``contracts.tools`` in ``plugin/openclaw.plugin.json`` (and, transitively,
-    ``MEMCLAW_TOOLS`` in ``plugin/src/tools.ts`` — the TS-side boot-time
+    ``CAURA_TOOLS`` in ``plugin/src/tools.ts`` — the TS-side boot-time
     drift check enforces that direction; this Python test pins the
     cross-language symmetry).
 
@@ -227,7 +227,7 @@ def test_install_script_alsoAllow_lockstep():
 
     ``caura_keystones_set`` is intentionally NOT in the install-script's
     ``alsoAllow`` because ``tools.json`` marks it ``plugin_exposed: false``
-    — it is the admin authoring path, served only via MCP (memclaw_server)
+    — it is the admin authoring path, served only via MCP (mcp_server)
     and never exposed to OpenClaw-side agents. The two sides of this test
     deliberately use the SAME canonical source (``contracts.tools``) so a
     future plugin_exposed flip is picked up automatically.

--- a/tests/test_production_startup_guards.py
+++ b/tests/test_production_startup_guards.py
@@ -69,7 +69,7 @@ def test_empty_strings_count_as_unset():
         )
 
 
-def test_memclaw_api_key_alone_is_an_acceptable_perimeter():
+def test_api_key_alone_is_an_acceptable_perimeter():
     """The network-exposed OSS pattern, and why the guard is not gateway-specific.
 
     When ``CAURA_API_KEY`` is set, auth.py's Path 2 either authenticates the


### PR DESCRIPTION
## Summary

Four commits of internal identifier renames on the rebrand's W5 (safe-rewrite) list. Nothing here is on a user's disk, in a published artifact, or on the wire — temp-directory prefixes, test function names, stale docstrings, and the repo-root private package name.

`legacy_name_ratchet.py --base origin/main`: **No new lines. 30 removed by this change (-30 net).**
`do_not_touch_sentinel.py`: **All 34 protected strings survive.**

## Related Issue

Part of the rebrand programme's W5 bucket (see the 2026-08-25 classification). No single issue.

## Type of Change

- [x] Refactor / internal cleanup

## What each commit does

| commit | lines | scope |
|---|---:|---|
| `test(plugin): brand the temp-dir prefixes in six suites` | 10 | `mkdtempSync` prefixes in `config`, `heartbeat`, `install-id`, `interview-buffer`, `interview-command`, `task-trail` |
| `test: retire the old brand from test names and docstrings` | 15 | 8 files under `tests/` |
| `chore(scripts): brand the wet-test clone dir, fix a stale constant name` | 2 | `scripts/wet-test-install.sh` |
| `chore: rename the root private package` | 3 | `package.json` + both lockfile `name` fields |

## Why each is safe

- **Temp-dir prefixes.** Each of the ten prefix strings was verified to appear in exactly one file — nothing asserts on them. The `.openclaw/plugins/` paths on adjacent lines are untouched.
- **Test names.** Verified no workflow, config or doc selects any of the renamed functions by name. The `memclaw_api_key` settings field the two guard tests assert on is unchanged.
- **Stale docstrings corrected to what the code actually does**: `MEMCLAW_TOOLS` → `CAURA_TOOLS` (that is the real export in `plugin/src/tools.ts`), `MEMCLAW_*` → `CAURA_*` in `test_api_plugin` (its assertions already check `CAURA_*`), `(memclaw_server)` → `(mcp_server)`.
- **One asserted value moves**: `test_api_plugin`'s example host `memclaw.example.com` → `caura.example.com`. The assertion four lines below it moves in the same commit.
- **`wet-test-install.sh`**: `CLONE_DIR` only — the string appears nowhere else in the repo. `PLUGIN_DIR` and the `plugins.allow` / `plugins.entries` keys are the real on-disk install and stay.
- **Root `package.json`**: `private: true`, no `workspaces` block, nothing imports it, never published. `clients/typescript`'s published manifest is untouched.

## How Has This Been Tested?

- The six plugin suites: `npx tsc && node --test dist/{config,heartbeat,install-id,interview-buffer,interview-command,task-trail}.test.js` — **86 pass / 13 fail, byte-identical before and after the change**. The 13 are pre-existing failures on the contributor's Windows machine, unrelated to this PR.
- `ruff check` on the eight touched `tests/` files: **0 findings before and after**. All eight `py_compile` clean.
- `bash -n scripts/wet-test-install.sh` clean.
- `npm ci --dry-run --ignore-scripts` exits 0; both JSON manifests parse.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] No new tests needed — this renames test identifiers and comments; no behaviour changes
- [x] `ruff check` passes on the touched files (unchanged finding count)
- [ ] `mypy` — not run locally; scoped by `scripts/mypy.ini` / per-service configs in CI
- [ ] `pytest` — **not run locally.** The root `conftest.py` requires a live Postgres (`memclaw`/`changeme`) that this machine has no access to, and Docker is unavailable. CI runs the full suite.
- [x] No documentation change needed
- [x] Not user-facing — no CHANGELOG entry

## Additional Notes

Two lines went slightly past the original scope, both inside a file already being edited: `test_plugin_source_manifest.py` also carried the pre-rename repo name and one prose line, corrected here rather than left for a two-line follow-up.

Three items originally scoped into this group turned out to need nothing: `smoke_test.py` and `latency_test.py` are already clean, and `forge_dry_run.py`'s one remaining line names the live `lifecycle` Pub/Sub topic, which moves with its family rather than with a sweep.
