### PR TITLE
fix(standalone): match a path-converter slug when the body guard skips injection

### DIFF
--- a/core-api/src/core_api/middleware/standalone_tenant.py
+++ b/core-api/src/core_api/middleware/standalone_tenant.py
@@ -154,11 +154,25 @@ def _body_model_accepts_tenant_id(scope) -> bool:
         return True
     method = scope.get("method", "").lower()
     path = scope.get("path", "")
-    return not any(methods and method in methods and pattern.match(path) for pattern, methods in skip)
+    # Two passes. A placeholder is one path segment first, which is what
+    # the template says. The schema cannot say that a parameter was declared
+    # ``{slug:path}`` and so carries slashes (the skills-inbox actions take a
+    # Forge slug, ``forge/<name>``), so a path no template matched one
+    # segment at a time is matched again with placeholders spanning slashes.
+    # The second pass is bounded by the literal segments around each
+    # placeholder and by the anchors, and it runs only when the first found
+    # nothing, so a route the first pass resolves keeps its answer.
+    for across_slashes in (False, True):
+        for strict, loose, methods in skip:
+            pattern = loose if across_slashes else strict
+            if methods and method in methods and pattern.match(path):
+                return False
+    return True
 
 
-# ``id(app)`` -> tuple of (compiled path regex, frozenset of lowercase methods)
-# for the operations whose JSON body schema has no ``tenant_id`` property.
+# ``id(app)`` -> tuple of (one-segment path regex, across-slashes path regex,
+# frozenset of lowercase methods) for the operations whose JSON body schema
+# has no ``tenant_id`` property.
 # Memoised because it is derived from a schema that cannot change after
 # startup; keyed by app identity so a test that builds a second app is correct
 # rather than merely fast.
@@ -192,7 +206,13 @@ def _no_tenant_id_body_routes(app) -> tuple | None:
                 if "tenant_id" not in resolved["properties"]:
                     methods.add(method.lower())
             if methods:
-                entries.append((_path_template_to_regex(raw_path), frozenset(methods)))
+                entries.append(
+                    (
+                        _path_template_to_regex(raw_path),
+                        _path_template_to_regex(raw_path, across_slashes=True),
+                        frozenset(methods),
+                    )
+                )
         result: tuple | None = tuple(entries)
     except Exception:  # pragma: no cover — never break requests over this
         result = None
@@ -218,10 +238,17 @@ def _resolve_schema(node: dict, components: dict) -> dict | None:
     return node
 
 
-def _path_template_to_regex(template: str):
-    """``/api/v1/memories/{memory_id}`` -> a pattern matching one concrete path."""
+def _path_template_to_regex(template: str, *, across_slashes: bool = False):
+    """``/api/v1/memories/{memory_id}`` -> a pattern matching one concrete path.
+
+    A placeholder matches one segment, or, with ``across_slashes``, any
+    non-empty run of characters including slashes: the shape of a parameter
+    declared with the ``:path`` converter, which the OpenAPI template renders
+    as a plain ``{name}``.
+    """
     parts = re.split(r"(\{[^/}]*\})", template)
-    pattern = "".join("[^/]+" if p.startswith("{") and p.endswith("}") else re.escape(p) for p in parts)
+    placeholder = ".+" if across_slashes else "[^/]+"
+    pattern = "".join(placeholder if p.startswith("{") and p.endswith("}") else re.escape(p) for p in parts)
     return re.compile(f"^{pattern}$")
 
 

