### PR TITLE
refactor(events): remove the unprovisioned Memory.CREATED topic

### DIFF
--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -6,8 +6,8 @@ that ask a subscriber to do work.
 
 Uses `enum.StrEnum` (Python 3.11+) so members behave like the underlying
 string in every context: equality, dict-key hashing, f-string formatting,
-and Pub/Sub `topic_path` building all see `Topics.Memory.CREATED` as
-the literal `"memclaw.memory.created"`. A plain `(str, enum.Enum)` mix
+and Pub/Sub `topic_path` building all see `Topics.Memory.EMBEDDED` as
+its literal string value. A plain `(str, enum.Enum)` mix
 equates but does NOT format as the value — `f"{M.X}"` returns
 `"M.X"` — which would corrupt any string-formatted use site.
 """
@@ -18,7 +18,6 @@ import enum
 
 
 class Memory(enum.StrEnum):
-    CREATED = "memclaw.memory.created"
     EMBED_REQUESTED = "memclaw.memory.embed-requested"
     EMBEDDED = "memclaw.memory.embedded"
     ENRICH_REQUESTED = "memclaw.memory.enrich-requested"
@@ -93,7 +92,7 @@ class Lifecycle(enum.StrEnum):
 
 class Topics:
     """Namespaced facade so call sites keep the ergonomic form
-    `Topics.Memory.CREATED` instead of importing each inner enum."""
+    `Topics.Memory.EMBEDDED` instead of importing each inner enum."""
 
     Memory = Memory
     Audit = Audit
@@ -172,11 +171,12 @@ def family(topic: str) -> str:
 # first SHARED one, so it lands in both repos in one cycle. Chosen over
 # ``memory``, the other remaining shared family, on provisioning completeness
 # rather than size: every one of the 9 topics this family declares is live in
-# both environments, whereas ``memory`` declares one topic (``.created``) that
-# exists in neither. That is the same defect that disqualifies ``pipeline``,
-# and while it is harmless there today — nothing publishes ``.created`` — a
-# flip is not the step at which to be relying on that. Evidence, measured
-# against the running world rather than the source tree:
+# both environments, whereas ``memory`` then declared one topic (``.created``)
+# that existed in neither. That is the same defect that disqualifies
+# ``pipeline``, and a flip is not the step at which to rely on a topic being
+# harmless because nothing publishes it. That declaration has since been
+# removed — see the ``memory`` note below. Evidence, measured against the
+# running world rather than the source tree:
 #
 #   * 12/12 pubsub-backed deployables reported EVENT_BUS_DUAL_SUBSCRIBE on at
 #     their RUNNING revision (``check_flip_readiness.py``, enterprise).
@@ -196,9 +196,12 @@ def family(topic: str) -> str:
 # evidence the flip works; the end-to-end signal is the staging deploy's
 # control-plane check. Do not report a green gate as a working flip.
 #
-# ``memory`` is next and is otherwise ready on the same evidence — 16/16 twin
-# durable subscriptions, no ephemerals. Provision or remove
-# ``Memory.CREATED`` first, so its flip does not have to carry an exception.
+# ``memory`` is next and is ready on the same evidence — 16/16 twin durable
+# subscriptions, no ephemerals. Its one blocker is cleared: the declared
+# ``.created`` topic was removed rather than provisioned, because it existed in
+# neither environment, appeared in no events manifest, and had no publisher or
+# subscriber in either repo. Provisioning it would have created topics that
+# nothing emits to and nothing reads.
 #
 # ``pipeline`` must NOT enter this set while it has zero live topics in either
 # environment: publishing to a topic that does not exist is silent loss, so

--- a/tests/test_events/test_inprocess_bus.py
+++ b/tests/test_events/test_inprocess_bus.py
@@ -44,13 +44,13 @@ async def test_publish_fans_out_to_multiple_subscribers() -> None:
     async def handler_b(_e: Event) -> None:
         counts["b"] += 1
 
-    bus.subscribe(Topics.Memory.CREATED, handler_a)
-    bus.subscribe(Topics.Memory.CREATED, handler_b)
+    bus.subscribe(Topics.Memory.ENRICHED, handler_a)
+    bus.subscribe(Topics.Memory.ENRICHED, handler_b)
 
     for _ in range(3):
         await bus.publish(
-            Topics.Memory.CREATED,
-            Event(event_type=Topics.Memory.CREATED, tenant_id="t1"),
+            Topics.Memory.ENRICHED,
+            Event(event_type=Topics.Memory.ENRICHED, tenant_id="t1"),
         )
     await bus.drain()
 
