### PR TITLE
fix(memories): require a tenant scope on bulk-get, and apply it in SQL

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1065,19 +1065,21 @@ class CoreStorageClient:
     async def bulk_get_memories(
         self,
         ids: list[str],
-        tenant_id: str | None = None,
+        tenant_id: str,
     ) -> list[dict | None]:
         """Fetch many memories in one round-trip; order matches input ``ids``.
 
-        Missing rows (deleted, nonexistent, or — when ``tenant_id`` is
-        provided — cross-tenant) come back as ``None`` in the same slot
-        rather than being dropped from the list. Lets callers zip the
-        response back to their original id list. Capped at 1000 ids
-        server-side; callers needing more must chunk client-side.
+        Missing rows — deleted, nonexistent, or belonging to another tenant —
+        come back as ``None`` in the same slot rather than being dropped from
+        the list. Lets callers zip the response back to their original id list.
+        Capped at 1000 ids server-side; callers needing more must chunk
+        client-side.
+
+        ``tenant_id`` is required. As an optional argument it was the client
+        half of GHSA-wgvw-28pq-jc36, and one of the two call sites did in fact
+        omit it.
         """
-        payload: dict[str, Any] = {"ids": ids}
-        if tenant_id is not None:
-            payload["tenant_id"] = tenant_id
+        payload: dict[str, Any] = {"ids": ids, "tenant_id": tenant_id}
         return await self._post(  # type: ignore[return-value]
             "/memories/bulk-get", payload, read=True
         )

