### PR TITLE
fix(observability): re-key the REST capability map to real route labels

### DIFF
--- a/core-api/src/core_api/middleware/request_observation.py
+++ b/core-api/src/core_api/middleware/request_observation.py
@@ -116,52 +116,78 @@ logger = logging.getLogger("core_api.access")
 # tool vocabulary (mcp_server tool names minus the ``caura_`` prefix, and
 # the manage/doc sub-ops) so REST and MCP roll up together in the report.
 #
+# The paths are ROUTER-RELATIVE — ``/memories``, not ``/api/v1/memories`` —
+# because that is what ``scope["route"].path`` carries and therefore what
+# ``http_route`` is matched against below. Same label space as
+# ``PROBE_ROUTES``; the note beside it in ``constants.py`` explains why.
+#
+# They were prefixed until 2026-08-29, and every lookup missed. #353 added
+# this map on 2026-06-14 when ``include_router(prefix=...)`` still flattened
+# the prefix into each route's own path, so the keys were right; #391 adopted
+# FastAPI 0.137 the very next day, which mounts the router instead and moves
+# the prefix into ``root_path``. The REST half of the adoption signal
+# recorded nothing at all from then until this was re-keyed. It failed
+# silently rather than loudly because the MCP half kept working, so the
+# report stayed plausible instead of going empty — and because the test
+# covering this registered its route directly on the app rather than through
+# a prefixed router, which is the one shape that makes a prefixed key match.
+#
+# ``/keystones`` is served twice: under the canonical ``/api/v1`` mount and
+# under the permanent legacy brand-prefixed alias mount beside it in
+# ``app.py``. Since the label drops the prefix, those two now collapse to a
+# single entry per verb rather than the two they needed before. That is only
+# safe because both mounts carry the same capability; the two URL forms are
+# no longer distinguishable in this signal, which is fine for adoption
+# accounting and would not be if they ever diverge.
+#
 # Routes NOT in this map are simply not recorded as capability usage (admin,
 # list/registry, ingest pipeline, health, plugin bootstrap). Extend this when
 # a new capability-bearing route is added — it's the REST half of the
 # transport-agnostic taxonomy; the MCP half is automatic via call_tool.
