### PR TITLE
refactor(scripts): refresh stale integration labels

### DIFF
--- a/scripts/forge_dry_run.py
+++ b/scripts/forge_dry_run.py
@@ -23,7 +23,7 @@ The script reads Caura connection params from the standard env
 (``DATABASE_URL``, ``OPENAI_API_KEY``) — see ``core_api.config``.
 
 This is NOT a production-grade scheduler. The real Forge run flows
-through the ``memclaw.lifecycle.forge-distill-requested`` event
+through the ``<brand>.lifecycle.forge-distill-requested`` event
 (SF-007); the scheduled-tick worker handler lands in Phase 1's
 final wiring step alongside the public lifecycle endpoint.
 """

--- a/scripts/gateway_integration_test.py
+++ b/scripts/gateway_integration_test.py
@@ -189,7 +189,7 @@ class GatewayIntegrationTest:
             self.test_educated_flag_exists,
             self.test_skill_md_exists,
             self.test_tools_md_has_tools_section,
-            self.test_agents_md_has_memclaw,
+            self.test_agents_md_has_memory_v2,
             self.test_heartbeat_md_exists,
             # ── Section 6: Memory prompt section injection ──
             self.test_prompt_section_file,
@@ -311,7 +311,7 @@ class GatewayIntegrationTest:
             )
 
     def test_openclaw_config_allowlist(self):
-        """Verify memclaw is in plugins.allow in openclaw.json."""
+        """Verify the plugin id is in plugins.allow in openclaw.json."""
         config_path = Path(self.openclaw_dir) / "openclaw.json"
         if not config_path.exists():
             self.skip("OpenClaw config: allowlist", "openclaw.json not found")
@@ -319,13 +319,13 @@ class GatewayIntegrationTest:
         config = json.loads(config_path.read_text())
         allow = config.get("plugins", {}).get("allow", [])
         self.check(
-            "OpenClaw config: memclaw in plugins.allow",
+            "OpenClaw config: plugin id in plugins.allow",
             "memclaw" in allow,
             f"allow={allow}",
         )
 
     def test_openclaw_config_tools(self):
-        """Verify all memclaw tools are in tools.alsoAllow."""
+        """Verify all Caura tools are in tools.alsoAllow."""
         config_path = Path(self.openclaw_dir) / "openclaw.json"
         if not config_path.exists():
             self.skip("OpenClaw config: tools", "openclaw.json not found")
@@ -694,7 +694,7 @@ class GatewayIntegrationTest:
             f"checked {len(workspaces)} workspace(s)",
         )
 
-    def test_agents_md_has_memclaw(self):
+    def test_agents_md_has_memory_v2(self):
         """Check AGENTS.md in at least one workspace has Memory V2 section."""
         workspaces = self._find_workspaces()
         if not workspaces:


### PR DESCRIPTION
## Summary

- Rename the gateway runner method to match the Memory V2 content it actually checks, together with its sole run-list reference.
- Replace stale plugin/tool labels while preserving the live plugin-id assertion.
- Make the Forge dry-run prose brand-neutral for the already-flipped lifecycle family.

## Safety checks

- The method and caller moved together: old name count 0, new name count 2.
- Frozen customer-state literals at lines 272, 292, 297, 323, 364, 620, 648, 724, and 739 are unchanged.
- Lines 716 and 728 remain untouched for PR9.
- No replacement retains the outgoing name, so no marker is needed.

## Verification

- Sentinel: All 39 protected strings survive.
- Legacy-name ratchet: no new lines; 6 removed; report is 727 lines across 149 files.
- Scripts mypy gate: no issues in 29 source files.
- Forge regression suite: 79 passed.
- Both scripts compile; both CLI help paths import successfully.
- Generic pre-commit checks passed.

OSS CI has no Ruff lint/format scope for scripts/. An optional whole-file Ruff pass reports only existing findings outside these edited lines; formatting was deliberately not applied because it would rewrite an excluded protected legacy-heading line.