### PR TITLE
docs(events): use brand-neutral topic examples

### DIFF
--- a/common/events/factory.py
+++ b/common/events/factory.py
@@ -55,7 +55,7 @@ def get_event_bus() -> EventBus:
             # "prod"/"staging") to isolate Pub/Sub topics across environments that
             # share one GCP project, eliminating cross-env message fan-out.
             # Strip so a fat-fingered secret (e.g. "prod ") can't produce an
-            # invalid GCP topic name like "prod --memclaw.memory.embedded".
+            # invalid GCP topic name like "prod --<brand>.memory.embedded".
             topic_prefix = (os.getenv("EVENT_BUS_TOPIC_PREFIX") or "").strip()
             if topic_prefix:
                 kwargs["topic_prefix"] = topic_prefix

--- a/common/events/lifecycle_archive_request.py
+++ b/common/events/lifecycle_archive_request.py
@@ -1,4 +1,4 @@
-"""Typed payloads for ``memclaw.lifecycle.<action>-requested`` topics.
+"""Typed payloads for ``<brand>.lifecycle.<action>-requested`` topics.
 
 Both archive ops (CAURA-655) share one model — the per-action
 behaviour is parameterised by the topic, not by payload fields.

--- a/common/events/lifecycle_forge_request.py
+++ b/common/events/lifecycle_forge_request.py
@@ -1,4 +1,4 @@
-"""Typed payload for ``memclaw.lifecycle.forge-distill-requested`` (Skill Factory SF-007).
+"""Typed payload for ``<brand>.lifecycle.forge-distill-requested`` (Skill Factory SF-007).
 
 Per-run Forge invocation. Carries the standard four
 :class:`LifecycleRequestBase` fields (``audit_id``, ``org_id``,

--- a/common/events/lifecycle_handlers.py
+++ b/common/events/lifecycle_handlers.py
@@ -1,4 +1,4 @@
-"""Consumers for ``memclaw.lifecycle.<action>-requested`` topics
+"""Consumers for ``<brand>.lifecycle.<action>-requested`` topics
 (CAURA-655 archive ops, CAURA-656 purge, CAURA-657 pipeline ops).
 
 Lives in ``common/`` rather than under either service so the same code

--- a/common/events/lifecycle_publishers.py
+++ b/common/events/lifecycle_publishers.py
@@ -1,4 +1,4 @@
-"""Publishers for ``memclaw.lifecycle.<action>-requested`` topics
+"""Publishers for ``<brand>.lifecycle.<action>-requested`` topics
 (CAURA-655 archive, CAURA-656 purge, CAURA-657 pipeline).
 
 Most publishers share :class:`LifecycleArchiveRequest` (no per-message

--- a/common/events/lifecycle_purge_request.py
+++ b/common/events/lifecycle_purge_request.py
@@ -1,4 +1,4 @@
-"""Typed payload for ``memclaw.lifecycle.purge-soft-deleted-requested``
+"""Typed payload for ``<brand>.lifecycle.purge-soft-deleted-requested``
 (CAURA-656). Diverges from
 :class:`~common.events.lifecycle_archive_request.LifecycleArchiveRequest`
 by carrying ``retention_days`` — the per-org policy snapshot that the

--- a/common/events/memory_embed_request.py
+++ b/common/events/memory_embed_request.py
@@ -1,4 +1,4 @@
-"""Typed payload for the ``memclaw.memory.embed-requested`` topic.
+"""Typed payload for the ``<brand>.memory.embed-requested`` topic.
 
 The publisher (core-api, write hot path under CAURA-594 full form) emits
 one of these per memory written with ``embedding=NULL``. The consumer

--- a/common/events/memory_embedded.py
+++ b/common/events/memory_embedded.py
@@ -1,4 +1,4 @@
-"""Typed payload for the ``memclaw.memory.embedded`` topic.
+"""Typed payload for the ``<brand>.memory.embedded`` topic.
 
 Counterpart to :class:`~common.events.memory_embed_request.MemoryEmbedRequest`:
 core-worker emits one of these *after* successfully PATCHing an

--- a/common/events/memory_enrich_request.py
+++ b/common/events/memory_enrich_request.py
@@ -1,4 +1,4 @@
-"""Typed payload for the ``memclaw.memory.enrich-requested`` topic.
+"""Typed payload for the ``<brand>.memory.enrich-requested`` topic.
 
 Publisher (core-api, write hot path under CAURA-595) emits one of these
 per memory written without inline enrichment. Consumer (core-worker)

--- a/common/events/memory_enriched.py
+++ b/common/events/memory_enriched.py
@@ -1,4 +1,4 @@
-"""Typed payload for the ``memclaw.memory.enriched`` topic (CAURA-595).
+"""Typed payload for the ``<brand>.memory.enriched`` topic (CAURA-595).
 
 Counterpart to :class:`~common.events.memory_enrich_request.MemoryEnrichRequest`:
 core-worker emits one of these *after* successfully PATCHing enrichment

--- a/common/events/org_settings_changed_event.py
+++ b/common/events/org_settings_changed_event.py
@@ -1,4 +1,4 @@
-"""Typed payload for ``memclaw.org.settings-changed`` (CAURA-571).
+"""Typed payload for ``<brand>.org.settings-changed`` (CAURA-571).
 
 Published by core-api after an org's settings row is written. Carries
 the ``org_id`` whose settings changed so every core-api process can drop
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 
 
 class OrgSettingsChangedEvent(BaseModel):
-    """Payload of ``memclaw.org.settings-changed`` — the ``org_id`` whose
+    """Payload of ``<brand>.org.settings-changed`` — the ``org_id`` whose
     cached settings every process should evict."""
 
     org_id: str

--- a/common/events/org_suppression_event.py
+++ b/common/events/org_suppression_event.py
@@ -1,4 +1,4 @@
-"""Typed payload for ``memclaw.org.suppression-changed`` (CAURA-694).
+"""Typed payload for ``<brand>.org.suppression-changed`` (CAURA-694).
 
 Published by enterprise platform-admin-api on every soft-delete /
 restore of an organization. Carries the list of tenant_ids the action
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field
 
 
 class OrgSuppressionEvent(BaseModel):
-    """Payload of ``memclaw.org.suppression-changed``.
+    """Payload of ``<brand>.org.suppression-changed``.
 
     ``tenant_ids`` is the explicit list of tenants the action covers —
     one org has many tenants, and the publisher (platform-admin-api)

--- a/common/events/suppression_handlers.py
+++ b/common/events/suppression_handlers.py
@@ -1,4 +1,4 @@
-"""Consumer for ``memclaw.org.suppression-changed`` (CAURA-694).
+"""Consumer for ``<brand>.org.suppression-changed`` (CAURA-694).
 
 Lives in ``common/`` so the same code can run in core-worker (the
 default SaaS subscriber) or in core-api (if a future OSS-standalone
@@ -49,7 +49,7 @@ class SuppressionStorageAdapter:
 async def _handle_suppression_changed(
     event: Event, *, adapter: SuppressionStorageAdapter
 ) -> None:
-    """Subscriber for ``memclaw.org.suppression-changed``.
+    """Subscriber for ``<brand>.org.suppression-changed``.
 
     Iterates the tenant_ids in the payload and upserts each into the
     suppression mirror via the adapter. Any per-tenant failure raises

--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -1,6 +1,6 @@
 """Canonical topic names as str-valued enum members.
 
-Convention: `memclaw.<domain>.<verb-past-participle>` for events that
+Convention: `<brand>.<domain>.<verb-past-participle>` for events that
 announce something that already happened, `.<verb-requested>` for events
 that ask a subscriber to do work.
 
@@ -52,8 +52,8 @@ class Org(enum.StrEnum):
 
 
 class Lifecycle(enum.StrEnum):
-    # One topic per action — matches the `memclaw.memory.embed-requested`
-    # vs `memclaw.memory.enrich-requested` convention. Keeping each
+    # One topic per action — matches the `<brand>.memory.embed-requested`
+    # vs `<brand>.memory.enrich-requested` convention. Keeping each
     # operation on its own topic gives clean per-subscription filtering
     # and lets each action evolve its payload independently.
     ARCHIVE_EXPIRED_REQUESTED = "memclaw.lifecycle.archive-expired-requested"


### PR DESCRIPTION
## Summary

- Replace 19 legacy-branded topic examples and docstrings with the established <brand> notation.
- Preserve every topic enum value, the generated events manifest, and the live IAM guidance for memory.enrich-requested.
- Mirror the two manually vendored files into caura-enterprise in the same sitting.

## Scope refresh

The plan listed 20 OSS lines, but PR #1039 already applied its challenged topics.py wording. That already-correct line remains untouched, leaving 19 OSS edits.

## Verification

- Sentinel: All 39 protected strings survive.
- Legacy-name ratchet: no new lines; 19 removed; report is 733 lines across 150 files.
- Event manifest regeneration: zero diff.
- Ruff check and format at exact CI scopes: passed.
- Mypy at exact CI scopes: passed.
- Relevant OSS tests: 304 passed, 1 skipped.
- uv.lock: unchanged.

Paired enterprise PR: https://github.com/caura-ai/caura-enterprise/pull/1390