### PR TITLE
perf(logs): drop the CAURA-132 diagnostics to DEBUG

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -570,7 +570,26 @@ async def _detect(
         # Symmetric to PATH_C_DETECTION entry log; lets us tell apart
         # "Path A ran but found no semantic candidates" from "Path A
         # ran, found candidates, and the LLM judge said no".
-        logger.info(
+        #
+        # All seven CAURA-132 diag sites in this module log at DEBUG, not
+        # INFO. They were added to answer one question — why the entity-
+        # aware judge returned verdict=False on populated contexts — and
+        # that wet-test has since run (see CAURA-133, whose test cites
+        # "the wet-test on dev v2.12.1 (CAURA-132 logs)"). What they cost
+        # in the meantime: two of them fire once per (memory x candidate)
+        # pair rather than once per memory, so on 2026-08-29 the seven
+        # accounted for 3,767 of this logger's 4,947 prod lines in 6h —
+        # 76% — against ~10 candidates per memory.
+        #
+        # DEBUG keeps them one env var away (LOG_LEVEL=DEBUG) rather than
+        # deleting them, because the question they answer can recur. What
+        # stays at INFO is everything that records an OUTCOME: the
+        # path_a/path_c_completed summaries (which already carry
+        # n_conflicts, n_candidates and elapsed_ms), the contradictions
+        # actually found, Path C retracting a Path A verdict, and the
+        # preflight fail-open notes. Losing those would cost real
+        # forensics; losing per-candidate trace lines does not.
+        logger.debug(
             "PATH_A_SEMANTIC entry memory=%s tenant=%s candidates_initial=%d",
             memory_id,
             tenant_id,
@@ -605,7 +624,7 @@ async def _detect(
             updates: dict[str, dict] = {}
             for candidate, (verdict, _confidence, _raw) in zip(candidates, judged):
                 # CAURA-132 diag — Path A semantic per-candidate verdict.
-                logger.info(
+                logger.debug(
                     "PATH_A_SEMANTIC verdict memory=%s candidate=%s verdict=%s confidence=%.2f",
                     memory_id,
                     candidate.get("id"),
@@ -2217,7 +2236,7 @@ async def detect_contradictions_by_entities_async(
         # could be either (a) zero candidates returned even though the
         # entity overlap exists, or (b) candidates returned but dropped
         # downstream. Without this log we can't distinguish them.
-        logger.info(
+        logger.debug(
             "PATH_C_DETECTION entry memory=%s tenant=%s fleet=%s candidates_initial=%d",
             memory_id,
             tenant_id,
@@ -2247,7 +2266,7 @@ async def detect_contradictions_by_entities_async(
         n_preflight_skipped = len(candidates) - len(filtered_candidates)
         candidates = filtered_candidates
         # CAURA-132 diag — A1 #17 outcome.
-        logger.info(
+        logger.debug(
             "PATH_C_DETECTION after_a1_17 memory=%s preflight_skipped=%d remaining=%d",
             memory_id,
             n_preflight_skipped,
@@ -2352,7 +2371,7 @@ async def detect_contradictions_by_entities_async(
                 # entity_links (eligible for the entity-aware judge) vs
                 # which are still in cold extraction (will fall back).
                 ctx_sizes = {cid: len(ctx) for cid, ctx in contexts.items()}
-                logger.info(
+                logger.debug(
                     "PATH_C_DETECTION context_fetched memory=%s new_ctx_size=%d cand_ctx_sizes=%s",
                     memory_id,
                     len(new_ctx),
@@ -2484,7 +2503,7 @@ async def detect_contradictions_by_entities_async(
         for c in candidates:
             cand_ctx = contexts.get(str(c.get("id")), []) if contexts_fetched else []
             judge_kinds.append("entity_aware" if (contexts_fetched and new_ctx and cand_ctx) else "base")
-        logger.info(
+        logger.debug(
             "PATH_C_DETECTION judge_selection memory=%s candidates=%d entity_aware=%d base=%d",
             memory_id,
             len(candidates),
@@ -2580,7 +2599,7 @@ async def detect_contradictions_by_entities_async(
             # the judge_kind so we can see whether the entity-aware
             # judge returns verdict=False when both contexts are
             # populated but no flag fires (the wet-test miss class).
-            logger.info(
+            logger.debug(
                 "PATH_C_DETECTION verdict memory=%s candidate=%s judge=%s verdict=%s confidence=%.2f",
                 memory_id,
                 candidate.get("id"),

--- a/tests/test_contradiction_diag_log_tier.py
+++ b/tests/test_contradiction_diag_log_tier.py
@@ -1,0 +1,134 @@
+"""The CAURA-132 diagnostics must not reach a default-level deployment.
+
+These seven sites fire once per (memory x candidate) pair rather than once
+per memory, so at INFO they dominated the module's output — 3,767 of 4,947 prod
+lines in 6h on 2026-08-29. Demoting them to DEBUG only helps if a default
+deployment actually filters DEBUG, so assert the tier at the call sites AND
+assert the filtering end to end.
+
+The lesson this encodes is a real one from the same week: the first
+UVICORN_ACCESS_LOG change asserted that a flag was passed rather than that
+logging stopped, shipped green, and changed nothing in production for a day.
+A verbosity test that only reads the source has the same defect, so the
+end-to-end case below drives a real logger through a real configuration.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import logging
+from pathlib import Path
+
+import pytest
+
+from common.structlog_config import _reset_for_testing, configure_logging
+
+MODULE = (
+    Path(__file__).resolve().parents[1]
+    / "core-api/src/core_api/services/contradiction_detector.py"
+)
+
+# Substrings identifying the CAURA-132 diagnostic messages. Matched against
+# the log format string, which is the first argument at each call site.
+DIAG_MESSAGES = (
+    "PATH_A_SEMANTIC entry",
+    "PATH_A_SEMANTIC verdict",
+    "PATH_C_DETECTION after_a1_17",
+    "PATH_C_DETECTION context_fetched",
+    "PATH_C_DETECTION entry",
+    "PATH_C_DETECTION judge_selection",
+    "PATH_C_DETECTION verdict",
+)
+
+# Outcome lines that must STAY at INFO: they are what a prod investigation
+# reads. Losing them costs real forensics, unlike per-candidate trace lines.
+OUTCOME_MESSAGES = (
+    "path_a_completed",
+    "path_c_completed",
+    "Semantic contradiction:",
+    "Entity-based contradiction:",
+)
+
+
+def _log_calls() -> list[tuple[str, str]]:
+    """Return (level, format_string) for every logger.<level>(...) call."""
+    tree = ast.parse(MODULE.read_text())
+    out: list[tuple[str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        if not isinstance(fn, ast.Attribute):
+            continue
+        if not (isinstance(fn.value, ast.Name) and fn.value.id == "logger"):
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            out.append((fn.attr, first.value))
+    return out
+
+
+@pytest.mark.parametrize("needle", DIAG_MESSAGES)
+def test_caura_132_diagnostics_log_at_debug(needle: str) -> None:
+    """Each diagnostic is emitted through logger.debug, never logger.info."""
+    matches = [(lvl, msg) for lvl, msg in _log_calls() if needle in msg]
+    assert matches, f"no log call found for {needle!r} — did the message change?"
+    for level, msg in matches:
+        assert level == "debug", (
+            f"{needle!r} logs at {level!r}; the CAURA-132 diagnostics fire "
+            f"per-candidate and must stay at DEBUG. Full message: {msg!r}"
+        )
+
+
+@pytest.mark.parametrize("needle", OUTCOME_MESSAGES)
+def test_outcome_lines_stay_at_info(needle: str) -> None:
+    """Guard the other direction: a later cleanup must not sweep these down.
+
+    These record what actually happened — conflict counts, timings, the
+    contradictions found. They are the reason the module is greppable in an
+    incident, and they cost a fraction of the per-candidate lines.
+    """
+    matches = [(lvl, msg) for lvl, msg in _log_calls() if needle in msg]
+    assert matches, f"no log call found for {needle!r} — did the message change?"
+    for level, msg in matches:
+        assert level == "info", (
+            f"{needle!r} logs at {level!r}; outcome lines must stay at INFO. "
+            f"Full message: {msg!r}"
+        )
+
+
+def test_debug_is_filtered_at_the_deployed_log_level() -> None:
+    """End to end: DEBUG must not reach output under the deployed config.
+
+    Asserting the call-site tier is necessary but not sufficient — it proves
+    the source says ``debug``, not that a deployment drops it. core-api's
+    settings default log_level to INFO and prod sets no override, so drive a
+    real logger through configure_logging() and check what comes out.
+    """
+    _reset_for_testing()
+    configure_logging("production", "INFO", json_logs=True, log_file=None)
+    root = logging.getLogger()
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    if root.handlers:
+        handler.setFormatter(root.handlers[0].formatter)
+    root.addHandler(handler)
+    try:
+        lg = logging.getLogger("core_api.services.contradiction_detector")
+        lg.debug("PATH_A_SEMANTIC verdict memory=%s candidate=%s", "m1", "c1")
+        lg.info("path_a_completed for memory %s n_conflicts=%d", "m1", 0)
+        out = buf.getvalue()
+        assert "PATH_A_SEMANTIC" not in out, (
+            "a DEBUG record reached output at log_level=INFO — demoting the "
+            "diagnostics would not reduce anything in production"
+        )
+        assert "path_a_completed" in out, (
+            "the INFO outcome line did not reach output; the test harness is "
+            "wrong, so the DEBUG assertion above proves nothing"
+        )
+    finally:
+        root.removeHandler(handler)
+        _reset_for_testing()


### PR DESCRIPTION
`contradiction_detector` has **21 `logger.info` calls and zero `logger.debug`** — it has no debug tier at all, so everything it says ships at production level. Seven of those calls are marked `CAURA-132 diag`, added to answer one question: why the entity-aware judge returned `verdict=False` on populated contexts.

Two of the seven fire **once per (memory × candidate) pair** rather than once per memory, against ~10 candidates per memory. Measured over 6h of prod on 2026-08-29, the seven were **3,767 of this logger's 4,947 lines — 76%**:

| pattern | lines / 6h |
|---|---|
| `PATH_A_SEMANTIC verdict` | 1,872 |
| `PATH_C_DETECTION verdict` | 1,128 |
| `PATH_A_SEMANTIC entry` | 174 |
| `PATH_C_DETECTION entry` | 165 |
| `PATH_C_DETECTION after_a1_17` | 150 |
| `PATH_C_DETECTION context_fetched` | 143 |
| `PATH_C_DETECTION judge_selection` | 135 |

The wet-test they were added for has already run — CAURA-133's test cites *"the wet-test on dev v2.12.1 (CAURA-132 logs)"*. They served their purpose and are now paying rent per candidate.

### What stays

**Demoted, not deleted.** `LOG_LEVEL=DEBUG` brings them straight back, and the question they answer can recur.

Everything that records an **outcome** stays at INFO — the `path_a_completed` / `path_c_completed` summaries (which already carry `n_conflicts`, `n_candidates`, `elapsed_ms`), the contradictions actually found, Path C retracting a Path A verdict, and the preflight fail-open notes. Losing those costs real forensics; losing per-candidate trace lines does not.

One INFO call *inside* a converted block was deliberately left alone: `"Path C preflight skipped all N candidates"` is a decision outcome, not a trace.

### Verified that DEBUG is actually filtered

This is the part I would not skip again. core-api defaults `log_level` to INFO and prod sets no override, and driving a real logger through `configure_logging("production", "INFO")` drops the DEBUG record while the INFO one emits.

That check exists because the `UVICORN_ACCESS_LOG` change earlier this week asserted that a *flag was passed* rather than that *logging stopped* — it shipped green and did nothing in production for a full day. A verbosity change that only reads the source has exactly the same defect.

### Tests

Three layers, and I confirmed each fails when broken rather than assuming:

- tier asserted at all seven call sites (AST, so it survives reformatting) — reverting one demotion **fails**
- a **reverse guard** on the outcome lines, so a later cleanup can't sweep them down too — demoting one outcome line **fails**
- end-to-end filtering through the real logging config

273 contradiction tests pass, 1 skipped. `ruff check` and `ruff format --check` clean.

### Worth knowing before you merge

This target is **#4**, not #1. In a clean post-access-log-fix window, prod's top loggers are:

```
platform_auth_api.routers.auth            2573
core_api.access                           2554   <- a second, app-level access log
mcp.server.streamable_http                 962
core_api.services.contradiction_detector   872   <- this PR
```

`core_api.access` is notable: a separate application-level access log that the uvicorn work did not touch. If the goal is volume rather than this specific module, those two are each roughly 3x the target here — happy to look at them next.