### PR TITLE
feat(contradiction): Path D — basis invalidation in shadow mode (A58)

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -334,6 +334,15 @@ class Settings(BaseSettings):
     # Additive: it never changes the status/supersedes effect, so retrieval is
     # unaffected. Default False; enable to start populating conflict records.
     contradiction_write_conflict_record: bool = False
+    # A58 — Path D (basis invalidation) in SHADOW mode: after Path A, one
+    # bridge LLM call proposes <=3 other predicates of the same subject whose
+    # practical basis the new memory may have broken; <=2 invalidation-judge
+    # calls produce verdicts that are LOGGED ONLY (``path_d_shadow`` lines).
+    # No status is ever written under this flag — it exists to measure the
+    # Type-II base rate + precision on real corpora before A59 builds the
+    # enforcing path (``unsafe`` status). Skipped when the new memory has no
+    # resolved subject_entity_id.
+    basis_invalidation_shadow: bool = False
     crystallizer_enabled: bool = True
     crystallizer_stale_days: int = 180
     crystallizer_dedup_sample_size: int = 1000

--- a/core-api/src/core_api/services/contradiction/basis_invalidation.py
+++ b/core-api/src/core_api/services/contradiction/basis_invalidation.py
@@ -1,0 +1,308 @@
+"""Path D — basis invalidation, SHADOW MODE (A58).
+
+The Type-II gap: a new memory can destroy the practical basis of an OLD
+memory about a *different* attribute of the same subject ("tore ACL, no
+weight-bearing" retires "commutes by bicycle") without contradicting it.
+Path A's question — "do these two make incompatible claims?" — is the wrong
+question for that failure mode, and cannot be tuned into the right one
+without a false-positive explosion (see
+``Downloads/cupmem_stale_contradiction_analysis.md`` §4.3).
+
+This module ports the portable core of CUP-Mem's write side (STALE paper,
+arXiv:2605.06527 — steps 6-8 of its pipeline) onto memclaw's existing
+``(subject_entity_id, predicate)`` slot model:
+
+    1. bridge (1 LLM call)  — which OTHER predicates of this subject may
+       have had their practical basis broken; menu-gated, ≤3.
+    2. scoped fetch (0 LLM) — active rows for (subject, bridged predicate)
+       via the existing rdf-conflicts endpoint; when the predicate route is
+       empty (predicates are sparsely populated today — A63's
+       canonicalization is still in flight), falls back to the caller's
+       entity-overlap candidates (already fetched by Path C, zero extra
+       storage calls). Verdict lines carry ``route=rdf|overlap`` so the
+       spike can measure both.
+    3. judge (≤2 LLM calls) — INDIRECT_INVALIDATE | WEAK_CHALLENGE |
+       SET_UNKNOWN_CURRENT | NO_OP per surviving candidate.
+
+**SHADOW MODE — this module never writes.** Verdicts are logged
+(``path_d_shadow``) so the Type-II base rate and precision can be measured
+on real corpora before any status write ships (that build is A59, including
+the ``unsafe`` status / migration 037). Flag: ``settings.basis_invalidation_shadow``
+(default off), mirroring ``contradiction_write_conflict_record``.
+
+Failure isolation: the single entry point swallows everything — Path D can
+never affect Path A's outcome or the write path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+from common.constants import SINGLE_VALUE_PREDICATES
+from core_api.clients.storage_client import get_storage_client
+from core_api.config import settings
+from core_api.providers._retry import call_with_fallback
+
+logger = logging.getLogger(__name__)
+
+# Across ALL bridged predicates, at most this many candidates reach the judge
+# (CUP-Mem ``invalidation_merge_max_keep``). Keeps worst-case LLM cost at
+# bridge + 2 judges per write.
+MAX_JUDGED = 2
+MAX_BRIDGE_PREDICATES = 3
+MIN_BRIDGE_CONFIDENCE = 0.5
+
+# Ported guardrails: the "practical basis" vocabulary and the
+# topic-overlap-is-not-enough clause are what keep precision up
+# (BUCKET_BRIDGE_PROPOSER_PROMPT). The menu is a hard gate — an off-menu
+# predicate is dropped, the analog of CUP-Mem's ``is_valid_bucket_track``.
+BASIS_BRIDGE_PROMPT = """\
+A memory store tracks facts about a subject as (predicate, value) pairs. A new \
+memory about this subject just arrived.
+
+New memory: "{new_content}"
+Its predicate (if any): {new_predicate}
+
+MENU of other single-value predicates the store can track:
+{menu}
+
+Propose AT MOST {max_n} predicates FROM THE MENU whose currently stored value \
+may no longer be safe to rely on as the subject's CURRENT default, because the \
+new memory broke its practical basis. Practical basis includes: access, \
+availability, continuity, recoverability, feasibility, responsibility, \
+arrangement, recurring coordination, institutional or status dependency.
+
+Rules:
+- Name the SPECIFIC broken basis for each proposal. Shared life domain, topic \
+overlap, or general relatedness is NOT enough.
+- Only predicates from the menu. If nothing qualifies, return an empty list — \
+an empty list is the common, correct answer.
+
+Return JSON only: {{"affected": [{{"predicate": "<from menu>", \
+"broken_basis": "<one sentence>", "confidence": <0..1>}}]}}"""
+
+# Ported INVALIDATION_JUDGE_PROMPT semantics. The enum is kept verbatim for
+# comparability with the paper; in memclaw terms every non-NO_OP verdict would
+# map to the future ``unsafe`` status (A59).
+BASIS_JUDGE_PROMPT = """\
+New evidence about a subject: "{new_content}"
+
+Old stored memory (predicate "{predicate}" of the same subject): "{old_content}"
+
+Question: does the new evidence BREAK THE PRACTICAL BASIS that made the old \
+memory safe to use as the subject's current default? This is NOT a \
+contradiction check — both statements may be simultaneously true, and the old \
+one can still be unsafe to act on.
+
+Guardrails:
+- Same-subject or topic proximity alone is not enough.
+- Do not invalidate the old memory merely because it is older or related.
+- Decide INDIRECT_INVALIDATE only when you can name the broken basis.
+
+Decisions:
+- INDIRECT_INVALIDATE: the old default's practical basis is broken.
+- WEAK_CHALLENGE: partially undermined; old value should be treated cautiously.
+- SET_UNKNOWN_CURRENT: the old default is unsafe AND no replacement is known.
+- NO_OP: the old memory remains a safe current default.
+
+Return JSON only: {{"decision": "<one of the four>", "reason": "<one \
+sentence naming the basis>", "confidence": <0..1>}}"""
+
+_DECISIONS = {"INDIRECT_INVALIDATE", "WEAK_CHALLENGE", "SET_UNKNOWN_CURRENT", "NO_OP"}
+
+
+def _parse_json(raw: Any) -> dict:
+    if isinstance(raw, dict):
+        return raw
+    try:
+        return json.loads(str(raw))
+    except (ValueError, TypeError):
+        return {}
+
+
+async def _bridge(new_content: str, new_predicate: str | None, menu: list[str], tenant_config) -> list[dict]:
+    prompt = BASIS_BRIDGE_PROMPT.format(
+        new_content=new_content[:500],
+        new_predicate=new_predicate or "(none)",
+        menu=", ".join(menu),
+        max_n=MAX_BRIDGE_PREDICATES,
+    )
+    provider_name = (
+        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
+    )
+
+    async def _do(llm) -> list[dict]:
+        raw = _parse_json(await llm.complete_json(prompt))
+        out = []
+        allowed = set(menu)
+        for p in raw.get("affected", [])[:MAX_BRIDGE_PREDICATES]:
+            pred = str(p.get("predicate", "")).strip()
+            conf = float(p.get("confidence") or 0.0)
+            # hard menu gate + confidence floor — the precision guardrails
+            if pred in allowed and conf >= MIN_BRIDGE_CONFIDENCE:
+                out.append(
+                    {"predicate": pred, "broken_basis": str(p.get("broken_basis", "")), "confidence": conf}
+                )
+        return out
+
+    return await call_with_fallback(
+        primary_provider_name=provider_name,
+        call_fn=_do,
+        fake_fn=lambda: [],
+        tenant_config=tenant_config,
+        service_label="basis_bridge",
+        model_attr="entity_extraction_model",
+        timeout=10.0,
+    )
+
+
+async def _judge(new_content: str, candidate: dict, tenant_config) -> dict:
+    prompt = BASIS_JUDGE_PROMPT.format(
+        new_content=new_content[:500],
+        predicate=candidate.get("predicate", ""),
+        old_content=(candidate.get("content") or "")[:500],
+    )
+    provider_name = (
+        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
+    )
+
+    async def _do(llm) -> dict:
+        raw = _parse_json(await llm.complete_json(prompt))
+        decision = str(raw.get("decision", "NO_OP")).strip().upper()
+        if decision not in _DECISIONS:
+            decision = "NO_OP"
+        return {
+            "decision": decision,
+            "reason": str(raw.get("reason", "")),
+            "confidence": float(raw.get("confidence") or 0.0),
+        }
+
+    return await call_with_fallback(
+        primary_provider_name=provider_name,
+        call_fn=_do,
+        fake_fn=lambda: {"decision": "NO_OP", "reason": "fake provider", "confidence": 0.0},
+        tenant_config=tenant_config,
+        service_label="basis_judge",
+        model_attr="entity_extraction_model",
+        timeout=10.0,
+    )
+
+
+async def run_basis_shadow(
+    new_memory: dict,
+    tenant_id: str,
+    fleet_id: str | None,
+    tenant_config=None,
+    overlap_candidates: list[dict] | None = None,
+) -> dict:
+    """Run Path D end-to-end in shadow mode. Returns a summary dict (for
+    tests and the shadow-spike harness); the only side effect is logging."""
+    t0 = time.monotonic()
+    memory_id = str(new_memory.get("id", ""))
+    summary: dict[str, Any] = {
+        "memory_id": memory_id,
+        "fired": False,
+        "skipped_reason": None,
+        "bridged": [],
+        "verdicts": [],
+    }
+    try:
+        subject = new_memory.get("subject_entity_id")
+        if not subject:
+            # No subject → no dependency graph → no point paying for the call.
+            summary["skipped_reason"] = "no_subject_entity_id"
+            return summary
+        new_content = new_memory.get("content") or ""
+        if not new_content.strip():
+            summary["skipped_reason"] = "empty_content"
+            return summary
+        new_predicate = new_memory.get("predicate") or None
+        menu = sorted(SINGLE_VALUE_PREDICATES - ({new_predicate} if new_predicate else set()))
+
+        bridged = await _bridge(new_content, new_predicate, menu, tenant_config)
+        summary["fired"] = True
+        summary["bridged"] = bridged
+        if not bridged:
+            logger.info(
+                "path_d_shadow completed memory=%s subject=%s bridged=0 verdicts=0 ms=%d",
+                memory_id,
+                subject,
+                int((time.monotonic() - t0) * 1000),
+            )
+            return summary
+
+        sc = get_storage_client()
+        candidates: list[dict] = []
+        route = "rdf"
+        for b in sorted(bridged, key=lambda x: -x["confidence"]):
+            rows = await sc.find_rdf_conflicts(
+                tenant_id=tenant_id,
+                subject_entity_id=str(subject),
+                predicate=b["predicate"],
+                exclude_id=memory_id or None,
+                fleet_id=fleet_id,
+            )
+            for r in rows:
+                if r.get("status") in ("outdated", "deleted"):
+                    continue  # already retired — nothing to invalidate
+                candidates.append({**r, "predicate": b["predicate"], "broken_basis": b["broken_basis"]})
+            if len(candidates) >= MAX_JUDGED:
+                break
+        if not candidates and overlap_candidates:
+            # Fallback: predicates are sparsely populated on real rows today,
+            # so the rdf route often has nothing to key on. Path C's
+            # entity-overlap candidates are the same-subject pool, already
+            # fetched — judge the freshest ones and mark the route.
+            route = "overlap"
+            top_basis = bridged[0]["broken_basis"]
+            for r in overlap_candidates:
+                if str(r.get("id", "")) == memory_id:
+                    continue
+                if r.get("status") in ("outdated", "deleted"):
+                    continue
+                candidates.append(
+                    {**r, "predicate": r.get("predicate") or "(none)", "broken_basis": top_basis}
+                )
+                if len(candidates) >= MAX_JUDGED:
+                    break
+        summary["route"] = route
+        candidates = candidates[:MAX_JUDGED]
+
+        for c in candidates:
+            verdict = await _judge(new_content, c, tenant_config)
+            entry = {
+                "target_memory_id": str(c.get("id", "")),
+                "predicate": c.get("predicate"),
+                "broken_basis": c.get("broken_basis"),
+                **verdict,
+            }
+            summary["verdicts"].append(entry)
+            # One greppable line per verdict — this IS the shadow deliverable.
+            logger.info(
+                "path_d_shadow verdict memory=%s subject=%s target=%s predicate=%s decision=%s confidence=%.2f reason=%s",
+                memory_id,
+                subject,
+                entry["target_memory_id"],
+                entry["predicate"],
+                entry["decision"],
+                entry["confidence"],
+                entry["reason"][:160],
+            )
+
+        logger.info(
+            "path_d_shadow completed memory=%s subject=%s bridged=%d verdicts=%d ms=%d",
+            memory_id,
+            subject,
+            len(bridged),
+            len(summary["verdicts"]),
+            int((time.monotonic() - t0) * 1000),
+        )
+        return summary
+    except Exception:
+        # Shadow mode must be invisible to the write pipeline — log and move on.
+        logger.warning("path_d_shadow failed memory=%s", memory_id, exc_info=True)
+        summary["skipped_reason"] = summary["skipped_reason"] or "error"
+        return summary

--- a/core-api/src/core_api/services/contradiction/basis_invalidation.py
+++ b/core-api/src/core_api/services/contradiction/basis_invalidation.py
@@ -9,7 +9,7 @@ without a false-positive explosion (see
 ``Downloads/cupmem_stale_contradiction_analysis.md`` §4.3).
 
 This module ports the portable core of CUP-Mem's write side (STALE paper,
-arXiv:2605.06527 — steps 6-8 of its pipeline) onto memclaw's existing
+arXiv:2605.06527 — steps 6-8 of its pipeline) onto caura's existing
 ``(subject_entity_id, predicate)`` slot model:
 
     1. bridge (1 LLM call)  — which OTHER predicates of this subject may
@@ -85,7 +85,7 @@ Return JSON only: {{"affected": [{{"predicate": "<from menu>", \
 "broken_basis": "<one sentence>", "confidence": <0..1>}}]}}"""
 
 # Ported INVALIDATION_JUDGE_PROMPT semantics. The enum is kept verbatim for
