### PR TITLE
fix(ratchet): pass -z when asking git which paths changed

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -391,12 +391,23 @@ def _changed_paths(base: str) -> set[str] | None:
     ``None`` rather than an empty set on failure, because the two mean opposite
     things to the caller: "could not tell" must fall back to the old tally-based
     selection, while "nothing changed" must select nothing.
+
+    ``-z`` for the same reason :func:`_grep` passes it, and it is load bearing
+    here in a way that is easy to miss. Without it git honours ``core.quotePath``
+    and returns a path holding any non-ASCII byte C-quoted — ``café.py`` comes
+    back as the ten characters ``"caf\\303\\251.py"``, quotes included. Every
+    other path in this module is raw, because ``_grep`` reads them with ``-z``,
+    so a quoted path matches nothing in ``after`` and the file drops silently out
+    of the selection below. It then falls back to the risen tally alone, which
+    reopens the net-zero-swap hole this function exists to close — for exactly
+    the files the tree is known to contain, since ``_git`` pins UTF-8 precisely
+    because there are accented names in the fixtures.
     """
     try:
         return {
-            line
-            for line in _git(["git", "diff", "--name-only", base]).splitlines()
-            if line
+            path
+            for path in _git(["git", "diff", "--name-only", "-z", base]).split("\0")
+            if path
         }
     except RuntimeError:
         return None

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -910,6 +910,43 @@ def test_a_net_zero_swap_of_exemptions_is_still_reported(repo: Path) -> None:
     assert "pre-existing alias one" not in out
 
 
+def test_a_net_zero_swap_is_reported_under_a_non_ascii_filename(repo: Path) -> None:
+    """Same swap, in a file git will not name plainly.
+
+    ``git diff --name-only`` honours ``core.quotePath`` and returns a path
+    holding any non-ASCII byte C-quoted — ``café.py`` comes back as
+    ``"caf\\303\\251.py"``, quotes included — while every other path in the
+    module is raw, because ``_grep`` reads them with ``-z``. A quoted path
+    matches nothing in the exempt tally, so the file drops out of the diff-based
+    selection and falls back to the risen tally alone, which is exactly the hole
+    this selection exists to close. The ASCII case above passes either way, so
+    this is the only test that pins the ``-z``.
+
+    Not a hypothetical class of file: ``_git`` pins UTF-8 rather than trusting
+    the locale precisely because the tree carries accented names in fixtures.
+    """
+    name = "café.py"
+    body = (
+        f'A = "{LEGACY}-one"  # legacy-name-ok: pre-existing alias one\n'
+        f'B = "{LEGACY}-two"  # legacy-name-ok: pre-existing alias two\n'
+    )
+    (repo / name).write_text(body, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "two aliases already here, under an accented name")
+    # "alias two" loses its marker and "alias three" arrives with one: flat.
+    (repo / name).write_text(
+        body.replace("  # legacy-name-ok: pre-existing alias two", "")
+        + f'C = "{LEGACY}-three"  # legacy-name-ok: brand new alias three\n',
+        encoding="utf-8",
+    )
+    _git(repo, "add", "-A")
+
+    out = _run(repo).stdout
+
+    assert "brand new alias three" in out
+    assert "1 exempt line(s) written by this change in 1 file(s)" in out
+
+
 def test_a_touched_file_whose_exemptions_are_all_old_says_nothing(repo: Path) -> None:
     """The cost of letting git choose the files, and the guard against paying it.
 


### PR DESCRIPTION
`_changed_paths()` called `git diff --name-only` **without `-z`**, so git honoured `core.quotePath` and returned any path holding a non-ASCII byte C-quoted:

```
git diff --name-only   →  "caf\303\251.py"   (C-quoted, quotes included)
git grep -z            →  café.py            (raw — what everything else uses)
```

Every other path in the module is raw, because `_grep()` reads them with `-z` and explains why in its own docstring. A quoted path therefore matches nothing in the exempt tally the selection intersects with, so the file drops silently out of the diff-based selection and falls back to the risen tally alone — reopening, **for exactly those files**, the net-zero exemption-swap blind spot `_changed_paths()` exists to close.

Not a hypothetical class of file here: `_git()` pins UTF-8 rather than trusting the locale precisely because the tree carries accented names in fixtures.

## Measured, with an ASCII control

Same swap in both cases — one marker removed from a file that already held exemptions, one newly marked line added:

| filename | before this PR |
|---|---|
| `ascii.py` | reported ✅ |
| `café.py` | **silently missed** ❌ |

## Report-only

`_changed_paths()` feeds the exemption report, which sits downstream of the pass/fail decision. Verified on this tree: **same exit code** either way. This changes what gets printed, never whether the gate fails.

## Test

`test_a_net_zero_swap_is_reported_under_a_non_ascii_filename` **fails without the `-z`**, while the existing ASCII swap test passes either way — which is why that one could never have caught this.

---

Found by the Claude reviewer on caura-ops#332 and fixed there first. The same missing `-z` was inherited from the canonical copy into every repo carrying `_changed_paths`; this is that one-line change in the copy that PR could not reach.
