### PR TITLE
fix(storage): accept discrete AlloyDB settings

### DIFF
--- a/core-storage-api/src/core_storage_api/config.py
+++ b/core-storage-api/src/core_storage_api/config.py
@@ -3,9 +3,20 @@
 from __future__ import annotations
 
 from typing import Any, Literal
+from urllib.parse import quote
 
-from pydantic import field_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+LOCAL_DATABASE_URL = "postgresql+asyncpg://memclaw:changeme@localhost:5432/memclaw"  # legacy-name-ok: existing local-dev compatibility default
+
+
+def _alloydb_database_url(*, host: str, port: int, user: str, password: str, database: str) -> str:
+    return (
+        "postgresql+asyncpg://"
+        f"{quote(user, safe='')}:{quote(password, safe='')}@"
+        f"{host}:{port}/{quote(database, safe='')}"
+    )
 
 
 class Settings(BaseSettings):
@@ -26,8 +37,15 @@ class Settings(BaseSettings):
     # search / GET traffic from the primary. Replication lag on a
     # streaming replica is typically <5s, acceptable for the read paths
     # we route.
-    database_url: str = "postgresql+asyncpg://memclaw:changeme@localhost:5432/memclaw"
-    read_database_url: str = ""
+    database_url: SecretStr = Field(default=SecretStr(LOCAL_DATABASE_URL), repr=False, exclude=True)
+    # SaaS can bind only ALLOYDB_PASSWORD from Secret Manager. These remain
+    # ordinary settings fields so constructor and .env sources work too.
+    alloydb_host: str = ""
+    alloydb_port: int | None = None
+    alloydb_user: str = ""
+    alloydb_password: SecretStr = SecretStr("")
+    alloydb_database: str = ""
+    read_database_url: SecretStr = Field(default=SecretStr(""), repr=False, exclude=True)
     # 5+5 matches the post-PR-#166 ``platform-storage-api`` defaults so
     # both services share the same pool sizing without per-environment
     # env-var overrides. Pre-this-fix the source defaults were 20+20,
@@ -59,6 +77,39 @@ class Settings(BaseSettings):
     # startup-probe deadline, or the probe kills the instance before this fires.
     # Env: MIGRATION_LOCK_WAIT_SECONDS.
     migration_lock_wait_seconds: int = 1800
+
+    @model_validator(mode="after")
+    def resolve_alloydb_database_url(self) -> Settings:
+        # Explicit DATABASE_URL wins, even when shared environment files carry
+        # incomplete ALLOYDB_* values for another service.
+        if "database_url" in self.model_fields_set:
+            return self
+
+        password = self.alloydb_password.get_secret_value()
+        values = {
+            "ALLOYDB_HOST": self.alloydb_host,
+            "ALLOYDB_USER": self.alloydb_user,
+            "ALLOYDB_PASSWORD": password,
+            "ALLOYDB_DATABASE": self.alloydb_database,
+        }
+        attempted = any(values.values()) or self.alloydb_port is not None
+        if not attempted:
+            return self
+
+        missing = [name for name, value in values.items() if not value]
+        if missing:
+            raise ValueError(f"incomplete AlloyDB configuration; missing: {', '.join(missing)}")
+
+        self.database_url = SecretStr(
+            _alloydb_database_url(
+                host=self.alloydb_host,
+                port=self.alloydb_port or 5432,
+                user=self.alloydb_user,
+                password=password,
+                database=self.alloydb_database,
+            )
+        )
+        return self
 
     # Service role (CAURA-591 Part B). "hybrid" keeps the original
     # single-service behaviour and is the safe default for OSS + any

--- a/core-storage-api/src/core_storage_api/database/init.py
+++ b/core-storage-api/src/core_storage_api/database/init.py
@@ -57,7 +57,7 @@ def get_engine() -> AsyncEngine:
     """Return the writer engine (primary DB), creating on first call."""
     global _engine
     if _engine is None:
-        _engine = _build_engine(settings.database_url)
+        _engine = _build_engine(settings.database_url.get_secret_value())
     return _engine
 
 
