### PR TITLE
feat(events): flip the lifecycle family's publishers to the caura twin

### DIFF
--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -157,19 +157,57 @@ def family(topic: str) -> str:
 
 # Families whose PUBLISHERS have been flipped to the renamed topics.
 #
-# Empty, and that is the point: with nothing here, ``publish_name`` is the
-# identity and publishing is byte-for-byte what it was before this module
-# changed. That is what makes binding both names safe to ship ahead of any
-# particular environment's deploy.
+# Add ONE family at a time, and only once every subscriber of that family is
+# confirmed deployed and bound to both names — confirmed per running service,
+# not per merged pull request; a merge is not a vendor and a vendor is not a
+# deploy.
 #
-# Flipping a family is a separate, later step. Add ONE family at a time, and
-# only once every subscriber of that family is confirmed deployed and bound to
-# both names — confirmed per running service, not per merged pull request; a
-# merge is not a vendor and a vendor is not a deploy. Order by blast radius:
-# "pipeline" or "org" first, and "audit" LAST, because those rows are
-# hash-chained and a lost or reordered audit event is the one failure in this
-# programme that cannot be undone.
-FLIPPED_FAMILIES: frozenset[str] = frozenset()
+# THIS SET IS NOT THE SAME IN BOTH REPOS, and mirroring the enterprise line
+# here would break this one. ``fleet`` and ``security`` are declared only in
+# enterprise, so naming either here makes ``_validate_flipped_families`` raise
+# at import in every OSS service. Rule 6 couples the two repos for a SHARED
+# family — which ``lifecycle`` is — and inverts for an enterprise-only one.
+#
+# ``lifecycle`` flipped 2026-08-28 — the third family in this programme and the
+# first SHARED one, so it lands in both repos in one cycle. Chosen over
+# ``memory``, the other remaining shared family, on provisioning completeness
+# rather than size: every one of the 9 topics this family declares is live in
+# both environments, whereas ``memory`` declares one topic (``.created``) that
+# exists in neither. That is the same defect that disqualifies ``pipeline``,
+# and while it is harmless there today — nothing publishes ``.created`` — a
+# flip is not the step at which to be relying on that. Evidence, measured
+# against the running world rather than the source tree:
+#
+#   * 12/12 pubsub-backed deployables reported EVENT_BUS_DUAL_SUBSCRIBE on at
+#     their RUNNING revision (``check_flip_readiness.py``, enterprise).
+#   * 36/36 legacy durable subscriptions across prod and staging (18 each) had
+#     a twin, each verified attached to the matching twin TOPIC and not merely
+#     present by name.
+#   * ``preflight_dual_subscribe.py`` exited 0 for both environments, with the
+#     topic-IAM half reachable, so the attach pairing was verified live and not
+#     merely in config.
+#   * This family has NO broadcast topic and no per-process ephemeral
+#     subscription in either environment, so there is no runtime-created
+#     binding to infer — every subscription it relies on is a durable resource
+#     that was listed.
+#
+# WHAT THAT DOES NOT PROVE. Both gates read CONFIGURATION. Neither observes a
+# message being delivered. A green gate is a necessary condition, never
+# evidence the flip works; the end-to-end signal is the staging deploy's
+# control-plane check. Do not report a green gate as a working flip.
+#
+# ``memory`` is next and is otherwise ready on the same evidence — 16/16 twin
+# durable subscriptions, no ephemerals. Provision or remove
+# ``Memory.CREATED`` first, so its flip does not have to carry an exception.
+#
+# ``pipeline`` must NOT enter this set while it has zero live topics in either
+# environment: publishing to a topic that does not exist is silent loss, so
+# flipping it would move nothing and report success. ``org`` is shared AND its
+# staging ephemeral pool was under investigation as a suspected subscription
+# leak. ``audit`` LAST, unconditionally — those rows are hash-chained, and a
+# lost or reordered audit event is the one failure here that replay cannot
+# repair.
+FLIPPED_FAMILIES: frozenset[str] = frozenset({"lifecycle"})
 
 
 def all_topics() -> tuple[str, ...]:

--- a/tests/test_events/test_factory.py
+++ b/tests/test_events/test_factory.py
@@ -10,6 +10,23 @@ from common.events.factory import reset_event_bus_for_testing
 pytestmark = pytest.mark.asyncio
 
 
