### PR TITLE
refactor(ratchet): file permanent names under the floor marker

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -207,7 +207,7 @@ DOC_MEMORY_URI_SCHEME = "caura-doc"
 # recognizer for doc-memory URIs (the reconciliation pass above) must accept
 # these schemes alongside it.
 LEGACY_DOC_MEMORY_URI_SCHEMES = (
-    "memclaw-doc",  # legacy-name-ok: scheme already persisted in customers' memories.source_uri
+    "memclaw-doc",  # legacy-name-ok: compat scheme persisted in customers' memories.source_uri
 )
 
 assert DOC_MEMORY_MAX_CHARS <= MAX_CONTENT_LENGTH, (

--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -693,7 +693,7 @@ _VALID_SKILL_AGENTS = {"claude-code", "codex", "both"}
 # reach either. ``memclaw`` is the default (the operational manual); the
 # opt-in ``company-brain`` posture skill layers on top of it.
 _SKILL_LABELS = {
-    "memclaw": "Caura",  # legacy-name-ok: wire — ?skill= param + on-disk dir
+    "memclaw": "Caura",  # legacy-name-floor: wire — ?skill= param + on-disk dir
     "company-brain": "Company Brain",
 }
 _VALID_SKILLS = frozenset(_SKILL_LABELS)

--- a/core-worker/pyproject.toml
+++ b/core-worker/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "core-worker"
 version = "2.34.0"
-description = "Caura core async worker — subscribes to memclaw.memory.embed-requested and backfills embeddings" # legacy-name-ok: frozen topic name
+description = "Caura core async worker — subscribes to memclaw.memory.embed-requested and backfills embeddings" # legacy-name-floor: frozen topic name
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [

--- a/docs/plugin-upgrade.md
+++ b/docs/plugin-upgrade.md
@@ -1,6 +1,6 @@
 # Upgrading the memclaw plugin
 
-**Audience:** operators running OpenClaw with the memclaw plugin against a Caura server (caura.ai, on-prem). <!-- legacy-name-ok: "memclaw" is the frozen plugin id --> Two flows are documented: the **automatic** path (heartbeat-driven) and the **manual** path (`/api/v1/install-plugin`).
+**Audience:** operators running OpenClaw with the memclaw plugin against a Caura server (caura.ai, on-prem). <!-- legacy-name-floor: "memclaw" is the frozen plugin id --> Two flows are documented: the **automatic** path (heartbeat-driven) and the **manual** path (`/api/v1/install-plugin`).
 
 ## When auto-upgrade runs
 

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -28,7 +28,7 @@ export { getPluginDir, getOpenClawConfigPath };
  * declaration means a rename is one edit, and ``config.test.ts`` asserts this
  * value still equals the manifest's so the two cannot drift apart again.
  */
-export const PLUGIN_ID = "memclaw";  // legacy-name-ok: the id keys every existing on-disk install
+export const PLUGIN_ID = "memclaw";  // legacy-name-floor: the id keys every existing on-disk install
 
 export function getPluginSrcPath(): string {
   return join(getPluginDir(), "src", "index.ts");

--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -680,10 +680,10 @@ describe("writeEducationFiles", () => {
       assert.equal(result.toolsUpdated, 1, "a pre-rename tool listing must be recognized as our block");
       const tools = readFile(join(wsDir, "TOOLS.md"));
       assert.ok(!tools.includes("memclaw_write_bulk"), "stale pre-rename body must be replaced"); // legacy-name-ok: asserts the old body is gone
-      assert.match(tools, /<!-- memclaw:tools v=[a-f0-9]{8} -->/); // legacy-name-ok: the fence tag is a pinned on-disk contract
+      assert.match(tools, /<!-- memclaw:tools v=[a-f0-9]{8} -->/); // legacy-name-floor: the fence tag is a pinned on-disk contract
       assert.ok(tools.startsWith(userBefore), "user content above the legacy block must be preserved");
       assert.ok(tools.includes("## Other"), "user content below the legacy block must be preserved");
-      assert.ok(existsSync(join(wsDir, "TOOLS.md.memclaw-bak")), "one-shot backup written before the splice"); // legacy-name-ok: the backup filename is a pinned on-disk contract
+      assert.ok(existsSync(join(wsDir, "TOOLS.md.memclaw-bak")), "one-shot backup written before the splice"); // legacy-name-floor: the backup filename is a pinned on-disk contract
     });
 
     test("backup is not overwritten on subsequent runs", () => {

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -471,7 +471,7 @@ const cauraPlugin = {
               `agents cannot use: ${missing.join(", ")}`,
             );
             console.warn(
-              `[caura] Fix: run "openclaw gateway memclaw.allowlist.fix" or set CAURA_AUTO_FIX_CONFIG=true`, // legacy-name-ok: gateway command is namespaced by the frozen plugin id
+              `[caura] Fix: run "openclaw gateway memclaw.allowlist.fix" or set CAURA_AUTO_FIX_CONFIG=true`, // legacy-name-floor: gateway command is namespaced by the frozen plugin id
             );
           }
           if (!isContextEngineSlotClaimed(config)) {
@@ -482,8 +482,8 @@ const cauraPlugin = {
               `OpenClaw will fall back to the default "legacy" context engine.`,
             );
             console.warn(
-              `[caura] Fix: set plugins.slots.contextEngine to "memclaw" in ~/.openclaw/openclaw.json, ` +  // legacy-name-ok: "memclaw" is the kept plugin id the user must type
-              `or run "openclaw gateway memclaw.allowlist.fix" / set CAURA_AUTO_FIX_CONFIG=true`, // legacy-name-ok: gateway command is namespaced by the frozen plugin id
+              `[caura] Fix: set plugins.slots.contextEngine to "memclaw" in ~/.openclaw/openclaw.json, ` +  // legacy-name-floor: "memclaw" is the kept plugin id the user must type
+              `or run "openclaw gateway memclaw.allowlist.fix" / set CAURA_AUTO_FIX_CONFIG=true`, // legacy-name-floor: gateway command is namespaced by the frozen plugin id
             );
           }
         }
@@ -753,7 +753,7 @@ const cauraPlugin = {
         api.registerContextEngine("memclaw", (config: Record<string, unknown> | undefined | null) => {
           return new CauraContextEngine(config);
         });
-        console.log("[caura] ContextEngine 'memclaw' registered");  // legacy-name-ok: names the kept engine id (info.id)
+        console.log("[caura] ContextEngine 'memclaw' registered");  // legacy-name-floor: names the kept engine id (info.id)
       }
     } catch (e: unknown) {
       logError("registerContextEngine failed", e);

--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -85,11 +85,18 @@ class Sentinel:
 
 # ── the list ─────────────────────────────────────────────────────────────────
 #
-# Entries whose pinned text contains the old brand carry ``legacy-name-ok``,
-# because this file is itself scanned by the ratchet, and the reason is the same
-# every time: the line exists to pin a string rule 3 keeps readable forever.
-# Entries pinning brand-free text need no marker and correctly have none — the
-# ratchet never sees them. Excluding this file from the ratchet instead would
+# Entries whose pinned text contains the old brand carry ``legacy-name-floor``,
+# because this file is itself scanned by the ratchet. The entry NAMES an exact
+# string rather than declaring that contract itself, even when the source line
+# it pins is a compat alias. A future entry that itself declares a compat alias
+# would carry ``legacy-name-ok`` instead.
+#
+# A marker here can be coupled to the line it pins. Where the pinned text
+# includes that line's own trailing comment, the marker is part of the string
+# being matched — so swapping one on the source line without swapping it here
+# (or the reverse) stops the pin matching, and this gate fails.
+#
+# Excluding this file from the ratchet instead would
 # leave a hole in that scan, which is the trade its author already refused once.
 
 SENTINELS: tuple[Sentinel, ...] = (
@@ -118,26 +125,26 @@ SENTINELS: tuple[Sentinel, ...] = (
     # -- The smoke probe: an emitter and a matcher that must move together. ----
     Sentinel(
         path="plugin/src/context-engine.ts",
-        text="memclaw-smoke-",  # legacy-name-ok: pinned floor string
+        text="memclaw-smoke-",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the health-check probe stops writing the title report_corpus.py filters on",
     ),
     Sentinel(
         path="core-api/src/core_api/services/report_corpus.py",
-        text="cache refresh|memclaw-smoke)",  # legacy-name-ok: pinned floor string
+        text="cache refresh|memclaw-smoke)",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="~200 probe facts/day stop being filtered and flood every per-agent report",
     ),
     # -- Wire contracts. A partial rename here does not degrade, it bricks. ----
     Sentinel(
         path="core-api/src/core_api/mcp_server.py",
-        text='name.startswith("memclaw_")',  # legacy-name-ok: pinned floor string
+        text='name.startswith("memclaw_")',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="every legacy-named tool call 404s — the alias shim is the whole promise",
     ),
     Sentinel(
         path="core-api/src/core_api/app.py",
-        text='prefix="/api/v1/memclaw"',  # legacy-name-ok: pinned floor string
+        text='prefix="/api/v1/memclaw"',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the keystones route mount moves and every deployed plugin loses keystones",
     ),
@@ -149,19 +156,19 @@ SENTINELS: tuple[Sentinel, ...] = (
     ),
     Sentinel(
         path="core-api/src/core_api/agent_ids.py",
-        text="memclaw-insighter",  # legacy-name-ok: pinned floor string
+        text="memclaw-insighter",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the insighter's existing rows orphan — migration 030 seeded this id",
     ),
     Sentinel(
         path="core-api/src/core_api/agent_ids.py",
-        text="memclaw-doc-indexer",  # legacy-name-ok: pinned floor string
+        text="memclaw-doc-indexer",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the doc indexer's existing rows orphan; nothing else references the literal",
     ),
     Sentinel(
         path="plugin/openclaw.plugin.json",
-        text='"id": "memclaw"',  # legacy-name-ok: pinned floor string
+        text='"id": "memclaw"',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="every installed plugin is orphaned — the id keys the on-disk install",
     ),
@@ -172,7 +179,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     # is the half that produces a config OpenClaw cannot match.
     Sentinel(
         path="plugin/src/config.ts",
-        text='PLUGIN_ID = "memclaw"',  # legacy-name-ok: pinned floor string
+        text='PLUGIN_ID = "memclaw"',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks=(
             "the id this plugin writes into plugins.allow, plugins.entries.<id> "
@@ -183,32 +190,32 @@ SENTINELS: tuple[Sentinel, ...] = (
     ),
     Sentinel(
         path="core-api/src/core_api/routes/plugin.py",
-        text=".openclaw/plugins/memclaw",  # legacy-name-ok: pinned floor string
+        text=".openclaw/plugins/memclaw",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the generated installer writes to a path no installed plugin reads",
     ),
     Sentinel(
         path="core-api/src/core_api/services/organization_settings.py",
-        text="memclaw.auto_upgrade_enabled",  # legacy-name-ok: pinned floor string
+        text="memclaw.auto_upgrade_enabled",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="stored tenant settings key off this string; a rename reverts them to default",
     ),
     # -- Published channel names. Renaming these strands installed users. ------
     Sentinel(
         path="clients/typescript/package.json",
-        text="@caura/memclaw-client",  # legacy-name-ok: pinned floor string
+        text="@caura/memclaw-client",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the published npm package name changes under everyone who installed it",
     ),
     Sentinel(
         path="clients/python/pyproject.toml",
-        text="memclaw-interviewer",  # legacy-name-ok: pinned floor string
+        text="memclaw-interviewer",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the installed console script disappears from every existing crontab",
     ),
     Sentinel(
         path="clients/python/src/caura_client/interviewer/installer.py",
-        text='".config" / "memclaw-interviewer"',  # legacy-name-ok: pinned floor string
+        text='".config" / "memclaw-interviewer"',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the interviewer stops finding config customers already have on disk",
     ),
@@ -229,7 +236,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     # a false red is loud and a gate that quietly stopped protecting is not.
     Sentinel(
         path="clients/python/src/caura_client/interviewer/installer.py",
-        text='CRON_MARKER = "# memclaw-interviewer (managed)"',  # legacy-name-ok: pinned floor string
+        text='CRON_MARKER = "# memclaw-interviewer (managed)"',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks=(
             "uninstall stops finding crontab entries customers already have, "
@@ -238,13 +245,13 @@ SENTINELS: tuple[Sentinel, ...] = (
     ),
     Sentinel(
         path=".github/workflows/publish-python-client.yml",
-        text="memclaw-client-v*",  # legacy-name-ok: pinned floor string
+        text="memclaw-client-v*",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the release tag pattern stops triggering a publish",
     ),
     Sentinel(
         path=".github/workflows/publish-npm-client.yml",
-        text="memclaw-client-ts-v*",  # legacy-name-ok: pinned floor string
+        text="memclaw-client-ts-v*",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the release tag pattern stops triggering a publish",
     ),
@@ -252,9 +259,9 @@ SENTINELS: tuple[Sentinel, ...] = (
     Sentinel(
         path=(
             "core-storage-api/src/core_storage_api/database/migrations/versions/"
-            "030_register_memclaw_insighter.py"  # legacy-name-ok: pinned floor string
+            "030_register_memclaw_insighter.py"  # legacy-name-floor: floor
         ),
-        text="WHERE m.agent_id = 'memclaw-insighter'",  # legacy-name-ok: pinned floor string
+        text="WHERE m.agent_id = 'memclaw-insighter'",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="a replayed migration seeds a different agent id than the one in live rows",
     ),
@@ -263,7 +270,7 @@ SENTINELS: tuple[Sentinel, ...] = (
             "core-storage-api/src/core_storage_api/database/migrations/versions/"
             "012_vector_dim_1024.py"
         ),
-        text='os.environ.get("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS"',  # legacy-name-ok: pinned floor string
+        text='os.environ.get("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS"',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the destructive-migration opt-out stops being readable by the env that sets it",
     ),
@@ -272,7 +279,7 @@ SENTINELS: tuple[Sentinel, ...] = (
             "core-storage-api/src/core_storage_api/database/migrations/versions/"
             "019_tenant_suppression.py"
         ),
-        text="memclaw.org.suppression-changed",  # legacy-name-ok: pinned floor string
+        text="memclaw.org.suppression-changed",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="the migration stops naming the topic it documents, before Phase 2 renames it",
     ),
@@ -298,7 +305,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     # matters is gone. Verified: each text below appears only on code lines.
     Sentinel(
         path="plugin/src/educate.ts",
-        text="const tag = `memclaw:${marker}`;",  # legacy-name-ok: pinned floor string
+        text="const tag = `memclaw:${marker}`;",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks=(
             "the fence tag written into every install's TOOLS.md/AGENTS.md as an "
@@ -309,7 +316,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     ),
     Sentinel(
         path="plugin/src/educate.ts",
-        text='"## MemClaw —",',  # legacy-name-ok: pinned floor string
+        text='"## MemClaw —",',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks=(
             "the legacyHeadingPrefix that finds pre-fence sections this plugin "
@@ -319,7 +326,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     ),
     Sentinel(
         path="plugin/src/educate.ts",
-        text='.memclaw-bak"',  # legacy-name-ok: pinned floor string
+        text='.memclaw-bak"',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks=(
             "the one-shot backup is written only when the path does not already "
@@ -330,7 +337,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     Sentinel(
         path="plugin/src/educate.ts",
         # Regex syntax, so this form cannot occur in prose about the phrase.
-        text="You have been connected to MemClaw[^\\n]*?always include your agent_id",  # legacy-name-ok: pinned floor string
+        text="You have been connected to MemClaw[^\\n]*?always include your agent_id",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks=(
             "the pre-C1 blurb stops being stripped and accumulates alongside "
@@ -339,7 +346,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     ),
     Sentinel(
         path="plugin/src/educate.ts",
-        text='includes("MemClaw — Tools Available")',  # legacy-name-ok: pinned floor string
+        text='includes("MemClaw — Tools Available")',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="phantom plugin-written files under workspaces/ stop being collected",
     ),
@@ -348,13 +355,13 @@ SENTINELS: tuple[Sentinel, ...] = (
     # not-installed, which is the shape of bug that gets chased for a week.
     Sentinel(
         path="plugin/src/heartbeat.ts",
-        text='"HEARTBEAT.md"), "utf-8").includes("memclaw")',  # legacy-name-ok: pinned floor string
+        text='"HEARTBEAT.md"), "utf-8").includes("memclaw")',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="heartbeat reports heartbeat_md=false for every install written before the rename",
     ),
     Sentinel(
         path="plugin/src/heartbeat.ts",
-        text='"TOOLS.md"), "utf-8").toLowerCase().includes("memclaw")',  # legacy-name-ok: pinned floor string
+        text='"TOOLS.md"), "utf-8").toLowerCase().includes("memclaw")',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks="heartbeat reports tools_md=false for every install written before the rename",
     ),
@@ -364,7 +371,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     # reason to think the marker should follow them. It must not.
     Sentinel(
         path="plugin/src/reconcile-skills.ts",
-        text='OWNED_MARKER = ".memclaw-owned"',  # legacy-name-ok: pinned floor string
+        text='OWNED_MARKER = ".memclaw-owned"',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks=(
             "the per-skill ownership marker already written into every managed "
@@ -390,7 +397,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     # If a future dual-read alias is added anywhere, it wants both.
     Sentinel(
         path="plugin/src/env.ts",
-        text="/^(?:CAURA|MEMCLAW)_[A-Z_]+$/",  # legacy-name-ok: pinned floor string
+        text="/^(?:CAURA|MEMCLAW)_[A-Z_]+$/",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks=(
             "the gate deciding which .env keys may reach process.env — drop the "
@@ -405,7 +412,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     # the stricter one survived — a pin satisfied by the wrong line.
     Sentinel(
         path="plugin/src/env.ts",
-        text="/^(?:CAURA|MEMCLAW)_/.test(key)",  # legacy-name-ok: pinned floor string
+        text="/^(?:CAURA|MEMCLAW)_/.test(key)",  # legacy-name-floor: floor
         kind=LITERAL,
         breaks=(
             "deploy.ts filters the operator's existing .env through this and then "
@@ -416,7 +423,7 @@ SENTINELS: tuple[Sentinel, ...] = (
     ),
     Sentinel(
         path="plugin/src/paths.ts",
-        text='join(getOpenClawBaseDir(), "plugins", "memclaw")',  # legacy-name-ok: pinned floor string
+        text='join(getOpenClawBaseDir(), "plugins", "memclaw")',  # legacy-name-floor: floor
         kind=LITERAL,
         breaks=(
             "the install root on every user's disk — the .env, install.json, "

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -287,7 +287,7 @@ Without the `contextEngine` slot, you still get all 11 agent-facing tools, promp
 [caura] Smoke test passed (score: 0.953)
 ```
 
-You will also see `ContextEngine 'memclaw' registered` in the same log — the context engine keeps the original plugin id. <!-- legacy-name-ok: frozen engine id shown in a log sample -->
+You will also see `ContextEngine 'memclaw' registered` in the same log — the context engine keeps the original plugin id. <!-- legacy-name-floor: frozen engine id shown in a log sample -->
 
 The node will appear in the Fleet page (`/ui/fleet.html`) within 60 seconds.
 
@@ -718,7 +718,7 @@ Content-hash rejects exact duplicates within a tenant+fleet scope (HTTP 409). Sa
 | Issue | Fix |
 |---|---|
 | Plugin tools don't appear | Ensure all three `plugins` keys are set in `openclaw.json`: `allow`, `entries`, and `load.paths`. Restart OpenClaw |
-| Tools not in agent sessions | Auto-fixed on first plugin load (adds v1.0 names, removes stale pre-v1.0 names). If it persists after restart, run `openclaw gateway memclaw.allowlist.fix` or check that `CAURA_AUTO_FIX_CONFIG` is not set to `false` <!-- legacy-name-ok: memclaw.allowlist.fix is the live gateway RPC method name --> |
+| Tools not in agent sessions | Auto-fixed on first plugin load (adds v1.0 names, removes stale pre-v1.0 names). If it persists after restart, run `openclaw gateway memclaw.allowlist.fix` or check that `CAURA_AUTO_FIX_CONFIG` is not set to `false` <!-- legacy-name-floor: memclaw.allowlist.fix is the live gateway RPC method name --> |
 | Plugin allowed but not loading | Missing `plugins.entries.memclaw.enabled: true` or `plugins.load.paths` entry — the installer and Fix Configuration set both |
 | All config issues | Use the "Fix Configuration" button in Fleet Browser Plugin Manager to auto-fix all settings |
 | `ECONNREFUSED` | Check `CAURA_API_URL`, ensure API is running |

--- a/static/skills/company-brain/SKILL.md
+++ b/static/skills/company-brain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: company-brain
-description: How an agent should operate as one mind inside a shared Company Brain built on Caura — recall before acting, obey fleet keystones, reuse and publish skills, and report outcomes so every task compounds across the whole organization. Use this whenever you work as part of a Caura-connected team or fleet and your work should build on, and feed back into, what the organization already knows; it sets the operating posture. For the mechanics of individual caura_* tools, see the companion "memclaw" skill. # legacy-name-ok: the companion skill's frozen slug
+description: How an agent should operate as one mind inside a shared Company Brain built on Caura — recall before acting, obey fleet keystones, reuse and publish skills, and report outcomes so every task compounds across the whole organization. Use this whenever you work as part of a Caura-connected team or fleet and your work should build on, and feed back into, what the organization already knows; it sets the operating posture. For the mechanics of individual caura_* tools, see the companion "memclaw" skill. # legacy-name-floor: the companion skill's frozen slug
 user-invocable: false
 ---
 

--- a/tests/test_client_metapackages.py
+++ b/tests/test_client_metapackages.py
@@ -44,7 +44,7 @@ PY_DISTS = {
 }
 
 NPM_DISTS = {
-    "typescript": "@caura/memclaw-client",  # legacy-name-ok: pins the immutable published implementation name
+    "typescript": "@caura/memclaw-client",  # legacy-name-floor: the published implementation name
     "npm-client": "@caura/client",
     "npm-sdk": "@caura/sdk",
 }

--- a/tests/test_doc_memory_spec.py
+++ b/tests/test_doc_memory_spec.py
@@ -58,7 +58,7 @@ def test_legacy_scheme_is_never_minted_but_stays_recognized():
     from core_api.constants import DOC_MEMORY_URI_SCHEME, LEGACY_DOC_MEMORY_URI_SCHEMES
 
     assert DOC_MEMORY_URI_SCHEME == "caura-doc"
-    assert "memclaw-doc" in LEGACY_DOC_MEMORY_URI_SCHEMES  # legacy-name-ok: pins the scheme persisted in customers' memories.source_uri
+    assert "memclaw-doc" in LEGACY_DOC_MEMORY_URI_SCHEMES  # legacy-name-ok: compat pin
     # Minting must never use a legacy scheme.
     assert DOC_MEMORY_URI_SCHEME not in LEGACY_DOC_MEMORY_URI_SCHEMES
 


### PR DESCRIPTION
Every exemption in this repo carried `legacy-name-ok`, whose report tells a reviewer to check each line is *"a compat alias, a redirect or a pinned wire format"*. Most were not. `legacy-name-floor` exists for the other claim — a line that merely **names** something the rename will never reach and cannot be correct without the literal — and nothing had been filed under it yet. This does that filing.

The split is what makes the alias list readable: rule 3's escape hatch is the thing that needs eyes, and it was diluted by lines nobody needs to re-litigate.

## How each line was decided

By what the line **does**, not by how its reason was worded, with **ties broken toward the alias** — an alias filed as floor is a rule 3 decision nobody looks at, while a floor mention filed as an alias is one extra line in a list already being read. Anything without a clear floor claim was left alone.

The bulk of what moved is `scripts/do_not_touch_sentinel.py`, whose entries pin exact text living elsewhere in the tree: rewording one breaks the sentinel, so nothing is declared there and the literal is load-bearing.

## Behaviour-neutral, and checked rather than assumed

Both markers exempt a line identically, so a swap cannot move a line in or out of the gate:

- exempt and non-exempt tallies **identical** before and after
- ratchet exits **0**
- `do_not_touch_sentinel.py` exits **0**
- the repo's ratchet and sentinel test suites pass

## Reason text shortened with the marker

Under a `legacy-name-floor` marker, `pinned floor string` and `…, which is floor` say nothing the marker has not. Shortening was applied **per claim, never per line** — the reason is the report's grouping key, so shortening only some lines of a group would split one claim across two headings.

## Expect a double report on this PR

Both halves are correct and neither is a failure: the swapped lines are new exempt *text*, so the new-exemption report lists them; the old text is gone, so the removal report lists them too. This was measured before the work started and is the known shape of a marker swap.
