### PR TITLE
fix(logging): UVICORN_ACCESS_LOG was inert — enforce it where it's undone

### DIFF
--- a/common/serve.py
+++ b/common/serve.py
@@ -42,12 +42,11 @@ from __future__ import annotations
 
 import argparse
 import importlib
-import os
 from typing import Any
 
 import uvicorn
 
-from common.structlog_config import configure_logging
+from common.structlog_config import access_log_enabled, configure_logging
 
 
 def _load(path: str) -> Any:
@@ -106,31 +105,23 @@ def main(argv: list[str] | None = None) -> None:
         log_file=settings.log_file or None,
     )
 
-    # UVICORN_ACCESS_LOG=false silences uvicorn's per-request access line.
+    # UVICORN_ACCESS_LOG=false drops uvicorn's per-request access line —
+    # the THIRD copy of one fact, and the only one of the three without a
+    # duration (the APM span and Cloud Run's own httpRequest entry both
+    # carry latency). Rationale and the opt-out default live on
+    # access_log_enabled(); the ENFORCEMENT lives in structlog_config's
+    # _route_third_party_to_root.
     #
-    # Defaults to ON, so OSS, on-prem and local runs are unchanged — there
-    # the access line is often the only per-request visibility there is. A
-    # managed deploy opts out, because there it is the THIRD copy of one
-    # fact, and the least useful of the three:
-    #
-    #   1. the APM span     — trace id, duration, route, tags, service map
-    #   2. Cloud Run's own  — httpRequest in Cloud Logging: method, status,
-    #      request log        url, AND latency; written by the platform, so
-    #                         it survives anything this process does
-    #   3. this line        — ip, method, path, status. No duration.
-    #
-    # Measured before removing rather than assumed: uvicorn.access emitted
-    # 3,690,995 lines in 24h, 53.6% of ALL prod logs, on 2026-08-28.
-    #
-    # Parsed inline rather than through common/env_utils.read_*_env, which
-    # is where an env-var reader would otherwise belong. This file is
-    # vendored into caura-enterprise as an identical-policy copy and
-    # common/env_utils.py does NOT exist in that repo, so importing it
-    # would re-vendor a serve.py that raises ImportError at startup for
-    # every platform service. Keep this module's imports to things that
-    # exist in BOTH repos.
-    raw_access_log = os.environ.get("UVICORN_ACCESS_LOG", "").strip().lower()
-    access_log = raw_access_log not in {"0", "false", "no", "off"}
+    # Passing access_log=False below is necessary but NOT sufficient, which
+    # is why the enforcement is elsewhere. uvicorn's Config only uses this
+    # flag to clear uvicorn.access's handlers and set propagate=False; its
+    # HTTP protocols then re-derive the decision per connection from
+    # ``self.access_logger.hasHandlers()``. Our own logger rerouting runs
+    # afterwards (at app import, in every worker) and sets propagate=True
+    # to pull uvicorn's lines into structlog — which makes hasHandlers()
+    # find the root handler and answer True again. Shipping only this
+    # kwarg is exactly what made the 2026-08-28 rollout a no-op.
+    access_log = access_log_enabled()
 
     # log_config=None: do NOT let uvicorn install its own stream handlers.
     # That keeps uvicorn.{error,access} propagating to the structlog root

--- a/common/structlog_config.py
+++ b/common/structlog_config.py
@@ -32,6 +32,7 @@ are width-independent) or enterprise CI goes red on the next re-vendor.
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import threading
 import warnings