+@pytest.fixture
+def dual_subscribe_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The dual-subscribe setting every deployed service actually runs with.
+
+    Since ``lifecycle`` was flipped, a Pub/Sub bus constructed with the flag off
+    is refused at construction — a flipped family would otherwise publish under
+    a name the bus does not bind, which delivers nothing and raises nothing. The
+    tests below are about the FACTORY's backend selection and its
+    ``max_messages`` plumbing, not about the flag, so they take the setting all
+    12 pubsub-backed deployables were confirmed running at their live revision.
+    Setting the env var rather than emptying ``FLIPPED_FAMILIES`` keeps the real
+    flag-parsing path under test; the parse rule itself is covered in
+    ``test_topic_rename_cutover.py``.
+    """
+    monkeypatch.setenv("EVENT_BUS_DUAL_SUBSCRIBE", "true")
+
+
 async def test_default_backend_is_inprocess(monkeypatch: pytest.MonkeyPatch) -> None:
     await reset_event_bus_for_testing()
     monkeypatch.delenv("EVENT_BUS_BACKEND", raising=False)
@@ -49,6 +66,7 @@ async def test_pubsub_backend_requires_subscription_prefix(
 
 async def test_pubsub_backend_constructs_when_env_complete(
     monkeypatch: pytest.MonkeyPatch,
+    dual_subscribe_on: None,
 ) -> None:
     await reset_event_bus_for_testing()
     monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
@@ -84,6 +102,7 @@ async def test_pubsub_backend_fails_fast_when_sdk_missing(
 
 async def test_pubsub_backend_honors_max_messages_override(
     monkeypatch: pytest.MonkeyPatch,
+    dual_subscribe_on: None,
 ) -> None:
     await reset_event_bus_for_testing()
     monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
@@ -97,6 +116,7 @@ async def test_pubsub_backend_honors_max_messages_override(
 
 async def test_pubsub_backend_default_max_messages_when_unset(
     monkeypatch: pytest.MonkeyPatch,
+    dual_subscribe_on: None,
 ) -> None:
     await reset_event_bus_for_testing()
     monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")
@@ -110,6 +130,7 @@ async def test_pubsub_backend_default_max_messages_when_unset(
 
 async def test_pubsub_backend_accepts_max_messages_upper_bound(
     monkeypatch: pytest.MonkeyPatch,
+    dual_subscribe_on: None,
 ) -> None:
     await reset_event_bus_for_testing()
     monkeypatch.setenv("EVENT_BUS_BACKEND", "pubsub")

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -31,7 +31,18 @@ from common.events.pubsub import (
 
 @pytest.fixture
 def bus() -> PubSubEventBus:
-    b = PubSubEventBus(project_id="proj", subscription_prefix="test")
+    # ``dual_subscribe=True`` here and at every other construction in this file.
+    # With ``lifecycle`` flipped, the construction guard refuses ``dual=False``
+    # (a flipped family would publish under a name the bus does not bind), so
+    # the default is no longer constructible in this repo. None of the tests
+    # here are ABOUT that default — they cover topic prefixing, tunables, env
+    # normalisation, the pull loop and broadcast bookkeeping — so they take the
+    # setting all 12 running deployables use rather than neutralising the guard.
+    # The dual default itself is covered in ``test_topic_rename_cutover.py``,
+    # which keeps a dedicated fixture for it.
+    b = PubSubEventBus(
+        project_id="proj", subscription_prefix="test", dual_subscribe=True
+    )
     # Pre-install a fake publisher so publish() doesn't touch the SDK.
     # spec-limited to the real PublisherClient surface we rely on: a
     # permissive MagicMock happily accepts .close(), which is exactly
@@ -78,13 +89,18 @@ async def test_topic_prefix_scopes_publish(bus: PubSubEventBus) -> None:
 
 def test_topic_name_prefix_and_no_op() -> None:
     scoped = PubSubEventBus(
-        project_id="proj", subscription_prefix="prod-core-api", topic_prefix="prod"
+        project_id="proj",
+        subscription_prefix="prod-core-api",
+        topic_prefix="prod",
+        dual_subscribe=True,
     )
     assert (
         scoped._topic_name("memclaw.memory.embedded") == "prod--memclaw.memory.embedded"
     )
     # Empty/unset prefix ⇒ the raw topic name (byte-identical to today's behaviour).
-    noop = PubSubEventBus(project_id="proj", subscription_prefix="test")
+    noop = PubSubEventBus(
+        project_id="proj", subscription_prefix="test", dual_subscribe=True
+    )
     assert noop._topic_name("memclaw.memory.embedded") == "memclaw.memory.embedded"
 
 
@@ -950,7 +966,9 @@ async def test_dispatch_all_runs_handlers_concurrently(bus: PubSubEventBus) -> N
 
 
 async def test_constructor_tunables_default_and_override() -> None:
-    default = PubSubEventBus(project_id="proj", subscription_prefix="test")
+    default = PubSubEventBus(
+        project_id="proj", subscription_prefix="test", dual_subscribe=True
+    )
     assert default._max_messages == 25
     assert default._pull_timeout == 20.0
     assert default._error_backoff == 5.0
@@ -961,6 +979,7 @@ async def test_constructor_tunables_default_and_override() -> None:
         max_messages=100,
         pull_timeout=5.0,
         error_backoff=1.0,
+        dual_subscribe=True,
     )
     assert custom._max_messages == 100
     assert custom._pull_timeout == 5.0
@@ -1067,7 +1086,10 @@ async def _drive_one_batch(bus: PubSubEventBus, received: list[Any]) -> dict[str
 
 async def test_publish_stamps_source_env_attribute() -> None:
     bus = PubSubEventBus(
-        project_id="proj", subscription_prefix="test", env="production"
+        project_id="proj",
+        subscription_prefix="test",
+        env="production",
+        dual_subscribe=True,
     )
     fake_publisher = MagicMock()
     fake_publisher.topic_path = lambda proj, topic: f"projects/{proj}/topics/{topic}"
@@ -1095,20 +1117,35 @@ async def test_publish_omits_source_env_when_env_unset(bus: PubSubEventBus) -> N
 
 async def test_env_is_normalised_and_empty_collapses_to_none() -> None:
     assert (
-        PubSubEventBus(project_id="p", subscription_prefix="s", env=" production ")._env
+        PubSubEventBus(
+            project_id="p",
+            subscription_prefix="s",
+            env=" production ",
+            dual_subscribe=True,
+        )._env
         == "production"
     )
     assert (
-        PubSubEventBus(project_id="p", subscription_prefix="s", env="   ")._env is None
+        PubSubEventBus(
+            project_id="p", subscription_prefix="s", env="   ", dual_subscribe=True
+        )._env is None
     )
-    assert PubSubEventBus(project_id="p", subscription_prefix="s", env="")._env is None
-    assert PubSubEventBus(project_id="p", subscription_prefix="s")._env is None
+    assert PubSubEventBus(
+        project_id="p", subscription_prefix="s", env="", dual_subscribe=True
+    )._env is None
+    assert PubSubEventBus(
+        project_id="p", subscription_prefix="s", dual_subscribe=True
+    )._env is None
 
 
 async def test_foreign_source_env_decision_matrix() -> None:
-    prod = PubSubEventBus(project_id="p", subscription_prefix="s", env="production")
+    prod = PubSubEventBus(
+        project_id="p", subscription_prefix="s", env="production", dual_subscribe=True
+    )
     # Guard disabled when this bus has no env.
-    no_env = PubSubEventBus(project_id="p", subscription_prefix="s")
+    no_env = PubSubEventBus(
+        project_id="p", subscription_prefix="s", dual_subscribe=True
+    )
 
     def msg(attrs: dict[str, str]) -> Any:
         m = MagicMock()
@@ -1127,7 +1164,10 @@ async def test_foreign_source_env_decision_matrix() -> None:
 
 async def test_pull_loop_drops_foreign_env_message_before_dispatch() -> None:
     bus = PubSubEventBus(
-        project_id="proj", subscription_prefix="test", env="production"
+        project_id="proj",
+        subscription_prefix="test",
+        env="production",
+        dual_subscribe=True,
     )
     foreign = _make_received(
         b'{"event_type": "memclaw.memory.embedded"}',
@@ -1145,7 +1185,10 @@ async def test_pull_loop_drops_foreign_env_message_before_dispatch() -> None:
 
 async def test_pull_loop_processes_same_env_message() -> None:
     bus = PubSubEventBus(
-        project_id="proj", subscription_prefix="test", env="production"
+        project_id="proj",
+        subscription_prefix="test",
+        env="production",
+        dual_subscribe=True,
     )
     local = _make_received(
         b'{"event_type": "memclaw.memory.embedded"}',
@@ -1163,7 +1206,10 @@ async def test_pull_loop_processes_message_without_source_env_attribute() -> Non
     # A publisher that predates the attribute (or an external producer) must
     # still be processed — the guard only drops *provably* foreign messages.
     bus = PubSubEventBus(
-        project_id="proj", subscription_prefix="test", env="production"
+        project_id="proj",
+        subscription_prefix="test",
+        env="production",
+        dual_subscribe=True,
     )
     legacy = _make_received(
         b'{"event_type": "memclaw.memory.embedded"}', "ack-legacy", {}
@@ -1181,7 +1227,9 @@ async def test_pull_loop_processes_message_without_source_env_attribute() -> Non
 def test_subscribe_broadcast_records_topic() -> None:
     # broadcast=True flags the topic for a per-process subscription; the
     # default keeps the shared work-queue subscription.
-    b = PubSubEventBus(project_id="proj", subscription_prefix="core-api")
+    b = PubSubEventBus(
+        project_id="proj", subscription_prefix="core-api", dual_subscribe=True
+    )
 
     async def handler(event: Event) -> None: ...
 

--- a/tests/test_events/test_topic_rename_cutover.py
+++ b/tests/test_events/test_topic_rename_cutover.py
@@ -9,9 +9,11 @@ makes flipping a publisher later a lossless operation instead of a gap.
 Two properties carry the whole step, and both are asserted here rather than
 described:
 
-* **Publishing is unchanged.** No family is flipped, so every publish still
-  targets the name it targeted before. If this stops being true the step is no
-  longer a runtime no-op and can no longer be shipped ahead of a deploy.
+* **Publishing moves one family at a time.** ``lifecycle`` flipped on
+  2026-08-28; every other family still targets the name it targeted before. The
+  per-family assertions below are what stop a further family riding along in a
+  diff that looks like it only touched one line — each flip has to restate the
+  set, which is the point.
 * **Never dual-publish.** One publish call produces exactly one message. The
   alternative cutover — publish to both names for a while — delivers every event
   twice to every subscriber bound to both, which is the failure the ordering
@@ -19,11 +21,21 @@ described:
 
 The rest is about which way each default points, because the two backends need
 opposite ones and a missing twin fails differently in each.
+
+THE FLIP CHANGED WHAT A DEFAULT-CONSTRUCTED BUS MEANS HERE. With ``lifecycle``
+in ``FLIPPED_FAMILIES`` and its twins unbound at ``dual=False``, the
+construction guard refuses that combination — so ``PubSubEventBus(...)`` with
+the flag off now raises in this repo too, by design. Tests that are about *the
+flag's parse rule* rather than *the flip* therefore take the ``nothing_flipped``
+fixture, which restores the pre-flip set for the duration. That is not the flip
+being papered over: the parse rule genuinely does not depend on which families
+are flipped, and the guard keeps its own dedicated tests further down.
 """
 
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -35,8 +47,31 @@ from common.events.factory import get_event_bus, reset_event_bus_for_testing
 
 
 @pytest.fixture
