### PR TITLE
fix(version): honor whitespace-empty overrides

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -74,7 +74,8 @@ def _resolve_version() -> str:
     Precedence (most to least authoritative):
 
     1. ``CAURA_VERSION`` env, or its legacy alias below — explicit deploy /
-       ad-hoc override. The new name wins when both are set.
+       ad-hoc override. The first non-empty value wins, with the new name
+       checked first.
     2. ``VERSION`` file baked into the image at build time from
        ``pyproject.toml`` (see ``core-api/Dockerfile``). Deterministic and
        independent of installed-package metadata — the prod Dockerfile
@@ -84,9 +85,12 @@ def _resolve_version() -> str:
     3. Installed package metadata — editable dev installs (``pip install -e``).
     4. ``"dev"`` — source-only checkout with none of the above.
     """
-    env = os.environ.get("CAURA_VERSION") or os.environ.get("MEMCLAW_VERSION")  # legacy-name-ok: alias
-    if env and env.strip():
-        return env.strip()
+    for name in (
+        "CAURA_VERSION",
+        "MEMCLAW_VERSION",  # legacy-name-ok: rule 3 dual-read alias
+    ):
+        if version := os.environ.get(name, "").strip():
+            return version
     # constants.py → core_api → src → core-api → repo root (image: /app).
     version_file = Path(__file__).resolve().parents[3] / "VERSION"
     try:

--- a/tests/test_env_dual_read.py
+++ b/tests/test_env_dual_read.py
@@ -13,7 +13,6 @@ import re
 from pathlib import Path
 
 import pytest
-
 from core_api import constants
 from core_api.config import Settings
 
@@ -80,10 +79,11 @@ class TestVersionResolution:
         clean_env.setenv(OLD_VERSION_ENV, "1.2.3-old")
         assert constants._resolve_version() == "1.2.3-new"
 
-    def test_blank_new_name_does_not_shadow_the_old_one(self, clean_env):
+    @pytest.mark.parametrize("new_value", ["", "   "], ids=["empty", "whitespace"])
+    def test_blank_new_name_does_not_shadow_the_old_one(self, clean_env, new_value):
         # The regression this guards: an operator who blanks the new name in a
         # deploy template must not lose a working old one.
-        clean_env.setenv(NEW_VERSION_ENV, "")
+        clean_env.setenv(NEW_VERSION_ENV, new_value)
         clean_env.setenv(OLD_VERSION_ENV, "1.2.3-old")
         assert constants._resolve_version() == "1.2.3-old"
 


### PR DESCRIPTION
## Summary

- strip each version environment candidate before choosing the first non-empty value
- preserve canonical CAURA_VERSION precedence when both values are meaningful
- cover both empty and whitespace-only canonical overrides with named parameterized cases

A whitespace-only CAURA_VERSION previously short-circuited the valid MEMCLAW_VERSION fallback, then fell through to the baked or package version.

Closes #1062

## Verification

- regression proved red before the fix: expected 1.2.3-old, received package version 2.28.0
- 22 focused version and status tests passed
- core-api mypy: 202 source files, no issues
- Ruff lint passed for core-api and the changed test file
- core-api formatter check passed: 202 files already formatted
- legacy-name ratchet: no new lines; 612 before and after
- sentinel: All 39 protected strings survive.
- focused /simplify review completed; no remaining findings
