### PR TITLE
feat(serve): let deployments opt out of uvicorn's per-request access log

### DIFF
--- a/common/serve.py
+++ b/common/serve.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import os
 from typing import Any
 
 import uvicorn
@@ -105,11 +106,42 @@ def main(argv: list[str] | None = None) -> None:
         log_file=settings.log_file or None,
     )
 
+    # UVICORN_ACCESS_LOG=false silences uvicorn's per-request access line.
+    #
+    # Defaults to ON, so OSS, on-prem and local runs are unchanged — there
+    # the access line is often the only per-request visibility there is. A
+    # managed deploy opts out, because there it is the THIRD copy of one
+    # fact, and the least useful of the three:
+    #
+    #   1. the APM span     — trace id, duration, route, tags, service map
+    #   2. Cloud Run's own  — httpRequest in Cloud Logging: method, status,
+    #      request log        url, AND latency; written by the platform, so
+    #                         it survives anything this process does
+    #   3. this line        — ip, method, path, status. No duration.
+    #
+    # Measured before removing rather than assumed: uvicorn.access emitted
+    # 3,690,995 lines in 24h, 53.6% of ALL prod logs, on 2026-08-28.
+    #
+    # Parsed inline rather than through common/env_utils.read_*_env, which
+    # is where an env-var reader would otherwise belong. This file is
+    # vendored into caura-enterprise as an identical-policy copy and
+    # common/env_utils.py does NOT exist in that repo, so importing it
+    # would re-vendor a serve.py that raises ImportError at startup for
+    # every platform service. Keep this module's imports to things that
+    # exist in BOTH repos.
+    raw_access_log = os.environ.get("UVICORN_ACCESS_LOG", "").strip().lower()
+    access_log = raw_access_log not in {"0", "false", "no", "off"}
+
     # log_config=None: do NOT let uvicorn install its own stream handlers.
     # That keeps uvicorn.{error,access} propagating to the structlog root
     # handler configured above (in the parent AND the workers), so every
     # uvicorn line — including the parent supervisor's — emits as JSON with a
     # Datadog status. Installing uvicorn's config would re-plain-text them.
+    #
+    # access_log is a separate lever from log_config: log_config decides how
+    # a record is FORMATTED, access_log decides whether uvicorn creates the
+    # record at all. Turning this off therefore costs nothing downstream —
+    # no handler, filter or sampling rule has to know about it.
     uvicorn.run(
         args.app,
         host=args.host,
@@ -118,6 +150,7 @@ def main(argv: list[str] | None = None) -> None:
         timeout_keep_alive=args.timeout_keep_alive,
         timeout_worker_healthcheck=args.timeout_worker_healthcheck,
         log_config=None,
+        access_log=access_log,
     )
 
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -137,3 +137,101 @@ def test_uvicorn_really_accepts_the_healthcheck_kwarg() -> None:
         in inspect.signature(uvicorn.Config.__init__).parameters
     )
     assert "timeout_worker_healthcheck" in inspect.signature(uvicorn.run).parameters
