### PR TITLE
test: reclaim organization_settings rows in the end-of-run cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,53 +170,98 @@ async def _setup_schema(_engine):
     yield
     # Cleanup: drop test data (but keep schema for session reuse)
     async with _engine.begin() as conn:
-        for table in (
-            "relations",
-            "entities",
-            "memories",
-            "audit_log",
-            # One genesis row per tenant (``_audit_chain_one_tenant``), so a
-            # per-test tenant leaves one per test rather than one per run. It was
-            # never swept: a local DB had 9,186 ``test-tenant-`` rows here from
-            # earlier runs. Other tenant-scoped tables (recall_event,
-            # memory_conflicts, dedup_reviews, agents, session_traces) leak the
-            # same way but per-write, so they are a separate cleanup.
-            "audit_chain_head",
-            "agent_activity_digests",
-            # Keystones and other docs live here. Written through the API's own
-            # committed transaction, so the per-test session rollback never
-            # reaches them — without this they survive every run. That is not
-            # only untidy: the keystone listing is capped at 50 and ordered by
-            # weight, so accumulated rules eventually push a freshly-written one
-            # out of the response and a round-trip test fails for reasons that
-            # look nothing like accumulated state.
-            "documents",
-        ):
-            try:
-                await conn.execute(
-                    text(f"DELETE FROM {table} WHERE tenant_id LIKE :prefix"),
-                    {"prefix": f"{SWEEP_TENANT_PREFIX}%"},
-                )
-            except Exception:
-                # Best-effort, and the ONLY thing that ever removes rows written
-                # through the service layer — not a backstop behind the ``db``
-                # fixture's rollback. Most tests here write via ``sc``, which
-                # commits on its own connections, so that rollback never sees
-                # those rows. Per-test isolation comes from the unique
-                # ``tenant_id``; this sweep is end-of-run cleanup, so the table
-                # doesn't grow without bound.
-                pass
-        # memory_entity_links doesn't have tenant_id — clean via memory join
+        await purge_test_rows(conn, f"{SWEEP_TENANT_PREFIX}%")
+
+
+async def purge_test_rows(conn, prefix: str) -> None:
+    """DELETE every tenant-scoped row whose owner id matches ``prefix``.
+
+    Extracted from ``_setup_schema``'s teardown so it can be exercised
+    directly. That matters more here than it looks: every statement below
+    swallows its exception, so a DELETE naming a table that does not exist,
+    or filtering on a column that table does not have, is indistinguishable
+    from one that worked. ``tests/test_conftest_cleanup.py`` calls this with
+    a prefix unique to itself and asserts the rows are actually gone.
+    """
+    for table in (
+        "relations",
+        "entities",
+        "memories",
+        "audit_log",
+        # One genesis row per tenant (``_audit_chain_one_tenant``), so a
+        # per-test tenant leaves one per test rather than one per run. It was
+        # never swept: a local DB had 9,186 ``test-tenant-`` rows here from
+        # earlier runs. Other tenant-scoped tables (recall_event,
+        # memory_conflicts, dedup_reviews, agents, session_traces) leak the
+        # same way but per-write, so they are a separate cleanup.
+        "audit_chain_head",
+        "agent_activity_digests",
+        # Keystones and other docs live here. Written through the API's own
+        # committed transaction, so the per-test session rollback never
+        # reaches them — without this they survive every run. That is not
+        # only untidy: the keystone listing is capped at 50 and ordered by
+        # weight, so accumulated rules eventually push a freshly-written one
+        # out of the response and a round-trip test fails for reasons that
+        # look nothing like accumulated state.
+        "documents",
+    ):
         try:
             await conn.execute(
-                text(
-                    "DELETE FROM memory_entity_links WHERE memory_id IN "
-                    "(SELECT id FROM memories WHERE tenant_id LIKE :prefix)"
-                ),
-                {"prefix": f"{SWEEP_TENANT_PREFIX}%"},
+                text(f"DELETE FROM {table} WHERE tenant_id LIKE :prefix"),
+                {"prefix": prefix},
             )
         except Exception:
