### PR TITLE
test(plugin): cover historical phantom-file cleanup

### DIFF
--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -396,6 +396,22 @@ describe("writeEducationFiles", () => {
     assert.ok(!existsSync(join(base, "workspaces", "AGENTS.md")));
   });
 
+  test("cleans up pre-existing phantom legacy TOOLS.md at <baseDir>/workspaces/", () => {
+    const base = tmpBase();
+    const phantomDir = join(base, "workspaces");
+    const phantomTools = join(phantomDir, "TOOLS.md");
+    mkdirSync(phantomDir, { recursive: true });
+    writeFileSync(
+      phantomTools,
+      "## MemClaw — Tools Available\n\nLegacy plugin content.\n", // legacy-name-ok: legacy on-disk heading compatibility fixture
+      "utf-8",
+    );
+
+    writeEducationFiles(buildToolsMd(), buildAgentsMd(), undefined, base);
+
+    assert.ok(!existsSync(phantomTools));
+  });
+
   test("cleanup leaves foreign content at <baseDir>/workspaces/ alone", () => {
     // Defensive: if a user happens to have unrelated TOOLS.md/AGENTS.md at
     // that path, we must not delete it. Cleanup is gated on our own section markers.


### PR DESCRIPTION
## Summary

- Adds the regression guard required by the OSS legacy-name review plan before or with PR2.
- Covers cleanup of a historical phantom TOOLS.md under the plural workspaces parent when it carries the old on-disk heading.
- Follow-up to #1051, which was human-merged before this guard could be added.

## Sensitivity proof

Temporarily disabling only the historical-heading predicate makes the new test fail because the phantom file survives. Restoring the predicate makes it pass.

## Validation

- Full plugin suite: 426 passed, 0 failed on the byte-identical tree
- TypeScript build and focused regression test: passed
- Do-not-touch sentinel: all 39 protected strings survive
- Legacy-name ratchet: one pinned compatibility fixture; no new lines
- Plugin version sync: 2.19.3 current
- Focused simplify pass: clean after correcting the marker kind

## Scope

Test-only. No product logic or persisted contract changes.