### PR TITLE
fix(fleet): require an explicit tenant scope on the command-status update

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/fleet.py
+++ b/core-storage-api/src/core_storage_api/routers/fleet.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Request
 
 from core_storage_api.schemas import FLEET_COMMAND_FIELDS, FLEET_NODE_FIELDS, orm_to_dict
-from core_storage_api.services.postgres_service import PostgresService
+from core_storage_api.services.postgres_service import UNSCOPED, PostgresService
 
 router = APIRouter(prefix="/fleet", tags=["Fleet"])
 _svc = PostgresService()
@@ -208,18 +208,37 @@ async def deploy_attempt_count(node_id: UUID, target_version: str, since: dateti
 async def update_command_status(command_id: UUID, request: Request) -> dict:
     """Update a command's status / result.
 
-    ``tenant_id`` (when present in the body) scopes the UPDATE so a tenant
-    can only complete its own commands — keying on ``command_id`` alone let
-    any caller that knew a command UUID mark another tenant's command
-    done/failed (cross-tenant BOLA). ``ok`` reports whether a row actually
-    matched so the caller can surface 404 instead of silently succeeding.
+    ``tenant_id`` scopes the UPDATE so a tenant can only complete its own
+    commands — keying on ``command_id`` alone let any caller that knew a
+    command UUID mark another tenant's command done/failed (cross-tenant
+    BOLA). ``ok`` reports whether a row actually matched so the caller can
+    surface 404 instead of silently succeeding.
+
+    The key must be **present**; ``null`` is the admin/unscoped opt-out.
+    Absent and null used to be the same request, which made the unscoped
+    UPDATE what a caller got by omission — the one mistake this endpoint
+    cannot afford, since storage authenticates nothing and trusts the
+    tenant its caller names. Distinguishing them costs the caller nothing:
+    core-api already sends ``{"tenant_id": auth.tenant_id}`` on every
+    call and serializes the admin case as an explicit ``null``.
     """
     body: dict = await request.json()
+    if "tenant_id" not in body:
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_id' is required; send null to update unscoped (admin callers)",
+        )
+    raw_tenant_id = body["tenant_id"]
+    if raw_tenant_id is not None and not isinstance(raw_tenant_id, str):
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_id' must be a string or null",
+        )
     completed_at_raw = body.get("completed_at")
     matched = await _svc.fleet_update_command_result(
         command_id=command_id,
         status=body["status"],
-        tenant_id=body.get("tenant_id"),
+        tenant_id=UNSCOPED if raw_tenant_id is None else raw_tenant_id,
         result=body.get("result"),
         completed_at=(datetime.fromisoformat(completed_at_raw) if completed_at_raw else datetime.now(UTC)),
     )

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -636,6 +636,38 @@ class BulkValidationError(ValueError):
     """
 
 
+class Unscoped:
+    """Marker for a call that deliberately spans every tenant.
+
+    A tenant-scope parameter typed ``str | None = None`` has the wrong
+    default: the value that means "no filter" is also the value you get by
+    forgetting the argument. GHSA-xw4x-jwf5-8m9h was that shape one layer
+    up — a request that named a tenant it was entitled to while addressing
+    a row belonging to another — and the fix for it left the storage-side
+    parameter defaulted to the unscoped behaviour it had just closed.
+
+    Typing the parameter ``str | Unscoped`` with no default moves both
+    failure modes to where they can be caught. Omitting it is a
+    ``TypeError`` at the call site rather than a silent cross-tenant
+    statement, and passing ``None`` is a mypy error rather than an accidental
+    opt-out, so widening the scope has to be spelled: ``tenant_id=UNSCOPED``.
+    That spelling is greppable and reviewable, which ``=None`` never was.
+
+    Deliberately not an ``Enum`` or ``object()``: a named class gives the
+    annotation a name that says what it means at every call site, and
+    ``isinstance`` narrows it for the type checker without a cast.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "UNSCOPED"
+
+
+UNSCOPED = Unscoped()
+"""The only ``Unscoped`` instance. Compare with ``isinstance``, not ``is``."""
+
+
 class PostgresService:
     """Single point of DB access for all core tables.
 
@@ -9023,7 +9055,7 @@ class PostgresService:
         *,
         command_id: UUID,
         status: str,
-        tenant_id: str | None = None,
+        tenant_id: str | Unscoped,
         result: dict | None = None,
         completed_at: datetime | None = None,
     ) -> bool:
@@ -9032,8 +9064,13 @@ class PostgresService:
         ``tenant_id`` scopes the UPDATE so a caller can only touch its own
         tenant's commands — keying on ``command_id`` alone let any
         authenticated tenant complete another tenant's command by UUID
-        (cross-tenant BOLA). ``None`` (admin / unscoped callers) skips the
-        filter. Returns ``True`` iff a row matched.
+        (cross-tenant BOLA). Returns ``True`` iff a row matched.
+
+        Required, and ``Unscoped`` rather than ``None``, because this method
+        previously defaulted to skipping the filter: the caller that forgot
+        the argument got the pre-fix cross-tenant UPDATE back with nothing to
+        notice it. Admin callers legitimately run unscoped and now say so —
+        ``tenant_id=UNSCOPED``. See :class:`Unscoped`.
         """
         values: dict
         if status == "acked":