+def nothing_flipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restore the pre-flip set, for tests about the flag rather than the flip.
+
+    ``dual=False`` stopped being constructible here the moment ``lifecycle`` was
+    flipped, because its twins are then published-to and unbound. Several tests
+    below predate that and are asking a different question — does a blank value
+    read as off, does the Pub/Sub backend bind one name by default — whose
+    answer does not depend on the flipped set at all. Emptying the set is the
+    narrowest way to keep asking it: the bus, the factory and the parse are all
+    still the real ones, and only the guard's precondition is removed.
+
+    The alternative, passing ``dual_subscribe=True``, would silently change what
+    those tests assert — they would stop covering the default path, which is the
+    one every standalone and on-prem deployment runs.
+    """
+    monkeypatch.setattr(topics_mod, "FLIPPED_FAMILIES", frozenset())
+
+
+@pytest.fixture
 def bus() -> PubSubEventBus:
-    b = PubSubEventBus(project_id="proj", subscription_prefix="test")
+    # dual on: post-flip this is the only configuration a bus in this repo can
+    # be constructed in, and it is what all 12 deployables actually run.
+    b = PubSubEventBus(
+        project_id="proj", subscription_prefix="test", dual_subscribe=True
+    )
     fake_publisher = MagicMock(spec=["topic_path", "publish", "stop"])
     fake_publisher.topic_path = lambda proj, topic: f"projects/{proj}/topics/{topic}"
     future = MagicMock()
@@ -100,14 +135,66 @@ def test_subscribe_names_dual_returns_both_without_duplicates() -> None:
 # ── publishing is unchanged: the property that makes step 2 shippable ─
 
 
-def test_no_family_is_flipped_yet() -> None:
-    """The literal precondition of this step.
+# Hand-spelled rather than derived from ``topics_mod``. Deriving them would make
+# every assertion below a tautology that holds for whatever the module happens to
+# say, including a family nobody meant to add. Spelling them here means a flip
+# has to be stated in exactly two places — the module, and this pair — and the
+# equality in ``test_exactly_the_flipped_families_are_flipped`` is what turns the
+# second one into a deliberate stop rather than a chore.
+FLIPPED = frozenset({"lifecycle"})
+# Per topic, not comprehended from ``FLIPPED`` over ``all_topics()``. A topic
+# added to an already-flipped family is published under the new name from its
+# first commit, so it needs its twin provisioned before it can ship; failing
+# here is how whoever adds one finds that out.
+FLIPPED_TOPICS = sorted(
+    [
+        str(Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED),
+        str(Topics.Lifecycle.ARCHIVE_STALE_REQUESTED),
+        str(Topics.Lifecycle.PURGE_SOFT_DELETED_REQUESTED),
+        str(Topics.Lifecycle.CRYSTALLIZE_REQUESTED),
+        str(Topics.Lifecycle.CRYSTALLIZE_ON_DEMAND_REQUESTED),
+        str(Topics.Lifecycle.ENTITY_LINK_REQUESTED),
+        str(Topics.Lifecycle.INSIGHTS_REQUESTED),
+        str(Topics.Lifecycle.EMBED_BACKFILL_REQUESTED),
+        str(Topics.Lifecycle.FORGE_DISTILL_REQUESTED),
+    ]
+)
 
