### PR TITLE
fix(observability): label mounted-app traffic instead of "unmatched"

### DIFF
--- a/core-api/src/core_api/middleware/request_observation.py
+++ b/core-api/src/core_api/middleware/request_observation.py
@@ -13,11 +13,24 @@ deployments they land in the JSON log file just like any other log line.
 
 Cardinality contract
 --------------------
-``http_route`` is ALWAYS the route template read from
-``scope["route"].path`` (e.g. ``/api/v1/memories/{id}``) or the literal
-``"unmatched"`` when no route matched (404s, or failures before routing).
-It is NEVER the raw request path with path params interpolated — raw paths
-would explode the metric's label cardinality and make it expensive.
+``http_route`` is ALWAYS one of three bounded things, in this order:
+
+1. the route template from ``scope["route"].path``
+   (e.g. ``/api/v1/memories/{id}``) — set by FastAPI's ``APIRoute``;
+2. the mount prefix (``/mcp``, ``/static``) for traffic served by a
+   mounted sub-app, which is NOT a FastAPI route and so never populates
+   ``scope["route"]``;
+3. the literal ``"unmatched"`` — genuine 404s and failures before
+   routing.
+
+It is NEVER the raw request path with path params interpolated — raw
+paths would explode the metric's label cardinality and make it
+expensive. Mount prefixes are safe on that count because mounts are
+declared statically in ``app.py``: one extra label each.
+
+Case 2 was folded into case 3 until 2026-08-29, which made ~40% of prod
+events unattributable and hid MCP traffic from the per-endpoint
+dashboard entirely — see the fallback in ``__call__`` for the numbers.
 
 ``scope["route"]`` only exists AFTER the router has run, so this middleware
 must inspect it once the downstream app returns, not before.
@@ -131,6 +144,14 @@ class RequestObservationMiddleware:
                 status_code = message["status"]
             await send(message)
 
+        # Captured BEFORE the downstream call: a Starlette ``Mount`` appends
+        # its prefix to ``scope["root_path"]``, so the delta across the call
+        # is the mount prefix and nothing else. Subtracting an app-level
+        # root_path any other way misfires — with the app served under one
+        # (``--root-path /gw``), a genuine 404 would otherwise be labelled
+        # ``/gw``. Verified against fastapi 0.128 / starlette 0.50 with and
+        # without an app root_path.
+        root_before = scope.get("root_path") or ""
         start = time.monotonic()
         try:
             await self.app(scope, receive, _send)
@@ -140,7 +161,44 @@ class RequestObservationMiddleware:
             # read it now, never before. Fall back to "unmatched" so 404s and
             # pre-routing failures bucket into a single bounded label.
             route = scope.get("route")
-            http_route = getattr(route, "path", None) or "unmatched"
+            http_route = getattr(route, "path", None)
+            if not http_route:
+                # Only FastAPI's APIRoute sets ``scope["route"]``; a Starlette
+                # ``Mount`` never does (starlette 0.50 has no such assignment
+                # at all). So every request into a mounted sub-app — app.py
+                # mounts ``/mcp`` and ``/static`` — fell into "unmatched"
+                # beside genuine 404s. In 6h of prod on 2026-08-29 that was
+                # 5,027 of 5,099 unmatched events (98.6%), every one of them
+                # SUCCESSFUL: ~40% of this metric's volume was unattributable
+                # and the MCP transport was invisible in the per-endpoint
+                # dashboard, while "unmatched" looked like a 404 problem.
+                #
+                # Labelling by mount prefix keeps the cardinality contract
+                # above: mounts are declared statically in app.py, so this
+                # adds one bounded label per mount, never a raw path. Genuine
+                # 404s and pre-routing failures have no mount and still read
+                # "unmatched", which now means what the contract says.
+                #
+                # This leans on two Starlette internals — that ``Mount``
+                # mutates THIS scope dict in place, and that it never sets
+                # ``scope["route"]`` — neither of which the ASGI spec
+                # guarantees, and starlette is not pinned directly here (only
+                # transitively, via ``fastapi>=0.115,<1``). Two things make
+                # that acceptable. It degrades safely: if either stops
+                # holding, the delta is empty and the label falls back to
+                # "unmatched", i.e. exactly today's behaviour, never a wrong
+                # or unbounded label. And it degrades LOUDLY in CI rather
+                # than silently in prod, because
+                # ``tests/test_request_observation.py`` drives real
+                # ``app.mount()`` calls through this middleware over a real
+                # ASGI transport — nothing about the framework is mocked — so
+                # a dependency bump that changes either behaviour turns those
+                # tests red. Keep them that way; a mock there would give the
+                # pin-free dependency a silent path back in.
+                root_after = scope.get("root_path") or ""
+                http_route = (
+                    root_after[len(root_before) :] if root_after.startswith(root_before) else ""
+                ) or "unmatched"
             # ``request.state`` is backed by ``scope["state"]``; ``get_auth_context``
             # stashes ``tenant_id`` there once the caller is authenticated. Absent
             # for unauthenticated routes and 401s — logged as None, which is fine.

