### PR TITLE
fix(interview): count the tenants and nodes a sweep silently skipped

### DIFF
--- a/core-api/src/core_api/services/interview_service.py
+++ b/core-api/src/core_api/services/interview_service.py
@@ -1102,6 +1102,14 @@ async def process_pending_interview_jobs(limit_per_tenant: int = 20) -> dict:
     tenants = await list_tenants_with_interviewer_enabled(read=False)
     summary = {
         "tenants": len(tenants),
+        # Tenants dropped from this tick by a storage error below. ``jobs_sweep_ok``
+        # only covers this function raising as a whole; the per-tenant handler
+        # catches and continues, so without this counter a sweep that failed for
+        # some tenants returns the same numbers as one where those tenants had
+        # nothing to do — the exact confusion #1019 removed one level up, and the
+        # one that lets a single tenant's interviewer stall indefinitely behind a
+        # summary that reads healthy.
+        "tenants_failed": 0,
         "jobs_processed": 0,
         "jobs_done": 0,
         "jobs_retried": 0,
@@ -1142,6 +1150,7 @@ async def process_pending_interview_jobs(limit_per_tenant: int = 20) -> dict:
             )
         except Exception:
             logger.exception("interview jobs: pending query failed (tenant=%s)", tenant_id)
+            summary["tenants_failed"] += 1
             continue
         stale = [row for row in processing or [] if _job_processing_is_stale(row, now)]
         # allow_stale_processing only for the stale rows: the sweep is the
@@ -1243,7 +1252,14 @@ async def run_interview_schedule() -> dict:
     tenants = await list_tenants_with_interviewer_enabled(read=False)
     summary = {
         "tenants": len(tenants),
+        # Same reason as the jobs sweep's counter: both loops below log-and-continue,
+        # so a scan that failed is otherwise reported as a tenant with no due nodes.
+        # ``nodes_failed`` also keeps the node counters self-consistent —
+        # ``nodes_considered`` is incremented before the per-node try, so without it
+        # a failing node is counted as considered and lands in no outcome bucket.
+        "tenants_failed": 0,
         "nodes_considered": 0,
+        "nodes_failed": 0,
         "commands_queued": 0,
         "skipped_pending": 0,
         "skipped_not_due": 0,
@@ -1264,6 +1280,7 @@ async def run_interview_schedule() -> dict:
             )
         except Exception:
             logger.exception("interview schedule: tenant scan failed (tenant=%s)", tenant_id)
+            summary["tenants_failed"] += 1
             continue
         pending_nodes = {str(c.get("node_id")) for c in pending}
 
@@ -1320,6 +1337,7 @@ async def run_interview_schedule() -> dict:
                     tenant_id,
                     node_id,
                 )
+                summary["nodes_failed"] += 1
     # #665: drain persisted async-submit jobs in the same sweep — the
     # durable retry path for jobs whose fire-and-forget processing at
     # submit time died with the process or failed transiently.
@@ -1327,6 +1345,12 @@ async def run_interview_schedule() -> dict:
     # the sweep succeeds or raises — callers index these keys directly.
     for key in ("jobs_processed", "jobs_done", "jobs_retried", "jobs_parked", "jobs_skipped"):
         summary[key] = 0
+    # The sweep's own ``tenants_failed`` is a DIFFERENT population from this
+    # function's: the sweep failed to query a tenant's job queue, this one failed
+    # to scan a tenant's nodes. A tick can hit either, both or neither, so they
+    # are carried side by side rather than summed into one number that answers
+    # neither question.
+    summary["jobs_tenants_failed"] = 0
     # ``jobs_sweep_ok`` exists because the zero-init above is otherwise
     # indistinguishable from a healthy idle sweep: a total failure and "no
     # pending jobs" both answer 200 with five zeros. The hourly cron reads
@@ -1350,4 +1374,5 @@ async def run_interview_schedule() -> dict:
     else:
         for key in ("jobs_processed", "jobs_done", "jobs_retried", "jobs_parked", "jobs_skipped"):
             summary[key] = jobs_summary.get(key, 0)
+        summary["jobs_tenants_failed"] = jobs_summary.get("tenants_failed", 0)
     return summary

--- a/tests/test_interview_async_submit.py
+++ b/tests/test_interview_async_submit.py
@@ -761,12 +761,17 @@ async def test_process_pending_jobs_returns_counts_summary(client, canned_llm):
     summary = await process_pending_interview_jobs()
     assert set(summary) == {
         "tenants",
+        # A tenant whose job query raised is skipped and logged; the counter is
+        # what stops that reading as a tenant with an empty queue. See
+        # tests/test_interview_sweep_freshness.py.
+        "tenants_failed",
         "jobs_processed",
         "jobs_done",
         "jobs_retried",
         "jobs_parked",
         "jobs_skipped",
     }
+    assert summary["tenants_failed"] == 0
     assert summary["tenants"] >= 1
     assert summary["jobs_processed"] >= 1
     assert summary["jobs_done"] >= 1

--- a/tests/test_interview_sweep_freshness.py
+++ b/tests/test_interview_sweep_freshness.py
@@ -18,6 +18,8 @@ uninformative ``assert 0 >= 1`` into a named error.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
 from core_api.services import interview_service