-    Asserted directly rather than inferred from the publish tests below, so that
-    flipping a family in a later step fails HERE, at the one line that says the
-    cutover has not started, instead of somewhere that reads like a broken test.
+
+def test_exactly_the_flipped_families_are_flipped() -> None:
+    """The state of the flip, asserted at the one line that states it.
+
+    Pinned as an EQUALITY rather than a membership check, so that adding a
+    further family to that literal fails here. One family at a time is the whole
+    discipline of this step: each flip is a separate change with its own
+    readiness evidence, and a diff adding two families reads exactly like a diff
+    adding one. This test failing is therefore the EXPECTED cost of a flip, and
+    updating it is part of the change.
+
+    ``lifecycle`` flipped 2026-08-28 — the first SHARED family, so the same
+    change lands in caura-enterprise in the same cycle (rule 6). That repo's set
+    also holds ``fleet`` and ``security``, which are declared only there; naming
+    either here would raise at import in every OSS service.
+
+    ``audit`` is called out because it must be flipped LAST — those rows are
+    hash-chained, and a lost or reordered audit event is the one failure in this
+    programme that cannot be undone.
+
+    ``pipeline`` is called out for the opposite reason: it is declared in both
+    repos but has no live topic in either environment, so flipping it would
+    publish into nothing and raise nothing. A no-op flip that reports success is
+    the worst outcome available in this cutover, because it also looks like
+    progress.
+
+    ``memory`` is the natural next family and is otherwise ready on the same
+    evidence, but it declares ``.created``, which exists in neither environment
+    — a smaller instance of what disqualifies ``pipeline``. Provision or remove
+    that member before flipping it, so the flip carries no exception.
     """
