### PR TITLE
docs(rebrand): two comments that use the old brand as the product's name

### DIFF
--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -826,7 +826,7 @@ async def install_skill_script(
         ),
     ),
 ):
-    """Bash installer for the direct-MCP memclaw skill.
+    """Bash installer for the direct-MCP Caura skill.
 
     Serves a shell script that fetches the SKILL.md adapter for the requested
     skill (default: memclaw) and writes it to the user-scope skills directory

--- a/plugin/src/heartbeat.ts
+++ b/plugin/src/heartbeat.ts
@@ -489,7 +489,7 @@ export async function sendHeartbeat(): Promise<void> {
       : false;
     const educated = existsSync(join(getPluginDir(), ".educated"));
 
-    // Check workspace files for MemClaw references. SKILL.md is no longer a
+    // Check workspace files for Caura references. SKILL.md is no longer a
     // per-workspace artifact — it ships at the plugin root and is discovered
     // by OpenClaw via `openclaw.plugin.json:skills`. The shared skill file's
     // presence is checked once below and reported on setup_status.


### PR DESCRIPTION
Comment-only follow-up to the comment scan: of 216 unmarked old-brand comment/docstring lines in this repo, ~166 quote a still-real identifier (plugin id, skill slug, `## …` on-disk headings, topic names, workspace paths) and are deliberately untouched — rewording those would make them describe names that don't exist; they await the `legacy-name-floor` marking pass. Only the lines where the old brand names the **product** are flipped:

- `plugin/src/config.ts` — allowlist rationale comment
- `plugin/src/heartbeat.ts` — workspace-scan comment
- `core-api/src/core_api/routes/plugin.py` — skill-installer docstring headline (the `(default: memclaw)` slug reference on the following line is a real value and stays)

**Verification**: ratchet `--base HEAD` −3 net / no new lines · sentinel pass · plugin `tsc` + 425/425 tests · ruff `core-api/src` check+format clean