### PR TITLE
chore(rebrand): sweep ten safe legacy-name lines (fix-plan O-groups head)

### DIFF
--- a/common/ruff.toml
+++ b/common/ruff.toml
@@ -1,5 +1,5 @@
 # Ruff contract for common/ — pinned deliberately, and SHARED VERBATIM between
-# caura-memclaw (OSS) and caura-memclaw-enterprise.
+# caura (OSS) and caura-enterprise.
 #
 # WHY THIS FILE EXISTS: common/ has no pyproject.toml of its own (it is
 # PYTHONPATH-mounted, not pip-installed), and neither repo has a root

--- a/common/serve.py
+++ b/common/serve.py
@@ -31,7 +31,7 @@ to uvicorn as a string so the workers can re-import it. ``<settings_import>`` is
 the app's own ``configure_logging()`` call exactly.
 
 Vendoring constraint: this file is vendored byte-for-byte into
-caura-memclaw-enterprise as an ``identical``-policy ``common/`` file, whose CI
+caura-enterprise as an ``identical``-policy ``common/`` file, whose CI
 runs ``ruff format --check`` with no resolved config (ruff's 88-col default).
 Keep every line <= 88 cols so the vendored copy stays format-stable there — a
 wider line passes OSS CI (which does not format-check ``common/``) but wedges

--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -22,7 +22,7 @@ their own `environment` and `log_level` so this module stays agnostic of
 per-service settings schemas.
 
 Vendoring constraint: this file is copied byte-identically into
-caura-memclaw-enterprise (scripts/vendored_files_manifest.json there,
+caura-enterprise (scripts/vendored_files_manifest.json there,
 policy=identical), whose CI runs `ruff format --check common/` at ruff's
 default 88-column width — OSS CI does not format-check common/ at all.
 Keep code format-stable at 88 columns (magic-trailing-comma collections

--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -488,7 +488,7 @@ echo "    Build successful"
 echo "[7/7] Configuring OpenClaw..."
 if [ -f "$CONFIG_PATH" ]; then
   # Write a temp script to safely modify JSON (avoids inline node -e quoting issues)
-  _SETUP_JS=$(mktemp /tmp/memclaw-setup-XXXXXX.mjs)
+  _SETUP_JS=$(mktemp /tmp/caura-setup-XXXXXX.mjs)
   cat > "$_SETUP_JS" << 'SETUP_EOF'
 import fs from 'fs';
 const configPath = process.argv[2];

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -13,6 +13,7 @@
 
 import { createHash } from "crypto";
 import { apiCall, parseSearchItems } from "./transport.js";
+import { PLUGIN_ID } from "./config.js";
 import {
   CAURA_FLEET_ID,
   CAURA_TENANT_ID,
@@ -502,7 +503,7 @@ export class CauraContextEngine {
    * it ``true``.
    */
   readonly info = {
-    id: "memclaw",
+    id: PLUGIN_ID,
     name: "Caura Context Engine",
     ownsCompaction: true,
   };

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -46,6 +46,7 @@ import {
 } from "./prompt-section.js";
 import { CAURA_TOOLS } from "./tools.js";
 import {
+  PLUGIN_ID,
   autoFixAllowlist,
   readOpenClawConfig,
   getOpenClawConfigPath,
@@ -128,7 +129,7 @@ async function searchMemories(
 let sideEffectsBootstrapped = false;
 
 const cauraPlugin = {
-  id: "memclaw",
+  id: PLUGIN_ID,
   name: "Caura",
   description:
     "Central persistent memory for OpenClaw agents with cross-fleet, multi-agent shared recall",
@@ -190,7 +191,7 @@ const cauraPlugin = {
     api.registerGatewayMethod("memclaw.status", ({ respond }: any) => {
       const config = readOpenClawConfig();
       respond({
-        id: "memclaw",
+        id: PLUGIN_ID,
         name: "Caura",
         version: PLUGIN_VERSION,
         status: "loaded",


### PR DESCRIPTION
## What

Seven W5 lines, all named in the rebrand plan's fix-plan O-groups and re-verified open at trunk. No behaviour change, no window, no customer risk. (Rebased onto today's #1012/#1013 sweeps: the root `package.json`/`package-lock.json` rename was absorbed by #1012 and is dropped; the `PLUGIN_ID` refactor now sits on #1013's `cauraPlugin` rename.)

- **plugin**: replace the three duplicated plugin-id literals (`index.ts` ×2, `context-engine.ts` `info.id`) with the `PLUGIN_ID` constant from `config.ts` — zero-behaviour refactor, the value is unchanged; the constant keeps its `legacy-name-ok` marker and its sentinel pin. `registerContextEngine` and the `backend`/`provider` values are deliberately untouched (decision-7 soft floor).
- **core-api** `routes/plugin.py`: the served setup script's mktemp template no longer mints an old-brand `/tmp` filename on every install (rule 7). Only reference repo-wide.
- **common/**: stale enterprise repo slug in the `serve.py` / `structlog_config.py` vendoring docstrings and the `ruff.toml` header → current slugs. Lands OSS-first per rule 6; enterprise picks it up on the nightly re-vendor (−2 there for free).

## Verification (post-rebase)

- Ratchet `--base origin/main`: **−7 net, no new lines**
- Do-not-touch sentinel: pass
- Plugin: `tsc` clean, **425/425** tests
- Ruff at CI's exact scope: clean