-    assert topics_mod.FLIPPED_FAMILIES == frozenset()
+    assert topics_mod.FLIPPED_FAMILIES == FLIPPED
+    assert "audit" not in topics_mod.FLIPPED_FAMILIES
+    assert "pipeline" not in topics_mod.FLIPPED_FAMILIES
+    assert "memory" not in topics_mod.FLIPPED_FAMILIES
 
 
 def test_known_families_are_derived_from_the_enums() -> None:
@@ -134,9 +221,32 @@ def test_a_misspelled_flipped_family_is_refused() -> None:
     than re-implementing the check and asserting the copy raises.
     """
     original = Path(topics_mod.__file__).read_text(encoding="utf-8")
-    target = "FLIPPED_FAMILIES: frozenset[str] = frozenset()"
-    assert target in original, "the literal moved; this test is no longer editing it"
-    source = original.replace(target, f'{target[:-11]}frozenset({{"audi"}})')
+    # Match the VALUE EXPRESSION — ``frozenset(...)`` through its closing paren —
+    # rather than the literal set or the physical line. The previous form named
+    # ``frozenset()`` outright and stopped matching the moment a family was
+    # added, which is the one change that must not silently disarm this test.
+    #
+    # A line-anchored ``^...$`` is the tempting replacement and is also wrong,
+    # which is worth recording because it fails SILENTLY. ``common/ruff.toml``
+    # sets line-length 88; this assignment is 59 characters at one family and
+    # passes 88 at four, so ``ruff format`` will eventually wrap it across three
+    # lines. A line anchor then rewrites only the first physical line, leaving
+    # the old set body orphaned and indented — the count check below still sees
+    # exactly one match, and the test fails with ``IndentationError`` instead of
+    # the ``ValueError`` it is asserting, pointing nowhere near the cause.
+    # Matching to the closing paren handles the flat and wrapped forms
+    # identically, and the optional ``{...}`` also covers the bare
+    # ``frozenset()`` this returns to after the contract step.
+    #
+    # The count assertion is what keeps the wildcard honest: a zero-match would
+    # otherwise exec an unmodified module, raise nothing, and pass vacuously.
+    prefix = "FLIPPED_FAMILIES: frozenset[str] = "
+    pattern = re.compile(re.escape(prefix) + r"frozenset\(\s*(?:\{[^}]*\})?\s*\)")
+    source, count = pattern.subn(f'{prefix}frozenset({{"audi"}})', original)
+    assert count == 1, (
+        f"expected exactly one {prefix!r} assignment to edit, found {count}; "
+        "the literal moved and this test is no longer editing it"
+    )
     assert source != original
 
     with pytest.raises(ValueError, match="match no topic family"):
@@ -151,14 +261,34 @@ def test_the_real_module_passes_its_own_guard() -> None:
     assert topics_mod.FLIPPED_FAMILIES - topics_mod.known_families() == frozenset()
 
 
-def test_publish_name_is_the_identity_while_nothing_is_flipped() -> None:
-    for topic in (
-        Topics.Memory.EMBEDDED,
-        Topics.Audit.EVENT_RECORDED,
-        Topics.Org.SETTINGS_CHANGED,
-        Topics.Lifecycle.INSIGHTS_REQUESTED,
-    ):
+def test_publish_name_is_the_identity_for_every_unflipped_family() -> None:
+    """Every unflipped family still publishes under the name it always did.
+
+    Enumerated from ``all_topics()`` rather than a hand-listed sample, so a
+    family flipped without updating this file fails here instead of passing
+    because nobody thought to add its topic to the list.
+    """
+    for topic in topics_mod.all_topics():
+        if topics_mod.family(topic) in FLIPPED:
+            continue
         assert topics_mod.publish_name(topic) == str(topic)
+
+
+def test_publish_name_moves_the_flipped_family_and_only_it() -> None:
+    """The flip itself: ``lifecycle`` publishes under the twin, nothing else."""
+    assert topics_mod.publish_name(Topics.Lifecycle.INSIGHTS_REQUESTED) == (
+        "caura.lifecycle.insights-requested"
+    )
+    # The twin literals themselves are pinned by
+    # ``test_renamed_rewrites_only_the_first_segment``; re-asserting them here
+    # would just duplicate it. What this test adds is that ``publish_name``
+    # actually routes to them, and that NOTHING ELSE moves.
+    moved = sorted(
+        t for t in topics_mod.all_topics() if topics_mod.publish_name(t) != str(t)
+    )
+    assert moved == FLIPPED_TOPICS, (
+        f"only the flipped family may change publish name; these moved: {moved}"
+    )
 
 
 async def test_publish_targets_the_unrenamed_topic(bus: PubSubEventBus) -> None:
@@ -190,7 +320,7 @@ async def test_dual_subscribe_does_not_dual_publish(bus: PubSubEventBus) -> None
 # ── the Pub/Sub backend: off by default, because on is not survivable ─
 
 
-def test_pubsub_subscribe_binds_one_name_by_default() -> None:
+def test_pubsub_subscribe_binds_one_name_by_default(nothing_flipped: None) -> None:
     """Default OFF, and the registry is byte-identical to before the change.
 
     On this backend a topic name is a provisioned subscription. Binding one that
