### PR TITLE
ci(release): accept a caura-spelled tag for the python client

### DIFF
--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -10,11 +10,12 @@ name: Publish caura-client to PyPI
 #   3. Create a GitHub environment named `pypi`.
 #
 # Release: bump the version in clients/python/pyproject.toml, then push a tag
-# `memclaw-client-v<version>` (or run this workflow manually). # legacy-name-ok: names the tag pattern kept below
+# `caura-client-v<version>` (or run this workflow manually).
 
 on:
   push:
     tags:
+      - "caura-client-v*"
       - "memclaw-client-v*" # legacy-name-ok: rule 3 keeps the published tag pattern working
   workflow_dispatch:
 


### PR DESCRIPTION
The python client could only be released under `memclaw-client-v*`. Its npm twin has accepted both spellings since the rename, so the two release paths disagreed about which brand a maintainer pushes — and the caura-spelled tag a reader would naturally guess at silently did nothing.

Surfaced while annotating that line in #1068; flagged there rather than folded in, because it is a behaviour change and that PR was annotation-only.

## The change

```diff
 # Release: bump the version in clients/python/pyproject.toml, then push a tag
-# `memclaw-client-v<version>` (or run this workflow manually). # legacy-name-ok: ...
+# `caura-client-v<version>` (or run this workflow manually).

 on:
   push:
     tags:
+      - "caura-client-v*"
       - "memclaw-client-v*" # legacy-name-ok: rule 3 keeps the published tag pattern working
```

Canonical first, mirroring the twin's ordering. **The legacy trigger is untouched**, under the marker it already carried — it is a published contract, and dropping it would break any release still using it.

| workflow | triggers |
|---|---|
| `publish-npm-client.yml` | `caura-client-ts-v*`, `memclaw-client-ts-v*` |
| `publish-python-client.yml` (after) | `caura-client-v*`, `memclaw-client-v*` |

## Why no version-extraction change is needed here

This is the part worth checking, because the npm twin *does* need one. It strips both prefixes off `GITHUB_REF_NAME` to compare against `package.json`:

```
TAG_VERSION="${GITHUB_REF_NAME#caura-client-ts-v}"
TAG_VERSION="${TAG_VERSION#memclaw-client-ts-v}"
```

so a second trigger pattern there required a second strip, or the guard would compare a prefixed string and fail every release.

The python workflow has no such logic. It builds from `pyproject.toml` and publishes; the tag is a pure trigger and is never read. Verified rather than assumed — `GITHUB_REF_NAME`, `github.ref` and `TAG_VERSION` appear **nowhere** in the file. So adding a spelling cannot desynchronise anything.

## Expect one removed exemption

The release-note line no longer spells the old tag, so it no longer needs the marker it carried, and the ratchet reports one removed exemption. That is correct, not a loss of protection: what the marker stood for still exists one line below, on the trigger itself, with its own marker.

## Checks

| check | result |
|---|---|
| `actionlint` | clean, exit 0 |
| workflow parses; triggers are exactly `['caura-client-v*', 'memclaw-client-v*']` | verified |
| `workflow_dispatch` still present; no marker text inside a value | verified |
| `legacy_name_ratchet.py` | exit 0 — 586 lines across 133 files |
| `do_not_touch_sentinel.py` | exit 0 — 39/39 |

## One thing I did not fix

The python workflow also lacks the npm twin's **tag-vs-package version guard** and its post-publish registry verification. So a tag whose version disagrees with `pyproject.toml` publishes silently under whatever `pyproject.toml` says. That is pre-existing and out of scope here, but it is the reason this workflow needed no strip logic — and it is worth its own issue.