+# ``tests/test_capability_usage.py`` asserts every key here matches a real
+# route on the real app, so a typo or a rename fails CI rather than quietly
+# switching a capability off.
 _REST_CAPABILITY: dict[tuple[str, str], tuple[str, str | None]] = {
     # memories
-    ("POST", "/api/v1/memories"): ("write", None),
-    ("GET", "/api/v1/memories"): ("list", None),
-    ("GET", "/api/v1/memories/stats"): ("stats", None),
-    ("POST", "/api/v1/memories/bulk-delete"): ("manage", "bulk_delete"),
-    ("DELETE", "/api/v1/memories"): ("manage", "bulk_delete"),
-    ("GET", "/api/v1/memories/{memory_id}"): ("manage", "read"),
-    ("GET", "/api/v1/memories/{memory_id}/contradictions"): ("manage", "read"),
-    ("DELETE", "/api/v1/memories/{memory_id}"): ("manage", "delete"),
-    ("PATCH", "/api/v1/memories/{memory_id}/status"): ("manage", "transition"),
-    ("PATCH", "/api/v1/memories/{memory_id}"): ("manage", "update"),
-    ("POST", "/api/v1/search"): ("search", None),
-    ("POST", "/api/v1/recall"): ("recall", None),
+    ("POST", "/memories"): ("write", None),
+    ("GET", "/memories"): ("list", None),
+    ("GET", "/memories/stats"): ("stats", None),
+    ("POST", "/memories/bulk-delete"): ("manage", "bulk_delete"),
+    ("DELETE", "/memories"): ("manage", "bulk_delete"),
+    ("GET", "/memories/{memory_id}"): ("manage", "read"),
+    ("GET", "/memories/{memory_id}/contradictions"): ("manage", "read"),
+    ("DELETE", "/memories/{memory_id}"): ("manage", "delete"),
+    ("PATCH", "/memories/{memory_id}/status"): ("manage", "transition"),
+    ("PATCH", "/memories/{memory_id}"): ("manage", "update"),
+    ("POST", "/search"): ("search", None),
+    ("POST", "/recall"): ("recall", None),
     # documents
-    ("POST", "/api/v1/documents"): ("doc", "write"),
-    ("GET", "/api/v1/documents"): ("doc", "read"),
-    ("GET", "/api/v1/documents/{doc_id}"): ("doc", "read"),
-    ("GET", "/api/v1/documents/collections"): ("doc", "list_collections"),
-    ("POST", "/api/v1/documents/query"): ("doc", "query"),
-    ("POST", "/api/v1/documents/search"): ("doc", "search"),
-    ("DELETE", "/api/v1/documents/{doc_id}"): ("doc", "delete"),
-    # keystones (router prefix /memclaw/keystones)
-    # Canonical brand-neutral paths (2026-08-14) + the permanent legacy alias.
-    ("GET", "/api/v1/keystones"): ("keystones", None),
-    ("POST", "/api/v1/keystones"): ("keystones_set", "set"),
-    ("DELETE", "/api/v1/keystones/{doc_id}"): ("keystones_set", "delete"),
-    ("GET", "/api/v1/memclaw/keystones"): ("keystones", None),
-    ("POST", "/api/v1/memclaw/keystones"): ("keystones_set", "set"),
-    ("DELETE", "/api/v1/memclaw/keystones/{doc_id}"): ("keystones_set", "delete"),
+    ("POST", "/documents"): ("doc", "write"),
+    ("GET", "/documents"): ("doc", "read"),
+    ("GET", "/documents/{doc_id}"): ("doc", "read"),
+    ("GET", "/documents/collections"): ("doc", "list_collections"),
+    ("POST", "/documents/query"): ("doc", "query"),
+    ("POST", "/documents/search"): ("doc", "search"),
+    ("DELETE", "/documents/{doc_id}"): ("doc", "delete"),
+    # keystones — one entry per verb covers BOTH the canonical mount
+    # (brand-neutral, 2026-08-14) and the permanent legacy brand-prefixed
+    # alias, since the label drops the prefix that distinguished them. See
+    # the note above the map.
+    ("GET", "/keystones"): ("keystones", None),
+    ("POST", "/keystones"): ("keystones_set", "set"),
+    ("DELETE", "/keystones/{doc_id}"): ("keystones_set", "delete"),
     # knowledge graph / entities
-    ("GET", "/api/v1/entities"): ("entity", "list"),
-    ("GET", "/api/v1/graph"): ("entity", "graph"),
-    ("POST", "/api/v1/entities/upsert"): ("entity", "write"),
-    ("GET", "/api/v1/entities/{entity_id}"): ("entity", "read"),
-    ("POST", "/api/v1/relations/upsert"): ("entity", "write"),
+    ("GET", "/entities"): ("entity", "list"),
+    ("GET", "/graph"): ("entity", "graph"),
+    ("POST", "/entities/upsert"): ("entity", "write"),
+    ("GET", "/entities/{entity_id}"): ("entity", "read"),
+    ("POST", "/relations/upsert"): ("entity", "write"),
     # insights / evolve / stats / tune
-    ("POST", "/api/v1/insights/generate"): ("insights", None),
-    ("POST", "/api/v1/evolve/report"): ("evolve", None),
-    ("GET", "/api/v1/stats"): ("stats", None),
-    ("GET", "/api/v1/agents/{agent_id}/tune"): ("tune", "read"),
-    ("PATCH", "/api/v1/agents/{agent_id}/tune"): ("tune", "update"),
+    ("POST", "/insights/generate"): ("insights", None),
+    ("POST", "/evolve/report"): ("evolve", None),
+    ("GET", "/stats"): ("stats", None),
+    ("GET", "/agents/{agent_id}/tune"): ("tune", "read"),
+    ("PATCH", "/agents/{agent_id}/tune"): ("tune", "update"),
 }
 
 

