### PR TITLE
refactor(core): refresh stale legacy-name prose

### DIFF
--- a/core-api/Dockerfile
+++ b/core-api/Dockerfile
@@ -73,6 +73,8 @@ RUN if [ "$WITH_RERANK_LOCAL" = "1" ]; then \
 # to find (the endpoint silently served "dev"). Read by
 # core_api.constants._resolve_version().
 ARG CAURA_VERSION=
+# Keep the legacy build arg unmarked: Docker treats inline ``#`` text as its
+# default value, so the ratchet's same-line marker would break the fallback.
 ARG MEMCLAW_VERSION=
 RUN VER="${CAURA_VERSION:-${MEMCLAW_VERSION:-$(python -c "import tomllib; print(tomllib.load(open('core-api/pyproject.toml','rb'))['project']['version'])")}}" && printf '%s' "$VER" > /app/VERSION && echo "Stamped Caura version: $VER" # legacy-name-ok: rule 3 dual-read alias
 

--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -70,7 +70,7 @@ _SKILL_SLUG_RE = re.compile(r"^(?:forge/|agent/)?[a-z0-9][a-z0-9._-]{0,99}$")
 # validator):
 #
 #   {
-#     "schema":               "memclaw.skill-factory.rollback.v1",
+#     "schema":               "caura.skill-factory.rollback.v1",
 #     "skill_slug":           "<slug>",
 #     "written_at":           "<iso>",
 #     "target_path":          "<absolute target file path>",

--- a/tests/test_api_status.py
+++ b/tests/test_api_status.py
@@ -179,15 +179,16 @@ def test_version_is_resolved_not_dev():
 
 
 def test_version_env_override_wins(monkeypatch):
-    """An explicit ``MEMCLAW_VERSION`` env beats file/metadata resolution."""
-    monkeypatch.setenv("MEMCLAW_VERSION", "9.9.9-test")
+    """An explicit ``CAURA_VERSION`` env beats file/metadata resolution."""
+    monkeypatch.setenv("CAURA_VERSION", "9.9.9-test")
     assert _resolve_version() == "9.9.9-test"
 
 
 def test_version_blank_env_override_ignored(monkeypatch):
-    """A blank/whitespace ``MEMCLAW_VERSION`` must not win — it falls through
+    """A blank/whitespace legacy version env must not win — it falls through
     to the file/metadata chain rather than serving an empty version."""
-    monkeypatch.setenv("MEMCLAW_VERSION", "   ")
+    monkeypatch.delenv("CAURA_VERSION", raising=False)
+    monkeypatch.setenv("MEMCLAW_VERSION", "   ")  # legacy-name-ok: rule 3 - a blank legacy value must not win
     resolved = _resolve_version()
     assert resolved.strip() == resolved
     assert resolved not in ("", "dev")

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -1,7 +1,7 @@
 """Integration tests: full search_memories pipeline with all P0 fixes.
 
 Requires a running PostgreSQL instance with pgvector.
-Set TEST_DATABASE_URL env var or use defaults (memclaw_test on localhost).
+Set TEST_DATABASE_URL env var, or use the default DSN in tests/conftest.py.
 
 These tests exercise the actual SQL expressions — freshness, recall boost,
 scoring blend, entity matching — end-to-end via the service layer.


### PR DESCRIPTION
## Summary

- use CAURA_VERSION in the explicit override test while preserving the whitespace-only MEMCLAW_VERSION compatibility test with its rule 3 marker
- update the unminted rollback schema example and stale integration database prose
- preserve the legacy Docker ARG and document why a same-line marker would change its default value

## Safety and reviewer checks

- The whitespace test still sets MEMCLAW_VERSION and now clears ambient CAURA_VERSION first, so it exercises the intended legacy branch.
- ARG MEMCLAW_VERSION= remains present; the VER fallback remains unchanged.
- The rollback discriminator is comment-only, has no writer or schema dispatch today, and keeps its column alignment. Phase 3 should still accept a memclaw-prefixed value defensively.
- Difference from the work order: the requested inline Docker marker is intentionally omitted. Docker treats a # that is not at the beginning of a line as instruction content, so adding the marker after ARG MEMCLAW_VERSION= would make the default non-empty and break fallback behavior. See the official Dockerfile reference: https://docs.docker.com/reference/dockerfile/#format
- Separate whitespace-resolution bug filed as #1062.

## Verification

- 58 targeted pytest tests passed
- ruff check core-api/src/ passed
- ruff format --check core-api/src/ passed: 202 files already formatted
- root test-file Ruff lint passed
- ratchet after PR8 rebase: 618 before, 612 after; no new lines; 6 removed. The expected seventh removal is the unsafe Docker marker described above. The original pre-PR8 measurement was 711 to 705, also minus 6.
- sentinel: All 39 protected strings survive.
- DCO sign-off present
