### PR TITLE
ci(release): assert the python client publishes what its tag claims

### DIFF
--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -30,6 +30,23 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      # A tag that disagrees with pyproject.toml does not fail — it publishes
+      # whatever pyproject.toml says, under a tag claiming otherwise. The release
+      # then looks done while PyPI serves a different version. Both prefixes are
+      # stripped so the check works on either tag. Skipped on workflow_dispatch,
+      # where there is no tag to agree with.
+      - name: The tag must agree with pyproject.toml
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#caura-client-v}"
+          TAG_VERSION="${TAG_VERSION#memclaw-client-v}" # legacy-name-ok: strips the tag pattern kept above
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::tag ${GITHUB_REF_NAME} says ${TAG_VERSION} but pyproject.toml says ${PKG_VERSION}"
+            exit 1
+          fi
+          echo "publishing $(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")==${PKG_VERSION}"
+        working-directory: clients/python
       - name: Build
         run: |
           pip install build
@@ -39,3 +56,47 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: clients/python/dist/
+
+      # A green publish step is not evidence PyPI serves it. The npm twin carries
+      # the same check after #870, where a version bump passed every gate and both
+      # registries went on serving the old build — the tick meant "nothing went
+      # wrong", not "it shipped". Ask the index. PyPI is not immediately
+      # consistent, hence the retries.
+      - name: PyPI must actually serve it
+        run: |
+          PKG_NAME=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          # Ask for the project and test membership, rather than requesting the
+          # version URL directly: PyPI answers that 404 in a way curl reports as
+          # exit 56 ("failure receiving network data"), which is indistinguishable
+          # from a real network fault.
+          #
+          # The two failures are then reported apart. "could not reach the index"
+          # and "index reachable, version absent" mean different things to whoever
+          # reads a red run: the first is infrastructure, the second is the release
+          # this step exists to catch. LAST_STATE carries that distinction into the
+          # final error so it survives past the per-attempt lines.
+          #
+          # Ten attempts with increasing backoff, 225s of waiting in total. PyPI's
+          # JSON index is not immediately consistent, and a flat 50s window can go
+          # red on a publish that actually succeeded.
+          ATTEMPTS=10
+          LAST_STATE="never ran"
+          for attempt in $(seq 1 "${ATTEMPTS}"); do
+            if ! curl -sf "https://pypi.org/pypi/${PKG_NAME}/json" -o /tmp/pypi.json; then
+              LAST_STATE="could not reach the PyPI index"
+              echo "attempt ${attempt}/${ATTEMPTS}: ${LAST_STATE}, retrying"
+            elif python -c "import json,sys; sys.exit(0 if sys.argv[1] in json.load(open('/tmp/pypi.json'))['releases'] else 1)" "${PKG_VERSION}"; then
+              echo "PyPI serves ${PKG_NAME}==${PKG_VERSION}"
+              exit 0
+            else
+              LAST_STATE="index reachable but ${PKG_VERSION} is not in it"
+              echo "attempt ${attempt}/${ATTEMPTS}: ${LAST_STATE}, waiting"
+            fi
+            if [ "${attempt}" -lt "${ATTEMPTS}" ]; then
+              sleep $((attempt * 5))
+            fi
+          done
+          echo "::error::published without error, but after ${ATTEMPTS} attempts: ${LAST_STATE} (${PKG_NAME}==${PKG_VERSION})"
+          exit 1
+        working-directory: clients/python


### PR DESCRIPTION
Closes #1071. Ports both release guards from `publish-npm-client.yml`, adapted rather than copied.

## 1. A tag that disagrees with `pyproject.toml` published silently

The workflow never read the tag — it builds from `pyproject.toml` and publishes. So pushing `caura-client-v2.0.0` against a pyproject saying `1.0.1` shipped **1.0.1** with a green tick, under a tag claiming otherwise. The release looked done; PyPI served something else.

```yaml
- name: The tag must agree with pyproject.toml
  if: startsWith(github.ref, 'refs/tags/')
```

**Both prefixes are stripped**, because #1070 gave this workflow two spellings. Stripping only the canonical one would fail every release tagged the legacy way — the same coupling the npm twin documents at its own strip. The `if:` matters too: this workflow also has `workflow_dispatch`, where there is no tag to agree with and the guard must not run.

## 2. A green publish step is not evidence PyPI serves it

The twin carries this check after #870, where a version bump passed every gate while both registries went on serving the old build — the tick meant "nothing went wrong", not "it shipped". This asks the index, with retries, since PyPI is not immediately consistent.

**One deliberate difference from the twin.** The check asks for the *project* JSON and tests membership, rather than requesting the version URL directly. Measured:

```
curl -sf https://pypi.org/pypi/caura-client/99.99.99/json   ->  exit 56
```

PyPI answers that 404 in a way curl reports as **56, "failure receiving network data"** — indistinguishable from a real network fault, so an absent version and a broken connection would have looked identical, and the retry loop would have burned five attempts either way without the log telling you which. Membership-testing separates them.

## Verified by execution, not by reading

| case | result |
|---|---|
| `caura-client-v1.0.1` vs pyproject `1.0.1` | strips to `1.0.1`, **passes** |
| `memclaw-client-v1.0.1` vs `1.0.1` | strips to `1.0.1`, **passes** |
| `caura-client-v2.0.0` vs `1.0.1` | **fails** — "tag says 2.0.0 but pyproject.toml says 1.0.1" |
| `memclaw-client-v9.9.9` vs `1.0.1` | **fails** with the same shape |
| probe, live `1.0.1` | reports served |
| probe, synthetic `99.99.99` | reports not served, loop would retry |
| `actionlint` | clean, exit 0 |

The name and version lookups both resolve against the real file (`caura-client`, `1.0.1`).

## Scope

Workflow-only. No product code, no change to what is built or where it is published, and the legacy tag trigger is untouched.