@@ -61,8 +61,8 @@ async def test_no_subscribers_is_noop() -> None:
     bus = InProcessEventBus()
     # Publishing to a topic no one subscribes to must not raise.
     await bus.publish(
-        Topics.Memory.CREATED,
-        Event(event_type=Topics.Memory.CREATED),
+        Topics.Memory.ENRICHED,
+        Event(event_type=Topics.Memory.ENRICHED),
     )
     await bus.drain()
 
@@ -108,13 +108,13 @@ async def test_drain_awaits_in_flight_tasks() -> None:
 
 
 async def test_event_envelope_auto_populates_id_and_timestamp() -> None:
-    e = Event(event_type=Topics.Memory.CREATED)
+    e = Event(event_type=Topics.Memory.ENRICHED)
     assert e.event_id is not None
     assert e.occurred_at is not None
 
 
 async def test_event_is_frozen() -> None:
-    e = Event(event_type=Topics.Memory.CREATED)
+    e = Event(event_type=Topics.Memory.ENRICHED)
     with pytest.raises((TypeError, ValueError)):
         e.event_type = "other"  # type: ignore[misc]
 
@@ -128,12 +128,12 @@ async def test_drain_raises_on_circular_publish_chain() -> None:
         await bus.publish(Topics.Memory.EMBEDDED, Event(event_type=Topics.Memory.EMBEDDED))
 
     async def handler_b(_e: Event) -> None:
-        await bus.publish(Topics.Memory.CREATED, Event(event_type=Topics.Memory.CREATED))
+        await bus.publish(Topics.Memory.ENRICHED, Event(event_type=Topics.Memory.ENRICHED))
 
-    bus.subscribe(Topics.Memory.CREATED, handler_a)
+    bus.subscribe(Topics.Memory.ENRICHED, handler_a)
     bus.subscribe(Topics.Memory.EMBEDDED, handler_b)
 
-    await bus.publish(Topics.Memory.CREATED, Event(event_type=Topics.Memory.CREATED))
+    await bus.publish(Topics.Memory.ENRICHED, Event(event_type=Topics.Memory.ENRICHED))
     with pytest.raises(CircularPublishChainError, match="circular event-publish chain"):
         await bus.drain(max_rounds=5)
     # drain() is responsible for cancelling the remaining cycle tasks
@@ -165,11 +165,11 @@ async def test_stop_swallows_circular_chain_runtime_error() -> None:
         await bus.publish(Topics.Memory.EMBEDDED, Event(event_type=Topics.Memory.EMBEDDED))
 
     async def cycle_b(_e: Event) -> None:
-        await bus.publish(Topics.Memory.CREATED, Event(event_type=Topics.Memory.CREATED))
+        await bus.publish(Topics.Memory.ENRICHED, Event(event_type=Topics.Memory.ENRICHED))
 
-    bus.subscribe(Topics.Memory.CREATED, cycle_a)
+    bus.subscribe(Topics.Memory.ENRICHED, cycle_a)
     bus.subscribe(Topics.Memory.EMBEDDED, cycle_b)
-    await bus.publish(Topics.Memory.CREATED, Event(event_type=Topics.Memory.CREATED))
+    await bus.publish(Topics.Memory.ENRICHED, Event(event_type=Topics.Memory.ENRICHED))
 
     # Low max_rounds so the test completes quickly, and this must not raise.
     await bus.stop()

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -105,7 +105,7 @@ def test_topic_name_prefix_and_no_op() -> None:
 
 
 async def test_decode_accepts_well_formed_envelope() -> None:
-    src = Event(event_type=Topics.Memory.CREATED, tenant_id="t1", payload={"k": "v"})
+    src = Event(event_type=Topics.Memory.ENRICHED, tenant_id="t1", payload={"k": "v"})
     bytes_ = src.model_dump_json().encode("utf-8")
     decoded = PubSubEventBus._decode(bytes_)
     assert decoded is not None