@@ -89,6 +91,177 @@ async def test_both_sweeps_read_the_enabled_tenant_list_from_the_writer(monkeypa
 
     assert seen, "the sweep did not consult the enabled-tenant list at all"
     assert all(r is False for r in seen), f"expected read=False (writer), got {seen}"
+
+
+# ── partial failure: the same lie, one level down ──
+#
+# ``jobs_sweep_ok`` covers the sweep raising *wholesale*. It cannot cover a
+# sweep that fails for SOME tenants, because both loops below catch per-tenant
+# (and per-node) exceptions, log them and ``continue`` — so the call returns
+# normally and ``jobs_sweep_ok`` stays True. The counters that would have moved
+# never move, which is indistinguishable from that tenant having nothing to do.
+# Same failure mode #1019 closed at the outer level, and with the same
+# consequence: one tenant's interviewer can stop working indefinitely while the
+# hourly tick reports a healthy queue. core-operations only logs this summary —
+# nothing branches on it — so the log line in core-api is the sole signal today.
+
+
+class _FailForTenant:
+    """Storage stub whose calls raise for one tenant and succeed for the rest."""
+
+    def __init__(self, broken: str, nodes: list[dict] | None = None):
+        self._broken = broken
+        self._nodes = nodes or []
+
+    def _guard(self, tenant_id: str) -> None:
+        if tenant_id == self._broken:
+            raise RuntimeError("db://user:pw@internal-host/secret path=/etc/x")
+
+    async def query_documents(self, spec: dict):
+        self._guard(str(spec.get("tenant_id")))
+        return []
+
+    async def list_nodes(self, tenant_id: str, *a, **kw):
+        self._guard(tenant_id)
+        return self._nodes
+
+    async def list_commands(self, tenant_id: str, *a, **kw):
+        self._guard(tenant_id)
+        return []
+
+
+async def test_a_tenant_the_job_sweep_could_not_query_is_counted_not_swallowed(monkeypatch):
+    """A tenant whose pending-jobs query raises is skipped. Without a counter
+    the summary is identical to that tenant having an empty queue."""
+
+    async def _tenants(*a, **kw):
+        return ["t-ok", "t-broken"]
+
+    monkeypatch.setattr(interview_service, "list_tenants_with_interviewer_enabled", _tenants)
+    monkeypatch.setattr(
+        interview_service, "get_storage_client", lambda: _FailForTenant("t-broken")
+    )
+
+    summary = await interview_service.process_pending_interview_jobs()
+
+    assert summary["tenants"] == 2
+    assert summary["jobs_processed"] == 0
+    assert summary["tenants_failed"] == 1, (
+        "a tenant dropped from the sweep by a storage error must be counted; "
+        "otherwise it reads as an idle tenant forever"
+    )
+
+
+async def test_a_tenant_the_schedule_could_not_scan_is_counted_not_swallowed(monkeypatch):
+    """The scheduling half has the identical hole in its own tenant loop."""
+
+    async def _tenants(*a, **kw):
+        return ["t-ok", "t-broken"]
+
+    async def _settings(_tenant_id):
+        return {"interviewer": {"enabled": True}}
+
+    async def _no_jobs(*a, **kw):
+        return dict.fromkeys(
+            ("jobs_processed", "jobs_done", "jobs_retried", "jobs_parked", "jobs_skipped"), 0
+        ) | {"tenants": 0, "tenants_failed": 0}
+
+    monkeypatch.setattr(interview_service, "list_tenants_with_interviewer_enabled", _tenants)
+    monkeypatch.setattr(interview_service, "get_settings_for_display", _settings)
+    monkeypatch.setattr(interview_service, "process_pending_interview_jobs", _no_jobs)
+    monkeypatch.setattr(
+        interview_service, "get_storage_client", lambda: _FailForTenant("t-broken")
+    )
+
+    summary = await interview_service.run_interview_schedule()
+
+    assert summary["tenants"] == 2
+    assert summary["nodes_considered"] == 0
+    assert summary["tenants_failed"] == 1
+
+
+async def test_the_schedule_surfaces_the_job_sweeps_partial_failures_too(monkeypatch):
+    """``tenants_failed`` from the jobs sweep is a different population from the
+    schedule's own scan failures, so it is copied under its own name rather than
+    summed into one ambiguous number."""
+
+    async def _tenants(*a, **kw):
+        return []
+
+    async def _partly_failed_sweep(*a, **kw):
+        return {
+            "tenants": 3,
+            "tenants_failed": 2,
+            "jobs_processed": 0,
+            "jobs_done": 0,
+            "jobs_retried": 0,
+            "jobs_parked": 0,
+            "jobs_skipped": 0,
+        }
+
+    monkeypatch.setattr(interview_service, "list_tenants_with_interviewer_enabled", _tenants)
+    monkeypatch.setattr(interview_service, "process_pending_interview_jobs", _partly_failed_sweep)
+
+    summary = await interview_service.run_interview_schedule()
+
+    assert summary["jobs_sweep_ok"] is True  # it returned; it did not raise
+    assert summary["jobs_tenants_failed"] == 2
+    assert summary["tenants_failed"] == 0  # the schedule's own scan was clean
+
+
+async def test_the_node_counters_add_up(monkeypatch):
+    """``nodes_considered`` is incremented before the per-node try, so a node
+    whose watermark read raises is counted as considered and then falls through
+    without landing in any outcome bucket. The invariant that makes that
+    visible: considered == queued + skipped_pending + skipped_not_due + failed."""
+    now = datetime.now(UTC).isoformat()
+    nodes = [
+        {"id": "n-ok", "node_name": "ok", "last_heartbeat": now},
+        {"id": "n-broken", "node_name": "broken", "last_heartbeat": now},
+    ]
+
+    async def _tenants(*a, **kw):
+        return ["t1"]
+
+    async def _settings(_tenant_id):
+        return {"interviewer": {"enabled": True}}
+
+    async def _no_jobs(*a, **kw):
+        return dict.fromkeys(
+            ("jobs_processed", "jobs_done", "jobs_retried", "jobs_parked", "jobs_skipped"), 0
+        ) | {"tenants": 0, "tenants_failed": 0}
+
+    # The watermark doc id is a hash of the node id, not the node id itself, so
+    # match on the real key rather than a substring that would never fire.
+    broken_doc_id = interview_service.watermark_doc_id("n-broken")
+
+    class _Client(_FailForTenant):
+        async def get_document(self, _tenant_id, _collection, doc_id, **kw):
+            if doc_id == broken_doc_id:
+                raise RuntimeError("watermark read failed")
+            return None
+
+        async def create_command(self, _payload):
+            return {}
+
+    monkeypatch.setattr(interview_service, "list_tenants_with_interviewer_enabled", _tenants)
+    monkeypatch.setattr(interview_service, "get_settings_for_display", _settings)
+    monkeypatch.setattr(interview_service, "process_pending_interview_jobs", _no_jobs)
+    monkeypatch.setattr(
+        interview_service, "get_storage_client", lambda: _Client("t-none", nodes=nodes)
+    )
+
+    summary = await interview_service.run_interview_schedule()
+
+    assert summary["nodes_considered"] == 2
+    assert summary["commands_queued"] == 1
+    assert summary["nodes_failed"] == 1
+    assert summary["nodes_considered"] == (
+        summary["commands_queued"]
+        + summary["skipped_pending"]
+        + summary["skipped_not_due"]
+        + summary["nodes_failed"]
+    )
 
 
 async def test_the_service_helper_forwards_read_to_the_storage_client(monkeypatch):


### PR DESCRIPTION
## The gap #1019 left

#1019 made a job sweep that **raised** distinguishable from an idle one, via `jobs_sweep_ok`. It cannot cover the **partial** case. Both tenant loops and the per-node loop catch their own exceptions, log and `continue`, so the call returns normally, `jobs_sweep_ok` stays `True`, and the counters that would have moved simply never move.

A tenant whose job query or node scan fails on every tick therefore reads exactly like a tenant with an empty queue — and reads that way indefinitely: `core-operations` only `logger.info`s this summary and nothing branches on it, so the core-api log line is the sole signal today.

That is the same failure mode #1019 closed, one level down.

## The change

One counter per silent-skip site:

| function | new keys |
| --- | --- |
| `process_pending_interview_jobs` | `tenants_failed` |
| `run_interview_schedule` | `tenants_failed`, `nodes_failed` |

The two `tenants_failed` count **different populations** — one failed to query a tenant's job queue, the other to scan its nodes. A tick can hit either, both or neither, so the sweep's is carried into the schedule summary as `jobs_tenants_failed` rather than summed into a single number that answers neither question.

`nodes_failed` also restores an invariant the node counters had quietly lost. `nodes_considered` is incremented *before* the per-node `try`, so a node whose watermark read raised was counted as considered and then landed in no outcome bucket at all. The test asserts the invariant rather than the individual numbers:

```
nodes_considered == commands_queued + skipped_pending + skipped_not_due + nodes_failed
```

Additive only — no key changes meaning, and the one test pinning the exact key set is updated deliberately.

## What this does not do

**It does not fix the intermittent `assert 0 >= 1` in `test_interview_async_submit.py`,** and it is not claimed to. That remains unreproduced:

- 13 further runs of the interview files, plus a full-suite run — all clean
- the last 60 CI runs contain **no** occurrence; every recorded sighting is local

What it removes is the last way for the sweep to under-report without saying so — the one hypothesis behind that assertion which the summary currently cannot rule in or out. If it recurs, `tenants_failed` now separates "the sweep skipped my tenant" from "there was genuinely nothing pending".

## Verification

- 4 new tests, each confirmed to **fail** before the service change (`KeyError` / wrong count) and pass after
- full suite: 5438 passed, no regressions
- `ruff check` + `ruff format --check core-api/src/` clean; `mypy src/` clean (202 files)

Root `tests/` is deliberately left unformatted — it sits above any `pyproject.toml`, so ruff there falls back to its 88-char default rather than the project's 110, and CI does not lint that path.