### PR TITLE
fix(interview): stop the sweep reporting silent failure as an idle tick

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2651,9 +2651,19 @@ class CoreStorageClient:
             raise RuntimeError("core-storage-api /tenants/agent-digest-enabled returned 404")
         return result.get("org_ids", [])
 
-    async def list_interviewer_enabled_orgs(self) -> list[str]:
-        """Orgs whose ``interviewer.enabled`` setting is True."""
-        result = await self._get("/tenants/interviewer-enabled")
+    async def list_interviewer_enabled_orgs(self, *, read: bool = True) -> list[str]:
+        """Orgs whose ``interviewer.enabled`` setting is True.
+
+        ``read`` defaults to True — the replica is right for anything merely
+        displaying the set. The interviewer sweep passes ``read=False``: it is
+        the entry point that decides which tenants get looked at *at all*, so
+        replica lag there does not delay one record, it drops a whole tenant
+        from the tick and everything under it. A tenant that enables the
+        interviewer and is swept before the row replicates is skipped
+        entirely, with a summary that reports success. Same reason the sweep
+        already pins the writer for its watermark read.
+        """
+        result = await self._get("/tenants/interviewer-enabled", read=read)
         if result is None:
             raise RuntimeError("core-storage-api /tenants/interviewer-enabled returned 404")
         return result.get("org_ids", [])

--- a/core-api/src/core_api/services/interview_service.py
+++ b/core-api/src/core_api/services/interview_service.py
@@ -1096,7 +1096,10 @@ async def process_pending_interview_jobs(limit_per_tenant: int = 20) -> dict:
     """
     sc = get_storage_client()
     now = datetime.now(UTC)
-    tenants = await list_tenants_with_interviewer_enabled()
+    # read=False → primary, same reason as the watermark read below: this call
+    # selects which tenants are swept at all, so replica lag drops a tenant
+    # from the tick entirely rather than merely returning it a stale field.
+    tenants = await list_tenants_with_interviewer_enabled(read=False)
     summary = {
         "tenants": len(tenants),
         "jobs_processed": 0,
@@ -1234,7 +1237,10 @@ async def run_interview_schedule() -> dict:
     """
     sc = get_storage_client()
     now = datetime.now(UTC)
