### PR TITLE
ci(release): fail early when the python client cannot authenticate to PyPI

### DIFF
--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -26,6 +26,27 @@ jobs:
     permissions:
       id-token: write # required for PyPI trusted publishing
     steps:
+      # Fail before doing any work if this job cannot mint a publishing
+      # credential at all. The npm twin checks its NPM_TOKEN secret here; there
+      # is no stored token to check for trusted publishing, so the equivalent
+      # condition is whether GitHub is willing to issue an OIDC token — which it
+      # signals by setting these two variables, and only when the job actually
+      # holds `id-token: write`. Drop that permission while editing this file and
+      # the run would otherwise get all the way to the publish action before
+      # failing inside it, with the cause several layers down.
+      #
+      # Deliberately does NOT request a token. Minting one would additionally
+      # prove the endpoint is healthy, but it puts a live credential in this
+      # step for no gain the publish action does not already provide seconds
+      # later — and the check exists to catch a misconfigured workflow, which
+      # the variables answer on their own.
+      - name: The publish credential must be obtainable
+        run: |
+          if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL}" || -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" ]]; then
+            echo "::error::No OIDC token-request context, so PyPI trusted publishing cannot authenticate. This job needs 'permissions: id-token: write'; there is no stored token to fall back on."
+            exit 1
+          fi
+          echo "OIDC token-request context is present"
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:


### PR DESCRIPTION
The last asymmetry with the npm release workflow. Follows #1072, which closed the other two.

## Why this one was missing

`publish-npm-client.yml` refuses to start without its `NPM_TOKEN` secret. The python workflow had no equivalent, and the reason is real rather than an oversight: it uses **PyPI trusted publishing via OIDC**, so there is no stored token to check for.

The condition that *does* exist is whether GitHub is willing to issue an OIDC token at all. It signals that by setting `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` — and **only when the job actually holds `id-token: write`**.

Drop that permission while editing this file and the run would otherwise reach the publish action before failing inside it, with the cause several layers below the error you get. Now it fails on the first step and names the permission.

## What it deliberately does not do

It does **not** request a token. Minting one would additionally prove the OIDC endpoint is healthy, but it would put a live credential in this step to learn something `pypa/gh-action-pypi-publish` establishes seconds later anyway. The check exists to catch a *misconfigured workflow*, and the two variables answer that on their own.

`ACTIONS_ID_TOKEN_REQUEST_TOKEN` is read only inside a `-z` emptiness test — never echoed, never sent anywhere, never written to disk. Audited in the diff:

```
if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL}" || -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" ]]; then
```

## Executed, not reasoned about

| state | result |
|---|---|
| both variables set (`id-token: write` granted) | **passes** |
| both unset (permission dropped) | **fails** with the remediation message |
| URL set, token missing | **fails** |
| token set, URL missing | **fails** |

The last two are why the test is `||` across both variables rather than `-z` on one — a single-variable check would let a half-present context through.

## Step parity is now complete

| `publish-python-client.yml` | `publish-npm-client.yml` |
|---|---|
| The publish credential must be obtainable | The publish credential must exist |
| The tag must agree with pyproject.toml | Install + build |
| Build | The tag must agree with package.json |
| Publish | Publish |
| PyPI must actually serve it | The registry must actually serve it |

One ordering difference remains, and it favours this file: the tag check runs **before** the build here, so a tag disagreeing with `pyproject.toml` costs nothing to reject, where the twin builds first. Left as is rather than matched.

## Checks

| check | result |
|---|---|
| `actionlint` | clean, exit 0 |
| YAML parses; `permissions`, `environment`, triggers unchanged | verified — `{'id-token': 'write'}`, `pypi`, `['caura-client-v*', 'memclaw-client-v*']` |
| `legacy_name_ratchet.py` | exit 0 — 586 lines / 133 files, unchanged |
| `do_not_touch_sentinel.py` | exit 0 — 39/39 |

Workflow-only. No product code, nothing about what is built or where it is published.