+
+
+def _run_main_capturing_uvicorn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> mock.MagicMock:
+    """Drive serve.main() with everything external mocked; return the run mock."""
+    fake_settings = types.SimpleNamespace(
+        environment="production",
+        log_level="INFO",
+        log_format_json=True,
+        log_file="",
+    )
+    monkeypatch.setattr(serve, "_load", lambda _path: fake_settings)
+    monkeypatch.setattr(serve, "configure_logging", mock.MagicMock())
+    run = mock.MagicMock()
+    monkeypatch.setattr(serve.uvicorn, "run", run)
+
+    serve.main(
+        [
+            "core_api.app:app",
+            "--settings",
+            "core_api.config:settings",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8000",
+            "--workers",
+            "2",
+            "--timeout-keep-alive",
+            "65",
+        ]
+    )
+    return run
+
+
+def test_access_log_defaults_on_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Absent env var must leave access logging ON.
+
+    This default is the whole reason the knob is opt-out. OSS, on-prem and
+    local runs have neither an APM span nor Cloud Run's httpRequest entry, so
+    the uvicorn access line is their only per-request visibility. Silencing it
+    by default would take that away from every self-hosted install to solve a
+    cost problem that only the managed deploy has.
+    """
+    monkeypatch.delenv("UVICORN_ACCESS_LOG", raising=False)
+
+    _args, kwargs = _run_main_capturing_uvicorn(monkeypatch).call_args
+
+    assert kwargs["access_log"] is True
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "FALSE", "No", " off ", "OFF"])
+def test_access_log_off_for_falsy_spellings(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """The managed deploy sets this; accept the spellings people actually type.
+
+    Case and surrounding whitespace are normalised because this value is
+    threaded through a comma-joined --update-env-vars string in the deploy
+    workflows, where a stray space is easy to introduce and impossible to see
+    in review.
+    """
+    monkeypatch.setenv("UVICORN_ACCESS_LOG", raw)
+
+    _args, kwargs = _run_main_capturing_uvicorn(monkeypatch).call_args
+
+    assert kwargs["access_log"] is False
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "yes", "on", "", "maybe"])
+def test_access_log_on_for_everything_else(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """Anything not clearly falsy keeps logging.
+
+    Including junk like "maybe": the failure modes are not symmetric. Reading
+    an unrecognised value as "off" silently drops request visibility and looks
+    identical to a healthy quiet service, whereas reading it as "on" costs
+    some log volume and is immediately obvious. Fail toward the loud side.
+    """
+    monkeypatch.setenv("UVICORN_ACCESS_LOG", raw)
+
+    _args, kwargs = _run_main_capturing_uvicorn(monkeypatch).call_args
+
+    assert kwargs["access_log"] is True
+
+
+def test_uvicorn_really_accepts_the_access_log_kwarg() -> None:
+    """Same guard as the healthcheck kwarg above, for the same reason.
+
+    The tests above assert against a MagicMock, which swallows any keyword.
+    If uvicorn ever renames or drops ``access_log``, they all keep passing
+    and the only place it surfaces is a TypeError on container startup.
+    """
+    assert "access_log" in inspect.signature(uvicorn.Config.__init__).parameters
+    assert "access_log" in inspect.signature(uvicorn.run).parameters


### PR DESCRIPTION
Adds a `UVICORN_ACCESS_LOG` env var to `common/serve.py`. **Default is ON, so this PR changes no behaviour on its own** — OSS, on-prem and local runs are untouched. The managed deploy opts out separately (enterprise PR, gated on this merging first since `common/serve.py` is `identical`-policy vendored).

## Why

In a deployed environment the uvicorn access line is the **third** record of one fact, and the least informative of the three:

| # | Source | Carries |
|---|---|---|
| 1 | **APM span** | trace id, duration, route, tags, service map |
| 2 | **Cloud Run `httpRequest`** (Cloud Logging) | method, status, url, **latency** — written by the platform, survives anything this process does |
| 3 | **`uvicorn.access`** | ip, method, path, status. **No duration.** |

Both other copies were confirmed present before proposing removal — the span via APM, and the Cloud Run entry by reading it back out of Cloud Logging — so silencing #3 loses nothing.

**Measured, not assumed** (2026-08-28): `uvicorn.access` emitted **3,690,995 lines in 24h — 53.6% of all prod logs**, by a wide margin the largest single logger.

## Why default-on

The knob is opt-out rather than opt-in because the redundancy argument only holds where an APM span and a Cloud Run request log both exist. A self-hosted install has neither, and defaulting to off would strip request visibility from every OSS user to solve a cost problem only the managed deploy has.

## Two things worth a reviewer's eye

**Inline env parsing, deliberately.** An env reader belongs in `common/env_utils.py` next to `read_int_env`/`read_float_env` — but this file is vendored into `caura-enterprise` as an `identical`-policy copy, and **`common/env_utils.py` does not exist in that repo**. Importing it would re-vendor a `serve.py` that raises `ImportError` at startup for every platform service. The comment says so at the call site so a future tidy-up doesn't reintroduce it.

**`access_log` is orthogonal to the existing `log_config=None`.** `log_config` decides how a record is *formatted*; `access_log` decides whether uvicorn *builds* it. So this costs nothing downstream — no handler, filter, or sampling rule needs to know.

## Tests

- default-on when unset
- falsy spellings, case- and whitespace-insensitive (the value rides in a comma-joined `--update-env-vars` string where a stray space is invisible in review)
- unrecognised input fails toward **ON** — reading junk as "off" silently drops request visibility and looks identical to a healthy quiet service
- the real `uvicorn` signature still has the kwarg, mirroring the existing `timeout_worker_healthcheck` guard (every other test mocks `uvicorn.run`, and a MagicMock swallows any keyword)

**Confirmed failing without the fix:** neutralising only the env parsing turns 6 of the new tests red.

| Check | Result |
|---|---|
| Full suite | 5484 passed, 4 skipped, 1 xfailed |
| `ruff check common/serve.py` | clean |
| `ruff format --check --isolated common/serve.py` | clean |
| Lines ≤88 cols in `common/serve.py` | verified (enterprise re-vendor format gate) |

Not addressed here, flagged for its own change: `core_api.services.contradiction_detector` is the second-largest logger at **1,007,293 lines/24h (14.6%)**. That's an application-verbosity judgement about which of its dozen-plus `logger.info` calls earn their keep, and doesn't belong bundled with a launcher flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)