--- a/tests/test_request_observation.py
+++ b/tests/test_request_observation.py
@@ -8,6 +8,7 @@ surfaces as an attribute on the captured ``LogRecord``.
 Contract pinned here:
   * exactly one ``http.request`` event per request,
   * ``http_route`` is the TEMPLATE (``/things/{id}``), never the raw path,
+  * mounted sub-apps label by mount prefix (``/mcp``), not ``"unmatched"``,
   * 404s and pre-routing failures bucket to ``"unmatched"``,
   * a crashing endpoint still emits one event, defaulting to status 500,
   * duration reflects the full downstream call (streaming included),
@@ -19,7 +20,7 @@ import logging
 
 import pytest
 from fastapi import FastAPI, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import PlainTextResponse, StreamingResponse
 from httpx import ASGITransport, AsyncClient
 
 from core_api.middleware.request_observation import RequestObservationMiddleware
@@ -53,6 +54,14 @@ def _build_test_app() -> FastAPI:
             yield b"b"
 
         return StreamingResponse(gen(), media_type="text/plain")
+
+    # A mounted sub-app is NOT a FastAPI route, so it never populates
+    # scope["route"] — the case that used to disappear into "unmatched".
+    async def _sub(scope, receive, send):
+        await PlainTextResponse("ok")(scope, receive, send)
+
+    app.mount("/mcp", _sub)
+    app.mount("/static", _sub)
 
     return app
 
@@ -137,3 +146,55 @@ async def test_streaming_duration_covers_full_response(caplog):
     # The generator sleeps 150ms mid-stream; duration must span it, proving
     # we measure to the final body chunk, not to response start.
     assert e.http_duration_ms >= 150.0
+
+
+@pytest.mark.parametrize(
+    "mount,path", [("/mcp", "/mcp/session"), ("/static", "/static/x.css")]
+)
+async def test_mounted_subapp_labels_by_mount_prefix(caplog, mount, path):
+    """Mounted traffic must carry its mount prefix, not "unmatched".
+
+    Only FastAPI's APIRoute sets ``scope["route"]``; a Starlette ``Mount``
+    never does. So this traffic used to land in the same bucket as 404s: in
+    6h of prod on 2026-08-29 that was 5,027 of 5,099 "unmatched" events, all
+    of them successful, which made ~40% of the metric unattributable and hid
+    the MCP transport from the per-endpoint dashboard.
+    """
+    app = _build_test_app()
+    with caplog.at_level(logging.INFO, logger="core_api.access"):
+        resp = await _get(app, path)
+    assert resp.status_code == 200
+
+    events = _events(caplog)
+    assert len(events) == 1
+    assert events[0].http_route == mount, (
+        f"mounted traffic labelled {events[0].http_route!r}; it must carry the "
+        f"mount prefix {mount!r} or it is indistinguishable from a 404"
+    )
+    # Still bounded: the prefix, never the raw path underneath it.
+    assert events[0].http_route == mount and path != mount
+
+
+async def test_unmatched_still_wins_when_there_is_no_mount(caplog):
+    """The mount fallback must not swallow the genuine-404 label."""
+    app = _build_test_app()
+    with caplog.at_level(logging.INFO, logger="core_api.access"):
+        resp = await _get(app, "/definitely/not/mounted")
+    assert resp.status_code == 404
+    assert _events(caplog)[0].http_route == "unmatched"
+
+
+async def test_app_level_root_path_does_not_leak_into_the_label(caplog):
+    """With the app served under a root_path, a 404 must stay "unmatched".
+
+    The mount prefix is derived as the root_path DELTA across the downstream
+    call, precisely so an app-level root_path (``--root-path /gw``) is not
+    mistaken for a mount. Subtracting ``app_root_path`` instead would label
+    this request ``/gw``.
+    """
+    app = _build_test_app()
+    transport = ASGITransport(app=app, raise_app_exceptions=False, root_path="/gw")
+    with caplog.at_level(logging.INFO, logger="core_api.access"):
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            await c.get("/nope")
+    assert _events(caplog)[0].http_route == "unmatched"