@@ -345,7 +475,10 @@ async def test_a_flipped_family_reaches_nobody_without_the_dual_binding(
     ],
 )
 async def test_dual_subscribe_flag_reads_anything_but_an_explicit_yes_as_off(
-    monkeypatch: pytest.MonkeyPatch, raw: str | None, expected: bool
+    monkeypatch: pytest.MonkeyPatch,
+    nothing_flipped: None,
+    raw: str | None,
+    expected: bool,
 ) -> None:
     """Which way the default points, asked of the flag itself.
 
@@ -388,15 +521,35 @@ async def test_dual_subscribe_flag_reads_anything_but_an_explicit_yes_as_off(
 # configuration rather than the broken one.
 
 
-def test_unbound_publish_topics_is_empty_in_the_shipped_state() -> None:
-    """Nothing flipped: no topic publishes anywhere unbound, either way.
+def test_nothing_publishes_unbound_in_the_configuration_the_services_run() -> None:
+    """The shipped-state property, restated for a world with a family flipped.
 
-    The byte-identical-behaviour property. If this fails, merging this guard
-    stopped being a runtime no-op.
+    Before the flip this asserted emptiness at BOTH settings, which was the
+    byte-identical-behaviour claim that made binding both names safe to ship
+    ahead of any deploy. That claim is spent: flipping a publisher is precisely
+    the point at which behaviour stops being identical, and ``dual=False``
+    becomes a state this repo must refuse rather than one it must support.
+
+    What has to hold now is narrower and is the actual precondition of the flip:
+    at ``dual=True`` — the setting every one of the 12 pubsub-backed deployables
+    was confirmed running at its live revision before this landed — no topic
+    publishes anywhere unbound. That is the property that makes the flip
+    lossless.
     """
-    assert topics_mod.FLIPPED_FAMILIES == frozenset()
-    assert topics_mod.unbound_publish_topics(dual=False) == ()
     assert topics_mod.unbound_publish_topics(dual=True) == ()
