### PR TITLE
fix(client): ship py.typed for legacy memclaw package

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -61,6 +61,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 caura_client = ["py.typed"]
+memclaw_client = ["py.typed"]
 
 [tool.ruff]
 target-version = "py39"


### PR DESCRIPTION
## Related issue

Closes #970.

## Background

The legacy `memclaw_client` package re-exports the typed Caura client but did not ship a PEP 561 marker, so type checkers treated imports through the compatibility package as untyped.

## Change

- Add `memclaw_client/py.typed`.
- Include the marker in the `memclaw_client` package data configuration.

## Verification

- `python -m build --wheel --outdir dist` — passed.
- Wheel inspection confirmed both `caura_client/py.typed` and `memclaw_client/py.typed` are packaged.
- `git diff --check` — passed.

The client tests were attempted with pytest but the Windows host has pre-existing environment incompatibilities (`fcntl` is unavailable and pytest temporary-directory setup raises `PermissionError`). No runtime code was changed.
