### PR TITLE
ci: test TypeScript client on supported Node versions

### DIFF
--- a/.github/workflows/client-typescript-ci.yml
+++ b/.github/workflows/client-typescript-ci.yml
@@ -14,6 +14,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["18", "20", "22"]
     defaults:
       run:
         working-directory: clients/typescript
@@ -21,8 +25,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node-version }}
       - name: Install
-        run: npm install
+        run: npm ci
       - name: Build + test
         run: npm test


### PR DESCRIPTION
## Summary / Problem

Closes #973. The TypeScript client workflow only exercised Node 20 even though the package declares Node >=18, and it used `npm install` despite the committed lockfile.

## Changes

- Test the client on Node 18, 20, and 22 with a non-failing matrix.
- Use the matrix Node version in the setup step.
- Use `npm ci` for deterministic lockfile-based installs.

## Tests

- `npm ci` (from `clients/typescript`) — passed.
- `npm test` (from `clients/typescript`) — passed; 14 tests passed.
- `git diff --check` — passed.

## Compatibility / Known limitations

This changes CI coverage and dependency installation only; it does not change the published client API or runtime behavior. The three Node versions will be exercised by the hosted GitHub Actions workflow after the PR is opened.

## Issue link

Closes https://github.com/caura-ai/caura/issues/973