+
+
+def test_the_flip_is_hazardous_at_the_default_and_says_so() -> None:
+    """The counterfactual, so the test above cannot pass by the guard being dead.
+
+    ``dual=False`` is the default and is what standalone and on-prem
+    deployments run. Post-flip it is genuinely unsafe HERE, and the module has
+    to name every offending topic rather than merely return a bool — the
+    operator reading this is deciding whether their environment is the one that
+    is wrong, and there are nine names to give them.
+    """
+    unbound = topics_mod.unbound_publish_topics(dual=False)
+    assert sorted(unbound) == FLIPPED_TOPICS
 
 
 def test_unbound_publish_topics_names_a_flipped_family_when_dual_is_off(

--- a/tests/test_pubsub_trace_filters.py
+++ b/tests/test_pubsub_trace_filters.py
@@ -311,7 +311,13 @@ async def test_publisher_only_bus_does_not_register_the_filter(
         PubSubEventBus, "_ensure_pubsub_sdk", staticmethod(lambda: object())
     )
 
-    bus = PubSubEventBus(project_id="proj", subscription_prefix="test")
+    # dual on because ``lifecycle`` is flipped: the construction guard refuses
+    # ``dual=False`` in this repo now. Irrelevant to what this asserts — a
+    # publisher-only bus has no pull loop either way — so it takes the setting
+    # the running services use rather than neutralising the guard.
+    bus = PubSubEventBus(
+        project_id="proj", subscription_prefix="test", dual_subscribe=True
+    )
     await bus.start()  # publisher-only: subscribe() never called
 
     assert bus._started is True, "the bus must still start"


### PR DESCRIPTION
Step 4 of the brand rename, **third family** to move after `fleet` and `security`, and the **first shared one**. Adds `lifecycle` to `FLIPPED_FAMILIES` so `publish_name()` returns `caura.lifecycle.<event>` for its 9 topics. `publish_name()` still returns exactly one name — this is not dual-publishing.

**Coupled PR (rule 6 — must land together):** caura-ai/caura-enterprise#1366

`lifecycle` is declared in both repos, so the coupled cluster moves across both in one cycle. The two `FLIPPED_FAMILIES` lines are **deliberately not identical**: this one names `lifecycle` alone, because `fleet` and `security` are declared only in enterprise and naming either here would make `_validate_flipped_families()` raise at import in every OSS service. Verified by *executing* `known_families()` in both checkouts, not by reading them — OSS `{audit, lifecycle, memory, org, pipeline}`; enterprise adds `{fleet, security}`.

## Why lifecycle and not memory

Both remaining shared families were measured against the live project, not assumed:

| | declared topics | live in both envs | live topics/env (incl. DLQ) | durable subs/env | ephemerals |
|---|---|---|---|---|---|
| **`lifecycle`** | 9 | **9 / 9** | 18 | 18 | none |
| `memory` | 5 | **4 / 5** | 8 | 8 | none |

`memory` declares `memclaw.memory.created`, which **exists in neither environment** — zero topics in the project match `*created*` at all. That is the same defect that disqualifies `pipeline` (both its topics likewise absent), and publishing to a topic that does not exist is *silent loss*, not an error. It is inert today because nothing publishes `Memory.CREATED` — the only references are the enum declaration, two docstrings and tests — but a flip is not the step at which to lean on that.

`lifecycle` is the **larger** family by resource count (18 vs 8) and that is not the risk: the flip is one frozenset lookup per publish, so it cannot partially apply. Provisioning completeness is the property that matters.

## Evidence, measured against the running world

**`scripts/check_flip_readiness.py`** (lives in enterprise; it enumerates the GCP project across all regions, not a checkout). Re-run with `lifecycle` in the set → exit 0, `flipping ['fleet', 'lifecycle', 'security'] is safe`. **12/12** pubsub-backed deployables report `EVENT_BUS_DUAL_SUBSCRIBE` on **at their running revision** (`latestReadyRevisionName`, not the service spec, not the workflow YAML):

| deployable | revision |
|---|---|
| `prod-memclaw-core-api` | `00138-85k` |
| `prod-memclaw-core-worker` | `00114-bjk` |
| `prod-memclaw-platform-admin` | `00119-nbv` |
| `prod-memclaw-platform-audit` | `00097-ffq` |
| `prod-memclaw-platform-auth` | `00119-hl4` |
| `staging-memclaw-core-api` | `01496-s72` |
| `staging-memclaw-core-worker` | `01315-w4q` |
| `staging-memclaw-platform-admin` | `01229-8cd` |
| `staging-memclaw-platform-audit` | `01221-67k` |
| `staging-memclaw-platform-auth` | `01237-p8c` |
| `prod-memclaw-core-worker-backfill` (job) | job spec |
| `staging-memclaw-core-worker-backfill` (job) | job spec |

Staging revisions advance continuously; these are the ones live at the run that produced this verdict. The two Cloud Run **jobs** are defined in neither repo — `git grep` finds nothing, only `gcloud run jobs list` sees them.

**`scripts/preflight_dual_subscribe.py`** — exit 0 for **prod** and **staging**, with **no IAM warning**, so the broadcast attach-binding pairing was verified *live* and not only in config.

**Subscription parity for this family — 36/36**, and each twin verified *attached to the matching twin topic* rather than merely present by name:

| env | legacy durable subs | twin | attached-correctly |
|---|---|---|---|
| prod | 18 | 18 | 18/18 |
| staging | 18 | 18 | 18/18 |

Split `core-api` (crystallize, crystallize-on-demand, entity-link, insights, forge-distill) and `core-worker` (archive-expired, archive-stale, embed-backfill, purge-soft-deleted); 9 topics + 9 DLQs per env.

**No broadcast topic and no per-process ephemeral subscription** for `lifecycle` in either environment. Unlike `fleet`, none of this family's readiness rests on a runtime-created binding that can only be inferred — every subscription it needs is a durable resource that was listed. The only broadcast topics in the project are `fleet.policy-events` and `org.settings-changed`.

## What none of this proves

Both gates read **configuration**. Neither observes that a subscription was created, or that anything is pulling one, at runtime. A green gate is a necessary condition for this flip, never evidence that it works; the end-to-end signal is the staging deploy's control-plane check. **Do not read a green gate as a working flip.**

## Tests

The flip changes what a default-constructed `PubSubEventBus` means here: with a family flipped and its twins unbound at `dual=False`, the construction guard refuses the default, so `PubSubEventBus(...)` with the flag off now raises in this repo. That is the guard's deliberate fleet-wide coupling, and it is why the test churn is broad but mechanical:

- Every construction in `test_pubsub_bus.py` and `test_pubsub_trace_filters.py` takes `dual_subscribe=True` — the setting all 12 deployables run — because none of those tests is *about* that default (they cover topic prefixing, tunables, env normalisation, the pull loop, broadcast bookkeeping).
- The tests that *are* about the flag or the default take a new opt-in `nothing_flipped` fixture, which empties `FLIPPED_FAMILIES` for their duration only. No autouse masking; the guard keeps its own dedicated tests.
- `test_factory.py`'s four backend-plumbing tests set `EVENT_BUS_DUAL_SUBSCRIBE=true` rather than emptying the set, so the real flag-parsing path stays under test.
- `test_a_misspelled_flipped_family_is_refused` now matches the assignment's **value expression** by regex instead of the bare `frozenset()` literal, which stopped matching the moment a family was added — the one change that must not silently disarm it. A line-anchored regex would break on a future `ruff format` wrap; matching to the closing paren handles flat and wrapped identically.

Confirmed the three new assertions **fail** with `FLIPPED_FAMILIES` reverted to `frozenset()` and pass with it, so none holds either way.

## Local verification

- `ruff check` and `ruff format --check` run **separately at each of CI's exact scopes**, discovery-based, no `--config`: clean.
- `mypy` at all five CI scopes (`core-api`, `core-storage-api`, `core-operations`, `core-worker`, `common/` via `--config-file common/mypy.ini`): clean.
- `scripts/legacy_name_ratchet.py --base origin/main` → exit **0**, "No new lines." No `legacy-name-ok` marker was needed: the new line contains no legacy brand name.
- `scripts/do_not_touch_sentinel.py` → exit **0**, "All 34 protected strings survive."
- `pytest tests/` → **5472 passed**, 4 skipped, 1 xfailed. `core-worker` 75, `core-operations` 50. (`core-storage-api/tests` has 146 pre-existing local-Postgres errors identical on `origin/main`; CI's fresh service container does not see them.)
- No `uv.lock` in this repo changed — hashed before and after every `uv` invocation, with `UV_FROZEN=1`.
- Rebased onto `origin/main` immediately before pushing and the suite re-run after.

## Not in this change

**No deploy.** The deploy is the reviewer's to run. And a flip is **not** a licence to delete the old topic: subscribers running with dual-subscribe on keep creating ephemerals on the legacy name, so that pool refills continuously. The order is flip publishers → contract the enum members → let the pool reap (86,400s TTL) → only then delete.

`memory` is the natural next cycle on identical evidence (16/16 twin durable subs, no ephemerals) — provision or remove `Memory.CREATED` first. `pipeline` must not enter the set while it has zero live topics. `org` is shared and its staging ephemeral pool was under investigation as a suspected leak. `audit` last, unconditionally.
