### PR TITLE
docs: refresh stale legacy-name prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,9 +661,9 @@ Automated agents (Claude Code, Codex) may refuse `curl | bash` for
 safety. Two-step install lets them audit the script first:
 
 ```bash
-curl -s "http://localhost:8000/api/v1/install-skill" > /tmp/install-memclaw-skill.sh
-less /tmp/install-memclaw-skill.sh      # review — it only does mkdir + curl + write
-bash /tmp/install-memclaw-skill.sh
+curl -s "http://localhost:8000/api/v1/install-skill" > /tmp/install-caura-skill.sh
+less /tmp/install-caura-skill.sh      # review — it only does mkdir + curl + write
+bash /tmp/install-caura-skill.sh
 ```
 
 #### Options

--- a/clients/python/src/caura_client/interviewer/__init__.py
+++ b/clients/python/src/caura_client/interviewer/__init__.py
@@ -1,4 +1,4 @@
-"""memclaw-interviewer — the Claude Code disk-parser adapter (Interviewer Phase 2).
+"""caura-interviewer — the Claude Code disk-parser adapter (Interviewer Phase 2).
 
 Reads Claude Code session transcripts (``~/.claude/projects/<slug>/<uuid>.jsonl``)
 READ-ONLY, tracks per-file cursors via the server's forward-only watermark

--- a/clients/python/src/caura_client/interviewer/cli.py
+++ b/clients/python/src/caura_client/interviewer/cli.py
@@ -1,4 +1,4 @@
-"""memclaw-interviewer CLI — run / status / hook.
+"""caura-interviewer CLI — run / status / hook.
 
 Config precedence: flags > env > defaults. Env vars:
   CAURA_API_KEY (required)      CAURA_TENANT_ID (required)

--- a/clients/python/tests/test_interviewer_cursor.py
+++ b/clients/python/tests/test_interviewer_cursor.py
@@ -214,13 +214,13 @@ def test_node_id_namespaced_per_harness(tmp_path):
 
 
 def test_invalid_harness_env_fails_loudly(monkeypatch, capsys):
