### PR TITLE
refactor(plugin): clean stale legacy-name prose

### DIFF
--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -258,7 +258,7 @@ describe("discoverAgentWorkspaces", () => {
 
 describe("writeEducationFiles", () => {
   // These are regression tests for the multi-agent education bug
-  // (memclaw memory 90b7d579-068a-4561-a740-73a76a74b1ac). The old
+  // (caura memory 90b7d579-068a-4561-a740-73a76a74b1ac). The old
   // implementation discovered workspaces via `readdirSync(baseDir)` filtered
   // by `startsWith("workspace")`, which silently skipped agents living under
   // `<baseDir>/workspaces/<name>/` and also wrote phantom education files
@@ -384,7 +384,7 @@ describe("writeEducationFiles", () => {
     assert.ok(!existsSync(join(base, "workspaces", "agent3", "TOOLS.md")) || !readFileSync(join(base, "workspaces", "agent3", "TOOLS.md"), "utf-8").includes("Caura"));
   });
 
-  test("cleans up pre-existing phantom MemClaw files at <baseDir>/workspaces/", () => {
+  test("cleans up pre-existing phantom Caura files at <baseDir>/workspaces/", () => {
     const base = tmpBase();
     mkdirSync(join(base, "workspaces"), { recursive: true });
     writeFileSync(join(base, "workspaces", "TOOLS.md"), buildToolsMd(), "utf-8");
@@ -396,9 +396,9 @@ describe("writeEducationFiles", () => {
     assert.ok(!existsSync(join(base, "workspaces", "AGENTS.md")));
   });
 
-  test("cleanup leaves non-MemClaw content at <baseDir>/workspaces/ alone", () => {
+  test("cleanup leaves foreign content at <baseDir>/workspaces/ alone", () => {
     // Defensive: if a user happens to have unrelated TOOLS.md/AGENTS.md at
-    // that path, we must not delete it. Cleanup is gated on memclaw markers.
+    // that path, we must not delete it. Cleanup is gated on our own section markers.
     const base = tmpBase();
     mkdirSync(join(base, "workspaces"), { recursive: true });
     writeFileSync(join(base, "workspaces", "TOOLS.md"), "# my own tools notes\n", "utf-8");
@@ -465,9 +465,9 @@ describe("writeEducationFiles", () => {
 
       const userBefore =
         "# Workspace tools\n\n" +
-        "Some user notes about tooling that predate MemClaw.\n\n";
+        "Some user notes about tooling that predate Caura.\n\n";
       const userAfter =
-        "\n\n## Notes\n\nMore user content below the MemClaw section.\n";
+        "\n\n## Notes\n\nMore user content below the Caura section.\n";
       const staleFenced =
         "<!-- memclaw:tools v=deadbeef -->\n" +
         "## MemClaw — Tools Available\n\nObsolete content from a previous version.\n" +
@@ -1426,7 +1426,7 @@ describe("buildAgentsMd", () => {
     // automatically by the runtime from the plugin manifest
     // (openclaw.plugin.json:skills). AGENTS.md — injected as bootstrap
     // every turn — must direct the model to open that skill before its
-    // first MemClaw tool call so the signatures, decision guidance, and
+    // first Caura tool call so the signatures, decision guidance, and
     // error codes are in context when needed.
     //
     // CAURA-000: AGENTS.md must NOT reference the skill by a filesystem

--- a/plugin/src/educate.ts
+++ b/plugin/src/educate.ts
@@ -206,7 +206,7 @@ export function cleanupStaleHeartbeatEducation(
  * Delete orphan TOOLS.md / AGENTS.md at <baseDir>/workspaces/ that the
  * pre-fix discovery wrote when it mistakenly treated the plural parent
  * directory as a single workspace. Idempotent: missing files are no-op,
- * non-MemClaw content at that path is left alone.
+ * content this plugin did not write at that path is left alone.
  */
 function cleanupPhantomEducationFiles(baseDir: string): void {
   const phantomDir = join(baseDir, "workspaces");
@@ -215,12 +215,12 @@ function cleanupPhantomEducationFiles(baseDir: string): void {
     if (!existsSync(fpath)) continue;
     try {
       const content = readFileSync(fpath, "utf-8");
-      const isMemClawOrphan =
+      const isPluginOrphan =
         (fname === "TOOLS.md" &&
           (content.includes("MemClaw — Tools Available") ||
             content.includes("Caura — Tools Available"))) ||
         (fname === "AGENTS.md" && content.includes("## Memory V2"));
-      if (isMemClawOrphan) {
+      if (isPluginOrphan) {
         unlinkSync(fpath);
       }
     } catch (e: unknown) {
@@ -331,7 +331,7 @@ export function educateAgents(
 //                contract, write triggers, capture cadences, quality
 //                enforcement, prohibited behaviors. Short supersession
 //                paragraph instructs the model to read SKILL.md before
-//                its first MemClaw call.
+//                its first Caura call.
 //
 // AGENTS.md idempotency is keyed off the substring "## Memory V2" in
 // writeEducationFiles() below; buildAgentsMd() must continue to emit that

--- a/plugin/src/env.test.ts
+++ b/plugin/src/env.test.ts
@@ -9,7 +9,7 @@ import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 
 // Set API key before importing env.ts so resolveTenantId won't early-exit.
-// Must be MEMCLAW_*-prefixed — env.ts only loads those from .env.
+// Must carry the CAURA_ prefix — env.ts only loads prefixed keys from .env.
 process.env.CAURA_API_KEY = "mc_test_key_for_env_tests";
 // Clear tenant id so resolveTenantId actually attempts a fetch.
 delete process.env.CAURA_TENANT_ID;

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -489,7 +489,7 @@ describe("reconcileSkills — configured targets", () => {
     mkdirSync(ext(slug), { recursive: true });
     writeFileSync(ext(slug, "SKILL.md"), body, "utf-8");
   };
-  const plantOwned = (slug: string, body = "# memclaw owned\n") => {
+  const plantOwned = (slug: string, body = "# plugin owned\n") => {
     mkdirSync(ext(slug), { recursive: true });
     writeFileSync(ext(slug, "SKILL.md"), body, "utf-8");
     writeFileSync(ext(slug, OWNED_MARKER), "x", "utf-8");
@@ -544,9 +544,9 @@ describe("reconcileSkills — configured targets", () => {
     assert.ok(!summary.skipped.includes("deploy-runbook"), "collisions are not conflated into skipped");
   });
 
-  test("additive: a MemClaw-owned skill dropped from the catalog IS removed", async () => {
+  test("additive: a plugin-owned skill dropped from the catalog IS removed", async () => {
     plantOnDisk("memclaw");
-    plantOwned("old-skill"); // previously written by MemClaw (has marker)
+    plantOwned("old-skill"); // previously written by this plugin (has marker)
     plantForeign("client-skill"); // foreign neighbour — must survive
     useAdditive();
     mockCatalog = []; // old-skill no longer active

--- a/plugin/src/tool-definitions.test.ts
+++ b/plugin/src/tool-definitions.test.ts
@@ -36,7 +36,7 @@ describe("tool-specs loader", () => {
   });
 
   test("getSpec throws for unknown tool", () => {
-    assert.throws(() => getSpec("memclaw_not_a_thing"), /Unknown tool/);
+    assert.throws(() => getSpec("caura_not_a_thing"), /Unknown tool/);
   });
 
   test("getSpec returns matching entry for known tool", () => {
@@ -119,7 +119,7 @@ describe("createToolFromSpec factory", () => {
 
   test("throws for a tool name not in tools.json", () => {
     assert.throws(
-      () => createToolFromSpec("memclaw_does_not_exist"),
+      () => createToolFromSpec("caura_does_not_exist"),
       /Unknown tool/,
     );
   });
@@ -334,7 +334,7 @@ describe("drift checks across tool surface artefacts", () => {
       );
     });
 
-    test("lists all currently-available MemClaw tools by name", () => {
+    test("lists all currently-available Caura tools by name", () => {
       for (const name of CAURA_TOOLS) {
         assert.ok(
           tools.includes(name),
@@ -383,7 +383,7 @@ describe("drift checks across tool surface artefacts", () => {
       );
     });
 
-    test("emits nothing when no MemClaw tools are available", () => {
+    test("emits nothing when no Caura tools are available", () => {
       const empty = cauraPromptSectionText(new Set());
       assert.equal(empty, "", "must emit empty string when no tools available");
     });
@@ -391,7 +391,7 @@ describe("drift checks across tool surface artefacts", () => {
 });
 
 describe("labelFor naming conversion", () => {
-  test("caura_doc → MemClaw Doc, caura_entity_get → MemClaw Entity Get", () => {
+  test("caura_doc → Caura Doc, caura_entity_get → Caura Entity Get", () => {
     assert.equal(createToolFromSpec("caura_doc").label, "Caura Doc");
     assert.equal(
       createToolFromSpec("caura_entity_get").label,


### PR DESCRIPTION
## Summary

- clean the 20 PR2 legacy-brand mentions proven safe in plugin prose, comments, test names, and inert fixtures
- rename the block-local isMemClawOrphan variable to isPluginOrphan
- use canonical caura_* names for two deliberately nonexistent tool fixtures
- correct stale test descriptions that contradicted current Caura behavior

## Scope guards

- leaves educate.test.ts lines 695 and 808 untouched; those memclaw_ comments pin pre-rename fixture behavior
- leaves every sentinel-pinned fence tag, heading, backup suffix, ownership marker, install path, plugin id, and skill slug unchanged
- changes no runtime, wire, persisted, or customer-disk contract

## Verification

- plugin TypeScript build passes
- full plugin suite: 425 passed
- affected plugin suites after rebase: 155 passed
- version sync: plugin 2.19.3 is current
- sentinel: All 39 protected strings survive.
- ratchet: No new lines. 20 removed by this change (-20 net).
- report: 752 lines across 162 files
- every CI Ruff check and format scope passes
- every CI mypy scope passes
- one DCO-signed commit