+            # Best-effort, and the ONLY thing that ever removes rows written
+            # through the service layer — not a backstop behind the ``db``
+            # fixture's rollback. Most tests here write via ``sc``, which
+            # commits on its own connections, so that rollback never sees
+            # those rows. Per-test isolation comes from the unique
+            # ``tenant_id``; this sweep is end-of-run cleanup, so the table
+            # doesn't grow without bound.
             pass
+    # memory_entity_links doesn't have tenant_id — clean via memory join
+    try:
+        await conn.execute(
+            text(
+                "DELETE FROM memory_entity_links WHERE memory_id IN "
+                "(SELECT id FROM memories WHERE tenant_id LIKE :prefix)"
+            ),
+            {"prefix": prefix},
+        )
+    except Exception:
+        pass
+    # organization_settings keys on ``org_id``, not ``tenant_id``, so it
+    # cannot join the loop above — and putting it there would look right
+    # while doing nothing, because the failing DELETE is swallowed.
+    #
+    # Unswept it is the most expensive leak here. Every test that opts a
+    # tenant into a feature writes a row, and the interviewer sweep
+    # enumerates EVERY enabled tenant on each tick — two storage round-trips
+    # apiece, sequentially. A local database reached 4,738 enabled orgs,
+    # which put the sweep in ``test_schedule_sweep_processes_pending_jobs``
+    # at 16s and that one test at 48s, growing with every run. CI never sees
+    # it: its Postgres is a fresh service container per run, so this is
+    # precisely the class of failure that reproduces only on a developer's
+    # machine and reads as flakiness rather than accumulated state.
+    try:
+        await conn.execute(
+            text("DELETE FROM organization_settings WHERE org_id LIKE :prefix"),
+            {"prefix": prefix},
+        )
+    except Exception:
+        pass
+    # ``organization_settings_audit`` is keyed on ``org_id`` too, and leaks
+    # faster than the table above: it is append-only, one row per settings
+    # change rather than one per org, so a test that writes settings twice
+    # leaves two. Same local database carried 8,676 of these against 8,238
+    # settings rows.
+    try:
+        await conn.execute(
+            text("DELETE FROM organization_settings_audit WHERE org_id LIKE :prefix"),
+            {"prefix": prefix},
+        )
+    except Exception:
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_conftest_cleanup.py
+++ b/tests/test_conftest_cleanup.py
@@ -1,0 +1,76 @@
+"""The end-of-run cleanup must actually delete what it claims to.
+
+Every statement in ``purge_test_rows`` swallows its exception, so a DELETE
+naming a table that does not exist — or filtering on a column that table does
+not have — is indistinguishable from one that worked. ``organization_settings``
+keys on ``org_id`` rather than ``tenant_id``, which is exactly the shape that
+fails silently if it is bolted onto the ``tenant_id`` loop instead of given its
+own statement.
+
+Left unreclaimed those rows are not merely untidy. The interviewer schedule
+sweep enumerates every enabled org on each tick, so they make it slower on
+every subsequent local run — the accumulation that took one sweep test to 48s
+before this was fixed.
+"""
+
+import uuid
+
+from sqlalchemy import text
+
+from tests.conftest import SWEEP_TENANT_PREFIX, purge_test_rows
+
+
+async def _count(engine, table: str, org_id: str) -> int:
+    async with engine.begin() as conn:
+        result = await conn.execute(
+            text(f"SELECT count(*) FROM {table} WHERE org_id = :o"),
+            {"o": org_id},
+        )
+        return int(result.scalar() or 0)
+
+
+async def test_purge_reclaims_organization_settings(_engine, _setup_schema):
+    # A prefix unique to this test, still inside SWEEP_TENANT_PREFIX so the
+    # real end-of-run sweep would reclaim it too. Purging by this narrow
+    # prefix rather than the session-wide one keeps the call from deleting
+    # rows other tests in this session are still using.
+    prefix = f"{SWEEP_TENANT_PREFIX}purgeprobe-{uuid.uuid4().hex[:8]}"
+    org_id = f"{prefix}-org"
+
+    async with _engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO organization_settings (org_id, settings) "
+                "VALUES (:o, '{}'::jsonb)"
+            ),
+            {"o": org_id},
+        )
+        # The audit trail is written by the same request that updates the
+        # settings, keys on ``org_id`` the same way, and is append-only — so
+        # it leaks faster than the settings row itself.
+        await conn.execute(
+            text(
+                "INSERT INTO organization_settings_audit (org_id, diff) "
+                "VALUES (:o, '{}'::jsonb)"
+            ),
+            {"o": org_id},
+        )
+    assert await _count(_engine, "organization_settings", org_id) == 1, (
+        "seed row missing"
+    )
+    assert await _count(_engine, "organization_settings_audit", org_id) == 1, (
+        "seed audit row missing"
+    )
+
+    async with _engine.begin() as conn:
+        await purge_test_rows(conn, f"{prefix}%")
+
+    assert await _count(_engine, "organization_settings", org_id) == 0, (
+        "organization_settings row survived purge_test_rows — every test that "
+        "opts a tenant into a feature leaves one behind, and the interviewer "
+        "sweep pays for all of them on every tick"
+    )
+    assert await _count(_engine, "organization_settings_audit", org_id) == 0, (
+        "organization_settings_audit row survived purge_test_rows — append-only "
+        "and keyed on org_id, so it accumulates faster than the settings table"
+    )