-    """A bad MEMCLAW_INTERVIEWER_HARNESS (choices= doesn't validate env
+    """A bad CAURA_INTERVIEWER_HARNESS (choices= doesn't validate env
     defaults) must exit 2 with guidance, not silently run as claude-code."""
     import pytest
 
     from caura_client.interviewer.cli import main
 
-    monkeypatch.setenv("MEMCLAW_INTERVIEWER_HARNESS", "Cursor")  # wrong case
+    monkeypatch.setenv("CAURA_INTERVIEWER_HARNESS", "Cursor")  # wrong case
     with pytest.raises(SystemExit) as exc:
         main(["run", "--all-projects", "--api-key", "k", "--tenant-id", "t"])
     assert exc.value.code == 2
@@ -236,7 +236,7 @@ def test_invalid_harness_env_never_breaks_hook(tmp_path, monkeypatch):
 
     path = _write_session(tmp_path)
     payload = json.dumps({"transcript_path": str(path), "hook_event_name": "sessionEnd"})
-    monkeypatch.setenv("MEMCLAW_INTERVIEWER_HARNESS", "GARBAGE")
+    monkeypatch.setenv("CAURA_INTERVIEWER_HARNESS", "GARBAGE")
     monkeypatch.setattr("sys.stdin", io.StringIO(payload))
     rc = main(["hook", "--projects", "Users-alice-*", "--api-key", "k", "--tenant-id", "t"])
     assert rc == 0  # bad env or not, the hook never fails the session

--- a/docs/component-registry.yaml
+++ b/docs/component-registry.yaml
@@ -63,10 +63,10 @@ cron_ticks:
     module: core_operations.app
 
 # The str-enum families in common/events/topics.py. Topic strings follow
-# ``memclaw.<domain>.<verb>``.
+# ``<brand>.<domain>.<verb>`` — the brand segment flips per family; see FLIPPED_FAMILIES.
 event_topic_families:
   - name: Memory
-    topics: 5   # created, embed-requested, embedded, enrich-requested, enriched
+    topics: 4   # embed-requested, embedded, enrich-requested, enriched
   - name: Audit
     topics: 1   # event-recorded
   - name: Pipeline
@@ -74,7 +74,7 @@ event_topic_families:
   - name: Org
     topics: 2   # suppression-changed, settings-changed
   - name: Lifecycle
-    topics: 8   # archive-expired/-stale/purge/crystallize/entity-link/insights/embed-backfill/forge-distill (all -requested)
+    topics: 9   # archive-expired/-stale/purge/crystallize/crystallize-on-demand/entity-link/insights/embed-backfill/forge-distill (all -requested)
 
 # Components that are NOT driven by core-operations' scheduler and need an
 # operator-provided external schedule.

--- a/docs/operator-forge-cron.md
+++ b/docs/operator-forge-cron.md
@@ -71,7 +71,7 @@ spec:
                     "$CORE_API_BASE_URL/admin/lifecycle/fanout/forge-distill"
               envFrom:
                 # whichever secret you use, it must expose ADMIN_API_KEY
-                - secretRef: { name: memclaw-admin }
+                - secretRef: { name: caura-admin }
           restartPolicy: OnFailure
 ```
 

--- a/docs/plugin-upgrade.md
+++ b/docs/plugin-upgrade.md
@@ -1,4 +1,4 @@
-# Upgrading the memclaw plugin
+# Upgrading the Caura plugin
 
 **Audience:** operators running OpenClaw with the memclaw plugin against a Caura server (caura.ai, on-prem). <!-- legacy-name-floor: "memclaw" is the frozen plugin id --> Two flows are documented: the **automatic** path (heartbeat-driven) and the **manual** path (`/api/v1/install-plugin`).
 

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -257,7 +257,7 @@ The plugin loads this `.env` file automatically. Both `CAURA_*` and `MEMCLAW_*` 
 }
 ```
 
-**Critical:** The `plugins.slots.memory` and `memory-core` disablement are required. OpenClaw only loads one `kind: "memory"` plugin at a time — without switching the slot, the gateway sees memclaw but never calls `register()`. The automated installer handles this automatically.
+**Critical:** The `plugins.slots.memory` and `memory-core` disablement are required. OpenClaw only loads one `kind: "memory"` plugin at a time — without switching the slot, the gateway sees the plugin but never calls `register()`. The automated installer handles this automatically.
 
 > Alternatively, use the Plugin Manager's **Fix Configuration** button or the OpenClaw CLI:
 > ```bash


### PR DESCRIPTION
## Summary

- refresh the PR5 legacy-brand prose and invalid-harness test env names
- keep the three-line installer example internally consistent
- correct the component registry after the Memory and Lifecycle topic changes

## Validation

- `clients/python/.venv/bin/pytest -q` — 142 passed
- `pytest -q tests/test_component_registry.py` — 3 passed
- `clients/python/.venv/bin/ruff check src tests` — passed
- `python3 scripts/legacy_name_ratchet.py --base origin/main` — no new lines; 12 removed
- ratchet report: 723 before, 711 after
- `python3 scripts/do_not_touch_sentinel.py` — `All 39 protected strings survive.`
- `git diff --check` — passed

`ruff format --check src tests` also ran. It reports the existing client formatter backlog (11 files, including two touched files); this PR leaves that unrelated reformatting out of the exact PR5 scope. Client CI currently runs Ruff lint, not Ruff format.

## Reviewer checklist

- `clients/python/src/caura_client/interviewer/cli.py` keeps the `memclaw-interviewer-<user>.lock` cross-version mutex unchanged.
- All three README installer-path lines move together.
- The component-registry convention remains a column-0 comment below line 65; its Memory and Lifecycle counts now match the enums.
- The arbitrary Secret example stays directly below the `ADMIN_API_KEY` requirement comment.
- The branch contains one signed commit.

Do not merge automatically.
