### PR TITLE
docs(forge): correct lifecycle topic name

### DIFF
--- a/docs/operator-forge-cron.md
+++ b/docs/operator-forge-cron.md
@@ -12,7 +12,7 @@ fanout pattern:
    Actions cron / `cron` in the deploy box) hits
    `POST /admin/lifecycle/fanout/forge-distill` periodically.
 2. **`core-api`** lists tenants with `skills_factory.enabled=true` and
-   publishes one `memclaw.lifecycle.forge-distill-requested` event per
+   publishes one `caura.lifecycle.forge-distill-requested` event per
    tenant.
 3. **The in-process consumer** in `core-api` (or `core-worker` in
    SaaS deployments) invokes `run_forge_cron_tick` for the tenant.


### PR DESCRIPTION
## Summary

- correct the Forge operator runbook to name the live `caura.lifecycle.forge-distill-requested` topic
- coupled with caura-ai/caura-enterprise#1387; the two documentation PRs should land together

## How Has This Been Tested?

- `pre-commit run --files docs/operator-forge-cron.md`
- `git diff --check origin/main...HEAD`
- independently verified the enterprise Terraform rename expansion provisions the lifecycle twin in prod and staging; the dedicated twin suite passes 11 tests

## Type of Change

- [x] Documentation update

## Additional Notes

Documentation-only correction. No enum or generated manifest changes.