--- a/tests/test_standalone_tenant_body_guard.py
+++ b/tests/test_standalone_tenant_body_guard.py
@@ -1,0 +1,93 @@
+"""The standalone middleware's body-injection guard and path converters.
+
+``StandaloneTenantMiddleware`` injects ``tenant_id`` into a JSON body only
+when the route's declared body schema takes the field (SAFE-01). The guard
+matches the request path against the OpenAPI path templates, and OpenAPI
+renders ``{slug:path}`` as ``{slug}``: a ``:path`` parameter carries slashes
+the template cannot show. The skills-inbox actions are such routes, and a
+Forge candidate's slug is ``forge/<name>``, so the guard must match a
+placeholder across slashes or the body gets the field its model forbids.
+"""
+
+import pytest
+from core_api.middleware import standalone_tenant as st
+from core_api.middleware.standalone_tenant import StandaloneTenantMiddleware
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel, ConfigDict
+
+pytestmark = pytest.mark.asyncio
+
+TENANT = "standalone-tenant"
+
+
+class StrictReason(BaseModel):
+    """The shape of the inbox action bodies: one field, extras forbidden."""
+
+    model_config = ConfigDict(extra="forbid")
+    reason: str
+
+
+class TakesTenant(BaseModel):
+    tenant_id: str | None = None
+    note: str
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+
+    @app.post("/api/v1/things/{slug:path}/act")
+    async def act(slug: str, body: StrictReason):
+        return {"slug": slug, "reason": body.reason}
+
+    @app.post("/api/v1/plain/{name}/act")
+    async def plain(name: str, body: StrictReason):
+        return {"name": name, "reason": body.reason}
+
+    @app.post("/api/v1/notes")
+    async def notes(body: TakesTenant):
+        return {"tenant_id": body.tenant_id, "note": body.note}
+
+    app.add_middleware(StandaloneTenantMiddleware)
+    return app
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(st, "get_standalone_tenant_id", lambda: TENANT)
+    app = _app()
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def test_path_converter_param_with_a_slash_gets_no_injection(client):
+    """``{slug:path}`` matched across slashes: the forbid-extra body passes."""
+    resp = await client.post("/api/v1/things/forge/handoff/act", json={"reason": "r"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"slug": "forge/handoff", "reason": "r"}
+
+
+async def test_single_segment_param_gets_no_injection(client):
+    """The control: a one-segment parameter already worked."""
+    resp = await client.post("/api/v1/plain/handoff/act", json={"reason": "r"})
+    assert resp.status_code == 200, resp.text
+
+
+async def test_body_that_takes_tenant_id_is_still_injected(client):
+    """The other half of the guard: a body that declares the field gets it."""
+    resp = await client.post("/api/v1/notes", json={"note": "n"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["tenant_id"] == TENANT
+
+
+def test_real_inbox_action_path_is_skipped():
+    """On the real app a Forge slug reaches the inbox actions untouched."""
+    from core_api.app import app
+
+    scope = {
+        "app": app,
+        "method": "POST",
+        "path": "/api/v1/skills-inbox/forge/summarize-oncall-handoff/reject",
+    }
+    assert st._body_model_accepts_tenant_id(scope) is False
+    scope["path"] = "/api/v1/skills-inbox/summarize-oncall-handoff/edit"
+    assert st._body_model_accepts_tenant_id(scope) is False


### PR DESCRIPTION
## Summary

In standalone mode the tenant middleware's body-injection guard matched OpenAPI path templates one segment per placeholder, so a `{slug:path}` parameter with a slash never matched and `tenant_id` was injected into the skills-inbox action bodies, which forbid extra fields. Every Forge or agent candidate has such a slug, so `reject`, `quarantine`, and `edit` answered 422. The guard now matches in two passes, one segment per placeholder and then across slashes when nothing matched.

## Related Issue

Closes #1028

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

`tests/test_standalone_tenant_body_guard.py`, written first: the converter case on a hermetic app (422 before, 200 after), the one-segment control, a body that declares `tenant_id` and still receives it, and the real inbox action path on the application (`_body_model_accepts_tenant_id` returns False). Reproduced on a standalone deployment of 2.33.1: `POST /api/v1/skills-inbox/agent/<slug>/reject` with `{"reason":"x"}` answered 422 `unknown field 'tenant_id'` with the tenant key and the admin key; the same call on a slug without a slash passed body validation.

```
pytest tests/test_standalone_tenant_body_guard.py tests/test_standalone.py tests/test_skills_inbox_routes.py tests/test_unknown_field_rejection.py tests/test_route_authz_gaps.py tests/test_stm_admin_tenant.py tests/test_env_write_new_names.py
150 passed
pytest tests/
16 failed, 5454 passed, 4 skipped, 1 xfailed
```

The 16 failures are the pre-existing ones in `test_integration_search`, `test_p3_2_relation_weights`, `test_a7_classifier_recall`, `pipeline/test_search_pipeline`, and `test_ph6_entity_linking_storage`, the same set as on `main` at 2913e61.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes (or explained why none are needed)
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes (the four errors it reports on this file are missing third-party stubs, identical on `main`)
- [x] `pytest` passes locally (at the baseline above)
- [x] I have updated relevant documentation (docstrings; no user-facing docs name the guard)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (release-please generates it from the commit subject)

## Additional Notes

The second pass is bounded by the literal segments around each placeholder and by the anchors, and it runs only when the first pass matched nothing, so a route the one-segment pass resolves keeps its answer. The alternative, reading the converter from the route objects, is what the guard's docstring already rules out for FastAPI 0.137's `_IncludedRouter`.