-    tenants = await list_tenants_with_interviewer_enabled()
+    # read=False → primary, same reason as the watermark read below: this call
+    # selects which tenants are swept at all, so replica lag drops a tenant
+    # from the tick entirely rather than merely returning it a stale field.
+    tenants = await list_tenants_with_interviewer_enabled(read=False)
     summary = {
         "tenants": len(tenants),
         "nodes_considered": 0,
@@ -1321,10 +1327,26 @@ async def run_interview_schedule() -> dict:
     # the sweep succeeds or raises — callers index these keys directly.
     for key in ("jobs_processed", "jobs_done", "jobs_retried", "jobs_parked", "jobs_skipped"):
         summary[key] = 0
+    # ``jobs_sweep_ok`` exists because the zero-init above is otherwise
+    # indistinguishable from a healthy idle sweep: a total failure and "no
+    # pending jobs" both answer 200 with five zeros. The hourly cron reads
+    # this endpoint, so a sweep that raised on every tick would look exactly
+    # like a quiet queue for as long as nobody read the logs. Keep the 200 —
+    # the scheduling half of the summary above is still valid and still worth
+    # returning — but say which of the two happened.
+    summary["jobs_sweep_ok"] = True
     try:
         jobs_summary = await process_pending_interview_jobs()
-    except Exception:
+    except Exception as exc:
         logger.exception("interview schedule: pending-jobs sweep failed")
+        summary["jobs_sweep_ok"] = False
+        # Type name only. The full exception is already in the log line above,
+        # and this string lands in an HTTP response body — some ``__str__``
+        # implementations carry hostnames, URLs or request fragments, which is
+        # the same reason ``_storage_detail`` refuses to forward a raw error
+        # body to a caller. The type is what a dashboard branches on; the
+        # detail belongs where it already is.
+        summary["jobs_sweep_error"] = type(exc).__name__
     else:
         for key in ("jobs_processed", "jobs_done", "jobs_retried", "jobs_parked", "jobs_skipped"):
             summary[key] = jobs_summary.get(key, 0)

--- a/core-api/src/core_api/services/tenants.py
+++ b/core-api/src/core_api/services/tenants.py
@@ -56,10 +56,14 @@ async def list_tenants_with_agent_digest_enabled(db: AsyncSession | None = None)
     return await get_storage_client().list_agent_digest_enabled_orgs()
 
 
-async def list_tenants_with_interviewer_enabled(db: AsyncSession | None = None) -> list[str]:
+async def list_tenants_with_interviewer_enabled(
+    db: AsyncSession | None = None, *, read: bool = True
+) -> list[str]:
     """Return ``org_id`` values whose ``interviewer.enabled`` is True, sorted.
 
     Used by the interviewer schedule tick so a tenant that hasn't opted in pays
     zero cost. Orgs without a settings row are excluded (default off). ``db`` is
-    ignored (reads via core-storage-api)."""
-    return await get_storage_client().list_interviewer_enabled_orgs()
+    ignored (reads via core-storage-api). Pass ``read=False`` to pin the writer —
+    the sweep does, because this call decides which tenants are considered at
+    all and a lagging replica silently drops one for a whole tick."""
+    return await get_storage_client().list_interviewer_enabled_orgs(read=read)

--- a/tests/test_interview_sweep_freshness.py
+++ b/tests/test_interview_sweep_freshness.py
@@ -1,0 +1,110 @@
+"""The interviewer sweep's two silent-failure modes.
+
+Both were found chasing an intermittent failure in
+``test_interview_async_submit.py``, where a sweep reported ``jobs_processed:
+0`` one line after the test had asserted its own job was ``pending``. Neither
+fix is proven to be that flake's trigger — that remains unreproduced under
+instrumentation — but both are real, both make the sweep lie about its own
+outcome, and the first turns exactly that assertion failure from an
+uninformative ``assert 0 >= 1`` into a named error.
+
+1. ``run_interview_schedule`` caught every exception from the job sweep and
+   returned the zero-initialised counters, so a sweep that raised was
+   byte-identical to a sweep that found nothing to do — over a 200.
+2. The enabled-tenant list was read from the replica. It is not one field
+   among many: it decides which tenants are examined at all, so lag drops a
+   whole tenant from the tick rather than returning it something stale.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core_api.services import interview_service
+from core_api.services import tenants as tenants_service
+
+
+async def test_a_failed_job_sweep_is_distinguishable_from_an_idle_one(monkeypatch):
+    """Without ``jobs_sweep_ok`` the two are the same five zeros and a 200 —
+    which is how a sweep raising on every hourly tick reads as a quiet queue."""
+
+    async def _no_tenants(*a, **kw):
+        return []
+
+    async def _boom(*a, **kw):
+        raise RuntimeError("db://user:pw@internal-host/secret path=/etc/x")
+
+    monkeypatch.setattr(interview_service, "list_tenants_with_interviewer_enabled", _no_tenants)
+    monkeypatch.setattr(interview_service, "process_pending_interview_jobs", _boom)
+
+    summary = await interview_service.run_interview_schedule()
+
+    assert summary["jobs_processed"] == 0
+    assert summary["jobs_sweep_ok"] is False
+    assert summary["jobs_sweep_error"] == "RuntimeError"
+    # The type is the whole payload: this string goes out in an HTTP response,
+    # and an exception's own message may carry a host, URL or request fragment.
+    # The full text stays in the log line the service already emits.
+    assert "internal-host" not in summary["jobs_sweep_error"]
+    assert "/etc/x" not in summary["jobs_sweep_error"]
+
+
+async def test_a_healthy_idle_sweep_reports_ok(monkeypatch):
+    """The other half of the distinction — zeros alone must not imply failure."""
+
+    async def _no_tenants(*a, **kw):
+        return []
+
+    monkeypatch.setattr(interview_service, "list_tenants_with_interviewer_enabled", _no_tenants)
+
+    summary = await interview_service.run_interview_schedule()
+
+    assert summary["jobs_processed"] == 0
+    assert summary["jobs_sweep_ok"] is True
+    assert "jobs_sweep_error" not in summary
+
+
+@pytest.mark.parametrize(
+    "sweep",
+    ["process_pending_interview_jobs", "run_interview_schedule"],
+)
+async def test_both_sweeps_read_the_enabled_tenant_list_from_the_writer(monkeypatch, sweep):
+    """``read=False`` on the call that selects which tenants exist for this
+    tick. A lagging replica here does not stale one field — it removes a
+    tenant, and everything under it, from the sweep entirely, while the
+    summary still reports success."""
+    seen: list[bool] = []
+
+    # ``*_a`` rather than naming ``db``: the real helper still accepts it
+    # positionally, but this spy never touches it, and a dead ``db`` parameter
+    # is exactly what tests/test_fixture_hygiene.py refuses — it makes callers
+    # request a session that goes nowhere.
+    async def _spy(*_a, read: bool = True):
+        seen.append(read)
+        return []
+
+    monkeypatch.setattr(interview_service, "list_tenants_with_interviewer_enabled", _spy)
+
+    await getattr(interview_service, sweep)()
+
+    assert seen, "the sweep did not consult the enabled-tenant list at all"
+    assert all(r is False for r in seen), f"expected read=False (writer), got {seen}"
+
+
+async def test_the_service_helper_forwards_read_to_the_storage_client(monkeypatch):
+    """The seam the sweeps rely on — if this silently drops ``read`` the fix
+    above is cosmetic and the sweeps go back to the replica."""
+    seen: dict = {}
+
+    class _FakeClient:
+        async def list_interviewer_enabled_orgs(self, *, read: bool = True):
+            seen["read"] = read
+            return ["t1"]
+
+    monkeypatch.setattr(tenants_service, "get_storage_client", lambda: _FakeClient())
+
+    assert await tenants_service.list_tenants_with_interviewer_enabled(read=False) == ["t1"]
+    assert seen["read"] is False
+
+    assert await tenants_service.list_tenants_with_interviewer_enabled() == ["t1"]
+    assert seen["read"] is True, "default must stay on the replica for display callers"


### PR DESCRIPTION
Two ways the interviewer sweep could report success while having done nothing. Both were found chasing an intermittent failure in `tests/test_interview_async_submit.py`; see the honesty note at the bottom about what this does and does not close.

## 1. A failed job sweep is indistinguishable from an idle one

`run_interview_schedule()` zero-inits the five job counters, then:

```python
try:
    jobs_summary = await process_pending_interview_jobs()
except Exception:
    logger.exception("interview schedule: pending-jobs sweep failed")
```

A sweep that raised therefore returned **exactly** what a sweep with nothing to do returns — `jobs_processed: 0` and four more zeros, over a `200`. The zero-init is deliberate and correct (callers index these keys directly), but it means the failure is only visible in the logs.

The hourly core-operations tick POSTs this endpoint. A sweep raising on every tick reads as a quiet queue for as long as nobody goes looking at logs.

Fixed by keeping the `200` — the scheduling half of the summary above is still valid and still worth returning — and adding `jobs_sweep_ok` plus `jobs_sweep_error` so the two states are tellable apart. The counter keys keep their unconditional zero-init, so the schema is unchanged for existing callers.

## 2. The enabled-tenant list was read from the replica

`list_interviewer_enabled_orgs()` took no `read` parameter at all, while siblings on the same client (`get_document`, `get_report`, `find_by_content_hash`) all do. It resolves to `tenants_list_interviewer_enabled()`, which uses `get_read_session()`.

This is not one stale field among many. It is the call that decides **which tenants are examined at all**, so replica lag does not return a tenant something out of date — it removes that tenant, and every node and job under it, from the tick entirely. And by design the summary then reports success, because from the sweep's point of view there was simply nothing there.

The same function already pins the writer 140 lines further down, for a strictly smaller problem:

```python
# read=False → primary, matching the advance path: a stale
# replica cursor would re-issue a consumed window ...
watermark = await sc.get_document(..., read=False)
```

Fixed by threading `read` through the client and the `services/tenants.py` helper, and passing `read=False` at both sweep call sites. Both additions are keyword-only with `read: bool = True`, so every display-path caller is unchanged.

## Tests

New `tests/test_interview_sweep_freshness.py`, five cases. Mutation-checked — each mutation killed by exactly its intended test, `__pycache__` purged before each:

```
BASELINE                                  5 passed
restore the exception swallow             1 failed  ..._failed_job_sweep_is_distinguishable...
sweeps back to the replica                2 failed  ..._both_sweeps_read_..._from_the_writer (both params)
helper silently drops read=               1 failed  ..._service_helper_forwards_read...
RESTORED                                  5 passed
```

The `read=` test is parameterised over **both** sweeps, because only one of the two call sites is on the path the flaky test exercises — fixing one and not the other is exactly the shape of the bug being fixed.

## Gates

`ruff check core-api/src/` clean · `ruff format --check core-api/src/` clean (201 files) · `mypy src/` clean (201 files) · ratchet and sentinel green · `tests/test_interview_async_submit.py` + `tests/test_api_interview.py` + the new file: **48 passed**.

## What this does not close

**The flake itself is not proven fixed, and I would rather say so than imply otherwise.**

It reproduced twice in three early runs, then survived eight further runs under instrumentation without recurring, so I never captured the failing path. What is established: the assertion is `assert 0 >= 1` on `jobs_processed`, which increments once per result unconditionally — so the collected job list was empty, or the sweep raised and was swallowed by the code fixed in §1.

Also worth recording, because it was the prevailing theory and it is wrong: **replica lag cannot be the local cause.** `tests/conftest.py` points `_session_factory` and `_read_session_factory` at the same engine — "reader and writer share the same engine in tests (no replica spun up)". Fix §2 is a real production bug, not the flake's trigger.

What §1 does buy: the next occurrence carries a named error instead of `assert 0 >= 1`, which is the difference between a diagnosable failure and another archaeology session.