--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -524,7 +524,7 @@ async def _run_crystallization(
     # deleted) — same per-row "skip missing" semantics the old loop's
     # ``if mem:`` gate provided, just with Nx fewer HTTPs (audit P5).
     memories_by_id: dict[UUID, dict] = {}
-    bulk_rows = await sc.bulk_get_memories([str(mid) for mid in total_ids])
+    bulk_rows = await sc.bulk_get_memories([str(mid) for mid in total_ids], tenant_id=tenant_id)
     for mid, mem in zip(total_ids, bulk_rows):
         if mem is not None:
             memories_by_id[mid] = mem

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -441,22 +441,24 @@ async def find_duplicate_hash(
 async def bulk_get_memories(request: Request) -> list[dict | None]:
     """Fetch many memories by id in a single round-trip.
 
-    Body: ``{"ids": ["uuid", ...], "tenant_id": "..." (optional)}``.
+    Body: ``{"ids": ["uuid", ...], "tenant_id": "..."}``.
 
     Returns a list of memory dicts in the **same order** as the input ids,
-    with ``null`` for ids that don't exist (or are soft-deleted, or — if
-    ``tenant_id`` is provided — belong to a different tenant). Order
-    preservation matters: callers (e.g. crystallizer archive sweep) zip
-    the response back to their original id list.
+    with ``null`` for ids that don't exist, are soft-deleted, or belong to a
+    different tenant. Order preservation matters: callers (e.g. crystallizer
+    archive sweep) zip the response back to their original id list.
 
-    Tenant filter is optional to mirror the single-row ``GET /memories/{id}``
-    contract. Callers that need tenant safety supply ``tenant_id``; the
-    request fails open per-row (returns ``null``) when an id belongs to a
-    different tenant, never with a 4xx.
+    ``tenant_id`` is **required**. It was optional — "to mirror the single-row
+    ``GET /memories/{id}`` contract" — and that is GHSA-wgvw-28pq-jc36: a body
+    with ids and no tenant returned any row by id, across every tenant, from a
+    service that authenticates nothing. Mirroring another endpoint's contract
+    is not a reason to make a tenant filter skippable; it only meant two
+    endpoints had the same hole.
 
     Cap: 1000 ids per request to bound query plan size and response payload.
     """
     body: dict = await request.json()
+    tenant_id = _require(body, "tenant_id")
     raw_ids = body.get("ids", [])
     if not isinstance(raw_ids, list):
         raise HTTPException(status_code=422, detail="'ids' must be a list")
@@ -473,16 +475,17 @@ async def bulk_get_memories(request: Request) -> list[dict | None]:
     except (ValueError, TypeError) as e:
         raise HTTPException(status_code=422, detail=f"invalid UUID in ids: {e}")
 
-    tenant_filter = body.get("tenant_id")
-    by_id = await _svc.memory_get_memories_by_ids(uids)
+    by_id = await _svc.memory_get_memories_by_ids(uids, tenant_id=tenant_id)
 
+    # No tenant comparison here any more: the query is scoped, so a row from
+    # another tenant is never fetched rather than being fetched and discarded.
+    # The per-id ``None`` is unchanged — a foreign id is still absent from the
+    # result rather than an error, which keeps this from being an existence
+    # oracle for memory UUIDs.
     out: list[dict | None] = []
     for uid in uids:
         mem = by_id.get(uid)
-        if mem is None or (tenant_filter is not None and mem.tenant_id != tenant_filter):
-            out.append(None)
-        else:
-            out.append(orm_to_dict(mem, MEMORY_FIELDS))
+        out.append(orm_to_dict(mem, MEMORY_FIELDS) if mem is not None else None)
     return out
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -4000,13 +4000,28 @@ class PostgresService:
     async def memory_get_memories_by_ids(
         self,
         memory_ids: list[UUID],
+        *,
+        tenant_id: str,
     ) -> dict[UUID, Memory]:
-        """Fetch multiple memories by ID, returned as {id: Memory}."""
+        """Fetch multiple memories by ID within one tenant, as {id: Memory}.
+
+        ``tenant_id`` is required and is applied in SQL. This method used to
+        take ids alone and return whatever they matched, leaving the caller to
+        compare ``tenant_id`` on each row afterwards — which is the primitive
+        GHSA-wgvw-28pq-jc36 describes. Two things were wrong with that. The
+        filter was optional one layer up, so a request that omitted it got
+        every row it named; and even when supplied, the rows crossed the
+        database boundary before anything checked them, so the protection was a
+        Python comparison the next refactor could drop with no test failing.
+
+        Filtering here means another tenant's row is never selected at all.
+        """
         if not memory_ids:
             return {}
         async with get_session() as session:
             stmt = select(Memory).where(
                 Memory.id.in_(memory_ids),
+                Memory.tenant_id == tenant_id,
                 Memory.deleted_at.is_(None),
             )
             result = await session.execute(stmt)

--- a/core-storage-api/tests/test_bulk_get_tenant_scope.py
+++ b/core-storage-api/tests/test_bulk_get_tenant_scope.py
@@ -1,0 +1,111 @@
+"""``POST /memories/bulk-get`` must be told which tenant it is reading for.
+
+This is GHSA-wgvw-28pq-jc36's exploit primitive. The route accepted a list of
+ids and an **optional** ``tenant_id``; omit it and every id you named came back,
+whichever tenant owned it, from a service that authenticates nothing. The
+docstring justified the optionality as mirroring the single-row
+``GET /memories/{id}`` contract — which only meant two endpoints shared a hole.
+
+The filter is now required *and* applied in SQL. Both halves matter and are
+tested separately: requiring it closes the omission, and pushing it into the
+query means a foreign row is never selected rather than selected and then
+dropped by a Python comparison that a later refactor could quietly remove.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def _memory(client: AsyncClient, tenant_id: str, content: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "agent-a",
+            "content": content,
+            "memory_type": "fact",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+class TestBulkGetTenantScope:
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """The advisory: no tenant key used to mean "any tenant"."""
+        tenant = f"bulk-{uuid.uuid4().hex[:8]}"
+        mem_id = await _memory(client, tenant, "a memory")
+
+        resp = await client.post(f"{PREFIX}/memories/bulk-get", json={"ids": [mem_id]})
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.json()["detail"]
+
+    async def test_another_tenants_id_reads_as_absent(self, client: AsyncClient) -> None:
+        """Naming a foreign id returns ``None`` in its slot, not the row.
+
+        Not a 404 for the whole request: a foreign id has to be
+        indistinguishable from a nonexistent one, or the endpoint becomes an
+        existence oracle for memory UUIDs.
+        """
+        victim = f"bulk-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"bulk-attacker-{uuid.uuid4().hex[:8]}"
+        victim_id = await _memory(client, victim, "victim's secret")
+        attacker_id = await _memory(client, attacker, "attacker's own")
+
+        resp = await client.post(
+            f"{PREFIX}/memories/bulk-get",
+            json={"ids": [attacker_id, victim_id], "tenant_id": attacker},
+        )
+
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()
+        assert len(rows) == 2
+        assert rows[0]["id"] == attacker_id
+        assert rows[1] is None, "another tenant's memory came back"
+
+    async def test_nonexistent_and_foreign_ids_are_indistinguishable(self, client: AsyncClient) -> None:
+        victim = f"bulk-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"bulk-attacker-{uuid.uuid4().hex[:8]}"
+        victim_id = await _memory(client, victim, "victim's secret")
+
+        resp = await client.post(
+            f"{PREFIX}/memories/bulk-get",
+            json={"ids": [victim_id, str(uuid.uuid4())], "tenant_id": attacker},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == [None, None]
+
+    async def test_own_ids_are_returned_in_input_order(self, client: AsyncClient) -> None:
+        """Order preservation is load-bearing — callers zip the response back."""
+        tenant = f"bulk-{uuid.uuid4().hex[:8]}"
+        first = await _memory(client, tenant, "first")
+        second = await _memory(client, tenant, "second")
+        missing = str(uuid.uuid4())
+
+        resp = await client.post(
+            f"{PREFIX}/memories/bulk-get",
+            json={"ids": [second, missing, first], "tenant_id": tenant},
+        )
+
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()
+        assert [r["id"] if r else None for r in rows] == [second, None, first]
+
+    async def test_empty_id_list_still_requires_the_tenant(self, client: AsyncClient) -> None:
+        """The guard runs before the empty-list short-circuit.
+
+        Otherwise ``{"ids": []}`` would be the one body that skips validation,
+        and the contract would depend on how many ids you happened to send.
+        """
+        resp = await client.post(f"{PREFIX}/memories/bulk-get", json={"ids": []})
+        assert resp.status_code == 422, resp.text

--- a/tests/test_storage_bulk_endpoints.py
+++ b/tests/test_storage_bulk_endpoints.py
@@ -174,7 +174,7 @@ async def test_bulk_get_memories_preserves_input_order(sc):
     b = await _write_memory(sc, tid, "B")
     c = await _write_memory(sc, tid, "C")
 
-    rows = await sc.bulk_get_memories([c["id"], a["id"], b["id"]])
+    rows = await sc.bulk_get_memories([c["id"], a["id"], b["id"]], tenant_id=tid)
     assert len(rows) == 3
     assert [r["id"] for r in rows] == [c["id"], a["id"], b["id"]]
     assert rows[0]["content"] == "C"
@@ -185,15 +185,20 @@ async def test_bulk_get_memories_returns_none_for_missing(sc):
     a = await _write_memory(sc, tid, "exists")
     ghost = str(uuid4())
 
-    rows = await sc.bulk_get_memories([a["id"], ghost])
+    rows = await sc.bulk_get_memories([a["id"], ghost], tenant_id=tid)
     assert len(rows) == 2
     assert rows[0]["id"] == a["id"]
     assert rows[1] is None
 
 
 async def test_bulk_get_memories_tenant_filter_yields_none(sc):
-    """If ``tenant_id`` is provided, cross-tenant ids return None (per-row
-    fail-closed) rather than leaking another tenant's memory dict."""
+    """Cross-tenant ids return None (per-row fail-closed) rather than leaking
+    another tenant's memory dict.
+
+    ``tenant_id`` is now required rather than optional — it was the optionality
+    that made this GHSA-wgvw-28pq-jc36 — and the filter is applied in SQL, so
+    the foreign row is never selected rather than selected and then masked.
+    """
     tid_a = _t()
     tid_b = _t()
     m_a = await _write_memory(sc, tid_a, "tenant A's")
@@ -205,7 +210,7 @@ async def test_bulk_get_memories_tenant_filter_yields_none(sc):
 
 
 async def test_bulk_get_memories_empty_input(sc):
-    assert await sc.bulk_get_memories([]) == []
+    assert await sc.bulk_get_memories([], tenant_id=_t()) == []
 
 
 # ============================================================================


### PR DESCRIPTION
Closes the remaining half of **GHSA-wgvw-28pq-jc36**. Follow-up to #1067, and the fix the round-1 review of #1069 asked for.

## What was wrong

`POST /memories/bulk-get` took a list of ids and an **optional** `tenant_id`. Omit it and every id you named came back, whichever tenant owned it, from a service that authenticates nothing:

```python
tenant_filter = body.get("tenant_id")          # optional
by_id = await _svc.memory_get_memories_by_ids(uids)   # no tenant in the query at all
...
if mem is None or (tenant_filter is not None and mem.tenant_id != tenant_filter):
```

The route's own docstring justified the optionality — *"to mirror the single-row `GET /memories/{id}` contract"*. That did not make it safe; it meant two endpoints shared a hole.

## Two changes, because the filter was weak in two different ways

**It could be omitted.** `tenant_id` is now a `_require` on the route and a non-defaulted argument on `CoreStorageClient.bulk_get_memories`. The client half was not hypothetical: of its two call sites, `entity_service` passed a tenant and **`crystallizer_service` did not** — with `tenant_id` in scope the whole time, simply never passed. That is what an optional security argument reliably produces.

**It was applied in Python, after the fact.** `memory_get_memories_by_ids` took ids alone and returned whatever they matched; the route then compared `tenant_id` per row and blanked the mismatches. So even on the path that *did* supply a tenant, another tenant's rows crossed the database boundary and were discarded afterwards by a comparison no test pinned. The predicate now lives in the query:

```python
stmt = select(Memory).where(
    Memory.id.in_(memory_ids),
    Memory.tenant_id == tenant_id,
    Memory.deleted_at.is_(None),
)
```

A foreign row is never selected, rather than selected and dropped.

**Unchanged:** the per-id `None`. A foreign id still reads as absent rather than erroring, so this does not become an existence oracle for memory UUIDs.

## Reachability, stated plainly

Through core-api the crystallizer's ids were already tenant-scoped upstream, so on that path this was defence-in-depth rather than a live leak. What made it an advisory is that storage authenticates nothing and trusts the tenant its caller names — so the filter being *skippable* is the whole vulnerability, and "the caller will remember" is not a control. One of the two callers did not remember.

## Tests

Five new. **Two fail on the parent commit**: an omitted tenant is rejected, and `{"ids": []}` is rejected too — the guard runs before the empty-list short-circuit, so the contract doesn't depend on how many ids you happen to send. The other three pin behaviour that must not change: a foreign id reads as absent, a foreign id is indistinguishable from a nonexistent one, and input order is preserved (callers zip the response back).

Three existing tests in `tests/test_storage_bulk_endpoints.py` called the client with no tenant and are updated — they were pinning the vulnerable contract, and their failure is the change working.

Verified against pgvector:pg16 — 180 core-storage-api tests, 5541 root tests, `ruff check` / `ruff format --check` and `mypy src/` for both `core-api` and `core-storage-api` at CI's scopes. `uv.lock` unchanged.

## Interaction with #1069

#1069 adds the CI gate that keeps this class of defect from recurring; its allowlist currently carries `route:POST /api/v1/storage/memories/bulk-get` and `method:memory_get_memories_by_ids` under `id-addressed`, annotated as this advisory. **When this merges, those two rows must come out** — `python3 scripts/tenant_scope_gate.py --write` does it, and the gate fails on the stale entries until someone does, which is the intended behaviour. Same shrink #1067 produced.

Does not touch `docker-compose.yml`, storage auth middleware, or the README's Self-Hosted section — that is the reachability/authentication half of GHSA-wgvw-28pq-jc36 and is being handled separately.