@@ -67,10 +67,11 @@ def get_read_engine() -> AsyncEngine:
     the replica so read traffic doesn't share primary's connection
     budget."""
     global _read_engine
-    if not settings.read_database_url:
+    read_database_url = settings.read_database_url.get_secret_value()
+    if not read_database_url:
         return get_engine()
     if _read_engine is None:
-        _read_engine = _build_engine(settings.read_database_url)
+        _read_engine = _build_engine(read_database_url)
     return _read_engine
 
 

--- a/core-storage-api/src/core_storage_api/database/migrations/env.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/env.py
@@ -51,7 +51,7 @@ async def run_migrations_cli():
     """CLI mode: create engine from settings and run migrations."""
     from core_storage_api.config import settings
 
-    engine = create_async_engine(settings.database_url)
+    engine = create_async_engine(settings.database_url.get_secret_value())
     async with engine.connect() as connection:
         await connection.run_sync(do_run_migrations)
     await engine.dispose()

--- a/core-storage-api/src/core_storage_api/scripts/preflight_012.py
+++ b/core-storage-api/src/core_storage_api/scripts/preflight_012.py
@@ -200,7 +200,7 @@ def _resolve_dsn() -> str:
     try:
         from core_storage_api.config import settings  # type: ignore[import-not-found]
 
-        return settings.database_url
+        return settings.database_url.get_secret_value()
     except Exception:
         import os
         from urllib.parse import quote_plus

--- a/core-storage-api/tests/conftest.py
+++ b/core-storage-api/tests/conftest.py
@@ -60,7 +60,7 @@ async def _ensure_schema():
 
     from core_storage_api.database.init import init_database
 
-    engine = create_async_engine(settings.database_url, echo=False)
+    engine = create_async_engine(settings.database_url.get_secret_value(), echo=False)
     async with engine.begin() as conn:
         # pgvector must exist before the migrations that declare vector columns.
         await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))

--- a/core-storage-api/tests/test_config.py
+++ b/core-storage-api/tests/test_config.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+
+from core_storage_api.config import LOCAL_DATABASE_URL, Settings
+
+ALLOYDB_NAMES = (
+    "ALLOYDB_HOST",
+    "ALLOYDB_PORT",
+    "ALLOYDB_USER",
+    "ALLOYDB_PASSWORD",
+    "ALLOYDB_DATABASE",
+)
+
+
+def _clear_database_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    for name in ALLOYDB_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_alloydb_fields_build_the_runtime_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv("ALLOYDB_HOST", "10.0.0.8")
+    monkeypatch.setenv("ALLOYDB_PORT", "6432")
+    monkeypatch.setenv("ALLOYDB_USER", "sandbox@user")
+    monkeypatch.setenv("ALLOYDB_PASSWORD", "p/a:ss word")
+    monkeypatch.setenv("ALLOYDB_DATABASE", "sandbox/name")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.database_url.get_secret_value() == (
+        "postgresql+asyncpg://sandbox%40user:p%2Fa%3Ass%20word@10.0.0.8:6432/sandbox%2Fname"
+    )
+
+
+def test_derived_database_url_is_hidden_from_settings_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv("ALLOYDB_HOST", "10.0.0.8")
+    monkeypatch.setenv("ALLOYDB_USER", "sandbox-user")
+    monkeypatch.setenv("ALLOYDB_PASSWORD", "sensitive-password")
+    monkeypatch.setenv("ALLOYDB_DATABASE", "sandbox-db")
+    monkeypatch.setenv(
+        "READ_DATABASE_URL",
+        "postgresql+asyncpg://reader:read-sensitive-password@replica/sandbox-db",
+    )
+
+    settings = Settings(_env_file=None)
+
+    assert "sensitive-password" not in repr(settings)
+    assert "sensitive-password" not in str(settings)
+    assert "sensitive-password" not in repr(dict(settings))
+    assert "read-sensitive-password" not in repr(settings)
+    assert "read-sensitive-password" not in str(settings)
+    assert "read-sensitive-password" not in repr(dict(settings))
+    assert "database_url" not in settings.model_dump()
+    assert "read_database_url" not in settings.model_dump()
+
+
+def test_explicit_database_url_wins_over_partial_alloydb_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://explicit/db")
+    monkeypatch.setenv("ALLOYDB_HOST", "ignored")
+
+    assert Settings(_env_file=None).database_url.get_secret_value() == "postgresql+asyncpg://explicit/db"
+
+
+def test_alloydb_fields_load_from_dotenv(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    _clear_database_env(monkeypatch)
+    dotenv = tmp_path / ".env"
+    dotenv.write_text(
+        "ALLOYDB_HOST=10.0.0.9\n"
+        "ALLOYDB_USER=dotenv-user\n"
+        "ALLOYDB_PASSWORD=dotenv-password\n"
+        "ALLOYDB_DATABASE=dotenv-db\n"
+    )
+
+    assert Settings(_env_file=dotenv).database_url.get_secret_value() == (
+        "postgresql+asyncpg://dotenv-user:dotenv-password@10.0.0.9:5432/dotenv-db"
+    )
+
+
+def test_alloydb_fields_load_from_constructor(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_database_env(monkeypatch)
+
+    settings = Settings(
+        _env_file=None,
+        alloydb_host="10.0.0.10",
+        alloydb_user="constructor-user",
+        alloydb_password="constructor-password",
+        alloydb_database="constructor-db",
+    )
+
+    assert settings.database_url.get_secret_value() == (
+        "postgresql+asyncpg://constructor-user:constructor-password@10.0.0.10:5432/constructor-db"
+    )
+
+
+def test_partial_alloydb_configuration_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv("ALLOYDB_HOST", "10.0.0.8")
+
+    with pytest.raises(ValueError, match="incomplete AlloyDB configuration"):
+        Settings(_env_file=None)
+
+
+def test_port_only_alloydb_configuration_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_database_env(monkeypatch)
+    monkeypatch.setenv("ALLOYDB_PORT", "6432")
+
+    with pytest.raises(ValueError, match="incomplete AlloyDB configuration"):
+        Settings(_env_file=None)
+
+
+def test_unconfigured_database_keeps_the_local_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_database_env(monkeypatch)
+
+    assert Settings(_env_file=None).database_url.get_secret_value() == LOCAL_DATABASE_URL

--- a/tests/test_dual_engine.py
+++ b/tests/test_dual_engine.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from pydantic import SecretStr
 
 pytestmark = pytest.mark.asyncio
 
@@ -25,7 +26,7 @@ async def test_read_engine_is_writer_when_read_url_empty():
     from core_storage_api.config import settings
     from core_storage_api.database import init as db_init
 
-    with patch.object(settings, "read_database_url", ""):
+    with patch.object(settings, "read_database_url", SecretStr("")):
         writer = db_init.get_engine()
         reader = db_init.get_read_engine()
     assert writer is reader
@@ -38,7 +39,7 @@ async def test_read_engine_is_distinct_when_read_url_set():
     with patch.object(
         settings,
         "read_database_url",
-        "postgresql+asyncpg://reader:changeme@replica:5432/memclaw",
+        SecretStr("postgresql+asyncpg://reader:changeme@replica:5432/caura"),
     ):
         writer = db_init.get_engine()
         reader = db_init.get_read_engine()


### PR DESCRIPTION
## Summary

- let core-storage derive `DATABASE_URL` from resolved `ALLOYDB_HOST`, `ALLOYDB_PORT`, `ALLOYDB_USER`, `ALLOYDB_PASSWORD`, and `ALLOYDB_DATABASE` settings
- preserve explicit `DATABASE_URL` precedence and the existing local-development fallback
- fail startup on partial AlloyDB configuration and URL-encode credential/database components

## Why

The sandbox workflow currently has to assemble a complete DSN before deploying core-storage. Cloud Run then stores that DSN as a plain environment value. Supporting discrete settings lets the password remain a Secret Manager binding while non-secret connection fields remain ordinary environment variables.

This is the OSS prerequisite for caura-enterprise #1358; that workflow continues to check out OSS `main`, so this PR must land before the enterprise secret-backed deployment path is enabled.

## Validation

- 7 focused configuration tests pass
- Ruff check and format pass
- mypy passes for `core_storage_api.config`
- configured pre-commit hooks pass
- legacy-name ratchet passes
- negative controls confirmed the derivation and partial-config tests fail against the previous behavior