-# comparability with the paper; in memclaw terms every non-NO_OP verdict would
+# comparability with the paper; in caura terms every non-NO_OP verdict would
 # map to the future ``unsafe`` status (A59).
 BASIS_JUDGE_PROMPT = """\
 New evidence about a subject: "{new_content}"

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -302,6 +302,7 @@ async def detect_contradictions_async(
                 len(contradictions),
                 memory_id,
             )
+
     except Exception:
         logger.exception("Async contradiction detection failed for memory %s", memory_id)
     finally:
@@ -2630,6 +2631,29 @@ async def detect_contradictions_by_entities_async(
                     path_c_result["skipped"],
                 )
         concluded = True
+
+        # A58 — Path D (basis invalidation) SHADOW. Fires HERE, not in Path A:
+        # ``subject_entity_id`` is populated by entity extraction (A63), so at
+        # Path A time it is still NULL on this stack. Runs under Path C's lock
+        # (double back-channel can't double-fire it), reuses this run's
+        # entity-overlap candidates as the fallback pool, logs verdicts,
+        # never writes. Own try/except inside; this guard keeps even an
+        # import error away from Path C's outcome.
+        if settings.basis_invalidation_shadow and new_memory.get("subject_entity_id"):
+            try:
+                from core_api.services.contradiction.basis_invalidation import (
+                    run_basis_shadow,
+                )
+
+                await run_basis_shadow(
+                    new_memory,
+                    tenant_id,
+                    fleet_id,
+                    tenant_config,
+                    overlap_candidates=candidates,
+                )
+            except Exception:
+                logger.warning("path_d_shadow wrapper failed for %s", memory_id, exc_info=True)
     except Exception:
         logger.exception("Entity-based contradiction detection failed for %s", memory_id)
     finally:

--- a/tests/test_a58_basis_shadow.py
+++ b/tests/test_a58_basis_shadow.py
@@ -1,0 +1,282 @@
+"""A58 — Path D basis-invalidation shadow: gating, guardrails, and purity.
+
+The contract under test:
+- fires only with a resolved subject_entity_id (no subject → no LLM spend);
+- the bridge's menu is a HARD gate (off-menu predicates dropped — the
+  ``is_valid_bucket_track`` analog) with a confidence floor;
+- at most MAX_JUDGED candidates ever reach the judge;
+- unknown judge decisions normalize to NO_OP;
+- SHADOW PURITY: the only storage call is the read (find_rdf_conflicts);
+  nothing is ever written, and no exception escapes the entry point.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from core_api.services.contradiction import basis_invalidation as bi
+
+pytestmark = pytest.mark.unit
+
+
+def _mem(
+    subject="ent-1",
+    predicate="commutes_by",
+    content="tore ACL, no weight-bearing for six weeks",
+):
+    return {
+        "id": "m-new",
+        "subject_entity_id": subject,
+        "predicate": predicate,
+        "content": content,
+    }
+
+
+class _FakeLLM:
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def complete_json(self, prompt, **kw):
+        return self.payload
+
+
+def _direct_call_with_fallback(payload):
+    """Replace call_with_fallback with 'just run call_fn against a fake llm'."""
+
+    async def _cwf(
+        *,
+        primary_provider_name,
+        call_fn,
+        fake_fn,
+        tenant_config,
+        service_label,
+        model_attr,
+        timeout,
+    ):
+        return await call_fn(_FakeLLM(payload))
+
+    return _cwf
+
+
+async def test_no_subject_skips_without_llm(monkeypatch):
+    called = AsyncMock()
+    monkeypatch.setattr(bi, "call_with_fallback", called)
+    out = await bi.run_basis_shadow(_mem(subject=None), "t", None)
+    assert out["skipped_reason"] == "no_subject_entity_id"
+    assert out["fired"] is False
+    called.assert_not_awaited()
+
+
+async def test_bridge_menu_is_a_hard_gate(monkeypatch):
+    payload = {
+        "affected": [
+            {
+                "predicate": "commute_vibes",
+                "broken_basis": "x",
+                "confidence": 0.9,
+            },  # off-menu
+            {
+                "predicate": "current_role",
+                "broken_basis": "low",
+                "confidence": 0.2,
+            },  # below floor
+            {
+                "predicate": "current_status",
+                "broken_basis": "injury blocks it",
+                "confidence": 0.8,
+            },
+        ]
+    }
+    monkeypatch.setattr(bi, "call_with_fallback", _direct_call_with_fallback(payload))
+    sc = MagicMock()
+    sc.find_rdf_conflicts = AsyncMock(return_value=[])
+    monkeypatch.setattr(bi, "get_storage_client", lambda: sc)
+    out = await bi.run_basis_shadow(_mem(), "t", None)
+    assert [b["predicate"] for b in out["bridged"]] == ["current_status"]
+
+
+async def test_judge_cap_and_shadow_purity(monkeypatch):
+    bridge_payload = {
+        "affected": [
+            {"predicate": "current_status", "broken_basis": "b1", "confidence": 0.9},
+            {"predicate": "current_role", "broken_basis": "b2", "confidence": 0.8},
+        ]
+    }
+    judge_payload = {
+        "decision": "INDIRECT_INVALIDATE",
+        "reason": "basis broken",
+        "confidence": 0.9,
+    }
+    calls = {"n": 0}
+
+    async def _cwf(
+        *,
+        primary_provider_name,
+        call_fn,
+        fake_fn,
+        tenant_config,
+        service_label,
+        model_attr,
+        timeout,
+    ):
+        calls["n"] += 1
+        payload = bridge_payload if service_label == "basis_bridge" else judge_payload
+        return await call_fn(_FakeLLM(payload))
+
+    monkeypatch.setattr(bi, "call_with_fallback", _cwf)
+    sc = MagicMock()
+    # three active candidates per predicate — more than MAX_JUDGED total
+    sc.find_rdf_conflicts = AsyncMock(
+        return_value=[
+            {"id": f"old-{i}", "status": "active", "content": f"old fact {i}"}
+            for i in range(3)
+        ]
+    )
+    monkeypatch.setattr(bi, "get_storage_client", lambda: sc)
+
+    out = await bi.run_basis_shadow(_mem(), "t", "f1")
+    assert len(out["verdicts"]) == bi.MAX_JUDGED
+    assert calls["n"] == 1 + bi.MAX_JUDGED  # 1 bridge + capped judges
+    # purity: ONLY the read endpoint was touched on storage
+    used = [
+        name
+        for name, m in vars(sc).items()
+        if isinstance(m, AsyncMock) and m.await_count
+    ]
+    assert used == ["find_rdf_conflicts"]
+    assert all(v["decision"] == "INDIRECT_INVALIDATE" for v in out["verdicts"])
+
+
+async def test_retired_candidates_are_not_rejudged(monkeypatch):
+    monkeypatch.setattr(
+        bi,
+        "call_with_fallback",
+        _direct_call_with_fallback(
+            {
+                "affected": [
+                    {
+                        "predicate": "current_status",
+                        "broken_basis": "b",
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+        ),
+    )
+    sc = MagicMock()
+    sc.find_rdf_conflicts = AsyncMock(
+        return_value=[{"id": "old-1", "status": "outdated", "content": "x"}]
+    )
+    monkeypatch.setattr(bi, "get_storage_client", lambda: sc)
+    out = await bi.run_basis_shadow(_mem(), "t", None)
+    assert out["verdicts"] == []
+
+
+async def test_unknown_decision_normalizes_to_no_op(monkeypatch):
+    async def _cwf(
+        *,
+        primary_provider_name,
+        call_fn,
+        fake_fn,
+        tenant_config,
+        service_label,
+        model_attr,
+        timeout,
+    ):
+        payload = (
+            {
+                "affected": [
+                    {
+                        "predicate": "current_status",
+                        "broken_basis": "b",
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+            if service_label == "basis_bridge"
+            else {"decision": "OBLITERATE", "reason": "?", "confidence": 1.0}
+        )
+        return await call_fn(_FakeLLM(payload))
+
+    monkeypatch.setattr(bi, "call_with_fallback", _cwf)
+    sc = MagicMock()
+    sc.find_rdf_conflicts = AsyncMock(
+        return_value=[{"id": "old-1", "status": "active", "content": "x"}]
+    )
+    monkeypatch.setattr(bi, "get_storage_client", lambda: sc)
+    out = await bi.run_basis_shadow(_mem(), "t", None)
+    assert out["verdicts"][0]["decision"] == "NO_OP"
+
+
+async def test_errors_never_escape(monkeypatch):
+    async def _boom(**kw):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(bi, "call_with_fallback", _boom)
+    out = await bi.run_basis_shadow(_mem(), "t", None)
+    assert out["skipped_reason"] == "error"
+    assert out["verdicts"] == []
+
+
+def test_detector_hook_respects_flag():
+    """Default off + the hook is actually wired in the detector source."""
+    from core_api.services import contradiction_detector as cd
+
+    assert cd.settings.basis_invalidation_shadow is False  # default off
+    from pathlib import Path
+
+    src = Path(cd.__file__).read_text()
+    assert "basis_invalidation_shadow" in src
+    assert "run_basis_shadow" in src
+
+
+async def test_overlap_fallback_when_rdf_route_is_empty(monkeypatch):
+    """Predicates are sparse on real rows — when the rdf route returns
+    nothing, the judge runs on the caller's entity-overlap candidates and the
+    summary carries route=overlap."""
+
+    async def _cwf(
+        *,
+        primary_provider_name,
+        call_fn,
+        fake_fn,
+        tenant_config,
+        service_label,
+        model_attr,
+        timeout,
+    ):
+        payload = (
+            {
+                "affected": [
+                    {
+                        "predicate": "current_status",
+                        "broken_basis": "injury",
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+            if service_label == "basis_bridge"
+            else {
+                "decision": "SET_UNKNOWN_CURRENT",
+                "reason": "basis broken, no replacement",
+                "confidence": 0.8,
+            }
+        )
+        return await call_fn(_FakeLLM(payload))
+
+    monkeypatch.setattr(bi, "call_with_fallback", _cwf)
+    sc = MagicMock()
+    sc.find_rdf_conflicts = AsyncMock(return_value=[])  # rdf route empty
+    monkeypatch.setattr(bi, "get_storage_client", lambda: sc)
+    overlap = [
+        {
+            "id": "m-new",
+            "status": "active",
+            "content": "self",
+        },  # the new row — must be excluded
+        {"id": "old-bike", "status": "active", "content": "commutes by bicycle"},
+        {"id": "old-dead", "status": "outdated", "content": "retired"},
+    ]
+    out = await bi.run_basis_shadow(_mem(), "t", None, overlap_candidates=overlap)
+    assert out["route"] == "overlap"
+    assert [v["target_memory_id"] for v in out["verdicts"]] == ["old-bike"]
+    assert out["verdicts"][0]["decision"] == "SET_UNKNOWN_CURRENT"


### PR DESCRIPTION
## Summary

**A58** — the first slice of the Type-II (propagated staleness) program. "Tore ACL, no weight-bearing for six weeks" retires "commutes by bicycle daily" — but the two statements are *simultaneously true*, so Path A's contradiction judge is **right** to say no, and cannot be tuned into catching this without a false-positive explosion. Type-II needs a differently-shaped question ("did the new evidence break the practical basis of the old default?") over a differently-selected candidate set. That is CUP-Mem's bucket-bridge mechanism (STALE, arXiv:2605.06527), ported here onto our existing `(subject_entity_id, predicate)` slot model.

**Shadow mode only — this PR writes nothing.** Verdicts are logged (`path_d_shadow` lines) so the Type-II base rate and precision can be measured on real corpora before A59 builds the enforcing path (`unsafe` status, migration 037).

## Design (per the analysis doc on the A58 canonical row)

1. **Bridge** (1 LLM call): which *other* predicates of this subject may have had their practical basis broken — hard-gated to a `SINGLE_VALUE_PREDICATES` menu with a confidence floor; the paper's precision guardrails ("shared life domain / topic overlap is not enough — name the broken basis") ported verbatim.
2. **Scoped fetch** (0 LLM): `rdf-conflicts` rows per bridged predicate. When that route is empty — predicates are sparsely populated until A63's canonicalization lands — it falls back to Path C's **already-fetched entity-overlap candidates** (`route=overlap`, zero extra storage calls).
3. **Judge** (≤2 LLM calls, CUP-Mem's `invalidation_merge_max_keep`): `INDIRECT_INVALIDATE | WEAK_CHALLENGE | SET_UNKNOWN_CURRENT | NO_OP`, enum verbatim for paper comparability.

**Hook placement matters**: it rides Path C's conclusion, *not* Path A — wet testing showed `subject_entity_id` resolves during entity extraction (A63 #1020), so it is always NULL at Path A time. Runs under Path C's idempotency lock; double-wrapped so no failure can reach Path C's outcome. Flag `basis_invalidation_shadow`, default off (mirrors `contradiction_write_conflict_record`).

## Testing

- 8 unit tests: no-subject gating (no LLM spend), menu hard-gate + confidence floor, judge cap + **storage purity** (asserts `find_rdf_conflicts` is the only storage call), retired-candidate skip, verdict normalization, error isolation, overlap fallback, hook wiring.
- Full root suite **5442 passed** (includes the 887 contradiction tests + the golden differential); mypy clean.
- **Wet test reproduced the paper's canonical bike/ACL case end-to-end** on the local stack: strong-mode writes, subject resolved by extraction, bridge fired, overlap route selected the bicycle memory, judge returned `WEAK_CHALLENGE` (0.78) — *"no weight-bearing for six weeks makes the prior assumption that Dana commutes by bicycle unsafe during recovery"* — and both rows' statuses stayed byte-untouched. +2.7s background, zero user-visible latency.

## Next (not in this PR)

The A58 spike: replay the 15 labeled STALE T2 pairs through the write path with the flag on and measure hit rate / false-positive rate — that number decides A59's build scope (`unsafe` status + write-side state materialization).

Refs: canonical A58; A59; analysis `cupmem_stale_contradiction_analysis.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)