### PR TITLE
fix(client-python): raise health check HTTP errors

### DIFF
--- a/clients/python/src/caura_client/client.py
+++ b/clients/python/src/caura_client/client.py
@@ -113,6 +113,7 @@ class Caura:
     def health(self) -> dict[str, Any]:
         """Liveness probe (GET /api/v1/health)."""
         response = self._http.get("/api/v1/health")
+        self._raise_for_status(response)
         return response.json()
 
     def get_document(

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -163,6 +163,25 @@ def test_health():
     assert make_client(handler).health()["status"] == "ok"
 
 
+def test_health_raises_auth_error():
+    def handler(request):
+        return httpx.Response(401, json={"error": {"message": "invalid key"}})
+
+    with pytest.raises(AuthError) as exc:
+        make_client(handler).health()
+    assert exc.value.status_code == 401
+
+
+def test_health_raises_api_error():
+    def handler(request):
+        return httpx.Response(503, json={"detail": "database unavailable"})
+
+    with pytest.raises(CauraAPIError) as exc:
+        make_client(handler).health()
+    assert exc.value.status_code == 503
+    assert str(exc.value) == "[503] database unavailable"
+
+
 def test_auth_error_parses_envelope():
     def handler(request):
         return httpx.Response(403, json={"error": {"message": "cross-fleet", "details": {"x": 1}}})


### PR DESCRIPTION
## Summary

Closes #971.

`Caura.health()` now uses the Python client's shared HTTP error mapping before decoding the response. This keeps health checks consistent with the other client methods and prevents HTTP failures from being returned as successful data.

## Implementation

- Call `_raise_for_status()` in `clients/python/src/caura_client/client.py`.
- Add mocked regression coverage for 401 authentication errors and 503 API errors while preserving the existing success test.

This changes error responses from returned dictionaries to the documented typed exceptions. Successful responses and the public method signature are unchanged. No live service or API key is required.

## Validation

- `python -m pytest clients/python/tests/test_client.py -q` (18 passed; external pytest plugin autoload disabled because the host has an incompatible global `langsmith` plugin)
- `python -m ruff check clients/python/src/caura_client/client.py clients/python/tests/test_client.py` (passed)
- `git diff --check` (passed)

## Not run / known limitations

- Full pytest suite was not run; this focused client test covers the changed behavior without external services.
- Full mypy reports 3 pre-existing errors in `clients/python/src/caura_client/interviewer/cli.py` for Windows-unavailable `fcntl.flock`, unrelated to this change.
- Repository-wide formatter check reports existing formatting differences in untouched files; no formatter-only changes were included.
