### PR TITLE
feat(entities): write the extraction-derived subject back to the memory row (A63)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -588,6 +588,21 @@ class CoreStorageClient:
     async def soft_delete_memory(self, memory_id: str) -> bool:
         return await self._delete(f"/memories/{memory_id}")
 
+    async def set_subject_entity_if_null(
+        self, memory_id: str, tenant_id: str, subject_entity_id: str
+    ) -> bool:
+        """A63 — conditional subject write-back from the extraction worker.
+
+        Storage-side single UPDATE guarded by ``subject_entity_id IS
+        NULL`` (the write-time triple path's value wins). Returns whether
+        the row was actually updated; ``False`` is a benign skip."""
+        result = await self._post(
+            f"/memories/{memory_id}/subject-entity",
+            {"tenant_id": tenant_id, "subject_entity_id": subject_entity_id},
+            read=False,
+        )
+        return bool(result and result.get("updated"))
+
     async def update_memory_status(
         self,
         memory_id: str,

--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -416,6 +416,55 @@ async def process_entity_extraction(
                         memory_id,
                     )
 
+            # ---- Step 3b: subject write-back (A63) ----
+            #
+            # ``memories.subject_entity_id`` is NULL on nearly every row
+            # because the write-time triple path (CAURA-123) only fires on
+            # narrow predicate regexes — which keeps the deterministic RDF
+            # contradiction path and the A1 #17 cross-subject preflight
+            # dormant, and blocks subject-scoped candidate selection.
+            # The extraction LLM already names a subject: when the links
+            # we just wrote contain EXACTLY ONE distinct subject-role
+            # entity, write it back. Ambiguity (0 or 2+ subjects) skips —
+            # a wrong subject is worse than none, because downstream
+            # gates treat the column as authoritative (A1 #17 compares it
+            # across rows). Storage-side the update is guarded by
+            # ``subject_entity_id IS NULL`` so a triple-path value or a
+            # concurrent delivery's write is never clobbered.
+            subject_ids = {
+                str(name_to_id[name])
+                for name, _et, role in filtered
+                if role == "subject" and name in name_to_id
+            }
+            if len(subject_ids) == 1:
+                subject_id = next(iter(subject_ids))
+                try:
+                    updated = await sc.set_subject_entity_if_null(
+                        memory_id=str(memory_id),
+                        tenant_id=tenant_id,
+                        subject_entity_id=subject_id,
+                    )
+                    logger.info(
+                        "subject_writeback memory=%s subject_entity_id=%s outcome=%s",
+                        memory_id,
+                        subject_id,
+                        "set" if updated else "kept_existing",
+                    )
+                except Exception:
+                    # Non-fatal: the row simply stays subject-less, which
+                    # is exactly today's behaviour.
+                    logger.warning(
+                        "subject_writeback failed for memory %s (non-fatal)",
+                        memory_id,
+                        exc_info=True,
+                    )
+            elif len(subject_ids) > 1:
+                logger.info(
+                    "subject_writeback memory=%s outcome=skipped_ambiguous n_subjects=%d",
+                    memory_id,
+                    len(subject_ids),
+                )
+
         # Upsert relations. Endpoints resolve by raw name first (today's
         # contract), then by ``canonical_match_key`` — the WT-2 dedupe above
         # can collapse a surface form out of ``filtered`` (e.g. ``analytics

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -503,6 +503,24 @@ async def bulk_find_by_content_hashes(request: Request) -> dict:
     return {ch: {"id": str(v["id"]), "client_request_id": v["client_request_id"]} for ch, v in result.items()}
 
 
+@router.post("/{memory_id}/subject-entity")
+async def set_subject_entity_if_null(memory_id: UUID, request: Request) -> dict:
+    """A63 — conditional write-back of the extraction-derived subject.
+
+    Sets ``memories.subject_entity_id`` ONLY when it is currently NULL —
+    the write-time triple path's value always wins. Returns
+    ``{"updated": bool}``; ``false`` covers absent / deleted /
+    foreign-tenant / already-set rows alike (callers treat it as a skip).
+    """
+    body: dict = await request.json()
+    updated = await _svc.memory_set_subject_entity_if_null(
+        memory_id=memory_id,
+        tenant_id=body["tenant_id"],
+        subject_entity_id=UUID(body["subject_entity_id"]),
+    )
+    return {"updated": updated}
+
+
 @router.get("/rdf-conflicts")
 async def find_rdf_conflicts(
     tenant_id: str,

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1140,6 +1140,36 @@ class PostgresService:
                     )
         return True
 
+    async def memory_set_subject_entity_if_null(
+        self, memory_id: UUID, tenant_id: str, subject_entity_id: UUID
+    ) -> bool:
+        """A63 — write-back of the extraction-derived subject entity.
+
+        One conditional UPDATE, guarded by ``subject_entity_id IS NULL``:
+        the write-time triple path (``EmitMemoryTriple``, CAURA-123) is
+        the higher-fidelity source when it fired — its value came from a
+        deterministic predicate match on the original text — so this
+        async write-back must never clobber it. The guard also makes
+        concurrent deliveries race-safe without a read-modify-write.
+
+        Returns ``True`` when the row was updated; ``False`` when the row
+        is absent, soft-deleted, belongs to another tenant, or already
+        carries a subject — callers log the distinction but treat all
+        ``False`` cases as a benign skip.
+        """
+        async with get_session() as session:
+            result = await session.execute(
+                sql_update(Memory)
+                .where(
+                    Memory.id == memory_id,
+                    Memory.tenant_id == tenant_id,
+                    Memory.deleted_at.is_(None),
+                    Memory.subject_entity_id.is_(None),
+                )
+                .values(subject_entity_id=subject_entity_id)
+            )
+            return (result.rowcount or 0) > 0  # type: ignore[attr-defined]
+
     async def memory_update_status(
         self,
         memory_id: UUID,

--- a/core-storage-api/tests/test_subject_writeback.py
+++ b/core-storage-api/tests/test_subject_writeback.py
@@ -1,0 +1,120 @@
+"""A63 — conditional subject write-back route.
+
+``POST /memories/{id}/subject-entity`` sets ``subject_entity_id`` ONLY
+when the column is NULL: the write-time triple path's value (CAURA-123)
+always wins over the async extraction-derived one, and concurrent
+deliveries can't clobber each other. Integration tests against real PG
+because the whole contract is one conditional UPDATE.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+import uuid
+
+from httpx import AsyncClient
+
+from common.constants import VECTOR_DIM
+
+PREFIX = "/api/v1/storage"
+
+
+def _fake_embedding(seed: str, dim: int = VECTOR_DIM) -> list[float]:
+    """Deterministic unit-length embedding — mirrors test_integration's helper."""
+    h = hashlib.sha256(seed.encode()).digest()
+    raw = h * (dim // len(h) + 1)
+    values = [struct.unpack_from("b", raw, i)[0] / 128.0 for i in range(dim)]
+    norm = sum(v * v for v in values) ** 0.5
+    return [v / norm for v in values]
+
+
+async def _create_memory(client: AsyncClient, tenant_id: str, fleet_id: str) -> str:
+    content = f"subject writeback test memory {tenant_id} {uuid.uuid4().hex[:8]}"
+    resp = await client.post(
+        f"{PREFIX}/memories",
+        json={
+            "tenant_id": tenant_id,
+            "fleet_id": fleet_id,
+            "agent_id": "a63-test-agent",
+            "memory_type": "fact",
+            "content": content,
+            "embedding": _fake_embedding(content),
+            "content_hash": hashlib.sha256(content.encode()).hexdigest(),
+            "weight": 0.7,
+            "visibility": "scope_team",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _create_entity(client: AsyncClient, tenant_id: str, fleet_id: str, name: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/entities",
+        json={
+            "tenant_id": tenant_id,
+            "fleet_id": fleet_id,
+            "entity_type": "person",
+            "canonical_name": name,
+            "attributes": {},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+class TestSubjectWriteback:
+    async def test_sets_when_null_and_visible_on_read(
+        self, client: AsyncClient, tenant_id: str, fleet_id: str
+    ) -> None:
+        memory_id = await _create_memory(client, tenant_id, fleet_id)
+        entity_id = await _create_entity(client, tenant_id, fleet_id, "Priya Writeback")
+
+        resp = await client.post(
+            f"{PREFIX}/memories/{memory_id}/subject-entity",
+            json={"tenant_id": tenant_id, "subject_entity_id": entity_id},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"updated": True}
+
+        row = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        assert row["subject_entity_id"] == entity_id
+
+    async def test_never_clobbers_an_existing_subject(
+        self, client: AsyncClient, tenant_id: str, fleet_id: str
+    ) -> None:
+        memory_id = await _create_memory(client, tenant_id, fleet_id)
+        first = await _create_entity(client, tenant_id, fleet_id, "First Subject")
+        second = await _create_entity(client, tenant_id, fleet_id, "Second Subject")
+
+        r1 = await client.post(
+            f"{PREFIX}/memories/{memory_id}/subject-entity",
+            json={"tenant_id": tenant_id, "subject_entity_id": first},
+        )
+        assert r1.json() == {"updated": True}
+
+        r2 = await client.post(
+            f"{PREFIX}/memories/{memory_id}/subject-entity",
+            json={"tenant_id": tenant_id, "subject_entity_id": second},
+        )
+        assert r2.json() == {"updated": False}
+
+        row = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        assert row["subject_entity_id"] == first
+
+    async def test_foreign_tenant_matches_no_row(
+        self, client: AsyncClient, tenant_id: str, fleet_id: str
+    ) -> None:
+        memory_id = await _create_memory(client, tenant_id, fleet_id)
+        entity_id = await _create_entity(client, tenant_id, fleet_id, "Cross Tenant Subject")
+
+        resp = await client.post(
+            f"{PREFIX}/memories/{memory_id}/subject-entity",
+            json={"tenant_id": f"other-{tenant_id}", "subject_entity_id": entity_id},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"updated": False}
+
+        row = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        assert row["subject_entity_id"] is None

--- a/tests/test_a63_subject_writeback.py
+++ b/tests/test_a63_subject_writeback.py
@@ -1,0 +1,194 @@
+"""A63 — the extraction worker writes the subject back to the memory row.
+
+``memories.subject_entity_id`` was NULL on nearly every row (CAURA-123's
+``EmitMemoryTriple`` only fires on narrow write-time predicate regexes),
+which kept the deterministic RDF contradiction path and the A1 #17
+cross-subject preflight dormant. The extraction LLM already names a
+subject per entity; after link creation the worker now writes it back —
+under strict conservatism:
+
+- EXACTLY ONE distinct subject-role entity → write it back (storage-side
+  guarded by ``subject_entity_id IS NULL``, triple-path value wins).
+- Zero or 2+ distinct subjects → skip. A wrong subject is worse than
+  none, because A1 #17 compares the column across rows as authoritative.
+- Two surface forms resolving to the SAME entity id count as one subject.
+- A write-back failure is non-fatal — extraction (and the Path C
+  dispatch behind it) proceeds exactly as before.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from core_api.services.entity_extraction_worker import process_entity_extraction
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+def _config(**overrides):
+    cfg = MagicMock()
+    cfg.auto_entity_linking_enabled = False
+    cfg.entity_blocklist = frozenset()
+    cfg.entity_extraction_provider = "openai"
+    cfg.entity_extraction_model = "gpt-4o-mini"
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _entity(name: str, entity_type: str = "person", role: str = "subject") -> MagicMock:
+    e = MagicMock()
+    e.canonical_name = name
+    e.entity_type = entity_type
+    e.role = role
+    return e
+
+
+def _graph(entities: list[MagicMock]) -> MagicMock:
+    g = MagicMock()
+    g.entities = entities
+    g.relations = []
+    return g
+
+
+def _sc(entity_ids: list[str]) -> MagicMock:
+    """Storage mock where entity i resolves as a fresh create with
+    ``entity_ids[i]``."""
+    sc = MagicMock()
+    sc.bulk_resolve_entities = AsyncMock(return_value=[None] * len(entity_ids))
+    sc.bulk_upsert_entities = AsyncMock(
+        return_value=[
+            {"input_idx": i, "entity_id": eid, "action": "created"}
+            for i, eid in enumerate(entity_ids)
+        ]
+    )
+    sc.bulk_upsert_entity_links = AsyncMock(
+        return_value=[{"input_idx": i, "created": True} for i in range(len(entity_ids))]
+    )
+    sc.set_subject_entity_if_null = AsyncMock(return_value=True)
+    return sc
+
+
+async def _run(mock_extract_graph, sc, memory_id=None):
+    with (
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(return_value=_config()),
+        ),
+        patch(
+            "core_api.services.entity_extraction_worker.extract_entities_from_content",
+            new=AsyncMock(return_value=mock_extract_graph),
+        ),
+        patch(
+            "core_api.services.entity_extraction_worker.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.entity_extraction_worker.get_embedding",
+            new=AsyncMock(return_value=[0.1] * 8),
+        ),
+        patch("core_api.services.entity_extraction_worker.log_action", new=AsyncMock()),
+        patch("core_api.tasks.track_task"),
+    ):
+        await process_entity_extraction(
+            memory_id=memory_id or uuid4(),
+            tenant_id="t1",
+            fleet_id=None,
+            agent_id="a1",
+            content="test content",
+            memory_type="fact",
+        )
+
+
+async def test_single_subject_written_back() -> None:
+    subject_id = str(uuid4())
+    other_id = str(uuid4())
+    sc = _sc([subject_id, other_id])
+    memory_id = uuid4()
+
+    await _run(
+        _graph(
+            [
+                _entity("Priya Nair", role="subject"),
+                _entity("ingest pipeline", "project", role="mentioned"),
+            ]
+        ),
+        sc,
+        memory_id=memory_id,
+    )
+
+    sc.set_subject_entity_if_null.assert_awaited_once_with(
+        memory_id=str(memory_id), tenant_id="t1", subject_entity_id=subject_id
+    )
+
+
+async def test_multiple_distinct_subjects_skip() -> None:
+    sc = _sc([str(uuid4()), str(uuid4())])
+    await _run(
+        _graph([_entity("Priya", role="subject"), _entity("Tom", role="subject")]), sc
+    )
+    sc.set_subject_entity_if_null.assert_not_awaited()
+
+
+async def test_no_subject_role_skips() -> None:
+    sc = _sc([str(uuid4()), str(uuid4())])
+    await _run(
+        _graph(
+            [
+                _entity("Acme", "organization", role="mentioned"),
+                _entity("Bazel", "tool", role="object"),
+            ]
+        ),
+        sc,
+    )
+    sc.set_subject_entity_if_null.assert_not_awaited()
+
+
+async def test_two_surface_forms_same_entity_count_as_one_subject() -> None:
+    shared_id = str(uuid4())
+    sc = MagicMock()
+    sc.bulk_resolve_entities = AsyncMock(return_value=[None, None])
+    # Both surface forms upsert to the SAME entity row.
+    sc.bulk_upsert_entities = AsyncMock(
+        return_value=[
+            {"input_idx": 0, "entity_id": shared_id, "action": "created"},
+            {"input_idx": 1, "entity_id": shared_id, "action": "merged"},
+        ]
+    )
+    sc.bulk_upsert_entity_links = AsyncMock(
+        return_value=[{"input_idx": 0, "created": True}]
+    )
+    sc.set_subject_entity_if_null = AsyncMock(return_value=True)
+
+    await _run(
+        _graph(
+            [_entity("Priya", role="subject"), _entity("Priya Nair", role="subject")]
+        ),
+        sc,
+    )
+
+    sc.set_subject_entity_if_null.assert_awaited_once()
+    assert (
+        sc.set_subject_entity_if_null.await_args.kwargs["subject_entity_id"]
+        == shared_id
+    )
+
+
+async def test_already_set_row_is_a_benign_skip() -> None:
+    sc = _sc([str(uuid4())])
+    sc.set_subject_entity_if_null = AsyncMock(
+        return_value=False
+    )  # storage kept existing
+    await _run(_graph([_entity("Priya", role="subject")]), sc)
+    sc.set_subject_entity_if_null.assert_awaited_once()
+
+
+async def test_writeback_failure_is_non_fatal() -> None:
+    sc = _sc([str(uuid4())])
+    sc.set_subject_entity_if_null = AsyncMock(side_effect=RuntimeError("storage down"))
+    # Must not raise — extraction completes and downstream dispatch still runs.
+    await _run(_graph([_entity("Priya", role="subject")]), sc)
+    sc.set_subject_entity_if_null.assert_awaited_once()


### PR DESCRIPTION
## Why

First PR of **A63** (judge misses update-style contradictions). `memories.subject_entity_id` is NULL on nearly every row: the write-time triple path (CAURA-123's `EmitMemoryTriple`) only fires on narrow predicate regexes, and the async extraction worker creates entity links without ever writing the subject back. That keeps two shipped mechanisms dormant — the deterministic RDF contradiction path and the A1 #17 cross-subject preflight (which requires the column non-NULL on both sides and so has never fired in practice) — and blocks A63's next step, subject-scoped candidate selection for the contradiction judge.

## What

- **Worker** (`entity_extraction_worker.py`): after link creation — and before the Path C dispatch at the function tail, so the first detection run already sees it — write back the subject under strict conservatism: **exactly one** distinct subject-role entity required (0 or 2+ → `skipped_ambiguous`; a wrong subject is worse than none because A1 #17 treats the column as authoritative); two surface forms resolving to one entity count as one; failures are non-fatal and logged.
- **Storage** (`POST /memories/{id}/subject-entity`): one conditional UPDATE guarded by `subject_entity_id IS NULL` — the triple path's higher-fidelity value is never clobbered, and concurrent deliveries are race-safe without read-modify-write. Column + index already exist (migration-free).
- Observability: `subject_writeback` log line with `outcome=set | kept_existing | skipped_ambiguous`.

## Tested

- 6 worker unit tests (single-subject set, multi-subject skip, no-subject skip, same-entity surface forms, benign already-set, non-fatal failure).
- 3 storage integration tests vs real PG (sets when NULL + visible on read, never clobbers, foreign-tenant no-op).
- Wet test on the local stack: `outcome=set` on real writes, populated `subject_entity_id` on read-back, `skipped_ambiguous n_subjects=4` on a multi-subject row.
- ruff / mypy (core-api + core-storage-api) / full root suite green.

## Next in A63

Predicate canonicalization → subject+predicate candidate selection alongside cosine (the semantically-distant-update miss class, STALE T2) → re-cut the `temporal_supersession` gate with planted-update bench cases. Note: the regression golden was re-baselined today against current main (post-#1011), so those follow-ups get a meaningful gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)