### PR TITLE
refactor(plugin): rename the default export, reword stale comments

### DIFF
--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -62,7 +62,7 @@ export function isCauraAllowed(config: Record<string, any>): boolean {
   // `/usr/lib/node_modules/openclaw/dist/*.js` on the wet-test VM).
   //
   // So a missing OR empty `plugins.allow` means "no restriction —
-  // every enabled plugin can load". Memclaw doesn't need to appear
+  // every enabled plugin can load". This plugin doesn't need to appear
   // in the array in those cases; it's allowed by default. Pre-fix this
   // function returned `false` for missing/empty allow, which drove
   // `autoFixAllowlist` step 1 to *create* an array containing only
@@ -85,7 +85,7 @@ export function isCauraPathLoaded(config: Record<string, any>): boolean {
 }
 
 /**
- * True iff OpenClaw's exclusive memory slot is claimed by memclaw. The plugin
+ * True iff OpenClaw's exclusive memory slot is claimed by Caura. The plugin
  * can be loaded and enabled but have another plugin hold the memory slot, in
  * which case `register()` runs but memory-runtime methods are never called.
  */
@@ -94,7 +94,7 @@ export function isMemorySlotClaimed(config: Record<string, any>): boolean {
 }
 
 /**
- * True iff OpenClaw's contextEngine slot is claimed by memclaw. The
+ * True iff OpenClaw's contextEngine slot is claimed by Caura. The
  * contextEngine slot is what gates ``ContextEngine.assemble()`` — the
  * code path that injects ``<keystone_rules>`` into the system prompt
  * on every turn. Without this slot, OpenClaw falls back to the default
@@ -138,7 +138,7 @@ export function autoFixAllowlist(options?: {
 
   const changes: string[] = [];
 
-  // 1. Ensure memclaw is in `plugins.allow` IF — and only if — the
+  // 1. Ensure the plugin is in `plugins.allow` IF — and only if — the
   //    user has an explicit, non-empty allowlist. CAURA-000: pre-fix
   //    this branch unconditionally created `["memclaw"]` from a
   //    missing/empty array, converting a permissive OpenClaw config
@@ -151,7 +151,7 @@ export function autoFixAllowlist(options?: {
   //    So the fix is: leave a missing/empty allowlist alone; only
   //    append to one that's already non-empty (i.e. the user has
   //    explicitly opted into the allowlist mechanism and we need to
-  //    make sure memclaw is in their list).
+  //    make sure the plugin is in their list).
   if (
     Array.isArray(config?.plugins?.allow) &&
     config.plugins.allow.length > 0 &&
@@ -161,7 +161,7 @@ export function autoFixAllowlist(options?: {
     changes.push("plugins.allow");
   }
 
-  // 2. Ensure memclaw is enabled in plugins.entries
+  // 2. Ensure the plugin is enabled in plugins.entries
   if (!isCauraEnabled(config)) {
     if (!config.plugins) config.plugins = {};
     if (!config.plugins.entries) config.plugins.entries = {};
@@ -179,7 +179,7 @@ export function autoFixAllowlist(options?: {
     changes.push("plugins.load.paths");
   }
 
-  // 4. Claim the exclusive memory slot for memclaw
+  // 4. Claim the exclusive memory slot for Caura
   if (!config.plugins) config.plugins = {};
   if (!config.plugins.slots) config.plugins.slots = {};
   if (config.plugins.slots.memory !== PLUGIN_ID) {

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -127,7 +127,7 @@ async function searchMemories(
 // so they don't run twice and produce duplicated logs.
 let sideEffectsBootstrapped = false;
 
-const memclawPlugin = {
+const cauraPlugin = {
   id: "memclaw",
   name: "Caura",
   description:
@@ -194,7 +194,7 @@ const memclawPlugin = {
         name: "Caura",
         version: PLUGIN_VERSION,
         status: "loaded",
-        description: memclawPlugin.description,
+        description: cauraPlugin.description,
         apiUrl: CAURA_API_URL,
         fleetId: CAURA_FLEET_ID || null,
         apiKeyHint: CAURA_API_KEY ? CAURA_API_KEY.slice(0, 6) + "..." : null,
@@ -822,4 +822,4 @@ const memclawPlugin = {
   },
 };
 
-export default memclawPlugin;
+export default cauraPlugin;

--- a/plugin/src/runtime-contract.test.ts
+++ b/plugin/src/runtime-contract.test.ts
@@ -3,7 +3,7 @@
  *
  * The runtime object passed to `api.registerMemoryRuntime(...)` is inline
  * inside `register()` and cannot be imported directly. These tests construct
- * a minimal fake OpenClaw API, invoke `memclawPlugin.register(fakeApi)`, and
+ * a minimal fake OpenClaw API, invoke `cauraPlugin.register(fakeApi)`, and
  * then exercise the captured runtime under known reachability states.
  *
  * The invariants pinned here are the ones that were silently broken before
@@ -28,7 +28,7 @@
 
 import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import memclawPlugin from "./index.js";
+import cauraPlugin from "./index.js";
 import {
   _resetReachabilityForTests,
   getReachability,
@@ -62,9 +62,9 @@ function buildFakeApi(): { api: Record<string, unknown>; captured: { runtime?: R
 
 function loadRuntime(): RegisteredRuntime {
   const { api, captured } = buildFakeApi();
-  memclawPlugin.register(api);
+  cauraPlugin.register(api);
   if (!captured.runtime) {
-    throw new Error("memclawPlugin.register did not call registerMemoryRuntime");
+    throw new Error("cauraPlugin.register did not call registerMemoryRuntime");
   }
   return captured.runtime;
 }
@@ -275,7 +275,7 @@ function _loadFlushPlanResolver(): _FlushPlanResolver {
     registerContextEngine: () => {},
     on: () => {},
   };
-  memclawPlugin.register(api);
+  cauraPlugin.register(api);
   if (!captured) throw new Error("registerMemoryFlushPlan was not called");
   return captured;
 }


### PR DESCRIPTION
## Summary

Two internal renames in the plugin, both on the rebrand's W5 (safe-rewrite) list. The module-local default-export binding, and seven comment lines whose surrounding code already goes through `PLUGIN_ID`.

`legacy_name_ratchet.py --base origin/main`: **No new lines. 15 removed by this change (-15 net).**
`do_not_touch_sentinel.py`: **All 34 protected strings survive.**

## Related Issue

Part of the rebrand programme's W5 bucket (2026-08-25 classification). No single issue.

## Type of Change

- [x] Refactor / internal cleanup

## `memclawPlugin` → `cauraPlugin`

A module-local `const` in `plugin/src/index.ts`, referenced three times there and imported into `runtime-contract.test.ts` under its own binding name. Eight references across two files — verified to be every occurrence in the repo, and zero remain. It is the **default** export, so no importer names it.

## Seven comment lines in `plugin/src/config.ts`

They used the old brand as a noun for the plugin. The code beside them already reads `PLUGIN_ID` and the predicates are already `isCaura*`, so the comments were simply stale.

**Left exactly as they are, deliberately:**

- `PLUGIN_ID = "memclaw"` — marked `legacy-name-ok`; the id keys every existing on-disk install
- the two comments quoting the literal `"memclaw"` / `["memclaw"]` config value that the pre-fix allowlist bug wrote
- the `openclaw gateway memclaw.allowlist.fix` command string in both operator messages
- the `memclaw_` tool-prefix check

And in `runtime-contract.test.ts`: the `backend` / `fallback` ids, the `memclaw/flush-*.md` relative-path shape, `engine.info.id`, and the `plugins.slots.contextEngine` value. All live contract.

## How Has This Been Tested?

- `npx tsc` — clean.
- `node --test dist/runtime-contract.test.js` — **46 pass / 0 fail.** This is the suite that actually exercises the renamed binding.
- The four suites covering both touched files (`config`, `runtime-contract`, `educate`, `tool-definitions`): **148 pass / 42 fail, byte-identical before and after.** The 42 are pre-existing failures on the contributor's Windows machine — `educate`/`reconcile` write to paths that behave differently there — and are unrelated to this PR.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] No new tests needed — a rename with no behaviour change; the existing contract suite covers it and passes 46/46
- [ ] `ruff` / `mypy` — N/A, TypeScript only
- [x] Plugin test suite run locally (see above)
- [x] No documentation change needed
- [x] Not user-facing — no CHANGELOG entry

## Additional Notes

`index.ts:110` still emits a `memclaw://` result path scheme. It has no other reader in the repo, so it is probably safe to move too, but it is a string handed out to OpenClaw rather than a module-local name — left out of this PR so it can be verified on its own.
