### PR TITLE
fix(storage): require shared-secret authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,10 @@ ADMIN_API_KEY=
 # Optional: when set, ALL non-admin requests must include this key via X-API-Key.
 # Useful when exposing the API to a network (not just localhost).
 CAURA_API_KEY=
+# Internal core-api → core-storage-api credential. Docker Compose generates a
+# random value in a private volume; non-Compose deployments must set the same
+# non-empty value on every storage caller and storage instance.
+# CORE_STORAGE_SHARED_SECRET=
 
 # -- Embedding provider -----------------------------------------------------
 # Options: openai | local | fake

--- a/README.md
+++ b/README.md
@@ -173,25 +173,38 @@ Anthropic, Gemini, and OpenRouter don't offer embedding APIs here — pair them 
 docker compose up -d
 ```
 
-By default this **pulls the multi-arch images from `ghcr.io`** (`linux/amd64` + `linux/arm64`) on first run — takes ~30 seconds. Subsequent `up` commands re-use the cached image (no registry round-trip, works offline). To pin a specific version, set `CAURA_VERSION=v1.2.3` in your `.env`. To build from local source instead (e.g. when iterating on a fork), run `docker compose up --build --no-pull`.
+> **Security requirement:** port 8002 belongs to the internal storage data
+> plane and must never be exposed to the host or any untrusted network. The
+> shipped Compose file does not publish it; `core-api` reaches it only across
+> the private Compose network and authenticates with a random, per-installation
+> secret generated into a private Docker volume.
+> Do not add an `8002:8002` port mapping. If local debugging absolutely requires
+> host access, bind only `127.0.0.1:8002:8002` and keep the
+> `CORE_STORAGE_SHARED_SECRET` check enabled. Only exact `GET /healthz` and
+> `GET /readyz` probes are public; every storage data route requires the secret.
+
+By default this **pulls the multi-arch images from `ghcr.io`** (`linux/amd64` + `linux/arm64`) on first run — takes ~30 seconds. Subsequent `up` commands re-use the cached image (no registry round-trip, works offline). To pin a specific version, set `CAURA_VERSION=v1.2.3` in your `.env`. To build from local source instead (e.g. when iterating on a fork), run `docker compose up --build --pull never`.
 
 To upgrade to a newer image at the same tag (e.g. `:latest` after we cut a new release), run `docker compose pull && docker compose up -d`. Without an explicit `pull`, the local cache wins — there's no silent version drift.
 
 > **Offline / air-gapped operation**: depending on whether the image is already cached locally:
-> - **Image cached, no network**: `docker compose up -d` works as-is — `pull_policy: missing` doesn't try to pull when the image is present. Use `docker compose up --no-pull` if you want to be explicit.
-> - **No local image, no network**: `docker compose up --build --no-pull` (build from source, don't try to pull).
+> - **Image cached, no network**: `docker compose up -d` works as-is — `pull_policy: missing` doesn't try to pull when the image is present. Use `docker compose up -d --pull never` if you want to be explicit.
+> - **No local image, no network**: `docker compose up --build --pull never` (build from source, don't try to pull).
 > - **Strict no-network guarantee** (e.g. an air-gapped pipeline that should never reach `ghcr.io`): drop a `docker-compose.override.yml` setting `pull_policy: never` for both services — Compose then fails fast if the image is absent rather than attempting a pull.
 
 | Service | URL |
 |---|---|
 | Core API (REST + MCP) | http://localhost:8000 |
-| Core Storage API | http://localhost:8002 |
 | PostgreSQL (pgvector) | localhost:5432 |
 | Redis | localhost:6379 |
 
+`core-storage-api` is intentionally reachable only by other services on the
+Compose network; it has no host URL.
+
 #### What the stack contains — and what it doesn't
 
-`docker compose up` starts exactly four containers:
+`docker compose up` starts four long-running containers plus a one-shot
+`storage-secret-init` container that creates the internal credential:
 
 | Container | Role |
 |---|---|
@@ -744,8 +757,16 @@ The **reader/writer split** is an opt-in topology for high-write-rate deploys th
 - Set `CORE_STORAGE_ROLE=writer` on the write-serving instance; `=reader` on the read-serving instance(s).
 - Set `CORE_STORAGE_READ_URL` on `core-api` to the reader service URL. Leave `CORE_STORAGE_API_URL` pointing at the writer.
 - `READ_DATABASE_URL` on each `core-storage-api` can point at a read replica if you have one.
+- Set the same non-empty `CORE_STORAGE_SHARED_SECRET` on `core-api`, every
+  `core-storage-api` writer/reader, and any other internal storage caller. All
+  storage requests must carry it as `X-Storage-Secret`; missing or incorrect
+  credentials are rejected before routing.
 
-**Defaults:** `CORE_STORAGE_ROLE=hybrid` and `CORE_STORAGE_READ_URL=""` — both null-safe, so single-node deploys need zero configuration to get the legacy single-service behavior.
+**Topology defaults:** `CORE_STORAGE_ROLE=hybrid` and
+`CORE_STORAGE_READ_URL=""`, so a single storage instance still serves both
+reads and writes. Docker Compose wires storage authentication automatically;
+manual deployments must configure `CORE_STORAGE_SHARED_SECRET` (or
+`CORE_STORAGE_SHARED_SECRET_FILE`) on the storage service and every caller.
 
 ---
 
@@ -1184,7 +1205,7 @@ These mirror the Configuration table above. See it for defaults.
 | Group | Vars |
 |---|---|
 | Database | `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_USE_IAM_AUTH`, `POSTGRES_REQUIRE_SSL` |
-| Auth | `ADMIN_API_KEY`, `CAURA_API_KEY`, `IS_STANDALONE` |
+| Auth | `ADMIN_API_KEY`, `CAURA_API_KEY`, `CORE_STORAGE_SHARED_SECRET`, `CORE_STORAGE_SHARED_SECRET_FILE`, `IS_STANDALONE` |
 | Providers | `EMBEDDING_PROVIDER`, `ENTITY_EXTRACTION_PROVIDER`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `USE_LLM_FOR_MEMORY_CREATION` |
 | Runtime | `CORS_ORIGINS`, `ENVIRONMENT`, `SETTINGS_ENCRYPTION_KEY`, `REDIS_URL` |
 

--- a/common/storage_auth.py
+++ b/common/storage_auth.py
@@ -1,0 +1,36 @@
+"""Shared configuration helpers for internal storage authentication."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+
+STORAGE_SHARED_SECRET_REJECTION_DETAIL = "invalid storage service credentials"
+
+
+def is_storage_shared_secret_rejection(response: httpx.Response) -> bool:
+    """Return whether storage rejected its service-to-service credential."""
+    if response.status_code != 401:
+        return False
+    try:
+        payload = response.json()
+    except (AttributeError, ValueError):
+        return False
+    return (
+        isinstance(payload, dict)
+        and payload.get("detail") == STORAGE_SHARED_SECRET_REJECTION_DETAIL
+    )
+
+
+def read_shared_secret_file(path: str) -> str:
+    """Read a non-empty shared secret from ``path`` when one is configured."""
+    if not path:
+        return ""
+    try:
+        secret = Path(path).read_text().strip()
+    except OSError as exc:
+        raise ValueError(f"cannot read CORE_STORAGE_SHARED_SECRET_FILE: {exc}") from exc
+    if not secret:
+        raise ValueError("CORE_STORAGE_SHARED_SECRET_FILE is empty")
+    return secret

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -116,15 +116,21 @@ class SecurityHeadersMiddleware:
         await self.app(scope, receive, send_with_headers)
 
 
-def _validate_production_settings(app_settings) -> None:  # type: ignore[no-untyped-def]
-    """Refuse to boot a production deployment that is missing a safety control.
+def _validate_startup_settings(app_settings) -> None:  # type: ignore[no-untyped-def]
+    """Refuse to boot when a required safety control is missing.
 
     Extracted from ``lifespan`` so these guards are reachable by tests. Buried in
     the lifespan they were untestable in practice, which is why a block whose
     entire job is to prevent unsafe production boots had no tests of its own.
 
-    No-op outside ``ENVIRONMENT=production``.
+    Storage authentication is required in every environment because the storage
+    service enforces it unconditionally. The remaining guards are production-only.
     """
+    storage_secret = app_settings.core_storage_shared_secret
+    if hasattr(storage_secret, "get_secret_value"):
+        storage_secret = storage_secret.get_secret_value()
+    if not storage_secret or not str(storage_secret).strip():
+        raise RuntimeError("CORE_STORAGE_SHARED_SECRET is required for core-api")
     if app_settings.environment != "production":
         return
     if app_settings.is_standalone:
@@ -204,6 +210,9 @@ async def lifespan(app):
     # post-import re-run from the ASGI lifespan startup safely routes them.
     reroute_third_party_loggers()
 
+    # Validate before initializing providers or accepting any request.
+    _validate_startup_settings(app_settings)
+
     # Increase default thread pool for concurrent LLM calls via asyncio.to_thread()
     import asyncio as _aio
     from concurrent.futures import ThreadPoolExecutor
@@ -242,9 +251,6 @@ async def lifespan(app):
     from core_api.providers._platform import init_platform_providers
 
     init_platform_providers()
-
-    # Fail-fast: validate production environment
-    _validate_production_settings(app_settings)
 
     async with mcp_lifespan():
         # Standalone mode: initialise fixed tenant id

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -13,6 +13,7 @@ import httpx
 
 from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
 from common.http_retry import CONNECT_PHASE_MAX_ATTEMPTS, with_connect_phase_retry, with_retry
+from common.storage_auth import is_storage_shared_secret_rejection
 from core_api.clients.identity_token import evict as _evict_id_token
 from core_api.clients.identity_token import fetch_auth_header
 from core_api.config import settings
@@ -363,11 +364,11 @@ class CoreStorageClient:
     # -- internal helpers ------------------------------------------------
 
     async def _auth_headers(self, *, read: bool) -> dict[str, str]:
-        """Identity-token Authorization header for Cloud Run
-        ``--no-allow-unauthenticated`` targets (CAURA-591 Part B Y3).
-        Empty when no credentials available (tests / local / legacy
-        allUsers services). The dict is cached and shared per audience
-        — httpx merges headers without mutation, so this is safe.
+        """Storage shared secret plus Cloud Run identity when applicable.
+
+        The shared secret authenticates every in-cluster request. HTTPS Cloud
+        Run targets additionally receive an identity-token Authorization
+        header for ``--no-allow-unauthenticated`` (CAURA-591 Part B Y3).
 
         Skip the metadata-server call entirely when the audience is
         plain HTTP — Cloud Run ``--no-allow-unauthenticated`` always
@@ -378,17 +379,25 @@ class CoreStorageClient:
         (not ``Exception``) which the inner catch misses, and the
         health endpoint flips to ``storage: unreachable`` for the
         duration of the failure-cache TTL."""
+        headers: dict[str, str] = {}
+        shared_secret = settings.core_storage_shared_secret.get_secret_value()
+        if shared_secret:
+            headers["X-Storage-Secret"] = shared_secret
+
         audience = self._read_base_url if read else self._base_url
         if audience.startswith("http://"):
-            return {}
-        return await fetch_auth_header(audience)
+            return headers
+        headers.update(await fetch_auth_header(audience))
+        return headers
 
     def _maybe_evict_on_auth_error(self, resp: httpx.Response, *, read: bool) -> None:
-        """If the target rejected our token, drop it from the cache so
-        the next request forces a fresh fetch. Self-heals after a
-        mid-TTL credential rotation or SA/binding fix instead of
-        making the operator wait out the 50 min cache."""
-        if resp.status_code == 401:
+        """Evict a rejected ID token, but retain it on secret mismatch.
+
+        Storage's own 401 has a distinct body and cannot be repaired by an ID
+        token refresh. Other 401s may come from Cloud Run IAM, where eviction
+        self-heals a mid-TTL credential rotation or service-account fix.
+        """
+        if resp.status_code == 401 and not is_storage_shared_secret_rejection(resp):
             audience = self._read_base_url if read else self._base_url
             _evict_id_token(audience)
 

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -1,8 +1,10 @@
 import logging
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
-from pydantic import SecretStr, field_validator, model_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings
+
+from common.storage_auth import read_shared_secret_file
 
 logger = logging.getLogger(__name__)
 
@@ -348,6 +350,17 @@ class Settings(BaseSettings):
     crystallizer_dedup_sample_size: int = 1000
     crystallizer_dedup_threshold: float = 0.95
     core_storage_api_url: str = "http://localhost:8002"
+    core_storage_shared_secret: SecretStr = Field(default=SecretStr(""), repr=False, exclude=True)
+    core_storage_shared_secret_file: str = ""
+
+    @model_validator(mode="after")
+    def resolve_core_storage_shared_secret(self) -> Self:
+        if not self.core_storage_shared_secret.get_secret_value():
+            self.core_storage_shared_secret = SecretStr(
+                read_shared_secret_file(self.core_storage_shared_secret_file)
+            )
+        return self
+
     # Enterprise SaaS splits core-storage-api into writer + reader Cloud Run
     # services (CAURA-591 Part B). When this is set, the storage client
     # routes GET + tagged-read POST calls here instead of ``core_storage_api_url``;

--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -27,7 +27,10 @@ configure_logging(
 )
 
 from core_storage_api.database.init import get_engine, init_database
-from core_storage_api.middleware import RejectWritesOnReaderMiddleware
+from core_storage_api.middleware import (
+    RejectWritesOnReaderMiddleware,
+    RequireStorageSharedSecretMiddleware,
+)
 from core_storage_api.routers import (
     agents_router,
     audit_router,
@@ -64,6 +67,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         "Starting core-storage-api",
         extra={"core_storage_role": settings.core_storage_role},
     )
+    if not settings.core_storage_shared_secret.get_secret_value():
+        logger.error(
+            "CORE_STORAGE_SHARED_SECRET is not configured; GET /readyz will return 503 "
+            "and storage data requests will reject authentication"
+        )
     await init_database()
     yield
     logger.info("Shutting down core-storage-api")
@@ -118,11 +126,17 @@ def create_app() -> FastAPI:
         return JSONResponse(status_code=422, content={"detail": "request body must be valid JSON"})
 
     # Order matters: Starlette executes middlewares in reverse registration
-    # order (last added = outermost). Register the reader filter FIRST so
-    # that CORS ends up outermost and its headers decorate the 405 response
-    # too — otherwise browsers see a CORS failure instead of the real 405.
+    # order (last added = outermost). Register the reader filter first, then the
+    # credential boundary, and CORS last. CORS can then answer browser preflight
+    # requests and decorate both authentication 401s and reader-role 405s;
+    # every actual data request still reaches authentication before a handler.
     if settings.core_storage_role == "reader":
         app.add_middleware(RejectWritesOnReaderMiddleware)
+
+    app.add_middleware(
+        RequireStorageSharedSecretMiddleware,
+        shared_secret=settings.core_storage_shared_secret.get_secret_value(),
+    )
 
     # Internal service — restrict CORS to known callers only. On the
     # reader role, narrow allow_methods so CORS preflights don't
@@ -184,9 +198,8 @@ def create_app() -> FastAPI:
     app.include_router(tenants_router, prefix=prefix)
     app.include_router(purge_router, prefix=prefix)
     # CAURA-696: per-tenant row counts for the deletion-preview panel.
-    # Mirrors ``purge``'s VPC-only trust model: no router-level auth,
-    # trusted callers only reach storage via core-api which applies
-    # the admin check.
+    # The app-wide storage-secret middleware authenticates the caller;
+    # core-api applies the route's admin authorization check.
     app.include_router(preview_router, prefix=prefix)
     # CAURA-694: tenant-suppression mirror. POST upsert for the OSS
     # suppression consumer (core-worker); GET is the boundary-guard

--- a/core-storage-api/src/core_storage_api/config.py
+++ b/core-storage-api/src/core_storage_api/config.py
@@ -8,6 +8,8 @@ from urllib.parse import quote
 from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from common.storage_auth import read_shared_secret_file
+
 LOCAL_DATABASE_URL = "postgresql+asyncpg://memclaw:changeme@localhost:5432/memclaw"  # legacy-name-ok: existing local-dev compatibility default
 
 
@@ -119,6 +121,18 @@ class Settings(BaseSettings):
     # migrations, skips write routes, and uses the read-pool URL as
     # its primary connection.
     core_storage_role: Literal["writer", "reader", "hybrid"] = "hybrid"
+    # Internal caller credential. Empty is deliberately not an auth bypass:
+    # the middleware rejects every HTTP request until a value is configured.
+    core_storage_shared_secret: SecretStr = Field(default=SecretStr(""), repr=False, exclude=True)
+    core_storage_shared_secret_file: str = ""
+
+    @model_validator(mode="after")
+    def resolve_core_storage_shared_secret(self) -> Settings:
+        if not self.core_storage_shared_secret.get_secret_value():
+            self.core_storage_shared_secret = SecretStr(
+                read_shared_secret_file(self.core_storage_shared_secret_file)
+            )
+        return self
 
     # Logging
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"

--- a/core-storage-api/src/core_storage_api/middleware/__init__.py
+++ b/core-storage-api/src/core_storage_api/middleware/__init__.py
@@ -1,5 +1,6 @@
 """Pure-ASGI middlewares for core-storage-api."""
 
 from core_storage_api.middleware.role_filter import RejectWritesOnReaderMiddleware
+from core_storage_api.middleware.shared_secret import RequireStorageSharedSecretMiddleware
 
-__all__ = ["RejectWritesOnReaderMiddleware"]
+__all__ = ["RejectWritesOnReaderMiddleware", "RequireStorageSharedSecretMiddleware"]

--- a/core-storage-api/src/core_storage_api/middleware/shared_secret.py
+++ b/core-storage-api/src/core_storage_api/middleware/shared_secret.py
@@ -1,0 +1,47 @@
+"""Fail-closed shared-secret boundary for core-storage-api."""
+
+from __future__ import annotations
+
+import hmac
+import json
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from common.storage_auth import STORAGE_SHARED_SECRET_REJECTION_DETAIL
+
+_BODY_401 = json.dumps({"detail": STORAGE_SHARED_SECRET_REJECTION_DETAIL}, separators=(",", ":")).encode()
+_PUBLIC_HEALTH_PATHS = frozenset({"/healthz", "/readyz"})
+
+
+class RequireStorageSharedSecretMiddleware:
+    """Require the internal secret outside the public liveness probes."""
+
+    def __init__(self, app: ASGIApp, *, shared_secret: str) -> None:
+        self.app = app
+        self.shared_secret = shared_secret.encode()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if scope["method"] == "GET" and scope["path"] in _PUBLIC_HEALTH_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        supplied = [value for name, value in scope.get("headers", []) if name.lower() == b"x-storage-secret"]
+        if len(supplied) == 1 and self.shared_secret and hmac.compare_digest(supplied[0], self.shared_secret):
+            await self.app(scope, receive, send)
+            return
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(_BODY_401)).encode()),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": _BODY_401, "more_body": False})

--- a/core-storage-api/src/core_storage_api/routers/health.py
+++ b/core-storage-api/src/core_storage_api/routers/health.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
+
+from core_storage_api.config import settings
 
 router = APIRouter(tags=["Health"])
 
@@ -14,4 +16,9 @@ async def healthz() -> dict[str, str]:
 
 @router.get("/readyz")
 async def readyz() -> dict[str, str]:
+    if not settings.core_storage_shared_secret.get_secret_value():
+        raise HTTPException(
+            status_code=503,
+            detail="storage service credentials not configured",
+        )
     return {"status": "ok"}

--- a/core-storage-api/tests/conftest.py
+++ b/core-storage-api/tests/conftest.py
@@ -16,6 +16,7 @@ os.environ.setdefault(
     "postgresql+asyncpg://memclaw:changeme@127.0.0.1:5432/memclaw",
 )
 os.environ.setdefault("LOG_LEVEL", "WARNING")
+os.environ.setdefault("CORE_STORAGE_SHARED_SECRET", "test-storage-secret")
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -81,7 +82,11 @@ async def client(_ensure_schema) -> AsyncClient:
     from core_storage_api.app import app
 
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Storage-Secret": settings.core_storage_shared_secret.get_secret_value()},
+    ) as c:
         yield c
 
 

--- a/core-storage-api/tests/test_config.py
+++ b/core-storage-api/tests/test_config.py
@@ -123,3 +123,22 @@ def test_unconfigured_database_keeps_the_local_default(monkeypatch: pytest.Monke
     _clear_database_env(monkeypatch)
 
     assert Settings(_env_file=None).database_url.get_secret_value() == LOCAL_DATABASE_URL
+
+
+def test_storage_secret_loads_from_file_and_stays_out_of_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("CORE_STORAGE_SHARED_SECRET", raising=False)
+    monkeypatch.delenv("CORE_STORAGE_SHARED_SECRET_FILE", raising=False)
+    secret_file = tmp_path / "storage-secret"
+    secret_file.write_text("file-storage-secret\n")
+
+    settings = Settings(
+        _env_file=None,
+        core_storage_shared_secret_file=str(secret_file),
+    )
+
+    assert settings.core_storage_shared_secret.get_secret_value() == "file-storage-secret"
+    assert "file-storage-secret" not in repr(settings)
+    assert "core_storage_shared_secret" not in settings.model_dump()

--- a/core-storage-api/tests/test_storage_auth.py
+++ b/core-storage-api/tests/test_storage_auth.py
@@ -1,0 +1,174 @@
+"""Authentication boundary for the internal storage service."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from pydantic import SecretStr
+
+from core_storage_api.app import create_app
+from core_storage_api.config import settings
+
+pytestmark = pytest.mark.asyncio
+
+_BULK_GET_BODY = {"ids": [], "tenant_id": "storage-auth-test"}
+
+
+async def test_requests_require_the_storage_shared_secret() -> None:
+    app = create_app()
+    secret = getattr(
+        settings,
+        "core_storage_shared_secret",
+        SecretStr("test-storage-secret"),
+    ).get_secret_value()
+    path = "/api/v1/storage/memories/bulk-get"
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        missing = await client.post(path, json=_BULK_GET_BODY)
+        wrong = await client.post(
+            path,
+            json=_BULK_GET_BODY,
+            headers={"X-Storage-Secret": "wrong"},
+        )
+        accepted = await client.post(
+            path,
+            json=_BULK_GET_BODY,
+            headers={"X-Storage-Secret": secret},
+        )
+
+    assert missing.status_code == 401
+    assert missing.json() == {"detail": "invalid storage service credentials"}
+    assert wrong.status_code == 401
+    assert accepted.status_code == 200
+
+
+async def test_empty_service_secret_fails_closed() -> None:
+    with patch.object(settings, "core_storage_shared_secret", SecretStr("")):
+        app = create_app()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/storage/memories/bulk-get",
+            json=_BULK_GET_BODY,
+            headers={"X-Storage-Secret": "anything"},
+        )
+
+    assert response.status_code == 401
+
+
+async def test_empty_service_secret_fails_readiness_but_not_liveness() -> None:
+    with patch.object(settings, "core_storage_shared_secret", SecretStr("")):
+        app = create_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            liveness = await client.get("/healthz")
+            readiness = await client.get("/readyz")
+
+    assert liveness.status_code == 200
+    assert readiness.status_code == 503
+    assert readiness.json() == {"detail": "storage service credentials not configured"}
+
+
+async def test_non_ascii_secret_header_is_refused_not_raised() -> None:
+    app = create_app()
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        request = client.build_request(
+            "POST",
+            "/api/v1/storage/memories/bulk-get",
+            json=_BULK_GET_BODY,
+            headers=[(b"X-Storage-Secret", b"\xff")],
+        )
+        response = await client.send(request)
+
+    assert response.status_code == 401
+
+
+async def test_duplicate_secret_headers_are_refused() -> None:
+    app = create_app()
+    secret = settings.core_storage_shared_secret.get_secret_value().encode()
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        request = client.build_request(
+            "POST",
+            "/api/v1/storage/memories/bulk-get",
+            json=_BULK_GET_BODY,
+            headers=[
+                (b"X-Storage-Secret", secret),
+                (b"X-Storage-Secret", secret),
+            ],
+        )
+        response = await client.send(request)
+
+    assert response.status_code == 401
+
+
+async def test_cors_preflight_reaches_cors_middleware() -> None:
+    app = create_app()
+    headers = {
+        "Origin": "http://localhost:8000",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "X-Storage-Secret",
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.options(
+            "/api/v1/storage/memories/bulk-get",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == headers["Origin"]
+    assert "x-storage-secret" in response.headers["access-control-allow-headers"].lower()
+
+
+async def test_cors_wraps_authentication_and_reader_role_responses() -> None:
+    with patch.object(settings, "core_storage_role", "reader"):
+        app = create_app()
+    origin = "http://localhost:8000"
+    path = "/api/v1/storage/memories/00000000-0000-0000-0000-000000000000"
+    secret = settings.core_storage_shared_secret.get_secret_value()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        unauthorized = await client.patch(path, headers={"Origin": origin})
+        read_only = await client.patch(
+            path,
+            headers={"Origin": origin, "X-Storage-Secret": secret},
+        )
+
+    assert unauthorized.status_code == 401
+    assert unauthorized.headers["access-control-allow-origin"] == origin
+    assert read_only.status_code == 405
+    assert read_only.headers["access-control-allow-origin"] == origin
+
+
+@pytest.mark.parametrize("path", ["/healthz", "/readyz"])
+async def test_public_health_probes_do_not_require_secret(path: str) -> None:
+    app = create_app()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(path)
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/healthz/"),
+        ("HEAD", "/healthz"),
+        ("POST", "/healthz"),
+        ("GET", "/api/v1/storage/healthz"),
+    ],
+)
+async def test_only_exact_read_only_health_probes_are_public(method: str, path: str) -> None:
+    app = create_app()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.request(method, path)
+
+    assert response.status_code == 401

--- a/core-worker/src/core_worker/app.py
+++ b/core-worker/src/core_worker/app.py
@@ -78,6 +78,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     logger.info("Starting core-worker", extra={"environment": settings.environment})
 
+    if not settings.core_storage_shared_secret.get_secret_value():
+        logger.error(
+            "CORE_STORAGE_SHARED_SECRET is not configured; outbound storage requests "
+            "would omit X-Storage-Secret and protected storage services would reject them"
+        )
+        raise RuntimeError("CORE_STORAGE_SHARED_SECRET is required for core-worker")
+
     # Eager platform-provider init: builds BOTH the embedding and LLM
     # singletons from ``PLATFORM_EMBEDDING_*`` / ``PLATFORM_LLM_*``. The
     # LLM half is what ``handle_enrich_request`` falls through to when

--- a/core-worker/src/core_worker/clients/storage_client.py
+++ b/core-worker/src/core_worker/clients/storage_client.py
@@ -12,12 +12,8 @@ Module-level singleton client (``get_storage_client()``) so connection
 pooling persists across pull-loop iterations. Closed via
 :func:`close_storage_client` from the FastAPI lifespan.
 
-CAURA-591 Y3 / CAURA-595 follow-up: every outbound request is signed
-with a Cloud Run ID token whose audience is the storage service URL.
-The identity_token helper transparently returns ``{}`` when no creds
-are available (local dev / OSS) so the unauthenticated docker-compose
-path continues to work; on Cloud Run the metadata server issues a
-real token and the writer's ``--no-allow-unauthenticated`` accepts it.
+Every outbound request carries the storage service shared secret. On Cloud Run
+it is also signed with an ID token whose audience is the storage service URL.
 """
 
 from __future__ import annotations
@@ -32,8 +28,10 @@ import httpx
 
 from common.constants import LIFECYCLE_STALE_ARCHIVE_WEIGHT
 from common.http_retry import with_connect_phase_retry
+from common.storage_auth import is_storage_shared_secret_rejection
 from core_worker.clients.identity_token import evict as _evict_id_token
 from core_worker.clients.identity_token import fetch_auth_header
+from core_worker.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -43,41 +41,37 @@ _client: httpx.AsyncClient | None = None
 # rstrip'd ``core_storage_api_url`` from settings, used both as the
 # httpx ``base_url`` and as the Cloud Run audience claim.
 _audience: str | None = None
+_storage_shared_secret: str | None = None
 _PREFIX = "/api/v1/storage"
 
 
 def get_storage_client() -> httpx.AsyncClient:
     """Return the singleton :class:`httpx.AsyncClient` used by the consumer.
 
-    Settings are read from a freshly-built ``Settings()`` on first call
-    only — subsequent calls return the cached instance regardless of
-    any env changes. Tests that need a different config call
-    :func:`close_storage_client` between cases to force re-construction.
+    Configuration comes from the module singleton; the HTTP client itself is
+    built on first call and reused until :func:`close_storage_client`.
     """
-    global _client, _audience
+    global _client, _audience, _storage_shared_secret
     if _client is None:
-        # Lazy import — avoids paying the pydantic-settings load cost
-        # on cold-start for the worker's healthz probe.
-        from core_worker.config import Settings
-
-        s = Settings()  # type: ignore[call-arg]
         # ``rstrip("/")`` so a trailing slash in the env var doesn't
         # produce a different audience string than Cloud Run validates.
-        _audience = s.core_storage_api_url.rstrip("/")
+        _audience = settings.core_storage_api_url.rstrip("/")
+        _storage_shared_secret = settings.core_storage_shared_secret.get_secret_value()
         _client = httpx.AsyncClient(
             base_url=_audience,
-            timeout=httpx.Timeout(s.storage_http_timeout_s),
+            timeout=httpx.Timeout(settings.storage_http_timeout_s),
         )
     return _client
 
 
 async def close_storage_client() -> None:
     """Close the singleton (idempotent). Called from app lifespan shutdown."""
-    global _client, _audience
+    global _client, _audience, _storage_shared_secret
     if _client is not None:
         await _client.aclose()
-        _client = None
-        _audience = None
+    _client = None
+    _audience = None
+    _storage_shared_secret = None
 
 
 async def _signed_call(
@@ -85,27 +79,22 @@ async def _signed_call(
     *args: Any,
     **kwargs: Any,
 ) -> httpx.Response:
-    """Issue ``fn(*args, **kwargs)`` with the Cloud Run ID-token
-    Authorization header attached, with one transparent retry on 401.
+    """Issue ``fn(*args, **kwargs)`` with storage and Cloud Run credentials.
 
     ``fn`` is a bound method on the caller's ``httpx.AsyncClient``
     (``client.get``, ``client.patch``, etc.) — single integration point
     so a future endpoint helper can't add a request without auth or
     skip the eviction-on-401 path.
 
-    On 401: evict the cached token (so a mid-TTL credential rotation or
-    SA/binding fix self-heals instead of waiting out the 50 min cache),
-    fetch a fresh token, and retry the request once. Without this
-    retry, every in-flight task during a rotation burns one Pub/Sub
-    delivery attempt against the DLQ budget; the retry makes a rotation
-    invisible to callers. A second 401 (rotation didn't help, or the
-    SA was actually unbound) propagates to the caller's normal
-    error-handling path.
+    On an identity-layer 401: evict the cached token (so a mid-TTL credential
+    rotation or SA/binding fix self-heals instead of waiting out the 50 min
+    cache), fetch a fresh token, and retry the request once. Storage's distinct
+    shared-secret 401 skips that ineffective refresh. A second identity 401
+    propagates to the caller's normal error-handling path.
 
-    On the OSS / local-dev path (``_audience`` unset, or google.auth
-    unavailable) the merged auth header is empty and the call goes
-    out unauthenticated — matching the docker-compose ``allUsers``
-    writer. 403 is intentionally NOT a trigger for eviction: 403 means
+    On the OSS / local-dev path the Cloud Run Authorization header may be
+    absent, but ``X-Storage-Secret`` is still required. 403 is intentionally
+    NOT a trigger for eviction: 403 means
     the token was accepted but IAM rejected the caller, which the
     cache cannot fix.
 
@@ -119,14 +108,19 @@ async def _signed_call(
     Pub/Sub delivery attempt against the DLQ budget for a request
     that never even reached storage (the 2026-06-11 incident shape).
     """
+    global _storage_shared_secret
     headers = dict(kwargs.pop("headers", None) or {})
+    if _storage_shared_secret is None:
+        _storage_shared_secret = settings.core_storage_shared_secret.get_secret_value()
+    if _storage_shared_secret:
+        headers["X-Storage-Secret"] = _storage_shared_secret
     if _audience is not None:
         headers.update(await fetch_auth_header(_audience))
     method = getattr(fn, "__name__", "?").upper()
     path = args[0] if args else ""
     label = f"{method} {path}".rstrip()
     resp = await with_connect_phase_retry(lambda: fn(*args, headers=headers, **kwargs), label=label)
-    if resp.status_code == 401 and _audience is not None:
+    if resp.status_code == 401 and _audience is not None and not is_storage_shared_secret_rejection(resp):
         _evict_id_token(_audience)
         # Rebind to a NEW dict rather than ``.update()`` in place — the
         # first call still holds a reference to the original headers

--- a/core-worker/src/core_worker/config.py
+++ b/core-worker/src/core_worker/config.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import field_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from common.storage_auth import read_shared_secret_file
 
 
 class Settings(BaseSettings):
@@ -21,6 +23,16 @@ class Settings(BaseSettings):
     # Storage backend — the worker PATCHes embeddings to core-storage-api
     # via this URL. Defaults to the local docker-compose service name.
     core_storage_api_url: str = "http://oss-core-storage-api:8002"
+    core_storage_shared_secret: SecretStr = Field(default=SecretStr(""), repr=False, exclude=True)
+    core_storage_shared_secret_file: str = ""
+
+    @model_validator(mode="after")
+    def resolve_core_storage_shared_secret(self) -> Settings:
+        if not self.core_storage_shared_secret.get_secret_value():
+            self.core_storage_shared_secret = SecretStr(
+                read_shared_secret_file(self.core_storage_shared_secret_file)
+            )
+        return self
 
     # Event bus — `inprocess` for tests/standalone OSS, `pubsub` for SaaS.
     event_bus_backend: Literal["inprocess", "pubsub"] = "inprocess"

--- a/core-worker/tests/conftest.py
+++ b/core-worker/tests/conftest.py
@@ -14,3 +14,4 @@ if _repo_root not in sys.path:
 
 # In-process bus by default — every test runs without a real Pub/Sub.
 os.environ.setdefault("EVENT_BUS_BACKEND", "inprocess")
+os.environ.setdefault("CORE_STORAGE_SHARED_SECRET", "test-storage-secret")

--- a/core-worker/tests/test_lifespan_platform_init.py
+++ b/core-worker/tests/test_lifespan_platform_init.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
+from pydantic import SecretStr
 
-from core_worker.app import create_app
+from core_worker.app import create_app, settings
 
 
 def test_lifespan_calls_init_platform_providers():
@@ -54,3 +56,25 @@ def test_lifespan_calls_init_platform_providers():
             pass
 
         init_mock.assert_called_once_with()
+
+
+def test_lifespan_refuses_to_consume_without_storage_credentials():
+    bus = MagicMock()
+    bus.start = AsyncMock(return_value=None)
+    bus.stop = AsyncMock(return_value=None)
+    bus.is_healthy = True
+
+    with (
+        patch.object(settings, "core_storage_shared_secret", SecretStr("")),
+        patch("core_worker.app.init_platform_providers"),
+        patch("core_worker.app.configure_consumer"),
+        patch("core_worker.app.register_consumers"),
+        patch("core_worker.app.get_event_bus", return_value=bus),
+        patch("core_worker.app.close_storage_client", new=AsyncMock()),
+    ):
+        app = create_app()
+        with pytest.raises(RuntimeError, match="CORE_STORAGE_SHARED_SECRET is required"):
+            with TestClient(app):
+                pass
+
+    bus.start.assert_not_awaited()

--- a/core-worker/tests/test_storage_client_auth.py
+++ b/core-worker/tests/test_storage_client_auth.py
@@ -1,7 +1,8 @@
 """Tests for CAURA-591 Y3 / CAURA-595: storage_client signs every
 request with a Cloud Run ID token bound to the writer service URL,
-evicts the cached token on 401, and retries once with a fresh token
-so a credential rotation is invisible to callers.
+evicts the cached token on an identity-layer 401, and retries once with a fresh
+token so a credential rotation is invisible to callers. Storage-secret 401s do
+not evict or retry because an identity-token refresh cannot repair them.
 
 Auth is wired through one private helper, ``_signed_call`` — these
 tests exercise it indirectly via the public endpoint helpers
@@ -30,6 +31,7 @@ def _reset_module_state() -> None:
     audience to the next test's HTTP mock."""
     storage_client._client = None
     storage_client._audience = None
+    storage_client._storage_shared_secret = None
     identity_token._cache.clear()
     identity_token._failure_cache.clear()
     identity_token._audience_locks.clear()
@@ -68,9 +70,7 @@ def _ok_response() -> MagicMock:
 
 
 async def test_unauthenticated_when_audience_unset() -> None:
-    """``get_storage_client()`` not called yet → no audience to sign
-    against; the request goes out without an Authorization header
-    so the docker-compose ``allUsers`` writer continues to accept it."""
+    """Local calls omit Cloud Run identity but retain the storage secret."""
     assert storage_client._audience is None
 
     client = MagicMock(spec=httpx.AsyncClient)
@@ -85,9 +85,10 @@ async def test_unauthenticated_when_audience_unset() -> None:
 
     headers = client.patch.await_args.kwargs["headers"]
     assert "Authorization" not in headers
+    assert headers["X-Storage-Secret"] == "test-storage-secret"
 
 
-# ── update_memory_embedding signs requests + evicts on 401 ───────────
+# ── update_memory_embedding signs requests + handles auth 401s ───────
 
 
 async def test_update_memory_embedding_sends_auth_header() -> None:
@@ -105,7 +106,10 @@ async def test_update_memory_embedding_sends_auth_header() -> None:
     )
 
     headers = client.patch.await_args.kwargs["headers"]
-    assert headers == {"Authorization": "Bearer tok-embed"}
+    assert headers == {
+        "Authorization": "Bearer tok-embed",
+        "X-Storage-Secret": "test-storage-secret",
+    }
 
 
 async def test_401_recovers_via_one_shot_retry_with_fresh_token() -> None:
@@ -133,8 +137,14 @@ async def test_401_recovers_via_one_shot_retry_with_fresh_token() -> None:
     assert client.patch.await_count == 2
     first_headers = client.patch.await_args_list[0].kwargs["headers"]
     second_headers = client.patch.await_args_list[1].kwargs["headers"]
-    assert first_headers == {"Authorization": "Bearer stale"}
-    assert second_headers == {"Authorization": "Bearer fresh"}
+    assert first_headers == {
+        "Authorization": "Bearer stale",
+        "X-Storage-Secret": "test-storage-secret",
+    }
+    assert second_headers == {
+        "Authorization": "Bearer fresh",
+        "X-Storage-Secret": "test-storage-secret",
+    }
     # Cache holds the rotated token, ready for the next request.
     assert identity_token._cache["https://writer.run.app"] == {"Authorization": "Bearer fresh"}
 
@@ -166,6 +176,42 @@ async def test_persistent_401_propagates_after_retry() -> None:
 
     # Two PATCHes: original + one retry, then propagate.
     assert client.patch.await_count == 2
+
+
+async def test_storage_secret_401_does_not_evict_or_retry() -> None:
+    """A mismatched service secret must not churn the metadata server."""
+    _seed_audience()
+    _seed_token("https://writer.run.app", "valid-token")
+
+    response = MagicMock(status_code=401)
+    response.json = MagicMock(return_value={"detail": "invalid storage service credentials"})
+    response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "storage auth",
+            request=MagicMock(),
+            response=response,
+        )
+    )
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.patch = AsyncMock(return_value=response)
+
+    with (
+        patch.object(
+            identity_token,
+            "_fetch_blocking",
+            side_effect=AssertionError("identity token must not be refreshed"),
+        ),
+        pytest.raises(httpx.HTTPStatusError),
+    ):
+        await storage_client.update_memory_embedding(
+            client,
+            memory_id=uuid4(),
+            tenant_id="tenant-A",
+            embedding=[0.1] * 8,
+        )
+
+    assert client.patch.await_count == 1
+    assert identity_token._cache["https://writer.run.app"] == {"Authorization": "Bearer valid-token"}
 
 
 async def test_update_memory_embedding_does_not_evict_on_403() -> None:
@@ -211,7 +257,10 @@ async def test_update_memory_enrichment_sends_auth_header() -> None:
     )
 
     headers = client.patch.await_args.kwargs["headers"]
-    assert headers == {"Authorization": "Bearer tok-enrich"}
+    assert headers == {
+        "Authorization": "Bearer tok-enrich",
+        "X-Storage-Secret": "test-storage-secret",
+    }
 
 
 async def test_update_memory_enrichment_skips_empty_patch_without_signing() -> None:
@@ -257,7 +306,10 @@ async def test_find_embedding_by_content_hash_sends_auth_header() -> None:
 
     assert result == [0.1] * 8
     headers = client.get.await_args.kwargs["headers"]
-    assert headers == {"Authorization": "Bearer tok-cache"}
+    assert headers == {
+        "Authorization": "Bearer tok-cache",
+        "X-Storage-Secret": "test-storage-secret",
+    }
 
 
 async def test_find_embedding_by_content_hash_returns_none_on_null_body() -> None:
@@ -313,7 +365,11 @@ async def test_get_storage_client_strips_trailing_slash_for_audience(monkeypatch
     """A trailing slash in ``CORE_STORAGE_API_URL`` would produce a
     different audience claim than Cloud Run validates against the
     canonical service URL — strip it before binding."""
-    monkeypatch.setenv("CORE_STORAGE_API_URL", "https://writer.run.app/")
+    monkeypatch.setattr(
+        storage_client.settings,
+        "core_storage_api_url",
+        "https://writer.run.app/",
+    )
 
     client = storage_client.get_storage_client()
     try:

--- a/core-worker/tests/test_storage_secret_config.py
+++ b/core-worker/tests/test_storage_secret_config.py
@@ -1,0 +1,45 @@
+"""Storage shared-secret configuration safety."""
+
+from __future__ import annotations
+
+import pytest
+
+from core_worker.config import Settings
+
+
+def test_storage_secret_is_excluded_from_repr_and_serialization() -> None:
+    settings = Settings(core_storage_shared_secret="worker-storage-secret")  # type: ignore[call-arg]
+
+    assert settings.core_storage_shared_secret.get_secret_value() == "worker-storage-secret"
+    assert "worker-storage-secret" not in repr(settings)
+    assert "core_storage_shared_secret" not in settings.model_dump()
+
+
+def test_storage_secret_loads_from_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("CORE_STORAGE_SHARED_SECRET", raising=False)
+    monkeypatch.delenv("CORE_STORAGE_SHARED_SECRET_FILE", raising=False)
+    secret_file = tmp_path / "storage-secret"
+    secret_file.write_text("worker-file-storage-secret\n")
+
+    settings = Settings(
+        _env_file=None,
+        core_storage_shared_secret_file=str(secret_file),
+    )
+
+    assert settings.core_storage_shared_secret.get_secret_value() == ("worker-file-storage-secret")
+
+
+def test_direct_storage_secret_wins_over_file(tmp_path) -> None:
+    secret_file = tmp_path / "storage-secret"
+    secret_file.write_text("ignored-file-secret\n")
+
+    settings = Settings(
+        _env_file=None,
+        core_storage_shared_secret="direct-worker-secret",
+        core_storage_shared_secret_file=str(secret_file),
+    )
+
+    assert settings.core_storage_shared_secret.get_secret_value() == "direct-worker-secret"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,6 +35,23 @@ services:
 
   # ── Core Storage API (hot-reload) ───────────────────────────────
 
+  storage-secret-init:
+    build:
+      context: .
+      dockerfile: core-storage-api/Dockerfile
+    user: "0:0"
+    entrypoint: ["python", "-c"]
+    command:
+      - |
+        from pathlib import Path
+        import secrets
+        path = Path("/run/caura-storage/shared-secret")
+        if not path.exists() or not path.read_text().strip():
+            path.write_text(secrets.token_urlsafe(48))
+        path.chmod(0o444)
+    volumes:
+      - storage_secret:/run/caura-storage
+
   core-storage-api:
     build:
       context: .
@@ -54,10 +71,11 @@ services:
       --reload-dir /app/core-storage-api/src
       --reload-dir /app/common
     ports:
-      - "8002:8002"
+      - "127.0.0.1:${STORAGE_API_PORT:-8002}:8002"
     volumes:
       - ./common:/app/common
       - ./core-storage-api/src:/app/core-storage-api/src
+      - storage_secret:/run/caura-storage:ro
     environment:
       PYTHONPATH: /app/core-storage-api/src:/app
       DATABASE_URL: postgresql+asyncpg://memclaw:changeme@db:5432/memclaw
@@ -68,11 +86,15 @@ services:
       POSTGRES_DB: memclaw
       POSTGRES_REQUIRE_SSL: "false"
       ENVIRONMENT: development
+      CORE_STORAGE_SHARED_SECRET: "${CORE_STORAGE_SHARED_SECRET:-}"
+      CORE_STORAGE_SHARED_SECRET_FILE: /run/caura-storage/shared-secret
     depends_on:
+      storage-secret-init:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8002/healthz')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8002/readyz')"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -107,10 +129,13 @@ services:
       - ./migrations:/app/migrations
       - ./plugin:/app/plugin
       - ./static:/app/static
+      - storage_secret:/run/caura-storage:ro
     environment:
       PYTHONPATH: /app/core-api/src:/app
       POSTGRES_HOST: db
       CORE_STORAGE_API_URL: http://core-storage-api:8002
+      CORE_STORAGE_SHARED_SECRET: "${CORE_STORAGE_SHARED_SECRET:-}"
+      CORE_STORAGE_SHARED_SECRET_FILE: /run/caura-storage/shared-secret
       REDIS_URL: redis://redis:6379/0
       # Pass through provider keys from host
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
@@ -171,4 +196,5 @@ services:
 volumes:
   pgdata:
   redis_data:
+  storage_secret:
   tei_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,25 @@ services:
 
   # ── Core Storage API (PostgreSQL CRUD) ──────────────────────────
 
+  storage-secret-init:
+    image: ghcr.io/caura-ai/caura-memclaw-core-storage-api:${CAURA_VERSION:-${MEMCLAW_VERSION:-latest}}  # legacy-name-ok: rule 3 dual-read alias
+    pull_policy: missing
+    build:
+      context: .
+      dockerfile: core-storage-api/Dockerfile
+    user: "0:0"
+    entrypoint: ["python", "-c"]
+    command:
+      - |
+        from pathlib import Path
+        import secrets
+        path = Path("/run/caura-storage/shared-secret")
+        if not path.exists() or not path.read_text().strip():
+            path.write_text(secrets.token_urlsafe(48))
+        path.chmod(0o444)
+    volumes:
+      - storage_secret:/run/caura-storage
+
   core-storage-api:
     # Pulls the published multi-arch image from ghcr.io.
     #
@@ -51,7 +70,7 @@ services:
     #     docker compose pull && docker compose up -d
     #
     # The ``build:`` block is for ``docker compose up --build
-    # --no-pull`` (``--no-pull`` is needed when no local image is
+    # --pull never`` (``--pull never`` is needed when no local image is
     # cached and you want to build from source without network: without
     # it, ``pull_policy: missing`` triggers a pull attempt before the
     # build starts and fails if the registry is unreachable. When the
@@ -74,8 +93,6 @@ services:
     build:
       context: .
       dockerfile: core-storage-api/Dockerfile
-    ports:
-      - "${STORAGE_API_PORT:-8002}:8002"
     environment:
       DATABASE_URL: postgresql+asyncpg://memclaw:changeme@db:5432/memclaw
       POSTGRES_HOST: db
@@ -86,11 +103,17 @@ services:
       POSTGRES_REQUIRE_SSL: "false"
       ENVIRONMENT: development
       LOG_FORMAT_JSON: "false"
+      CORE_STORAGE_SHARED_SECRET: "${CORE_STORAGE_SHARED_SECRET:-}"
+      CORE_STORAGE_SHARED_SECRET_FILE: /run/caura-storage/shared-secret
+    volumes:
+      - storage_secret:/run/caura-storage:ro
     depends_on:
+      storage-secret-init:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8002/healthz')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8002/readyz')"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -116,6 +139,8 @@ services:
       # Override DB host for Docker network
       POSTGRES_HOST: db
       CORE_STORAGE_API_URL: http://core-storage-api:8002
+      CORE_STORAGE_SHARED_SECRET: "${CORE_STORAGE_SHARED_SECRET:-}"
+      CORE_STORAGE_SHARED_SECRET_FILE: /run/caura-storage/shared-secret
       REDIS_URL: redis://redis:6379/0
       # Provider keys and embedding config (OPENAI_API_KEY, ANTHROPIC_API_KEY,
       # OPENROUTER_API_KEY, OPENAI_EMBEDDING_BASE_URL / _MODEL / _SEND_DIMENSIONS /
@@ -141,6 +166,8 @@ services:
       tei:
         condition: service_healthy
         required: false  # only enforced when --profile embed-local is active
+    volumes:
+      - storage_secret:/run/caura-storage:ro
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]
       interval: 15s
@@ -195,4 +222,5 @@ services:
 volumes:
   pgdata:
   redis_data:
+  storage_secret:
   tei_cache:

--- a/scripts/capture_pg_locks_during_storm.py
+++ b/scripts/capture_pg_locks_during_storm.py
@@ -29,16 +29,20 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import os
 import sys
 import time
 import urllib.error
 import urllib.request
 
 
-def _snapshot(base: str, timeout: float = 5.0) -> dict:
+def _snapshot(base: str, secret: str, timeout: float = 5.0) -> dict:
     """Fetch one /_debug/pg_locks payload."""
     url = f"{base.rstrip('/')}/api/v1/storage/_debug/pg_locks"
-    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    req = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "X-Storage-Secret": secret},
+    )
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read())
 
@@ -49,6 +53,11 @@ def main() -> int:
         "--base",
         default="http://localhost:8080",
         help="Base URL of the local proxy to storage-api (default: http://localhost:8080)",
+    )
+    parser.add_argument(
+        "--secret",
+        default=os.environ.get("CORE_STORAGE_SHARED_SECRET", ""),
+        help="Storage shared secret (default: CORE_STORAGE_SHARED_SECRET)",
     )
     parser.add_argument(
         "--duration",
@@ -68,6 +77,8 @@ def main() -> int:
         help="Output JSONL path (default: stdout)",
     )
     args = parser.parse_args()
+    if not args.secret:
+        parser.error("--secret or CORE_STORAGE_SHARED_SECRET is required")
 
     # ``contextlib.nullcontext(sys.stdout)`` keeps the ``with`` shape
     # consistent across stdout and a real file, and inlining ``open()``
@@ -86,7 +97,7 @@ def main() -> int:
             while time.monotonic() < deadline:
                 t0 = time.monotonic()
                 try:
-                    payload = _snapshot(args.base)
+                    payload = _snapshot(args.base, args.secret)
                     sink.write(
                         json.dumps(
                             {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ _TEST_DEFAULTS = {
     # silently break tests; flag-off / deferred-path tests override
     # this to ``"deferred"``.
     "DEPLOYMENT_MODE": "inline",
+    "CORE_STORAGE_SHARED_SECRET": "test-storage-secret",
     # Interviewer async submit (#665) defaults ON in prod, but the legacy
     # route tests (tests/test_api_interview.py) assert the inline path's
     # response shape (committed/memories_written/504-on-timeout), so tests
@@ -270,6 +271,7 @@ async def purge_test_rows(conn, prefix: str) -> None:
 
 _storage_asgi_http = None
 _storage_sc = None
+_storage_app = None
 
 
 @pytest.fixture(autouse=True)
@@ -280,7 +282,7 @@ async def _patch_storage_client(_engine, _setup_schema):
     in-process, so tests don't need a running server on port 8002.
     The core-storage-api session factory is pointed at the test engine.
     """
-    global _storage_asgi_http, _storage_sc
+    global _storage_asgi_http, _storage_sc, _storage_app
     import httpx
     from httpx import ASGITransport
     from core_storage_api.app import create_app as create_storage_app
@@ -299,8 +301,8 @@ async def _patch_storage_client(_engine, _setup_schema):
         )
 
     if _storage_asgi_http is None:
-        storage_app = create_storage_app()
-        transport = ASGITransport(app=storage_app)
+        _storage_app = create_storage_app()
+        transport = ASGITransport(app=_storage_app)
         _storage_asgi_http = httpx.AsyncClient(
             transport=transport,
             base_url="http://test-storage:8002",
@@ -355,7 +357,7 @@ async def sc():
 
 
 @pytest.fixture
-def storage_http(_patch_storage_client):
+async def storage_http(_patch_storage_client):
     """Raw httpx client bridged to the in-process core-storage-api app.
 
     For tests that POST malformed/raw bodies the typed storage client would
@@ -363,7 +365,22 @@ def storage_http(_patch_storage_client):
     Depends on ``_patch_storage_client`` so the ASGI bridge + test-engine
     session factory are wired up first.
     """
-    return _storage_asgi_http
+    import httpx
+    from httpx import ASGITransport
+
+    # This client exists specifically for tests that address storage routes
+    # directly. Keep its credentials separate from ``_storage_asgi_http``:
+    # that unadorned transport is injected into ``CoreStorageClient``, so the
+    # ordinary core-api path only succeeds when the production client adds
+    # its own shared-secret header.
+    transport = ASGITransport(app=_storage_app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://test-storage:8002",
+        follow_redirects=True,
+        headers={"X-Storage-Secret": _TEST_DEFAULTS["CORE_STORAGE_SHARED_SECRET"]},
+    ) as raw_client:
+        yield raw_client
 
 
 @pytest.fixture

--- a/tests/test_production_startup_guards.py
+++ b/tests/test_production_startup_guards.py
@@ -1,4 +1,4 @@
-"""``_validate_production_settings`` — the guards that refuse an unsafe prod boot.
+"""Startup guards that refuse an unusable or unsafe boot.
 
 H-11 of the 2026-08-14 OSS/platform audit: production did not require
 ``GATEWAY_SHARED_SECRET``, and the X-Tenant-ID header-trust path's perimeter check
@@ -15,7 +15,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from core_api.app import _validate_production_settings
+from core_api.app import _validate_startup_settings
+from pydantic import SecretStr
 
 
 def _prod(**overrides):
@@ -28,19 +29,20 @@ def _prod(**overrides):
         "admin_api_key": "a-real-admin-key",
         "gateway_shared_secret": "a-real-gateway-secret",
         "memclaw_api_key": None,
+        "core_storage_shared_secret": SecretStr("a-real-storage-secret"),
     }
     base.update(overrides)
     return SimpleNamespace(**base)
 
 
 def test_a_fully_configured_production_boot_is_allowed():
-    _validate_production_settings(_prod())
+    _validate_startup_settings(_prod())
 
 
 @pytest.mark.parametrize("environment", ["development", "sandbox"])
-def test_non_production_environments_are_not_gated(environment):
-    """The guards are production-only; dev/sandbox keep booting bare."""
-    _validate_production_settings(
+def test_non_production_environments_skip_production_only_guards(environment):
+    """With storage auth configured, dev/sandbox skip production-only guards."""
+    _validate_startup_settings(
         _prod(
             environment=environment,
             gateway_shared_secret=None,
@@ -58,13 +60,13 @@ def test_production_requires_a_perimeter():
     weakening it — the check is ``if gw_secret and not compare_digest(...)``.
     """
     with pytest.raises(RuntimeError, match="GATEWAY_SHARED_SECRET"):
-        _validate_production_settings(_prod(gateway_shared_secret=None))
+        _validate_startup_settings(_prod(gateway_shared_secret=None))
 
 
 def test_empty_strings_count_as_unset():
     """`""` is the shape a missing env var actually takes in a container."""
     with pytest.raises(RuntimeError, match="GATEWAY_SHARED_SECRET"):
-        _validate_production_settings(
+        _validate_startup_settings(  # fmt: skip - preserve the ratcheted legacy-key line
             _prod(gateway_shared_secret="", memclaw_api_key="")
         )
 
@@ -79,35 +81,57 @@ def test_api_key_alone_is_an_acceptable_perimeter():
     Sentry, and must not be forced to invent a gateway secret it has no gateway
     for.
     """
-    _validate_production_settings(
+    _validate_startup_settings(
         _prod(gateway_shared_secret=None, memclaw_api_key="a-real-memclaw-key")
     )
 
 
 def test_gateway_secret_alone_is_an_acceptable_perimeter():
-    _validate_production_settings(
+    _validate_startup_settings(
         _prod(gateway_shared_secret="a-real-gateway-secret", memclaw_api_key=None)
     )
 
 
 def test_production_refuses_standalone_mode():
     with pytest.raises(RuntimeError, match="IS_STANDALONE=true is not allowed"):
-        _validate_production_settings(_prod(is_standalone=True))
+        _validate_startup_settings(_prod(is_standalone=True))
 
 
 def test_production_requires_the_settings_encryption_key():
     with pytest.raises(RuntimeError, match="SETTINGS_ENCRYPTION_KEY must be set"):
-        _validate_production_settings(_prod(settings_encryption_key=None))
+        _validate_startup_settings(_prod(settings_encryption_key=None))
 
 
 def test_production_requires_the_admin_api_key():
     with pytest.raises(RuntimeError, match="ADMIN_API_KEY must be set"):
-        _validate_production_settings(_prod(admin_api_key=None))
+        _validate_startup_settings(_prod(admin_api_key=None))
+
+
+@pytest.mark.parametrize("environment", ["development", "sandbox", "production"])
+def test_every_environment_requires_the_storage_shared_secret(environment):
+    with pytest.raises(RuntimeError, match="CORE_STORAGE_SHARED_SECRET"):
+        _validate_startup_settings(
+            _prod(
+                environment=environment,
+                core_storage_shared_secret=SecretStr(""),
+            )
+        )
+
+
+@pytest.mark.parametrize("secret_value", [" ", "\t"])
+def test_blank_storage_shared_secrets_are_also_rejected(secret_value):
+    with pytest.raises(RuntimeError, match="CORE_STORAGE_SHARED_SECRET"):
+        _validate_startup_settings(
+            _prod(
+                environment="development",
+                core_storage_shared_secret=SecretStr(secret_value),
+            )
+        )
 
 
 def test_production_refuses_the_default_jwt_secret():
     with pytest.raises(RuntimeError, match="JWT_SECRET must be changed"):
-        _validate_production_settings(_prod(jwt_secret="change-me-in-production"))
+        _validate_startup_settings(_prod(jwt_secret="change-me-in-production"))
 
 
 def test_a_secretstr_wrapped_default_is_still_caught():
@@ -121,6 +145,4 @@ def test_a_secretstr_wrapped_default_is_still_caught():
             return self._v
 
     with pytest.raises(RuntimeError, match="JWT_SECRET must be changed"):
-        _validate_production_settings(
-            _prod(jwt_secret=_Secret("change-me-in-production"))
-        )
+        _validate_startup_settings(_prod(jwt_secret=_Secret("change-me-in-production")))

--- a/tests/test_role_flag.py
+++ b/tests/test_role_flag.py
@@ -43,7 +43,11 @@ async def client_for_role():
     async def _make(role: str) -> AsyncClient:
         app = _APP_CACHE.setdefault(role, _build_app(role))
         transport = ASGITransport(app=app, raise_app_exceptions=False)
-        client = AsyncClient(transport=transport, base_url="http://test")
+        client = AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            headers={"X-Storage-Secret": "test-storage-secret"},
+        )
         clients.append(client)
         return client
 

--- a/tests/test_storage_client_routing.py
+++ b/tests/test_storage_client_routing.py
@@ -271,6 +271,7 @@ async def test_authorization_header_attached_on_reader_calls() -> None:
         )
         await client.get_memory("11111111-1111-1111-1111-111111111111")
     assert reader.requests[0].headers["Authorization"] == "Bearer tok-reader"
+    assert reader.requests[0].headers["X-Storage-Secret"] == "test-storage-secret"
 
 
 async def test_authorization_header_attached_on_writer_calls() -> None:
@@ -281,6 +282,7 @@ async def test_authorization_header_attached_on_writer_calls() -> None:
         )
         await client.create_memory({"tenant_id": "t", "content": "c"})
     assert writer.requests[0].headers["Authorization"] == "Bearer tok-writer"
+    assert writer.requests[0].headers["X-Storage-Secret"] == "test-storage-secret"
 
 
 async def test_authorization_header_attached_on_patch() -> None:
@@ -289,8 +291,11 @@ async def test_authorization_header_attached_on_patch() -> None:
         client, writer, reader = await _fresh_client(
             writer_url="https://writer:8002", reader_url="https://reader:8002"
         )
-        await client.update_embedding("11111111-1111-1111-1111-111111111111", "t", [0.1])
+        await client.update_embedding(
+            "11111111-1111-1111-1111-111111111111", "t", [0.1]
+        )
     assert writer.requests[0].headers["Authorization"] == "Bearer tok-writer"
+    assert writer.requests[0].headers["X-Storage-Secret"] == "test-storage-secret"
 
 
 async def test_authorization_header_attached_on_delete() -> None:
@@ -301,6 +306,7 @@ async def test_authorization_header_attached_on_delete() -> None:
         )
         await client.delete_agent("agent-1", tenant_id="t")
     assert writer.requests[0].headers["Authorization"] == "Bearer tok-writer"
+    assert writer.requests[0].headers["X-Storage-Secret"] == "test-storage-secret"
 
 
 async def test_http_audience_skips_token_fetch() -> None:
@@ -316,6 +322,7 @@ async def test_http_audience_skips_token_fetch() -> None:
         )
         await client.get_memory("11111111-1111-1111-1111-111111111111")
     assert "Authorization" not in reader.requests[0].headers
+    assert reader.requests[0].headers["X-Storage-Secret"] == "test-storage-secret"
 
 
 async def test_no_authorization_header_when_no_credentials() -> None:
@@ -329,6 +336,7 @@ async def test_no_authorization_header_when_no_credentials() -> None:
         )
         await client.get_memory("11111111-1111-1111-1111-111111111111")
     assert "Authorization" not in reader.requests[0].headers
+    assert reader.requests[0].headers["X-Storage-Secret"] == "test-storage-secret"
 
 
 class _StatusCodeTransport(httpx.AsyncBaseTransport):
@@ -338,17 +346,21 @@ class _StatusCodeTransport(httpx.AsyncBaseTransport):
     permission denial by the target and does NOT imply the token is
     bad, so we keep the cache intact."""
 
-    def __init__(self, status_code: int) -> None:
+    def __init__(self, status_code: int, content: bytes = b"{}") -> None:
         self.requests: list[httpx.Request] = []
         self._status = status_code
+        self._content = content
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         self.requests.append(request)
-        return httpx.Response(self._status, content=b"{}", request=request)
+        return httpx.Response(self._status, content=self._content, request=request)
 
 
 async def _run_auth_status_test(
-    status_code: int, *, expect_evicted: bool
+    status_code: int,
+    *,
+    expect_evicted: bool,
+    content: bytes = b"{}",
 ) -> None:
     """Shared harness — seed a cached token, issue a request that
     gets ``status_code`` back, and assert whether the cache entry
@@ -371,7 +383,7 @@ async def _run_auth_status_test(
         client = CoreStorageClient()
 
     client._http = httpx.AsyncClient(
-        transport=_StatusCodeTransport(status_code),
+        transport=_StatusCodeTransport(status_code, content),
         timeout=client._http.timeout,
     )
     client._read_http = httpx.AsyncClient(
@@ -392,6 +404,15 @@ async def test_401_response_evicts_cached_id_token() -> None:
     cache entry must go so the next request forces a fresh fetch —
     otherwise every request 401s for 50 min."""
     await _run_auth_status_test(401, expect_evicted=True)
+
+
+async def test_storage_secret_401_keeps_cached_id_token() -> None:
+    """A storage-secret mismatch cannot be repaired by refreshing IAM."""
+    await _run_auth_status_test(
+        401,
+        expect_evicted=False,
+        content=b'{"detail":"invalid storage service credentials"}',
+    )
 
 
 async def test_403_response_keeps_cached_id_token() -> None:

--- a/tests/test_storage_secret_config.py
+++ b/tests/test_storage_secret_config.py
@@ -1,0 +1,49 @@
+"""Storage shared-secret configuration safety in core-api."""
+
+from __future__ import annotations
+
+import pytest
+from core_api.config import Settings
+
+
+def test_storage_secret_is_excluded_from_repr_and_serialization() -> None:
+    settings = Settings(core_storage_shared_secret="api-storage-secret")
+
+    assert (
+        settings.core_storage_shared_secret.get_secret_value() == "api-storage-secret"
+    )
+    assert "api-storage-secret" not in repr(settings)
+    assert "core_storage_shared_secret" not in settings.model_dump()
+
+
+def test_storage_secret_loads_from_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("CORE_STORAGE_SHARED_SECRET", raising=False)
+    monkeypatch.delenv("CORE_STORAGE_SHARED_SECRET_FILE", raising=False)
+    secret_file = tmp_path / "storage-secret"
+    secret_file.write_text("api-file-storage-secret\n")
+
+    settings = Settings(
+        _env_file=None,
+        core_storage_shared_secret_file=str(secret_file),
+    )
+
+    assert (
+        settings.core_storage_shared_secret.get_secret_value()
+        == "api-file-storage-secret"
+    )
+
+
+def test_direct_storage_secret_wins_over_file(tmp_path) -> None:
+    secret_file = tmp_path / "storage-secret"
+    secret_file.write_text("ignored-file-secret\n")
+
+    settings = Settings(
+        _env_file=None,
+        core_storage_shared_secret="direct-api-secret",
+        core_storage_shared_secret_file=str(secret_file),
+    )
+
+    assert settings.core_storage_shared_secret.get_secret_value() == "direct-api-secret"


### PR DESCRIPTION
## Summary

- stop publishing `core-storage-api` from the default Compose stack and bind the development-only port to loopback
- require a fail-closed `X-Storage-Secret` before storage routing and attach it at every core API and worker storage-call choke point
- preserve the one-command quick start with a persistent random secret generated in a private Docker volume, and document the deployment requirement

Non-Compose deployments must set the same non-empty `CORE_STORAGE_SHARED_SECRET` (or mounted `CORE_STORAGE_SHARED_SECRET_FILE`) on storage and every direct caller before deploying this change.

## Validation

- regression test fails on the parent commit: unauthenticated `memories/bulk-get` returns 200 instead of the required 401
- root suite: 5,527 passed, 4 skipped, 1 xfailed
- core-storage-api: 173 passed; core-worker: 78 passed
- all CI Ruff check/format scopes and all six mypy scopes pass
- legacy-name ratchet and do-not-touch sentinel pass
- both Compose files render; rebuilt stack healthy; storage port 8002 has no host mapping; missing secret returns 401 and configured callers return 200
- `uv.lock` files unchanged