@@ -464,6 +465,27 @@ def configure_logging(
         _configured = True
 
 
+def access_log_enabled() -> bool:
+    """Whether uvicorn should emit its per-request access line.
+
+    ``UVICORN_ACCESS_LOG`` is opt-OUT: anything but a clearly falsy value
+    keeps the line, so OSS, on-prem and local runs are unchanged — there it
+    is often the only per-request visibility there is. A managed deploy sets
+    it false because there the line is the THIRD copy of one fact: the APM
+    span and Cloud Run's own httpRequest entry both already record the
+    request, and unlike this line both also carry latency.
+
+    Read here rather than in ``common/serve.py`` because this module is
+    where the setting has to be ENFORCED (see ``_route_third_party_to_root``),
+    and because ``common/env_utils`` — where an env reader would otherwise
+    belong — does not exist in the caura-enterprise repo this file is
+    vendored into byte-for-byte. ``serve.py`` imports this helper, so the
+    parsing lives in exactly one place across both repos.
+    """
+    raw = os.environ.get("UVICORN_ACCESS_LOG", "").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
 # Names of third-party loggers that install their own (typically stderr,
 # plain-text) handlers OR set ``propagate=False``, bypassing the root
 # ``ProcessorFormatter`` without explicit re-routing. CAURA-588.
@@ -480,6 +502,8 @@ _THIRD_PARTY_LOGGERS_TO_REROUTE: tuple[str, ...] = (
     # uvicorn ships three loggers with propagate=False + own StreamHandlers
     # via uvicorn.config.LOGGING_CONFIG.
     "uvicorn",
+    # Rerouted only when access logging is ON; otherwise silenced outright —
+    # see the uvicorn.access branch in _route_third_party_to_root.
     "uvicorn.access",
     "uvicorn.error",
     # FastMCP / underlying mcp library register their own stream handler.
@@ -530,6 +554,38 @@ def _route_third_party_to_root() -> None:
         # initialised) would fall through to the early-exit branch and
         # emit a spurious WARNING about rerouting being a no-op.
         if name in _third_party_logger_original_state:
+            continue
+        # uvicorn does NOT keep the ``access_log=False`` it was configured
+        # with. Its HTTP protocols re-derive the decision per connection:
+        #
+        #     self.access_log = self.access_logger.hasHandlers()
+        #     (uvicorn/protocols/http/{h11,httptools}_impl.py)
+        #
+        # ``hasHandlers()`` walks ancestors while each one propagates, so
+        # rerouting this logger — no handlers, ``propagate=True`` — makes it
+        # find the ROOT handler and answer True, silently re-enabling the
+        # access line that ``Config.configure_logging()`` had just switched
+        # off. That is not a hypothetical: it is exactly why the 2026-08-28
+        # rollout of UVICORN_ACCESS_LOG=false changed nothing in staging —
+        # the env var was set, the flag was passed, and every request was
+        # still logged.
+        #
+        # So when the line is unwanted, silence the logger instead of
+        # rerouting it: no handlers AND ``propagate=False`` is what makes
+        # hasHandlers() answer False, because the walk stops at the first
+        # non-propagating logger. Snapshot first so _reset_for_testing can
+        # still restore. Doing it here rather than in serve.py also means
+        # the switch works for the services that exec the uvicorn CLI
+        # directly and never run serve.py at all.
+        if name == "uvicorn.access" and not access_log_enabled():
+            _third_party_logger_original_state[name] = (
+                list(lg.handlers),
+                lg.propagate,
+                lg.level,
+            )
+            for h in list(lg.handlers):
+                lg.removeHandler(h)
+            lg.propagate = False
             continue
         # Library hasn't installed its own handlers and still propagates — there
         # is nothing to reroute, and crucially nothing is LOST: a handler-less,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -244,6 +244,151 @@ def test_route_third_party_to_root_clears_handlers_and_enables_propagation() -> 
         target.propagate = True
 
 
+# ─── UVICORN_ACCESS_LOG ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def uvicorn_access_sandbox():
+    """Fully restore every global these tests mutate.
+
+    They reach into process-wide logging state — the uvicorn.access logger,
+    the ROOT logger's handlers, and the module's reroute bookkeeping — so
+    without an exact restore they leak into whatever runs next in the same
+    process. Restoring by hand in each test's ``finally`` is what leaked the
+    first time: clearing ``_third_party_logger_original_state`` also discards
+    the snapshots taken for uvicorn / fastmcp / mcp / slowapi, leaving the
+    module believing it had never rerouted anything.
+    """
+    lg = logging.getLogger("uvicorn.access")
+    root = logging.getLogger()
+    saved_handlers = list(lg.handlers)
+    saved_propagate = lg.propagate
+    saved_level = lg.level
+    saved_root_handlers = list(root.handlers)
+    saved_state = dict(_third_party_logger_original_state)
+    # Start from a clean reroute ledger so the branch under test actually
+    # runs rather than hitting the already-done guard.
+    _third_party_logger_original_state.clear()
+    try:
+        yield lg
+    finally:
+        lg.handlers[:] = saved_handlers
+        lg.propagate = saved_propagate
+        lg.setLevel(saved_level)
+        root.handlers[:] = saved_root_handlers
+        _third_party_logger_original_state.clear()
+        _third_party_logger_original_state.update(saved_state)
+
+
+def _simulate_uvicorn_shipped_access_logger() -> logging.Handler:
+    """Put uvicorn.access into the state uvicorn.config.LOGGING_CONFIG leaves."""
+    lg = logging.getLogger("uvicorn.access")
+    handler = logging.NullHandler()
+    lg.addHandler(handler)
+    lg.propagate = False
+    return handler
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "FALSE", "No", " off ", "OFF"])
+def test_access_log_enabled_false_for_falsy_spellings(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """Case and surrounding whitespace are normalised: the value is threaded
+    through a delimited --update-env-vars string in the deploy workflows,
+    where a stray space is easy to introduce and invisible in review."""
+    monkeypatch.setenv("UVICORN_ACCESS_LOG", raw)
+    assert structlog_config.access_log_enabled() is False
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "yes", "on", "", "maybe"])
+def test_access_log_enabled_true_for_everything_else(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """Anything not clearly falsy keeps the line. The failure modes are not
+    symmetric: reading junk as "off" silently drops request visibility and
+    looks identical to a healthy quiet service, whereas reading it as "on"
+    costs log volume and is immediately obvious. Fail toward the loud side."""
+    monkeypatch.setenv("UVICORN_ACCESS_LOG", raw)
+    assert structlog_config.access_log_enabled() is True
+
+
+def test_access_log_enabled_defaults_true_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opt-OUT, so OSS / on-prem / local installs are unaffected."""
+    monkeypatch.delenv("UVICORN_ACCESS_LOG", raising=False)
+    assert structlog_config.access_log_enabled() is True
+
+
+def test_access_log_disabled_makes_uvicorn_see_no_handlers(
+    monkeypatch: pytest.MonkeyPatch, uvicorn_access_sandbox: logging.Logger
+) -> None:
+    """THE regression test: assert the property uvicorn actually reads.
+
+    uvicorn does not keep the ``access_log=False`` it was configured with —
+    its HTTP protocols re-derive the decision per connection from
+    ``self.access_logger.hasHandlers()``. Passing the kwarg therefore proves
+    nothing on its own, and the first cut of this feature shipped green
+    tests asserting exactly that kwarg while every request kept being logged
+    in staging. Rerouting uvicorn.access (handlers=[], propagate=True) is
+    what re-enabled it: hasHandlers() then walks up to the root handler and
+    answers True.
+
+    Assert the end state instead: no handlers AND propagate=False, so the
+    walk stops here and answers False.
+    """
+    monkeypatch.setenv("UVICORN_ACCESS_LOG", "false")
+    lg = uvicorn_access_sandbox
+    handler = _simulate_uvicorn_shipped_access_logger()
+    # A root handler makes hasHandlers() answer True for any logger that
+    # still propagates — i.e. the exact trap this guards against.
+    logging.getLogger().addHandler(logging.NullHandler())
+
+    _route_third_party_to_root()
+
+    assert handler not in lg.handlers
+    assert lg.propagate is False
+    assert lg.hasHandlers() is False, (
+        "uvicorn re-derives access logging from hasHandlers(); it must be "
+        "False or every request is logged despite UVICORN_ACCESS_LOG=false"
+    )
+
+
+def test_access_log_enabled_still_reroutes_uvicorn_access(
+    monkeypatch: pytest.MonkeyPatch, uvicorn_access_sandbox: logging.Logger
+) -> None:
+    """The default path is untouched: with the line wanted, uvicorn.access is
+    rerouted like any other third-party logger so it reaches structlog as
+    JSON, and hasHandlers() stays True so uvicorn keeps emitting it."""
+    monkeypatch.delenv("UVICORN_ACCESS_LOG", raising=False)
+    lg = uvicorn_access_sandbox
+    handler = _simulate_uvicorn_shipped_access_logger()
+    logging.getLogger().addHandler(logging.NullHandler())
+
+    _route_third_party_to_root()
+
+    assert handler not in lg.handlers
+    assert lg.propagate is True
+    assert lg.hasHandlers() is True
+
+
+def test_access_log_disabled_state_is_restorable(
+    monkeypatch: pytest.MonkeyPatch, uvicorn_access_sandbox: logging.Logger
+) -> None:
+    """The silencing branch must snapshot like the rerouting one, or
+    _reset_for_testing leaves uvicorn.access permanently muted for every
+    later caller in the process."""
+    monkeypatch.setenv("UVICORN_ACCESS_LOG", "false")
+    handler = _simulate_uvicorn_shipped_access_logger()
+
+    _route_third_party_to_root()
+
+    assert "uvicorn.access" in _third_party_logger_original_state
+    snapshot = _third_party_logger_original_state["uvicorn.access"]
+    assert handler in snapshot[0]
+    assert snapshot[1] is False
+
+
 def test_route_third_party_to_root_is_idempotent() -> None:
     """Calling twice doesn't change state on the second call (already-rerouted
     loggers stay handler-less, propagate stays True)."""


### PR DESCRIPTION
The knob added in caura-ai/caura#1037 **does nothing**. I verified the deployment rather than assuming it: staging has `UVICORN_ACCESS_LOG=false` on every service, current images, a successful deploy — and hours later was still emitting **~2,400 access lines/hour**, from the serving revision.

### Why

uvicorn does not keep the `access_log=False` it is configured with. Its HTTP protocols re-derive the decision **once per connection**:

```python
self.access_log = self.access_logger.hasHandlers()
# uvicorn/protocols/http/{h11,httptools}_impl.py
```

`Config.configure_logging()` acts on the flag by clearing `uvicorn.access`'s handlers and setting `propagate=False`. Our own `_route_third_party_to_root` then runs — at app import, in every worker, *after* uvicorn's `Config` — and sets `propagate=True` to pull uvicorn's lines into structlog. `hasHandlers()` walks ancestors while they propagate, finds the **root** handler, and answers True. Every request is logged again.

Reproduced end to end:

```
after uvicorn access_log=False  -> hasHandlers() = False
after structlog reroute         -> hasHandlers() = True
=> uvicorn protocol sets self.access_log = True   (logs every request)
```

### The fix

Enforce the setting in the module that undoes it. When the line is unwanted, `uvicorn.access` is **silenced** rather than rerouted — no handlers **and** `propagate=False`, which is what makes `hasHandlers()` answer False, because the walk stops at the first non-propagating logger. The snapshot is still taken so `_reset_for_testing` restores.

Two things fall out of putting it here rather than in `serve.py`:

- the parse moves to `access_log_enabled()`, so it lives in **one** place instead of being inlined (`common/env_utils`, where it would otherwise belong, does not exist in the enterprise repo this file is vendored into byte-for-byte)
- it now works for the services that exec the **uvicorn CLI** directly and never run `serve.py` — core-worker, core-operations, platform-operations — which the previous approach structurally could not reach

`serve.py` still passes `access_log=`; it is correct and explicit, just not sufficient alone, and its comment now says so.

### On the tests — this is the part worth reviewing

The original tests asserted `uvicorn.run` was called with `access_log=False`. That was true, and irrelevant: they tested **the call, not the behaviour**, so they passed green while the feature did nothing. There is also a signature guard, which only proved the parameter exists.

The new test asserts the property uvicorn actually reads, with a root handler installed — the exact trap:

```python
assert logging.getLogger("uvicorn.access").hasHandlers() is False
```

Confirmed it **fails without the fix** and passes with it. Also confirmed the snapshot test fails if the snapshot is dropped from the new branch, so neither test passes either way.

They also get a save/restore fixture, because my first cut restored by hand and leaked — clearing `_third_party_logger_original_state` discards the snapshots taken for uvicorn / fastmcp / mcp / slowapi too, leaving the module believing it had never rerouted anything.

### Checks

- `tests/test_logging.py` + `tests/test_serve.py`: **78 passed**
- full suite: 38 failed / 5452 passed here vs **39 failed / 5435 passed on `origin/main`** — the same pre-existing environment failures (pubsub, provider protocols, gemini, ingest), 17 more passing on this branch. None are logging-related.
- `ruff format --check --isolated` clean on both vendored files (the enterprise re-vendor gate), `ruff check` clean, all lines ≤88 cols

### Follow-on

Both files are `identical`-policy vendored, so the enterprise side re-vendors automatically once this merges. No enterprise change is needed — caura-ai/caura-enterprise#1369 already set the env var on the seven `common.serve` services; the three uvicorn-CLI services it deliberately skipped are now covered for free, and their exclusion comment there is worth revisiting separately.