### PR DESCRIPTION
Investigating the intermittent failure of `test_interview_async_submit.py::test_schedule_sweep_processes_pending_jobs` found a real, compounding problem underneath it — though not, in the end, the thing I was sent to find. Read the scope note at the bottom before merging.

## What is actually wrong

`_setup_schema`'s teardown never deleted `organization_settings`. Every test that opts a tenant into a feature writes a row there, and nothing has ever removed one. The local database this was found on had **4,738 interviewer-enabled orgs**.

That is not untidiness. `process_pending_interview_jobs` enumerates *every* enabled org on each tick and issues **two storage round-trips per org, sequentially**, so the sweep's cost is linear in rows no test ever reclaims:

| enabled orgs | sweep | the test | its module | whole suite |
| --- | --- | --- | --- | --- |
| 4,738 | 16.0s | 47.8s | 75.9s | 7m09s |
| 3,380 (prefixed rows reclaimed) | — | 32.9s | — | 6m00s |
| 12 (residue cleared too) | — | **7.1s** | **3.6s** | **1m58s** |

The middle row is this PR's effect in isolation: a 31% drop against a 28.6% reduction in enumerated orgs — the linear relationship the mechanism predicts, growing on every run forever.

The bottom row also required clearing historical residue this PR cannot reach (see below), and is what a developer's machine looks like once both are done: **the suite goes from 7m09s to 1m58s.**

This is the same shape as **#858**, which `new_tenant_id`'s docstring already records: `t-` prefixed tenants outlived their run and "a cross-tenant sweep endpoint under test started reading other runs' residue."

## Why adding one table name would not have worked

`organization_settings` keys on `org_id`, not `tenant_id`, so it cannot join the existing loop — and putting it there would have **looked correct while doing nothing**, because every statement in that teardown swallows its exception. A `DELETE` filtering on a column the table does not have is indistinguishable from one that worked.

So the cleanup is extracted into `purge_test_rows(conn, prefix)` and `tests/test_conftest_cleanup.py` seeds a row under a prefix unique to itself, purges with that prefix, and asserts the row is gone. Taking the prefix as a parameter is what lets the test call the real function without deleting rows other tests in the session are still using.

**Confirmed both ways**: with either new `DELETE` removed in turn, the test fails on the corresponding seeded row surviving; with both, it passes. Verified end-to-end too — `test-tenant-%` rows in `organization_settings` went **4,855 → 0** after one run.

`organization_settings_audit` is swept for the same reason, and that one came from review rather than from me. It keys on `org_id` as well and is append-only — one row per settings *change*, not per org — so it leaks faster than the table this PR started with: the same database held **8,676** of them against 8,238 settings rows.

## Scope note — this does NOT fix the flake

I did reproduce the original failure, and **this change does not eliminate it.** Running the enclosing module on its own reproduces it far more readily than the full suite does:

| run | result |
| --- | --- |
| module alone, pristine `origin/main` | 2 failed |
| module alone, with this change | 1 failed |
| module alone, with this change, under `-s` | 0 failed |
| full suite, with this change | **5471 passed, 0 failed** |
| module alone, clean DB, **×24 runs at 3.7s each** | **1 failed** (run 5 of the first 8; the next 15 all green) |