@@ -9046,7 +9083,7 @@ class PostgresService:
                 values["completed_at"] = completed_at
         async with get_session() as session:
             stmt = sql_update(FleetCommand).where(FleetCommand.id == command_id)
-            if tenant_id is not None:
+            if not isinstance(tenant_id, Unscoped):
                 stmt = stmt.where(FleetCommand.tenant_id == tenant_id)
             res = await session.execute(stmt.values(**values))
             return (res.rowcount or 0) > 0  # type: ignore[attr-defined]

--- a/core-storage-api/tests/test_fleet_command_status_tenant_scope.py
+++ b/core-storage-api/tests/test_fleet_command_status_tenant_scope.py
@@ -1,0 +1,173 @@
+"""``PATCH /fleet/commands/{id}/status`` must be told which tenant it scopes to.
+
+GHSA-xw4x-jwf5-8m9h was a fleet-command route that validated the tenant the
+caller named and never checked it against the row it addressed. The fix landed
+on the *create* path. The *status* path kept the same hazard in a quieter form:
+``tenant_id`` was optional on the wire and defaulted to ``None`` in the SQL
+layer, and ``None`` meant "no WHERE clause" — so the cross-tenant UPDATE was
+what a caller got by leaving the field out.
+
+Storage authenticates nothing (GHSA-wgvw-28pq-jc36) and trusts the tenant its
+caller names, so "the caller will remember" is not a control. These tests pin
+the distinction the endpoint now draws: **absent** is a 422, **null** is the
+admin opt-out, and a **wrong** tenant matches no row.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from core_storage_api.services.postgres_service import UNSCOPED, Unscoped
+from tests.test_integration import PREFIX
+
+# On the class rather than the module: the sentinel check below is synchronous,
+# and a module-level asyncio mark warns on every non-async test it covers.
+
+
+def test_unscoped_sentinel_reads_as_its_name() -> None:
+    """A sentinel whose point is being explicit should say so when logged.
+
+    The default ``object`` repr would put a memory address in the log line
+    where the reader needs the word "unscoped".
+    """
+    assert repr(UNSCOPED) == "UNSCOPED"
+    assert isinstance(UNSCOPED, Unscoped)
+
+
+async def _node_and_command(client: AsyncClient, tenant_id: str) -> str:
+    """Create a node + a queued command for ``tenant_id``; return the command id."""
+    node = await client.post(
+        f"{PREFIX}/fleet/nodes",
+        json={
+            "tenant_id": tenant_id,
+            "fleet_id": "fleet-a",
+            "node_name": f"node-{uuid.uuid4().hex[:8]}",
+        },
+    )
+    assert node.status_code == 200, node.text
+    node_id = node.json()["id"]
+
+    command = await client.post(
+        f"{PREFIX}/fleet/commands",
+        json={
+            "tenant_id": tenant_id,
+            "node_id": node_id,
+            "command": "deploy",
+            "status": "queued",
+        },
+    )
+    assert command.status_code == 200, command.text
+    return command.json()["id"]
+
+
+async def _status_of(client: AsyncClient, tenant_id: str, command_id: str) -> str:
+    listed = await client.get(f"{PREFIX}/fleet/commands", params={"tenant_id": tenant_id})
+    assert listed.status_code == 200, listed.text
+    rows = [r for r in listed.json() if r["id"] == command_id]
+    assert rows, f"command {command_id} not visible to {tenant_id}"
+    return rows[0]["status"]
+
+
+class TestCommandStatusTenantScope:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """The bug: no ``tenant_id`` key used to mean "update it unscoped"."""
+        tenant = f"fleet-scope-{uuid.uuid4().hex[:8]}"
+        command_id = await _node_and_command(client, tenant)
+
+        resp = await client.patch(
+            f"{PREFIX}/fleet/commands/{command_id}/status",
+            json={"status": "done"},
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.json()["detail"]
+        # The row is untouched — the 422 fires before any statement is built.
+        assert await _status_of(client, tenant, command_id) == "queued"
+
+    async def test_omitted_tenant_id_cannot_complete_another_tenants_command(
+        self, client: AsyncClient
+    ) -> None:
+        """The reachable consequence, stated as the attack rather than the guard.
+
+        Two tenants, one command each. Addressing the victim's command by UUID
+        with no tenant scope is exactly the request the old default served.
+        """
+        victim = f"fleet-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"fleet-attacker-{uuid.uuid4().hex[:8]}"
+        victim_command = await _node_and_command(client, victim)
+        await _node_and_command(client, attacker)
+
+        resp = await client.patch(
+            f"{PREFIX}/fleet/commands/{victim_command}/status",
+            json={"status": "failed", "result": {"error": "forged"}},
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert await _status_of(client, victim, victim_command) == "queued"
+
+    async def test_wrong_tenant_matches_no_row(self, client: AsyncClient) -> None:
+        """Naming a tenant you do not own reports ``ok: false``, not success."""
+        victim = f"fleet-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"fleet-attacker-{uuid.uuid4().hex[:8]}"
+        victim_command = await _node_and_command(client, victim)
+
+        resp = await client.patch(
+            f"{PREFIX}/fleet/commands/{victim_command}/status",
+            json={"status": "done", "tenant_id": attacker},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"ok": False}
+        assert await _status_of(client, victim, victim_command) == "queued"
+
+    async def test_own_tenant_updates(self, client: AsyncClient) -> None:
+        tenant = f"fleet-scope-{uuid.uuid4().hex[:8]}"
+        command_id = await _node_and_command(client, tenant)
+
+        resp = await client.patch(
+            f"{PREFIX}/fleet/commands/{command_id}/status",
+            json={"status": "done", "tenant_id": tenant},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"ok": True}
+        assert await _status_of(client, tenant, command_id) == "done"
+
+    async def test_explicit_null_is_the_admin_opt_out(self, client: AsyncClient) -> None:
+        """core-api sends ``{"tenant_id": auth.tenant_id}`` — ``null`` for admin
+        credentials, which legitimately operate across tenants. That request
+        must keep working, or the guard above would be a breaking change
+        dressed as a fix."""
+        tenant = f"fleet-scope-{uuid.uuid4().hex[:8]}"
+        command_id = await _node_and_command(client, tenant)
+
+        resp = await client.patch(
+            f"{PREFIX}/fleet/commands/{command_id}/status",
+            json={"status": "done", "tenant_id": None},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"ok": True}
+        assert await _status_of(client, tenant, command_id) == "done"
+
+    async def test_non_string_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """``{"tenant_id": []}`` is neither a tenant nor the admin opt-out.
+
+        Without the type check it reaches SQLAlchemy as a bind parameter and
+        surfaces as a 500 — a server fault for what is a malformed request.
+        """
+        tenant = f"fleet-scope-{uuid.uuid4().hex[:8]}"
+        command_id = await _node_and_command(client, tenant)
+
+        resp = await client.patch(
+            f"{PREFIX}/fleet/commands/{command_id}/status",
+            json={"status": "done", "tenant_id": []},
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert await _status_of(client, tenant, command_id) == "queued"


### PR DESCRIPTION
## What

`PATCH /fleet/commands/{command_id}/status` took `tenant_id` as an optional body field and passed it to `fleet_update_command_result`, which defaulted it to `None` — and `None` meant *build the UPDATE with no tenant predicate*:

```python
stmt = sql_update(FleetCommand).where(FleetCommand.id == command_id)
if tenant_id is not None:                      # omitted -> no scope at all
    stmt = stmt.where(FleetCommand.tenant_id == tenant_id)
```

The cross-tenant write was what a caller got by **leaving the field out**, addressing any tenant's command by UUID.

## Why it matters

This is the shape of GHSA-xw4x-jwf5-8m9h one endpoint over. That advisory was a fleet-command route that validated the tenant the caller *named* and never checked it against the row it *addressed*. Its fix (`6db0ae57`) landed on the create path, which now checks the node/tenant pair. The status path kept the same hazard in a quieter form: the guard existed, but skipping it was the default. The method's own docstring named the vulnerability class — *"keying on `command_id` alone let any authenticated tenant complete another tenant's command by UUID (cross-tenant BOLA)"* — directly above a parameter that defaulted to exactly that.

Reachability, stated honestly: through core-api this was **not** exploitable by an ordinary tenant. `command_result` sends `tenant_id: auth.tenant_id`, which is `None` only for admin credentials. What this fixes is the *default*: storage authenticates nothing (GHSA-wgvw-28pq-jc36) and trusts the tenant its caller names, so the safe behaviour depended on every present and future call site remembering an optional kwarg. That is defence-in-depth, not an emergency — but it is the exact defect class both advisories came from.

## How

Two changes, one per layer.

**Wire contract** — absent and null are no longer the same request. Absent is a 422; `null` is the admin/unscoped opt-out. This costs the only caller nothing: core-api already sends `{"tenant_id": auth.tenant_id}` on every call, and `httpx`'s `json=` serializes the admin case as an explicit `null`, so the request that was always correct stays correct.

**Type** — `fleet_update_command_result` now takes `tenant_id: str | Unscoped` with no default. Widening the scope has to be spelled `tenant_id=UNSCOPED`, which is greppable and reviewable in a way `=None` never was. Both failure modes now fail loudly, verified rather than asserted:

```
error: Argument "tenant_id" ... has incompatible type "None"; expected "str | Unscoped"  [arg-type]
error: Missing named argument "tenant_id" for "fleet_update_command_result"  [call-arg]
```

A non-string `tenant_id` is also rejected at the edge instead of reaching asyncpg as a bind parameter, where it surfaced as a 500 for what is squarely a malformed request.

## Tests

Seven new tests. **Three fail on the parent commit** — omitted `tenant_id` rejected, the two-tenant attack blocked, non-string rejected. The other four pin behaviour that must *not* change: a wrong tenant matches no row, the owning tenant updates, `null` is still the admin opt-out, and the sentinel reads as its own name in a log line.

Verified locally against pgvector:pg16 — 175 core-storage-api tests, 5541 root tests, `ruff check` / `ruff format --check` at CI's scopes, and `mypy src/` all clean.

## Scope

Deliberately narrow: this is one endpoint and one method. The broader question — that the tenancy invariant is enforced by convention across 187 storage routes and 192 SQL-layer methods with nothing checking it — is a follow-up PR that adds a CI gate and a shrinking allowlist. This lands first so that gate starts with one fewer exception.

Does **not** touch `docker-compose.yml`, storage auth middleware, or the README's Self-Hosted section — that is GHSA-wgvw-28pq-jc36's territory and is being handled separately.