### PR TITLE
docs: cite this repo as caura, not its former name

### DIFF
--- a/common/http_retry.py
+++ b/common/http_retry.py
@@ -14,7 +14,7 @@ History (load-bearing for the policy split):
   detection, 42 failures) and ``create_audit_logs_bulk`` (audit events
   dropped) both died on first-attempt ``ConnectTimeout`` behind the VPC
   connector because POSTs had no retry at all. Connection-phase retry
-  for non-idempotent methods landed in response (caura-memclaw#333).
+  for non-idempotent methods landed in response (caura#333).
 * 2026-06-16 prod — a steady trickle of ``httpx.ConnectTimeout`` still
   reached core-api on the Pub/Sub enrichment, entity-extraction,
   contradiction and audit-flush paths (storage-api cold starts /

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -6766,7 +6766,7 @@ class PostgresService:
         Uses ``INSERT ... ON CONFLICT (tenant_id, agent_id) DO NOTHING
         RETURNING ...`` paired with a same-session re-SELECT for the
         conflicted case. The same shape ``memory_add_all`` uses for
-        per-attempt idempotency (caura-memclaw#23): it avoids the
+        per-attempt idempotency (caura#23): it avoids the
         ``flush() → IntegrityError → rollback() → re-SELECT`` pattern's
         mid-session rollback, which is brittle (the rollback aborts any
         other pending writes in the same session) and forced

--- a/core-worker/tests/test_storage_client_retry.py
+++ b/core-worker/tests/test_storage_client_retry.py
@@ -1,4 +1,4 @@
-"""Connection-phase retry in ``_signed_call`` (port of caura-memclaw#333).
+"""Connection-phase retry in ``_signed_call`` (port of caura#333).
 
 Prod 2026-06-11: core-api's unretried storage POSTs died on
 first-attempt ``httpx.ConnectTimeout`` behind the VPC connector

--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -572,7 +572,7 @@ async def test_search_pipeline_empty_results():
 
 # ---------------------------------------------------------------------------
 # Recall of a memory whose embedding backfill has not landed yet
-# (caura-memclaw#687)
+# (caura#687)
 # ---------------------------------------------------------------------------
 
 
@@ -660,7 +660,7 @@ async def test_recall_returns_memory_with_pending_embedding(db, monkeypatch, use
 
     assert str(created.id) in {str(r.id) for r in results}, (
         f"a memory whose embedding backfill has not landed was not returned by "
-        f"recall (caura-memclaw#687). query={token!r} matched the row's content "
+        f"recall (caura#687). query={token!r} matched the row's content "
         f"exactly and search_vector @@ plainto_tsquery is true, yet search "
         f"returned {len(results)} other row(s): "
         f"{[str(r.id) for r in results]}"


### PR DESCRIPTION
Five stale citations of **this repository** by its former name, in docstrings, comments and one assertion message:

```
common/http_retry.py:17                          caura-memclaw#333 -> caura#333
core-storage-api/.../postgres_service.py:6739    caura-memclaw#23  -> caura#23
core-worker/tests/test_storage_client_retry.py:1 caura-memclaw#333 -> caura#333
tests/pipeline/test_search_pipeline.py:575,663   caura-memclaw#687 -> caura#687
```

The repo is `caura`. The PR numbers are unchanged and GitHub redirects the old path either way, so nothing is being repointed — the text was simply describing a name that no longer exists.

## Scope

Prose only. **No identifier, resource, image, wire format or credential is touched.** That matters here more than usual, because most remaining `memclaw` strings in this repo are load-bearing rather than stale — the compatibility aliases (`export const MemClaw = Caura`), the plugin id in users' configs, the `## MemClaw —` markers written into existing workspaces, the skill name users type, `MEMCLAW_*` env vars, and the CI Postgres role that must keep mirroring prod until Wave 5a moves it. Those all stay.

The one non-comment change is an assertion **message**, not an asserted value:

```python
assert str(created.id) in {...}, (
    f"... recall (caura#687). query={token!r} ..."
)
```

Checked that nothing greps or asserts on that text.

## Verification

`ruff check common/ core-storage-api/src/` clean · `ruff format --check` clean (82 files) · sentinel green · ratchet **−5 net, no new lines** · `core-worker/tests/test_storage_client_retry.py` 6 passed.