--- a/tests/test_capability_usage.py
+++ b/tests/test_capability_usage.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 
 import pytest
-from fastapi import FastAPI, Request
+from fastapi import APIRouter, FastAPI, Request
 from httpx import ASGITransport, AsyncClient
 
 from core_api.services import capability_usage as cu
@@ -151,17 +151,27 @@ async def test_rest_middleware_records_mapped_capability(monkeypatch):
         lambda **kw: calls.append(kw),
     )
 
-    app = FastAPI()
-    app.add_middleware(RequestObservationMiddleware)
+    # Registered through include_router(prefix=...), the way app.py does it —
+    # NOT as @app.post("/api/v1/recall") directly on the app. The distinction
+    # is the entire point: FastAPI 0.137 mounts a prefixed router, so the
+    # label reaching _REST_CAPABILITY is the router-relative "/recall". Hung
+    # off the app directly the label would be "/api/v1/recall" instead, which
+    # is a shape production never produces — and this test passed for ~2.5
+    # months against a map that could not match a single real request.
+    router = APIRouter()
 
-    @app.post("/api/v1/recall")
+    @router.post("/recall")
     async def recall(request: Request):
         request.state.tenant_id = "t-rest"
         return {"ok": True}
 
-    @app.get("/api/v1/unmapped")
+    @router.get("/unmapped")
     async def unmapped():
         return {"ok": True}
+
+    app = FastAPI()
+    app.add_middleware(RequestObservationMiddleware)
+    app.include_router(router, prefix="/api/v1")
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
@@ -226,3 +236,55 @@ async def test_mcp_call_tool_records_error_on_raise(monkeypatch):
     assert len(calls) == 1
     assert calls[0]["capability"] == "write"
     assert calls[0]["status"] == "error"
+
+
+async def test_every_capability_key_matches_a_real_route():
+    """Every map key must correspond to a real (method, label) on the real app.
+
+    This is the guard that would have caught the ~2.5-month outage: when
+    FastAPI 0.137 moved the router prefix out of ``scope["route"].path``,
+    all 35 keys stopped matching at once and nothing said so. Asserting the
+    keys against the app itself makes that failure loud, and also catches
+    the mundane version — a route renamed or removed while its capability
+    entry is left behind, silently switching that capability off.
+
+    Deliberately a test rather than an import-time check in ``app.py``.
+    Recovering the label space means descending through FastAPI's
+    ``_IncludedRouter`` via the private ``original_router``, because
+    ``include_router(prefix=...)`` mounts opaquely; the existing
+    ``_TIMEOUT_OPT_OUT_PATHS`` guard can live at import time only because
+    ``app.openapi()`` is public and prefixed. Wiring a private attribute
+    into startup would turn a dependency bump into a production boot
+    failure. Failing CI is the right blast radius for this.
+
+    Self-validating: if the walk stops descending, no key matches and this
+    fails loudly rather than passing on an empty comparison.
+    """
+    import collections
+
+    from core_api.app import app
+    from core_api.middleware.request_observation import _REST_CAPABILITY
+
+    real: dict[str, set[str]] = collections.defaultdict(set)
+
+    def walk(routes):
+        for r in routes:
+            inner = getattr(r, "original_router", None)
+            if inner is not None:
+                walk(inner.routes)
+                continue
+            path, methods = getattr(r, "path", None), getattr(r, "methods", None)
+            if path is not None and methods:
+                real[path] |= set(methods)
+
+    walk(app.routes)
+
+    missing = sorted(
+        (m, p) for (m, p) in _REST_CAPABILITY if m not in real.get(p, ())
+    )
+    assert not missing, (
+        f"{len(missing)} of {len(_REST_CAPABILITY)} capability keys match no "
+        f"route on the real app, so those capabilities record nothing: "
+        f"{missing[:5]}{'...' if len(missing) > 5 else ''}. Keys are "
+        f"router-relative ('/memories'), not URL paths ('/api/v1/memories')."
+    )


