### PR TITLE
fix(client-python): health() now raises on HTTP errors (not silent data)

### DIFF
--- a/clients/python/src/caura_client/client.py
+++ b/clients/python/src/caura_client/client.py
@@ -113,6 +113,7 @@ class Caura:
     def health(self) -> dict[str, Any]:
         """Liveness probe (GET /api/v1/health)."""
         response = self._http.get("/api/v1/health")
+        self._raise_for_status(response)
         return response.json()
 
     def get_document(

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -163,6 +163,14 @@ def test_health():
     assert make_client(handler).health()["status"] == "ok"
 
 
+def test_health_raises_on_http_error():
+    def handler(request):
+        return httpx.Response(503, json={"message": "unavailable"})
+
+    with pytest.raises(CauraAPIError):
+        make_client(handler).health()
+
+
 def test_auth_error_parses_envelope():
     def handler(request):
         return httpx.Response(403, json={"error": {"message": "cross-fleet", "details": {"x": 1}}})


### PR DESCRIPTION
Fixes #971

`Caura.health()` was the only client method that skipped `_raise_for_status`, so a 401/503 liveness response was returned to the caller as ordinary data instead of raising — a failed health check looked like success.

**Change:**
```python
def health(self) -> dict[str, Any]:
    """Liveness probe (GET /api/v1/health)."""
    response = self._http.get("/api/v1/health")
    self._raise_for_status(response)   # now raises like every other method
    return response.json()
```

**Regression test added:** `test_health_raises_on_http_error` — a 503 on `/api/v1/health` must raise `CauraAPIError` (verified: fails without the fix, passes with it).

**Test suite:** 143 passed.