### PR TITLE
fix(contradiction): lower the candidate floor to 0.45 so paraphrased updates reach the judge (A63)

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -10,6 +10,8 @@ files, which is the drift it exists to remove.
 from datetime import timedelta
 from typing import NamedTuple
 
+from common.env_utils import read_float_env, read_int_env
+
 # ── Memory liveness ──
 # The statuses that mean "this memory is live". Broader than the literal
 # ``active`` value: enrichment promotes writes past ``active`` on the normal
@@ -49,12 +51,43 @@ SEMANTIC_DEDUP_JUDGE_THRESHOLD = 0.85  # broad enough to catch refinements,
 # happen to share vocabulary.
 
 # ── Contradiction detection ──
-CONTRADICTION_SIMILARITY_THRESHOLD = (
-    0.70  # cosine similarity above this triggers LLM check
+# A63 — cosine floor for semantic contradiction CANDIDATES (the rows the
+# LLM judge gets to look at). Lowered 0.70 -> 0.45 on measured evidence:
+# four genuine, deliberately paraphrased updates written through the real
+# local pipeline scored 0.483 / 0.503 / 0.568 / 0.607 against the facts
+# they supersede — EVERY ONE below the old 0.70 floor, so Path A returned
+# ZERO candidates for all four (logs: candidates_initial=0) and the judge
+# never saw the contradiction it exists to catch. That is the STALE
+# Type-II miss class: an update phrased in different words than the fact
+# it replaces.
+#
+# Why this is close to free rather than a cost increase: the candidate
+# query is ``WHERE (1 - distance) >= threshold ORDER BY distance LIMIT
+# <max>``, so the LIMIT — not the threshold — bounds how many rows the
+# judge sees. Lowering the floor cannot add a 21st candidate; it changes
+# WHICH rows fill the window (and takes the sparse case from 0 to a few).
+# Judge output per clean candidate is ~1.5 tokens post-E4 (#1011), so
+# even the sparse-case delta is negligible.
+#
+# Precision is the judge's job, and it now does it: #1023 removed the
+# Gate-2 veto that was overriding true update verdicts, so a wider net
+# gets adjudicated rather than rubber-stamped. Env-tunable for
+# incident-time adjustment without a deploy.
+CONTRADICTION_SIMILARITY_THRESHOLD = read_float_env(
+    "CONTRADICTION_SIMILARITY_THRESHOLD", 0.45
 )
 CONTRADICTION_CANDIDATE_MAX = (
     8  # max similar memories to check (LLM is the quality gate)
 )
+# A63 — the window the /similar-candidates ROUTE applies, which is what prod
+# actually runs: the route's caller (the contradiction detector) passes no
+# ``limit``, and the route's own default has always been 20, not
+# ``CONTRADICTION_CANDIDATE_MAX``'s 8. Named here so the value prod uses is
+# declared rather than buried as a literal in the route, and so the
+# cost-bounding argument on the threshold above points at something real.
+# Deliberately left at 20: E3/E4 established this window's cost, and A63
+# widens the FLOOR, not the window.
+CONTRADICTION_CANDIDATE_WINDOW = read_int_env("CONTRADICTION_CANDIDATE_WINDOW", 20)
 
 # ── Recall boost ──
 RECALL_BOOST_SCALE = 10  # recalls needed to reach half of max boost
@@ -478,12 +511,24 @@ SEARCH_KNOBS: dict[str, SearchKnob] = {
     # deliberate ceiling rather than the widest of the three.
     "graph_max_hops": SearchKnob(int, (0, 3), agent_tunable=True),
     # ── scoring knobs storage reads positionally ──
-    "fts_weight": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True, agent_tunable=True),
-    "freshness_floor": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True, agent_tunable=True),
-    "freshness_decay_days": SearchKnob(int, (7, 730), sql=True, sql_required=True, agent_tunable=True),
-    "recall_boost_cap": SearchKnob(float, (1.0, 3.0), sql=True, sql_required=True, agent_tunable=True),
-    "recall_decay_window_days": SearchKnob(int, (7, 365), sql=True, sql_required=True, agent_tunable=True),
-    "similarity_blend": SearchKnob(float, (0.0, 1.0), sql=True, sql_required=True, agent_tunable=True),
+    "fts_weight": SearchKnob(
+        float, (0.0, 1.0), sql=True, sql_required=True, agent_tunable=True
+    ),
+    "freshness_floor": SearchKnob(
+        float, (0.0, 1.0), sql=True, sql_required=True, agent_tunable=True
+    ),
+    "freshness_decay_days": SearchKnob(
+        int, (7, 730), sql=True, sql_required=True, agent_tunable=True
+    ),
+    "recall_boost_cap": SearchKnob(
+        float, (1.0, 3.0), sql=True, sql_required=True, agent_tunable=True
+    ),
+    "recall_decay_window_days": SearchKnob(
+        int, (7, 365), sql=True, sql_required=True, agent_tunable=True
+    ),
+    "similarity_blend": SearchKnob(
+        float, (0.0, 1.0), sql=True, sql_required=True, agent_tunable=True
+    ),
     # ── scoring knobs with a server-side default, so optional on the wire ──
     # #687: scale on ts_rank_cd before saturation. Floor is 1.0, not 0 — that is
     # the pre-#687 formula, so a tenant can revert but cannot weaken keyword