### PR DESCRIPTION
Follow-up to #1050, which surfaced this while verifying the route-label space.

## The bug

Every one of the 35 entries in `_REST_CAPABILITY` was keyed `/api/v1/...`, but
the `http_route` the middleware looks them up by is **router-relative**. Measured
against the real app rather than argued:

```
real labels: 96   map entries: 35
map keys that MATCH a real (method, label) pair:  0 of 35
after stripping the prefix:                      35 of 35
```

So `record_usage` has never fired for REST traffic. The MCP half (via the
`call_tool` wrapper) kept working, which is why the adoption report looked
plausible instead of empty — a silent failure, not a visible one.

## How it broke

- **#353** (`0421ceb0`, 2026-06-14) added the map, prefixed. Correct at the time.
- **#391** (`fdcec535`, 2026-06-15) adopted FastAPI 0.137, which mounts a
  prefixed router instead of flattening it, moving the prefix into `root_path`.

It worked for one day and has recorded nothing for ~2.5 months.

## Why no test caught it

`test_rest_middleware_records_mapped_capability` registered its route as
`@app.post("/api/v1/recall")` — directly on the app. That is the **one shape**
that makes a prefixed key match, because without a router there is no prefix to
move. The test was green the entire time production recorded nothing.

It now builds the app the way `app.py` really does:

```python
router = APIRouter()

@router.post("/recall")
async def recall(request: Request): ...

app.include_router(router, prefix="/api/v1")
```

## The guard that prevents recurrence

`test_every_capability_key_matches_a_real_route` walks the **real** app and
asserts every key corresponds to a real `(method, label)` pair. It catches both
this failure and the mundane one — a route renamed while its capability entry is
left behind, silently switching that capability off.

**On the suggested import-time guard in `app.py`:** I deliberately did not add
one. Recovering the label space requires descending through FastAPI's
`_IncludedRouter` via the private `original_router`, because
`include_router(prefix=...)` mounts opaquely. The existing
`_TIMEOUT_OPT_OUT_PATHS` check can live at import time precisely because
`app.openapi()` is public and prefixed; there is no public API exposing the
label space. Wiring a private attribute into startup would convert a dependency
bump into a **production boot failure**. Failing CI is the right blast radius.

The walk is self-validating: if it ever stops descending, no key matches and the
test fails loudly rather than passing on an empty comparison.

## Confirmed failing before the fix

```
FAILED test_rest_middleware_records_mapped_capability
E       assert 0 == 1

FAILED test_every_capability_key_matches_a_real_route
E       AssertionError: 35 of 35 capability keys match no route on the real app,
        so those capabilities record nothing: [('DELETE', '/api/v1/documents/{doc_id}'), ...]
```

And confirmed working end-to-end against the real `core_api.app` after:

```
POST /api/v1/recall       -> record_usage(capability='recall', transport='rest')
GET  /api/v1/memories/abc -> record_usage(capability='manage', op='read', transport='rest')
GET  /api/v1/health       -> no call (not a capability route)
```

## One semantic change worth flagging

`/keystones` is served under both `/api/v1` and the legacy `/api/v1/memclaw`
alias. Since the label drops the prefix, those two **collapse to a single entry
per verb** — 35 entries become 32. Both aliases already mapped to identical
capabilities so nothing is lost today, but the two URL forms are no longer
distinguishable in this signal. That would matter only if they ever need to
diverge, and it's noted in the code.

## Expect the numbers to move

This turns a signal back on rather than changing one. REST capability usage will
go from zero to real values, so the adoption report's REST/MCP split will shift
noticeably on deploy — that is the fix working, not a regression. Worth knowing
before anyone reads the next report.