@@ -132,7 +132,7 @@ async def test_dispatch_all_returns_true_when_all_handlers_succeed(
         nonlocal called
         called += 1
 
-    result = await bus._dispatch_all([h1, h2], Event(event_type=Topics.Memory.CREATED))
+    result = await bus._dispatch_all([h1, h2], Event(event_type=Topics.Memory.ENRICHED))
     assert result is True
     assert called == 2
 
@@ -147,7 +147,7 @@ async def test_dispatch_all_returns_false_when_any_handler_raises(
         pass
 
     result = await bus._dispatch_all(
-        [good, bad], Event(event_type=Topics.Memory.CREATED)
+        [good, bad], Event(event_type=Topics.Memory.ENRICHED)
     )
     assert result is False
 
@@ -165,7 +165,7 @@ async def test_dispatch_all_reraises_cancellation(bus: PubSubEventBus) -> None:
         raise asyncio.CancelledError("simulated stop()")
 
     with pytest.raises(asyncio.CancelledError):
-        await bus._dispatch_all([handler], Event(event_type=Topics.Memory.CREATED))
+        await bus._dispatch_all([handler], Event(event_type=Topics.Memory.ENRICHED))
 
 
 async def test_dispatch_all_logs_all_exceptions_before_reraising_cancellation(
@@ -185,7 +185,7 @@ async def test_dispatch_all_logs_all_exceptions_before_reraising_cancellation(
     with caplog.at_level("ERROR"), pytest.raises(asyncio.CancelledError):
         await bus._dispatch_all(
             [cancelled_handler, failing_handler],
-            Event(event_type=Topics.Memory.CREATED),
+            Event(event_type=Topics.Memory.ENRICHED),
         )
 
     assert any(
@@ -216,7 +216,7 @@ async def test_dispatch_all_runs_every_handler_even_after_earlier_raise(
 
     result = await bus._dispatch_all(
         [bad_first, good_after_bad, bad_last],
-        Event(event_type=Topics.Memory.CREATED),
+        Event(event_type=Topics.Memory.ENRICHED),
     )
     assert ran == ["bad_first", "good_after_bad", "bad_last"]
     assert result is False
@@ -245,11 +245,11 @@ async def test_subscribe_before_start_records_handlers(bus: PubSubEventBus) -> N
     async def h(_e: Event) -> None:
         return None
 
-    bus.subscribe(Topics.Memory.CREATED, h)
-    bus.subscribe(Topics.Memory.CREATED, h)
+    bus.subscribe(Topics.Memory.ENRICHED, h)
+    bus.subscribe(Topics.Memory.ENRICHED, h)
     bus.subscribe(Topics.Memory.EMBEDDED, h)
 
-    assert len(bus._handlers[Topics.Memory.CREATED]) == 2
+    assert len(bus._handlers[Topics.Memory.ENRICHED]) == 2
     assert len(bus._handlers[Topics.Memory.EMBEDDED]) == 1
     # No SDK was touched — start() isn't called here.
     assert bus._subscriber is None
@@ -378,7 +378,7 @@ async def test_stop_allows_clean_restart(bus: PubSubEventBus) -> None:
 
     # subscribe() no longer raises; the guard reads _pull_tasks which is
     # now empty.
-    bus.subscribe(Topics.Memory.CREATED, handler)
+    bus.subscribe(Topics.Memory.ENRICHED, handler)
     # Lazy access recreates a fresh executor — different object than
     # the one we got before stop().
     new_executor = bus._get_publish_executor()
@@ -404,7 +404,7 @@ async def test_subscribe_after_start_raises(bus: PubSubEventBus) -> None:
         return None
 
     with pytest.raises(RuntimeError, match="before start"):
-        bus.subscribe(Topics.Memory.CREATED, handler)
+        bus.subscribe(Topics.Memory.ENRICHED, handler)
 
 
 async def test_subscribe_after_start_raises_even_for_publisher_only(
@@ -422,7 +422,7 @@ async def test_subscribe_after_start_raises_even_for_publisher_only(
         return None
 
     with pytest.raises(RuntimeError, match="before start"):
-        bus.subscribe(Topics.Memory.CREATED, handler)
+        bus.subscribe(Topics.Memory.ENRICHED, handler)
 
 
 async def test_start_is_idempotent(bus: PubSubEventBus) -> None:
@@ -458,17 +458,17 @@ async def test_publish_warns_when_subscribers_registered_without_start(
     async def handler(_e: Event) -> None:
         return None
 
-    bus.subscribe(Topics.Memory.CREATED, handler)
+    bus.subscribe(Topics.Memory.ENRICHED, handler)
 
     with caplog.at_level("WARNING"):
         await bus.publish(
-            Topics.Memory.CREATED, Event(event_type=Topics.Memory.CREATED)
+            Topics.Memory.ENRICHED, Event(event_type=Topics.Memory.ENRICHED)
         )
         first_warnings = [
             r for r in caplog.records if "start() was never awaited" in r.message
         ]
         await bus.publish(
-            Topics.Memory.CREATED, Event(event_type=Topics.Memory.CREATED)
+            Topics.Memory.ENRICHED, Event(event_type=Topics.Memory.ENRICHED)
         )
         all_warnings = [
             r for r in caplog.records if "start() was never awaited" in r.message
@@ -485,7 +485,7 @@ async def test_publish_does_not_warn_when_no_subscribers_registered(
     # — no warning there.
     with caplog.at_level("WARNING"):
         await bus.publish(
-            Topics.Memory.CREATED, Event(event_type=Topics.Memory.CREATED)
+            Topics.Memory.ENRICHED, Event(event_type=Topics.Memory.ENRICHED)
         )
     assert not any("start()" in r.message for r in caplog.records)
 
@@ -624,7 +624,7 @@ async def test_start_constructs_subscriber_off_event_loop(
     async def _h(_e: Event) -> None:
         return None
 
-    bus.subscribe(Topics.Memory.CREATED, _h)
+    bus.subscribe(Topics.Memory.ENRICHED, _h)
 
     sub_ctor_calls = 0
 
@@ -851,7 +851,7 @@ async def test_start_aborts_when_stop_races_subscriber_construction(
     async def _h(_e: Event) -> None:
         return None
 
-    bus.subscribe(Topics.Memory.CREATED, _h)
+    bus.subscribe(Topics.Memory.ENRICHED, _h)
 
     real_run = asyncio.get_running_loop().run_in_executor
 
@@ -898,7 +898,7 @@ async def test_pull_loop_records_failed_subscription_on_unexpected_cancellation(
     )
     # Pull returns one fake message so dispatch fires.
     fake_msg = MagicMock()
-    fake_msg.message.data = b'{"event_type": "memclaw.memory.created"}'
+    fake_msg.message.data = b'{"event_type": "memclaw.memory.enriched"}'  # legacy-name-ok: rule 3 — pins the wire format a live subscriber must still decode
     fake_msg.ack_id = "ack-1"
     fake_response = MagicMock(received_messages=[fake_msg])
     fake_subscriber.pull = MagicMock(return_value=fake_response)
@@ -957,7 +957,7 @@ async def test_dispatch_all_runs_handlers_concurrently(bus: PubSubEventBus) -> N
 
     t0 = time.perf_counter()
     result = await bus._dispatch_all(
-        [slow, slow, slow, slow], Event(event_type=Topics.Memory.CREATED)
+        [slow, slow, slow, slow], Event(event_type=Topics.Memory.ENRICHED)
     )
     elapsed = time.perf_counter() - t0
     assert result is True
@@ -998,7 +998,7 @@ async def test_decode_handles_pydantic_validation_error() -> None:
 
     # Wrong type for `occurred_at` — invalid datetime string.
     bad_ts = _json.dumps(
-        {"event_type": "memclaw.memory.created", "occurred_at": "not-a-date"}
+        {"event_type": "memclaw.memory.enriched", "occurred_at": "not-a-date"}  # legacy-name-ok: rule 3 — pins the wire format a live subscriber must still decode
     ).encode()
     assert PubSubEventBus._decode(bad_ts) is None
 

--- a/tests/test_events/test_topics.py
+++ b/tests/test_events/test_topics.py
@@ -6,22 +6,22 @@ from common.events import Topics
 
 
 def test_members_compare_equal_to_their_string_value() -> None:
-    assert Topics.Memory.CREATED == "memclaw.memory.created"
+    assert Topics.Memory.ENRICHED == "memclaw.memory.enriched"  # legacy-name-ok: rule 3 — asserts the enum's current wire value
     assert Topics.Audit.EVENT_RECORDED == "memclaw.audit.event-recorded"
 
 
 def test_members_format_as_their_string_value() -> None:
-    # f-string format MUST produce the value, not "Memory.CREATED".
+    # f-string format MUST produce the value, not "Memory.ENRICHED".
     # Pub/Sub's topic_path uses f-string interpolation; regressing here
     # breaks every publish.
-    assert f"{Topics.Memory.CREATED}" == "memclaw.memory.created"
+    assert f"{Topics.Memory.ENRICHED}" == "memclaw.memory.enriched"  # legacy-name-ok: rule 3 — asserts the enum's current wire value
     assert str(Topics.Memory.EMBED_REQUESTED) == "memclaw.memory.embed-requested"
 
 
 def test_members_hash_equal_to_their_string_value() -> None:
     # Dict lookup on a handler map keyed by topic name must find the
     # enum member when looked up by the string and vice versa.
-    d = {Topics.Memory.CREATED: 1}
-    assert d["memclaw.memory.created"] == 1
-    d2 = {"memclaw.memory.created": 2}
-    assert d2[Topics.Memory.CREATED] == 2
+    d = {Topics.Memory.ENRICHED: 1}
+    assert d["memclaw.memory.enriched"] == 1  # legacy-name-ok: rule 3 — asserts the enum's current wire value
+    d2 = {"memclaw.memory.enriched": 2}  # legacy-name-ok: rule 3 — asserts the enum's current wire value
+    assert d2[Topics.Memory.ENRICHED] == 2


### PR DESCRIPTION
Removes `Topics.Memory.CREATED`, the one declared-but-unprovisioned topic blocking the `memory` family's rename cycle.

## Why remove rather than provision

`memclaw.memory.created` was declared and never wired to anything. Measured against the running project, not the source tree:

| check | result |
| --- | --- |
| topic in GCP, either name, either environment | **absent** — 143 topics enumerated in `alpine-theory-469016-c8` |
| the other four `memory` topics | present in all four env x name combinations, each with a DLQ |
| listed in `common/events/events_manifest.json` | **absent** — the other four appear under both prefixes |
| Terraform subscription | none |
| publisher or subscriber, either repo, non-test | **none** |
| references outside `caura` / `caura-enterprise` | none |

Its only uses were the enum declaration, two docstring examples, and tests that had picked it as an arbitrary sample topic.

Provisioning it would have meant creating 4 topics plus 4 DLQs, their subscriptions and IAM across staging and prod, and then carrying all of it through the rename — for an event nothing emits and nothing reads.

Leaving it in place is what blocks `memory`. A family that declares a topic which does not exist cannot be flipped safely: publishing into a missing topic is silent loss that Pub/Sub reports as success. That is the same defect that disqualifies `pipeline`, recorded in the `FLIPPED_FAMILIES` comment this PR updates.

## Test substitution, and the trap avoided

Tests used `Memory.CREATED` as a stand-in topic for bus mechanics. They now use `Memory.ENRICHED`, chosen because it appears **nowhere else** in those three files.

The obvious choice, `EMBEDDED`, would have been wrong. `test_drain_raises_on_circular_publish_chain` and `test_stop_swallows_circular_chain_runtime_error` each build a deliberate **two-topic** cycle — handler A publishes B, handler B publishes A. Both files already use `EMBEDDED` as the other half of that pair, so substituting it would have collapsed each cycle into a self-loop. Those tests would very likely still pass, while no longer testing the scenario their own comments describe.

## Legacy-name ratchet

Rewriting a line containing `memclaw` makes it new text, so grandfathered lines lose their exemption. Handled two ways, per the ratchet's own guidance that rewording beats marking:

- **Reworded** (no exemption needed): the module docstring now names the enum member without pinning its literal string. This drops a legacy-name occurrence outright, and stops the docstring going stale when `memory` flips.
- **Marked** `legacy-name-ok` (6 lines): assertions in `test_topics.py` and two wire payloads in `test_pubsub_bus.py`. These pin the current wire format on purpose — interpolating the enum instead would make them self-referential and assert nothing about the bytes on the bus.

## Verification

Run at this repo's exact CI scopes, exit codes read directly rather than through a pipe:

- `ruff check common/` — 0, clean
- `ruff format --check --isolated` (the three gated vendored files, plus `common/events/topics.py`) — 0, already formatted
- `scripts/legacy_name_ratchet.py --base origin/main` — 0, the 6 exemptions listed above reported for review
- `scripts/do_not_touch_sentinel.py` — 0, all 34 protected strings survive
- `pytest tests/ -m "not benchmark"` — 5469 passed, 4 skipped, 1 xfailed, 16 deselected

**One unresolved failure — do not merge until it is settled.** The full run on this branch reported `test_interview_async_submit.py::test_schedule_sweep_processes_pending_jobs` as failed (5469 passed, 1 failed).

A full-suite baseline on pristine `origin/main`, same machine and same venv recipe, came back **clean**: 5470 passed, 0 failed. So this cannot be written off as pre-existing, and I am not claiming it is.

What points the other way, for whatever it is worth: the test passes on its own twice against this branch, and the file contains no reference to `Memory.CREATED`, to `__members__`, or to any all-topics iteration, so there is no evident mechanism by which removing an unused enum member reaches it. It also runs ~41s and is a scheduler sweep, which is the shape a timing-dependent test takes.

A second full-suite run on this branch is in progress to separate a flake from a real ordering interaction. I will post the result here either way.

`uv.lock` files hashed before and after every `uv` command and are unchanged; `UV_FROZEN=1` throughout.

## Downstream note

This repo is public, so this removes a public enum member. It was never functional — the topic exists in no environment, so publishing through it would have raised `NotFound`. Flagging it rather than burying it, since it is an API surface change and not purely dead-code removal.

## Coupling

`common/events/topics.py` is vendored into `caura-enterprise` under the `manual` policy, so the two copies move together as one cluster. Enterprise counterpart: caura-ai/caura-enterprise#1373
