### PR TITLE
fix(observability): stop logging successful health and version probes

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -150,6 +150,22 @@ MEMORY_STATUSES_PATTERN = (
 # — return ``0`` / "unreachable" rather than block landing-page hits).
 PROBE_TIMEOUT_SECONDS = 5.0
 
+# Probe route paths, declared here rather than inline in ``routes/health.py``
+# so that exactly one string backs both the route decorator and the
+# access-log suppression in ``middleware/request_observation.py``. Those two
+# have to agree or successful-probe traffic silently returns to the logs, and
+# a shared constant makes disagreement impossible instead of merely
+# detectable — renaming the endpoint moves the suppression with it.
+#
+# These are ROUTER-RELATIVE, which is what ``scope["route"].path`` carries and
+# therefore what the access log's ``http_route`` label is. ``app.py`` serves
+# them under ``include_router(prefix="/api/v1")``, so the URL a caller hits is
+# ``/api/v1/health`` while the label is ``/health``. Keep that distinction:
+# writing the prefixed form here would match nothing.
+HEALTH_PATH = "/health"
+VERSION_PATH = "/version"
+PROBE_ROUTES = frozenset({HEALTH_PATH, VERSION_PATH})
+
 # ── Memory visibility levels ──
 # Named constants are the SoT — ``MEMORY_VISIBILITIES`` and the regex below
 # derive from them so a rename here propagates to membership checks and

--- a/core-api/src/core_api/middleware/request_observation.py
+++ b/core-api/src/core_api/middleware/request_observation.py
@@ -5,18 +5,27 @@ Pure ASGI middleware — matches the ``SecurityHeadersMiddleware`` /
 than ``BaseHTTPMiddleware`` (which wraps in Starlette's task groups and has
 known edge cases around cancellation and streaming responses).
 
-Emits exactly one structured ``http.request`` log event per HTTP request,
+Emits at most one structured ``http.request`` log event per HTTP request,
 carrying the *templated* route, method, status, and wall-clock duration.
 These events back a log-based distribution metric for per-endpoint
 API-usage dashboards on Cloud-Logging deployments; on file-logging
 deployments they land in the JSON log file just like any other log line.
 
+"At most" rather than "exactly": a liveness/readiness probe that SUCCEEDS
+is not logged, because it is infrastructure chatter rather than API usage.
+A probe that FAILS still is. See ``PROBE_ROUTES`` for the routes, the
+rationale, and what that costs.
+
 Cardinality contract
 --------------------
 ``http_route`` is ALWAYS one of three bounded things, in this order:
 
-1. the route template from ``scope["route"].path``
-   (e.g. ``/api/v1/memories/{id}``) — set by FastAPI's ``APIRoute``;
+1. the route template from ``scope["route"].path`` — set by FastAPI's
+   ``APIRoute``. Note this is the template as the ROUTER declares it, with
+   no router prefix on it: a GET of ``/api/v1/memories/abc`` is labelled
+   ``/memories/{memory_id}``. Since FastAPI 0.137,
+   ``include_router(prefix=...)`` mounts the router instead of flattening
+   it, so the prefix lives in ``root_path`` and never reaches this label;
 2. the mount prefix (``/mcp``, ``/static``) for traffic served by a
    mounted sub-app, which is NOT a FastAPI route and so never populates
    ``scope["route"]``;
@@ -62,9 +71,44 @@ from typing import Any
 from starlette.types import ASGIApp as ASGIApplication
 from starlette.types import Receive, Scope, Send
 
+from core_api.constants import PROBE_ROUTES
 from core_api.services.capability_usage import record_usage
 
 logger = logging.getLogger("core_api.access")
+
+# Liveness/readiness probe routes, whose SUCCESSFUL requests are not logged.
+#
+# ``PROBE_ROUTES`` is imported rather than restated because ``routes/health.py``
+# builds its route decorators from the very same constants — one string backs
+# both, so the endpoint cannot be renamed out from under this check. See the
+# note beside it in ``constants.py`` for why the values are router-relative
+# (``/health``, not ``/api/v1/health``).
+#
+# Why drop them: Cloud Run probes each instance on a fixed interval, so
+# these arrive at a near-constant rate no matter what real traffic does —
+# ~5.4k/day in prod, of which 100% over 7 days to 2026-08-29 (37,850 events)
+# were untenanted infrastructure calls, never a real API consumer. As a
+# SHARE of this metric they are wildly unstable for the same reason: 1.3% on
+# a busy day, 12.5% on a quiet one. The stable number is the absolute rate.
+#
+# Why only the successful ones: a probe that returns 200 answers no question
+# this metric exists to answer, but a failing one is exactly what an
+# incident investigation reaches for — prod served 440 ``/health`` 503s in
+# that same week. Suppressing by route alone would have thrown all 440 away
+# to save 1.2% more volume. Non-2xx probes stay.
+#
+# What this gives up: "are probes arriving at all?" can no longer be
+# answered from these logs, since silence now means both "healthy" and
+# "nothing is calling us". Cloud Run reports instance health directly, and a
+# probe that fails still logs, so that gap is covered elsewhere.
+#
+# And the denominator for these two routes is now gone, so a per-route ERROR
+# RATE (failures / total) is meaningless for them — every probe event that
+# survives is a failure, so any such ratio reads 100% the moment one 503
+# lands. For PROBE_ROUTES read the absolute failure COUNT instead. Nothing
+# in-repo derives a rate from this metric today; the point is that an alert
+# added later must not, and an on-call engineer seeing "100% errors on
+# /health" should recognise it as this suppression rather than an outage.
 
 # REST route-template → (capability, op) for the adoption signal. Keyed by
 # (METHOD, templated path) so the same path under different verbs maps to the
@@ -122,7 +166,11 @@ _REST_CAPABILITY: dict[tuple[str, str], tuple[str, str | None]] = {
 
 
 class RequestObservationMiddleware:
-    """ASGI middleware that emits one ``http.request`` event per request."""
+    """ASGI middleware emitting at most one ``http.request`` event per request.
+
+    "At most" because a SUCCESSFUL liveness/readiness probe emits none; see
+    ``PROBE_ROUTES``. Every other request, failed probes included, emits one.
+    """
 
     def __init__(self, app: ASGIApplication) -> None:
         self.app = app
@@ -149,8 +197,8 @@ class RequestObservationMiddleware:
         # is the mount prefix and nothing else. Subtracting an app-level
         # root_path any other way misfires — with the app served under one
         # (``--root-path /gw``), a genuine 404 would otherwise be labelled
-        # ``/gw``. Verified against fastapi 0.128 / starlette 0.50 with and
-        # without an app root_path.
+        # ``/gw``. Verified against the locked fastapi 0.141.1 / starlette
+        # 1.3.1, with and without an app root_path.
         root_before = scope.get("root_path") or ""
         start = time.monotonic()
         try:
@@ -164,7 +212,7 @@ class RequestObservationMiddleware:
             http_route = getattr(route, "path", None)
             if not http_route:
                 # Only FastAPI's APIRoute sets ``scope["route"]``; a Starlette
-                # ``Mount`` never does (starlette 0.50 has no such assignment
+                # ``Mount`` never does (starlette 1.3.1 has no such assignment
                 # at all). So every request into a mounted sub-app — app.py
                 # mounts ``/mcp`` and ``/static`` — fell into "unmatched"
                 # beside genuine 404s. In 6h of prod on 2026-08-29 that was
@@ -183,7 +231,7 @@ class RequestObservationMiddleware:
                 # mutates THIS scope dict in place, and that it never sets
                 # ``scope["route"]`` — neither of which the ASGI spec
                 # guarantees, and starlette is not pinned directly here (only
-                # transitively, via ``fastapi>=0.115,<1``). Two things make
+                # transitively, via ``fastapi>=0.141.1,<1``). Two things make
                 # that acceptable. It degrades safely: if either stops
                 # holding, the delta is empty and the label falls back to
                 # "unmatched", i.e. exactly today's behaviour, never a wrong
@@ -205,16 +253,24 @@ class RequestObservationMiddleware:
             state = scope.get("state") or {}
             tenant_id = state.get("tenant_id")
             method = scope.get("method", "?")
-            logger.info(
-                "http.request",
-                extra={
-                    "http_route": http_route,
-                    "http_method": method,
-                    "http_status_code": status_code,
-                    "http_duration_ms": round(duration_ms, 1),
-                    "tenant_id": tenant_id,
-                },
-            )
+            # A probe that SUCCEEDED tells us nothing this metric exists to
+            # answer, so don't pay to store it. One that failed is exactly
+            # what an investigation wants, so it still goes out — see
+            # ``PROBE_ROUTES``. Guard the emit with a condition rather than
+            # returning early: this is a ``finally`` block, and a ``return``
+            # here would swallow an in-flight exception from the downstream
+            # call.
+            if not (http_route in PROBE_ROUTES and status_code < 400):
+                logger.info(
+                    "http.request",
+                    extra={
+                        "http_route": http_route,
+                        "http_method": method,
+                        "http_status_code": status_code,
+                        "http_duration_ms": round(duration_ms, 1),
+                        "tenant_id": tenant_id,
+                    },
+                )
             # Adoption signal: record capability usage for mapped REST routes
             # (transport=rest). MCP traffic (POST /mcp) is recorded separately
             # by the call_tool wrapper, and /mcp isn't in the map, so there's

--- a/core-api/src/core_api/routes/health.py
+++ b/core-api/src/core_api/routes/health.py
@@ -10,7 +10,12 @@ from core_api import openapi_responses as _oar
 from core_api.cache import redis_healthy
 from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
-from core_api.constants import PROBE_TIMEOUT_SECONDS, VERSION
+from core_api.constants import (
+    HEALTH_PATH,
+    PROBE_TIMEOUT_SECONDS,
+    VERSION,
+    VERSION_PATH,
+)
 from core_api.providers._platform import (
     get_platform_embedding,
     get_platform_init_errors,
@@ -25,7 +30,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["System"])
 
 
-@router.get("/version", responses={200: {"model": _oar.VersionResponse}})
+@router.get(VERSION_PATH, responses={200: {"model": _oar.VersionResponse}})
 async def version():
     return {"version": VERSION}
 
@@ -175,7 +180,7 @@ async def _probe_dependencies() -> tuple[dict[str, Any], list[str]]:
     return result, unhealthy
 
 
-@router.get("/health", responses={200: {"model": _oar.HealthResponse}})
+@router.get(HEALTH_PATH, responses={200: {"model": _oar.HealthResponse}})
 async def health(response: Response):
     """Liveness + readiness probe.
 

--- a/tests/test_request_observation.py
+++ b/tests/test_request_observation.py
@@ -10,6 +10,8 @@ Contract pinned here:
   * ``http_route`` is the TEMPLATE (``/things/{id}``), never the raw path,
   * mounted sub-apps label by mount prefix (``/mcp``), not ``"unmatched"``,
   * 404s and pre-routing failures bucket to ``"unmatched"``,
+  * a SUCCESSFUL liveness/readiness probe emits no event at all, while a
+    failing one still does,
   * a crashing endpoint still emits one event, defaulting to status 500,
   * duration reflects the full downstream call (streaming included),
   * ``tenant_id`` stashed on ``request.state`` reaches the event.
@@ -19,10 +21,11 @@ import asyncio
 import logging
 
 import pytest
-from fastapi import FastAPI, Request
-from fastapi.responses import PlainTextResponse, StreamingResponse
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from httpx import ASGITransport, AsyncClient
 
+from core_api.constants import PROBE_ROUTES, VERSION_PATH
 from core_api.middleware.request_observation import RequestObservationMiddleware
 
 pytestmark = pytest.mark.asyncio
@@ -198,3 +201,191 @@ async def test_app_level_root_path_does_not_leak_into_the_label(caplog):
         async with AsyncClient(transport=transport, base_url="http://test") as c:
             await c.get("/nope")
     assert _events(caplog)[0].http_route == "unmatched"
+
+
+# --- Probe suppression -------------------------------------------------
+#
+# These build the app the way app.py really does — a router included under
+# ``prefix="/api/v1"`` — rather than hanging ``/health`` straight off the
+# app. That difference is the whole point. Since FastAPI 0.137 an
+# ``include_router(prefix=...)`` MOUNTS the router, so the label reaching
+# ``http_route`` is the inner ``/health``, not the requested
+# ``/api/v1/health``. A test that registered ``@app.get("/health")``
+# directly would produce the label ``/health`` too, and would therefore
+# pass whether or not the middleware handles the real prefixed case — the
+# kind of green that means nothing.
+
+
+def _build_probe_app(*, healthy: bool = True) -> FastAPI:
+    router = APIRouter()
+
+    @router.get("/health")
+    async def health():
+        if not healthy:
+            return JSONResponse({"ok": False}, status_code=503)
+        return {"ok": True}
+
+    @router.get("/version")
+    async def version():
+        return {"version": "1"}
+
+    @router.get("/things/{thing_id}")
+    async def get_thing(thing_id: str):
+        return {"id": thing_id}
+
+    app = FastAPI()
+    app.add_middleware(RequestObservationMiddleware)
+    app.include_router(router, prefix="/api/v1")
+    return app
+
+
+@pytest.mark.parametrize("path", ["/api/v1/health", "/api/v1/version"])
+async def test_successful_probe_emits_no_event(caplog, path):
+    """A 200 from a liveness/readiness probe must not be logged at all."""
+    app = _build_probe_app()
+    with caplog.at_level(logging.INFO, logger="core_api.access"):
+        resp = await _get(app, path)
+    assert resp.status_code == 200
+    events = _events(caplog)
+    assert events == [], (
+        f"{path} emitted {len(events)} event(s) "
+        f"({[e.http_route for e in events]}); successful probes are "
+        "infrastructure chatter and must be suppressed"
+    )
+
+
+async def test_failing_probe_is_still_logged(caplog):
+    """A probe that FAILS is the one an investigation needs — keep it.
+
+    Prod served 440 ``/health`` 503s in the week to 2026-08-29. Suppressing
+    by route alone would have discarded every one of them.
+    """
+    app = _build_probe_app(healthy=False)
+    with caplog.at_level(logging.INFO, logger="core_api.access"):
+        resp = await _get(app, "/api/v1/health")
+    assert resp.status_code == 503
+    events = _events(caplog)
+    assert len(events) == 1, (
+        f"a failing probe emitted {len(events)} events; it must emit exactly "
+        "one, otherwise the 503s vanish along with the healthy noise"
+    )
+    assert events[0].http_route == "/health"
+    assert events[0].http_status_code == 503
+
+
+async def test_prefixed_non_probe_route_still_logs_its_stripped_label(caplog):
+    """Pins the label space the suppression list is written against.
+
+    ``PROBE_ROUTES`` holds ``/health``, not ``/api/v1/health``, because
+    FastAPI mounts prefixed routers. If a future FastAPI went back to
+    flattening prefixes, ``http_route`` here would become
+    ``/api/v1/things/{thing_id}`` — and the suppression above would silently
+    stop matching anything. This assertion turns that into a red test rather
+    than a quiet return of the probe traffic.
+    """
+    app = _build_probe_app()
+    with caplog.at_level(logging.INFO, logger="core_api.access"):
+        resp = await _get(app, "/api/v1/things/42")
+    assert resp.status_code == 200
+    events = _events(caplog)
+    assert len(events) == 1
+    assert events[0].http_route == "/things/{thing_id}", (
+        f"prefixed route labelled {events[0].http_route!r}; PROBE_ROUTES is "
+        "written in this label space and must be updated together with it"
+    )
+
+
+async def test_real_health_router_probe_is_suppressed(caplog):
+    """The decisive one: the REAL router, not a hand-built stand-in.
+
+    Every other test here builds its own ``/health``, so all of them would
+    stay green if ``routes/health.py`` renamed the endpoint or app.py changed
+    how it is registered. This imports the production router and serves it
+    the way ``app.py`` does, so it answers the only question that matters:
+    does the traffic prod actually generates get suppressed?
+
+    ``/version`` is the probe to drive here because it has no dependencies —
+    ``/health`` returns 503 without redis/storage, which is a valid response
+    but tests the failure path rather than the suppression path.
+    """
+    from core_api.routes.health import router as real_health_router
+
+    app = FastAPI()
+    app.add_middleware(RequestObservationMiddleware)
+    app.include_router(real_health_router, prefix="/api/v1")
+
+    with caplog.at_level(logging.INFO, logger="core_api.access"):
+        resp = await _get(app, "/api/v1/version")
+    assert resp.status_code == 200, "the real /version route did not serve"
+    assert _events(caplog) == [], (
+        "the REAL /api/v1/version emitted an access event; the label it "
+        f"produces is not in PROBE_ROUTES ({sorted(PROBE_ROUTES)}) and probe "
+        "traffic is still being logged in production"
+    )
+
+
+async def test_probe_constants_are_the_ones_the_router_registers():
+    """PROBE_ROUTES and the route decorators must be the same strings.
+
+    They already are by construction — ``routes/health.py`` decorates with
+    these very constants — and this asserts that construction still holds, so
+    reintroducing a literal path in either place is caught here.
+    """
+    from core_api.routes.health import router as real_health_router
+
+    declared = {r.path for r in real_health_router.routes if hasattr(r, "methods")}
+    missing = PROBE_ROUTES - declared
+    assert not missing, (
+        f"{sorted(missing)} is suppressed from the access log but is not a "
+        f"path the health router registers ({sorted(declared)}) — the "
+        "suppression matches nothing and probe traffic is being logged"
+    )
+    assert VERSION_PATH in PROBE_ROUTES
+
+
+async def test_no_other_router_declares_a_probe_path():
+    """Suppression matches a bare label, so only ONE router may declare it.
+
+    ``PROBE_ROUTES`` holds router-relative templates (``/health``), and the
+    middleware matches on that string alone with no notion of which router
+    produced it. A second router declaring its own ``/health`` — an admin
+    sub-app, say — would therefore have its successful traffic silently
+    suppressed too, and nothing else in the system would say so.
+
+    Rather than couple the middleware to the health router at runtime, pin
+    the assumption here: exactly one declaration per probe path, across the
+    whole real app.
+
+    The walk descends through FastAPI's ``_IncludedRouter`` via
+    ``original_router``, since ``include_router(prefix=...)`` mounts the
+    router opaquely (``app.py`` documents the same obstacle). That is a
+    private attribute, so the count assertions below double as a check that
+    the walk still works: if it stops descending, the probes are found zero
+    times and this test fails rather than quietly passing.
+    """
+    import collections
+
+    from core_api.app import app
+
+    counts: collections.Counter = collections.Counter()
+
+    def walk(routes):
+        for r in routes:
+            inner = getattr(r, "original_router", None)
+            if inner is not None:
+                walk(inner.routes)
+                continue
+            path = getattr(r, "path", None)
+            if path is not None and hasattr(r, "methods"):
+                counts[path] += 1
+
+    walk(app.routes)
+
+    for probe in sorted(PROBE_ROUTES):
+        assert counts[probe] == 1, (
+            f"{probe!r} is declared by {counts[probe]} route(s) in the real "
+            f"app; the access-log suppression matches this label with no "
+            f"regard for which router owns it, so anything other than exactly "
+            f"1 means either the walk stopped working (0) or a second router "
+            f"is having its successful traffic silently dropped (>1)"
+        )


### PR DESCRIPTION
Follow-up to #1048, which established that `core_api.access` is worth keeping
because it carries `tenant_id` and backs a per-endpoint API-usage metric. This
removes the one part of its volume that is definitively *not* API usage.

## What and why

Cloud Run probes `/api/v1/health` and `/api/v1/version` on a fixed interval per
instance. Over the 7 days to 2026-08-29 prod logged **37,850** successful
probes, and **100% of them were untenanted** — not one came from a real API
consumer:

| route | tenant | status | 7d count |
|---|---|---|---|
| `/health` | *(none)* | 200 | 32,047 |
| `/version` | *(none)* | 200 | 5,804 |
| `/health` | *(none)* | 503 | 440 |
| `/version` | *(none)* | 405 | 3 |
| `/health` | *(none)* | 405 | 2 |

`/health` was the **third-busiest route** on a dashboard whose purpose is
showing which endpoints customers use.

## Successful probes only

The 440 `/health` 503s in that table are the reason this filters on status
rather than route. A failing probe is precisely what an incident investigation
reaches for; suppressing by route alone would have discarded all 440 to save
1.2% more volume. Non-2xx probes still log.

What this gives up: "are probes arriving at all?" is no longer answerable from
these logs, because silence now means both "healthy" and "nothing is calling
us". Cloud Run reports instance health directly and failures still log, so that
gap is covered elsewhere. It's noted in the code.

## Correcting my own number from #1048

I wrote in the #1048 body that probes were "12% of these events". **That was a
sampling artifact and I was wrong to state it unqualified.** The probe rate is
near-constant while real traffic swings ~8×, so the *share* moves entirely with
the denominator:

| day | total | probe (ok) | share |
|---|---|---|---|
| 2026-08-23 | 377,252 | 5,665 | 1.5% |
| 2026-08-24 | 342,713 | 4,564 | 1.3% |
| 2026-08-26 | 405,511 | 5,145 | 1.3% |
| 2026-08-27 | 255,618 | 5,504 | 2.2% |
| 2026-08-28 | 46,568 | 5,827 | **12.5%** |

My 6h sample landed on 08-28, a quiet day. The honest figure is the absolute
one: **~5.4k lines/day, permanently**. That is a *small* win on volume — the
stronger case for this change is that it stops infrastructure noise from
dominating a customer-usage dashboard.

## The subtle part: which path space?

`_PROBE_ROUTES` holds `/health`, **not** `/api/v1/health`. Since FastAPI 0.137,
`include_router(prefix=...)` mounts the router instead of flattening it, so the
prefix lives in `root_path` and never reaches `http_route`. Verified against the
locked fastapi 0.141.1 / starlette 1.3.1 by driving real requests through the
real `core_api.app`:

```
GET /api/v1/version      -> 200, no event emitted        (suppressed)
GET /api/v1/health       -> 503, http_route='/health'    (failure kept)
GET /api/v1/memories/abc -> 401, http_route='/memories/{memory_id}'
GET /api/v1/nope         -> 404, http_route='unmatched'
```

**The tests build the app with `include_router(prefix=...)`, not
`@app.get("/health")`.** That distinction is the whole point: registering the
route directly on the app produces the label `/health` by coincidence, so such
a test passes whether or not the real prefixed case works. Getting this wrong is
not hypothetical — see below.

Confirmed the two suppression tests fail without the middleware change:

```
FAILED test_successful_probe_emits_no_event[/api/v1/health]
FAILED test_successful_probe_emits_no_event[/api/v1/version]
```

`test_prefixed_non_probe_route_still_logs_its_stripped_label` pins the label
space itself, so a future FastAPI that returns to flattening prefixes turns CI
red rather than silently restoring the probe traffic.

## Also corrected

Three claims in this file that were wrong, two of them mine from #1048:

- pinned versions are **fastapi 0.141.1 / starlette 1.3.1**, not "0.128 / 0.50"
- the dependency range is `fastapi>=0.141.1,<1`, not `>=0.115,<1`
- the cardinality contract's example label was `/api/v1/memories/{id}` — a label
  this metric never emits

## Separately: `_REST_CAPABILITY` is dead and I have not touched it here

While verifying the label space I found that all 35 entries in
`_REST_CAPABILITY` (same file) are keyed `/api/v1/...`, so **none can ever
match** — the REST half of the capability adoption signal has recorded nothing
since FastAPI 0.137 was adopted:

- #353 added the map on 2026-06-14, correct at the time
- #391 adopted FastAPI 0.137 on 2026-06-15, changing the label space

It worked for one day. `tests/test_capability_usage.py:157` registers
`@app.post("/api/v1/recall")` directly on the app, which is why it stays green.
Only the MCP half still records, so the adoption report looks plausible rather
than empty.

I've deliberately left it out of this PR — it's a behavioural change to a
different signal and deserves its own review and its own revert boundary.