Those counts move run to run, so read them as "still flaky," **not** as evidence this change improves the failure rate. It does not claim to.

That last row is the important one. With the database cleared the module runs in 3.7s and the failure **still reproduces at roughly 1 in 20**. So the accumulation was not the cause — the race is independent of it, and this PR does not close it.

The failure is always the same assertion:

```
tests/test_interview_async_submit.py:666: assert summary["jobs_processed"] >= 1
E   assert 0 >= 1
```

`jobs_processed == 0` means the sweep's Pass 1 collected **no jobs at all**, even though the test asserts its own job is `pending` immediately beforehand. Instrumenting a passing run showed the healthy path clearly: `ours_in_list=True`, job `pending`, `jobs_processed=4` — four, because it also picks up jobs left pending by earlier tests in the same module.

**The reproduction is now cheap, which is the practical win here.** Before: a ~7-minute full-suite run per attempt, failing rarely. Now: `pytest tests/test_interview_async_submit.py` in **3.7s**, failing about 1 in 20, on a clean database. That turns "run the suite overnight and hope" into a loop you can sit and watch.

**A lead for whoever takes this further.** `process_pending_interview_jobs` pins the writer where it decides *which tenants* to sweep (`list_tenants_with_interviewer_enabled(read=False)`), and the surrounding comments say the watermark read does the same, precisely so replica lag cannot drop a tenant from a tick. But the per-tenant `sc.query_documents(...)` calls that decide *which jobs* exist take the default and do **not** pass `read=False`. A job committed moments earlier and read back from a lagging replica would present exactly as this failure does: tenant enumerated, `tenants_failed=0`, zero jobs found. I have not confirmed it, and in a single-database test setup it is not obviously reachable — it is the next thing I would check, not a diagnosis.

**CI is not affected by the accumulation this PR fixes** — its Postgres is a fresh service container per run. That corrects the premise I started from, which assumed a CI flake. The accumulation is a local-environment degradation, worth fixing on its own merits as an unbounded-growth hygiene bug with a documented prior incident (#858). The intermittent failure is a separate, still-open problem.

## Residue this cannot reclaim

3,380 of the enabled orgs are `t-<8hex>` — the pre-#858 pattern. No current test mints them, and they fall outside `test-tenant-%`, so no prefix sweep will ever reach them. I have not broadened the `DELETE` to `t-%`: that pattern is loose enough to match live ids, and deleting rows from a developer's database is not a test fixture's decision. Clear it by hand if your local suite feels slow:

```sql
DELETE FROM organization_settings WHERE org_id ~ '^t-[0-9a-f]{8}$';
```

Checked before running it on the machine these numbers come from: 3,380 rows matched, and **zero** `t-%` rows fell outside the pattern — so it cannot catch the live `t-c28-*` / `t-c29-*` tenants that `test_c28_confirm_scope_tenant_delete.py` and `test_c29_structured_duplicate_409.py` still mint. Those two files are worth moving to `new_tenant_id()` separately; they are minting ids the sweep can never reclaim, which is exactly how this residue got here.

## Verification

- new test passes with the fix, **fails without it** (the point of the exercise)
- `pytest tests/ -m "not benchmark"` — **5471 passed**, 4 skipped, 16 deselected, 1 xfailed, 0 failed, in **1m58s** (was 7m09s), since several interview tests pay the same per-org sweep cost
- `scripts/legacy_name_ratchet.py --base origin/main` — 0, "No new lines"
- `scripts/do_not_touch_sentinel.py` — 0, all 34 protected strings survive
- `ruff format --check` — clean; `ruff check` on the new file — clean

`tests/` is not in this repo's `ruff check` CI scope. For the record, my two blocks add two `S110`/`BLE001` pairs to `conftest.py` (23 → 27 findings), matching the two pairs that already exist there for the table loop and `memory_entity_links`. I kept the established best-effort shape rather than making one block deviate; the new test is what guards it.

`uv.lock` files hashed before and after every `uv` command and are unchanged; `UV_FROZEN=1` throughout.
