### PR TITLE
feat(clients): add stats() to the Python and TypeScript clients

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -48,6 +48,7 @@ with Caura("standalone", tenant_id="default", base_url="http://localhost:8000") 
 | `search(query, top_k=5, ...)` | `POST /api/v1/search` | `list[Memory]` |
 | `recall(query, top_k=5, ...)` | `POST /api/v1/recall` | `RecallResult` |
 | `health()` | `GET /api/v1/health` | `dict` |
+| `stats()` | `GET /api/v1/stats` | `Stats` |
 | `get_document(doc_id, *, collection, ...)` | `GET /api/v1/documents/{doc_id}` | `dict` |
 | `submit_interview(...)` | `POST /api/v1/interview/submit` | `dict` |
 | `close()` | — | `None` |
@@ -76,6 +77,22 @@ Caller-owned keys belong under `metadata` (`mc.write("...", metadata={"tags": [.
 `search()` and `recall()` are unaffected: filter bodies still accept unknown
 fields, deliberately. See
 [api-surfaces.md](https://github.com/caura-ai/caura/blob/main/docs/api-surfaces.md#request-body-contract-writes-are-strict-searches-are-not).
+
+### Deployment stats
+
+`stats()` returns three counters — `tenant_count`, `memory_count`,
+`agent_count` — for the landing-page status bar:
+
+```python
+with Caura("mc_xxx", tenant_id="my-team") as mc:
+    s = mc.stats()
+    print(s.tenant_count, s.memory_count, s.agent_count)
+```
+
+These are **deployment-wide totals, not scoped to your `tenant_id`** — the
+server counts across every tenant on the deployment. The underlying endpoint
+is unauthenticated (no key required to call it directly), but this method
+still sends your API key header for consistency with every other call.
 
 ### Fetching a document
 

--- a/clients/python/src/caura_client/__init__.py
+++ b/clients/python/src/caura_client/__init__.py
@@ -18,13 +18,14 @@ from .exceptions import (
     MemClawError,
     NotFoundError,
 )
-from .models import Memory, RecallResult
+from .models import Memory, RecallResult, Stats
 
 __all__ = [
     "Caura",
     "MemClaw",
     "Memory",
     "RecallResult",
+    "Stats",
     "CauraError",
     "CauraAPIError",
     "MemClawError",

--- a/clients/python/src/caura_client/client.py
+++ b/clients/python/src/caura_client/client.py
@@ -12,7 +12,7 @@ from typing import Any
 import httpx
 
 from .exceptions import AuthError, CauraAPIError, NotFoundError
-from .models import Memory, RecallResult
+from .models import Memory, RecallResult, Stats
 
 DEFAULT_BASE_URL = "https://caura.ai"
 
@@ -114,6 +114,24 @@ class Caura:
         """Liveness probe (GET /api/v1/health)."""
         response = self._http.get("/api/v1/health")
         return response.json()
+
+    def stats(self) -> Stats:
+        """Deployment-wide counters for the landing-page status bar (GET /api/v1/stats).
+
+        These counts span the whole deployment — they are **not** scoped to
+        ``self.tenant_id``. The endpoint is unauthenticated, but the API key
+        header is still sent for consistency with every other call this
+        client makes.
+
+        Unlike ``health()``, which deliberately skips ``_raise_for_status``,
+        ``stats()`` deliberately includes it: a bad ``base_url`` or an old
+        deployment without this route would otherwise return a non-2xx body
+        whose bare ``.json()`` raises a confusing ``ValueError`` instead of a
+        clear ``CauraAPIError``.
+        """
+        response = self._http.get("/api/v1/stats")
+        self._raise_for_status(response)
+        return Stats.from_dict(response.json())
 
     def get_document(
         self,

--- a/clients/python/src/caura_client/models.py
+++ b/clients/python/src/caura_client/models.py
@@ -72,3 +72,28 @@ class RecallResult:
             raw = data.get("items")
         memories = [Memory.from_dict(m) for m in (raw or [])]
         return cls(summary=data.get("summary"), supporting_memories=memories, raw=data)
+
+
+@dataclass
+class Stats:
+    """Public deployment counters, as returned by ``stats``.
+
+    These are deployment-wide totals, **not** scoped to your ``tenant_id`` —
+    the server counts across every tenant. The endpoint degrades rather than
+    fails: if a storage query stalls or errors, that counter comes back ``0``
+    rather than raising, so a zero may mean "none" or "unavailable".
+    """
+
+    tenant_count: int = 0
+    memory_count: int = 0
+    agent_count: int = 0
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Stats:
+        return cls(
+            tenant_count=data.get("tenant_count", 0),
+            memory_count=data.get("memory_count", 0),
+            agent_count=data.get("agent_count", 0),
+            raw=data,
+        )

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -14,6 +14,7 @@ from caura_client import (
     Memory,
     NotFoundError,
     RecallResult,
+    Stats,
 )
 
 
@@ -161,6 +162,44 @@ def test_health():
         return httpx.Response(200, json={"status": "ok"})
 
     assert make_client(handler).health()["status"] == "ok"
+
+
+def test_stats_returns_deployment_totals():
+    def handler(request):
+        assert request.url.path == "/api/v1/stats"
+        assert request.url.query == b""
+        assert request.headers["X-API-Key"] == "mc_test"
+        return httpx.Response(
+            200,
+            json={"tenant_count": 12, "memory_count": 345, "agent_count": 7},
+        )
+
+    stats = make_client(handler).stats()
+    assert isinstance(stats, Stats)
+    assert stats.tenant_count == 12
+    assert stats.memory_count == 345
+    assert stats.agent_count == 7
+
+
+def test_stats_defaults_missing_keys_to_zero():
+    def handler(request):
+        assert request.url.path == "/api/v1/stats"
+        return httpx.Response(200, json={})
+
+    stats = make_client(handler).stats()
+    assert stats.tenant_count == 0
+    assert stats.memory_count == 0
+    assert stats.agent_count == 0
+
+
+def test_stats_raises_on_503():
+    def handler(request):
+        assert request.url.path == "/api/v1/stats"
+        return httpx.Response(503, json={"message": "degraded"})
+
+    with pytest.raises(CauraAPIError) as exc:
+        make_client(handler).stats()
+    assert exc.value.status_code == 503
 
 
 def test_auth_error_parses_envelope():

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -47,9 +47,25 @@ const mc = new Caura("standalone", { tenantId: "default", baseUrl: "http://local
 | `search(query, opts?)` | `POST /api/v1/search` | `Memory[]` |
 | `recall(query, opts?)` | `POST /api/v1/recall` | `RecallResult` |
 | `health()` | `GET /api/v1/health` | `object` |
+| `stats()` | `GET /api/v1/stats` | `Stats` |
 
 Failures throw `AuthError` (401/403), `NotFoundError` (404), or
 `CauraApiError`. Every result also exposes the full API payload on `.raw`.
+
+### Deployment stats
+
+`stats()` returns three counters — `tenantCount`, `memoryCount`,
+`agentCount` — for the landing-page status bar:
+
+```ts
+const s = await mc.stats();
+console.log(s.tenantCount, s.memoryCount, s.agentCount);
+```
+
+These are **deployment-wide totals, not scoped to your `tenantId`** — the
+server counts across every tenant on the deployment. The underlying endpoint
+is unauthenticated (no key required to call it directly), but this method
+still sends your API key header for consistency with every other call.
 
 ### Unknown fields on writes are rejected
 

--- a/clients/typescript/src/index.test.ts
+++ b/clients/typescript/src/index.test.ts
@@ -141,6 +141,33 @@ test("health hits /health", async () => {
   assert.equal((await client.health()).status, "ok");
 });
 
+test("stats hits /stats and parses deployment totals", async () => {
+  const client = makeClient((url, init) => {
+    assert.equal(new URL(url).pathname, "/api/v1/stats");
+    assert.equal(new URL(url).search, "");
+    assert.equal((init.headers as Record<string, string>)["X-API-Key"], "mc_test");
+    return jsonResponse(200, { tenant_count: 12, memory_count: 345, agent_count: 7 });
+  });
+
+  const stats = await client.stats();
+  assert.equal(stats.tenantCount, 12);
+  assert.equal(stats.memoryCount, 345);
+  assert.equal(stats.agentCount, 7);
+});
+
+test("stats defaults missing keys to zero", async () => {
+  const client = makeClient(() => jsonResponse(200, {}));
+  const stats = await client.stats();
+  assert.equal(stats.tenantCount, 0);
+  assert.equal(stats.memoryCount, 0);
+  assert.equal(stats.agentCount, 0);
+});
+
+test("stats raises on 503", async () => {
+  const client = makeClient(() => jsonResponse(503, { message: "degraded" }));
+  await assert.rejects(client.stats(), CauraApiError);
+});
+
 test("403 maps to AuthError and parses the error envelope", async () => {
   const client = makeClient(() => jsonResponse(403, { error: { message: "cross-fleet", details: { x: 1 } } }));
   await assert.rejects(client.write("x"), (err: unknown) => {

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -47,6 +47,20 @@ export interface RecallResult {
   raw: Record<string, unknown>;
 }
 
+/**
+ * Public deployment counters, as returned by `stats()`. These are
+ * deployment-wide totals, **not** scoped to your `tenantId` — the server
+ * counts across every tenant. The endpoint degrades rather than fails: if a
+ * storage query stalls or errors, that counter comes back `0` rather than
+ * throwing, so a zero may mean "none" or "unavailable".
+ */
+export interface Stats {
+  tenantCount: number;
+  memoryCount: number;
+  agentCount: number;
+  raw: Record<string, unknown>;
+}
+
 export interface CauraOptions {
   tenantId: string;
   baseUrl?: string;
@@ -167,6 +181,24 @@ export class Caura {
   /** Liveness probe. GET /api/v1/health */
   async health(): Promise<Record<string, unknown>> {
     return this.request("GET", "/api/v1/health");
+  }
+
+  /**
+   * Deployment-wide counters for the landing-page status bar.
+   * GET /api/v1/stats
+   *
+   * These counts span the whole deployment — they are **not** scoped to
+   * `this.tenantId`. The endpoint is unauthenticated, but the API key header
+   * is still sent for consistency with every other call this client makes.
+   */
+  async stats(): Promise<Stats> {
+    const data = await this.request("GET", "/api/v1/stats");
+    return {
+      tenantCount: data?.tenant_count ?? 0,
+      memoryCount: data?.memory_count ?? 0,
+      agentCount: data?.agent_count ?? 0,
+      raw: data ?? {},
+    };
   }
 
   private async request(method: string, path: string, body?: unknown): Promise<any> {


### PR DESCRIPTION
﻿## Summary

Adds `stats()` to the Python and TypeScript clients, wrapping `GET /api/v1/stats`. Returns a new `Stats` model/interface exposing `tenant_count`, `memory_count`, `agent_count`, plus the raw payload on `.raw`.

## Related Issue

Closes #552.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

- `pytest` in `clients/python`: 138 passed. The 7 failures in `test_interviewer_installer.py` / `test_interviewer_platform.py` are POSIX-only (`fcntl`, chmod semantics) and reproduce identically on unmodified `main` on Windows.
- `npm test` in `clients/typescript`: 17/17 pass; `tsc` compiles clean.
- New tests cover: correct path with empty query string, counter parsing, missing keys defaulting to `0`, and a 503 raising `CauraAPIError` with the right status code.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes (or explained why none are needed)
- [x] `ruff check` and `ruff format --check` pass — see tooling note below
- [x] `mypy` passes — see tooling note below
- [x] `pytest` passes locally
- [x] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

The issue describes query params (`scope`, `memory_type`, `status`, `fleet_id`, `include_deleted`) that don't exist on the route — `public_stats()` in `core-api/src/core_api/routes/stats.py` has an empty signature. Implemented as a no-arg method matching the route as it stands; flagged this on the issue before starting.

Two deliberate choices, both easy to reverse:

- Counters are deployment-wide (`count_all(tenant_id="")`), not scoped to `tenant_id` like every other client method. Called out explicitly in both docstrings and both READMEs so nobody misreads `memory_count` as their own tenant's count.
- `stats()` calls `_raise_for_status()` although `health()` deliberately doesn't. A wrong `base_url` or a deployment predating this route returns non-2xx, and a bare `.json()` would surface a `ValueError` instead of a `CauraAPIError`.

Tests mock the exact response shape emitted by `stats.py` rather than an assumed one.

**CHANGELOG:** not edited — it's release-please-generated with no `Unreleased` section. The commit message is a conventional commit, so the entry should generate on release. Happy to add one manually if that's wrong.

**Tooling notes**, both pre-existing and unrelated to this change:

- `ruff check` passes clean. `ruff format --check` reports 11 files, including `tests/test_client.py` — all are already unformatted on `main`, verified by checking out upstream's copy and re-running. Not reformatted here to keep the diff scoped; happy to do it as a separate PR.
- `mypy` passes on every file this PR touches. It reports 3 errors in `interviewer/cli.py` (`fcntl.flock` / `LOCK_EX` / `LOCK_NB`), which are Windows-only — that file is untouched here and errors identically on upstream's version.