### PR DESCRIPTION
I went to cut `core_api.access` volume and came back with the opposite recommendation, plus a defect.

## Don't cut this one

It is **not** the `uvicorn.access` case. This line carries `http_route`, `http_method`, `http_status_code`, `http_duration_ms` **and `tenant_id`**, and its own docstring says it backs a **log-based distribution metric** for per-endpoint API-usage dashboards. Removing or filtering it takes out the metric. Nothing else in the stack carries per-tenant request attribution.

What *is* wrong with it is the label.

## The defect

Only FastAPI's `APIRoute` sets `scope["route"]`. A Starlette `Mount` never does — starlette 0.50 contains no such assignment at all. `app.py` mounts `/mcp` and `/static`, so every request into either fell through to `"unmatched"`, the bucket documented as *"404s, or failures before routing"*.

6h of prod, 2026-08-29:

| | count |
|---|---|
| `unmatched` GET 200 | 4,115 |
| `unmatched` POST 200 | 838 |
| `unmatched` POST 202 | 74 |
| `unmatched` 4xx — the only real 404s | 69 |

**5,027 of 5,099 (98.6%) were successful requests.** That is ~40% of the metric's events unattributable, the entire MCP transport invisible in the per-endpoint dashboard, and an `unmatched` count that looks like a 404 problem and isn't.

## The fix

Fall back to the **mount prefix**. That keeps the cardinality contract — mounts are declared statically in `app.py`, so it adds one bounded label each, never a raw path. Genuine 404s still read `unmatched`, and that label now means what the docstring says.

The prefix is the `root_path` **delta** across the downstream call (captured before, read after), because a `Mount` appends to `root_path`. Subtracting `app_root_path` instead looks equivalent and is not: with the app served under `--root-path /gw`, a genuine 404 gets labelled `/gw`. There is a test for exactly that, and it fails against the `app_root_path` version — I checked rather than reasoned.

## Verification

- Reproduced against **fastapi 0.128 / starlette 0.50**, with and without an app-level root_path, rather than assuming framework behaviour
- Confirmed **no capability-map key** collides with `/mcp` or `/static` (35 keys, 0 hits), so mounted traffic still records no REST capability and the adoption signal is unchanged
- Three new tests, each confirmed to **fail without its fix**: mount labelling (both mounts), 404-still-wins, and app-root_path-does-not-leak
- 20 passed across `test_request_observation.py` + `test_capability_usage.py`; ruff check and format clean

## On volume

**This commit changes volume by zero**, which is not what I was asked for, so to be explicit about the trade: cutting a metric's source to save log lines is the wrong direction, and I would rather say so than quietly ship it.

The one real volume option here is that `/health` and `/version` probes are **12%** of these events and are not "API usage" — arguably they inflate the dashboard as well as the bill. But that is a call for whoever owns the dashboard, not for a log-reduction pass. Happy to do it on request.