@@ -499,11 +544,17 @@ SEARCH_KNOBS: dict[str, SearchKnob] = {
 # The wire contract, derived. Core-api's two search-path builders project
 # ``search_params`` through the first; the storage route rejects a payload
 # missing any of the second.
-SQL_SCORING_PARAM_KEYS: tuple[str, ...] = tuple(k for k, v in SEARCH_KNOBS.items() if v.sql)
-SQL_SCORING_REQUIRED_KEYS: tuple[str, ...] = tuple(k for k, v in SEARCH_KNOBS.items() if v.sql_required)
+SQL_SCORING_PARAM_KEYS: tuple[str, ...] = tuple(
+    k for k, v in SEARCH_KNOBS.items() if v.sql
+)
+SQL_SCORING_REQUIRED_KEYS: tuple[str, ...] = tuple(
+    k for k, v in SEARCH_KNOBS.items() if v.sql_required
+)
 # The agent-facing tuning surface, derived the same way: ``SearchProfileUpdate``
 # and the ``caura_tune`` MCP tool expose exactly these.
-AGENT_TUNABLE_KEYS: tuple[str, ...] = tuple(k for k, v in SEARCH_KNOBS.items() if v.agent_tunable)
+AGENT_TUNABLE_KEYS: tuple[str, ...] = tuple(
+    k for k, v in SEARCH_KNOBS.items() if v.agent_tunable
+)
 
 
 # ---------------------------------------------------------------------------

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -9,7 +9,12 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
 
-from common.constants import CRYSTALLIZER_SHORT_CONTENT_CHARS, SQL_SCORING_REQUIRED_KEYS
+from common.constants import (
+    CONTRADICTION_CANDIDATE_WINDOW,
+    CONTRADICTION_SIMILARITY_THRESHOLD,
+    CRYSTALLIZER_SHORT_CONTENT_CHARS,
+    SQL_SCORING_REQUIRED_KEYS,
+)
 from common.events.lifecycle_purge_request import (
     MEMORY_RETENTION_MAX_DAYS,
     MEMORY_RETENTION_MIN_DAYS,
@@ -394,8 +399,16 @@ async def find_similar_candidates(request: Request) -> list[dict]:
         embedding=body["embedding"],
         memory_id=UUID(body["memory_id"]),
         visibility=body.get("visibility", "scope_team"),
-        threshold=body.get("threshold", 0.7),
-        limit=body.get("limit", 20),
+        # A63 — fall back to the shared constants rather than literals. The
+        # hardcoded 0.7 here silently outranked
+        # ``CONTRADICTION_SIMILARITY_THRESHOLD`` for every caller (none pass
+        # ``threshold``), so lowering the constant alone would have changed
+        # nothing — the same third-place-duplication trap the scored-search
+        # route documents. ``limit`` keeps its 20 (the value prod runs, and
+        # the bound that makes the lower floor cost-neutral) but now says so
+        # through the constant.
+        threshold=body.get("threshold", CONTRADICTION_SIMILARITY_THRESHOLD),
+        limit=body.get("limit", CONTRADICTION_CANDIDATE_WINDOW),
     )
     return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
 

--- a/tests/test_a63_candidate_gate_wiring.py
+++ b/tests/test_a63_candidate_gate_wiring.py
@@ -1,0 +1,66 @@
+"""A63 — the candidate floor the ROUTE applies must be the shared constant.
+
+The `/memories/similar-candidates` route defaulted ``threshold`` to a
+hardcoded ``0.7`` and ``limit`` to a hardcoded ``20``, while the service
+signature defaulted to ``CONTRADICTION_SIMILARITY_THRESHOLD`` /
+``CONTRADICTION_CANDIDATE_MAX``. No caller passes either value — the
+contradiction detector sends neither — so the ROUTE's literals were the
+values prod actually ran, and the constants were decorative. Lowering the
+constant alone would have changed nothing.
+
+That is the same third-place-duplication trap the scored-search route
+documents at length (two ranking features shipped applying to one search
+path only because a route-level allowlist shadowed the caller). These
+tests pin the wiring so it cannot silently drift back.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from common.constants import (
+    CONTRADICTION_CANDIDATE_WINDOW,
+    CONTRADICTION_SIMILARITY_THRESHOLD,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _route_source() -> str:
+    from core_storage_api.routers import memories as router_mod
+
+    src = inspect.getsource(router_mod)
+    start = src.index("async def find_similar_candidates")
+    return src[start : src.index("@router.", start + 10)]
+
+
+def test_route_defaults_come_from_constants_not_literals() -> None:
+    src = _route_source()
+    assert "CONTRADICTION_SIMILARITY_THRESHOLD" in src, (
+        "the route must default the candidate floor to the shared constant; a "
+        "literal here shadows it for every caller and makes the constant dead"
+    )
+    assert "CONTRADICTION_CANDIDATE_WINDOW" in src
+    assert '"threshold", 0.7' not in src and "'threshold', 0.7" not in src
+    assert '"limit", 20' not in src and "'limit', 20" not in src
+
+
+def test_floor_admits_the_measured_real_updates() -> None:
+    """The four paraphrased updates measured through the real pipeline
+    (A63 probe, 2026-08-27) must clear the floor — they are the miss class
+    this change exists to fix."""
+    measured = [0.483, 0.503, 0.568, 0.607]
+    assert all(sim >= CONTRADICTION_SIMILARITY_THRESHOLD for sim in measured), (
+        f"floor {CONTRADICTION_SIMILARITY_THRESHOLD} would still drop "
+        f"{[s for s in measured if s < CONTRADICTION_SIMILARITY_THRESHOLD]}"
+    )
+
+
+def test_window_is_what_bounds_judge_cost() -> None:
+    """The cost argument for the lower floor rests on the window staying
+    put: ORDER BY similarity LIMIT N means the floor cannot add an
+    (N+1)-th candidate. If someone raises the window, judge cost per write
+    rises with it and the E3/E4 measurements no longer describe prod."""
+    assert CONTRADICTION_CANDIDATE_WINDOW == 20

--- a/tests/test_p1_contradiction.py
+++ b/tests/test_p1_contradiction.py
@@ -35,16 +35,27 @@ class TestContradictionConstants:
     """Verify P1 constant changes."""
 
     def test_threshold_value(self):
-        """Threshold should be 0.70 — entity-based detection handles wider matches."""
-        assert CONTRADICTION_SIMILARITY_THRESHOLD == 0.70
+        """A63 — the candidate FLOOR is 0.45, not P1's 0.70.
+
+        Measured through the real local pipeline: four genuine paraphrased
+        updates scored 0.483 / 0.503 / 0.568 / 0.607 against the facts they
+        supersede, so a 0.70 floor returned ZERO candidates for every one and
+        the judge never saw them. Cost is bounded by
+        ``CONTRADICTION_CANDIDATE_WINDOW`` (ORDER BY similarity LIMIT N), not
+        by the floor, so widening it cannot add candidates beyond the window.
+        """
+        assert CONTRADICTION_SIMILARITY_THRESHOLD == 0.45
 
     def test_candidate_max_raised(self):
         """Candidate limit should be 8 (up from 3) — async makes extra LLM calls free."""
         assert CONTRADICTION_CANDIDATE_MAX == 8
 
     def test_threshold_reasonable_range(self):
-        """Threshold should stay in [0.5, 0.9] — too low = noise, too high = misses."""
-        assert 0.5 <= CONTRADICTION_SIMILARITY_THRESHOLD <= 0.9
+        """Floor stays in [0.35, 0.9]: below ~0.35 the window fills with
+        unrelated rows (the judge pays for them and precision leans on the
+        gates alone); above ~0.62 it starts cutting measured real updates —
+        the highest observed genuine-update similarity was 0.607."""
+        assert 0.35 <= CONTRADICTION_SIMILARITY_THRESHOLD <= 0.9
 
     def test_candidate_max_reasonable_range(self):
         """Candidate max should be in [3, 20] — enough recall without excess LLM cost."""


### PR DESCRIPTION
## Why

Part 4 of **A63**. Measured through the real local pipeline: four genuine updates, each deliberately worded differently from the fact it supersedes, scored **0.483 / 0.503 / 0.568 / 0.607** cosine against those facts. Every one sits below the 0.70 candidate floor, so Path A returned **zero** candidates for all four (`candidates_initial=0`) and the judge never saw the contradiction it exists to catch. That is the STALE Type-II miss class.

**After: the same probe takes reachability from 1/4 to 4/4.**

## Why it is cost-neutral

The candidate query is `WHERE (1 - distance) >= floor ORDER BY distance LIMIT <window>` — the **window** bounds how many rows the judge sees, not the floor. Lowering it cannot add a 21st candidate; it changes which rows fill the window, and takes the sparse case from 0 to a few. Post-#1011 a clean candidate costs ~1.5 output tokens.

## Also: a no-op trap removed

`/similar-candidates` defaulted `threshold` to a hardcoded `0.7` and `limit` to `20`, while the service defaulted to the shared constants — and **no caller passes either**, so the route's literals were what prod ran and the constants were decorative. *Lowering the constant alone would have changed nothing.* Both now come from named constants (`CONTRADICTION_SIMILARITY_THRESHOLD`, new `CONTRADICTION_CANDIDATE_WINDOW=20`, both env-tunable), with a test pinning the wiring. Same third-place-duplication trap the scored-search route documents at length.

## Bench — reports a FAIL, and I want the reviewer to judge it, not me

67-question sample, d=0, vs the golden captured today on merged main:

| category | Δ accuracy | Δ recall@20 |
|---|---|---|
| single-session-user | **+7.7pp** | +0.0 |
| single-session-preference | **+8.3pp** | +0.0 |
| multi-session | +0.0 | −2.5pp |
| temporal-reasoning | **+14.3pp** | −8.0pp ❌ threshold |
| knowledge-update | −7.2pp | −4.2pp |
| **overall accuracy** | **+4.7pp (78.1 → 82.8)** | |

Per-question analysis of every negative cell:

- **The TR/KU recall dips are all multi-gold aggregation questions** ("total weeks spent reading", "order of airlines flown", "wake-up time Tue/Thu") where answer correctness was **unchanged** (False→False, False→False, True→True) and one even improved rank 2→1. The lost recall is set-recall on rows this change correctly demotes as superseded.
- **The KU accuracy drop is one question with IDENTICAL retrieval** (recall 1.0, rank 2 in both runs) — the answer generator phrased it badly; not a retrieval regression.

So the breach is the bench's recall metric counting superseded memories as required gold — the third time this has happened since supersession started actually working. I have **not** touched the golden or the thresholds to make this pass; filed as a separate finding instead.

## Honest limit found while validating this

With candidates now reaching it, gpt-5.4-nano still answers "clean" on 3/4 of these pairs: it will not connect *"finished the Snowflake cutover"* to *"the warehouse is BigQuery"*, or *"paging duty transferred to Lior"* to *"Oren holds the pager"*. I tried softening #1011's batch calibration; one case flipped — **but only while my probe sentences were quoted verbatim in the prompt**, and the win vanished when I rewrote the same guidance generically. I reverted that edit rather than ship something that scores well only on its own test set. Cross-vocabulary attribute matching is a judge-capability limit, which argues for predicate canonicalization (deterministic RDF, no LLM inference) or a tiered judge — filed as follow-ups.

Full suite 5,465 + storage 160 green; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
