### PR TITLE
fix(memories): require a tenant scope on GET /memories/{id}

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -573,19 +573,22 @@ class CoreStorageClient:
                 _storage_detail(exc.response), _storage_duplicate_fields(exc.response)
             ) from exc
 
-    async def get_memory(self, memory_id: str, *, read: bool = True) -> dict | None:
-        """Fetch one memory by id.
+    async def get_memory(self, memory_id: str, tenant_id: str, *, read: bool = True) -> dict | None:
+        """Fetch one memory by id, within ``tenant_id``.
+
+        ``tenant_id`` is required. This method used to take an id alone, and
+        eleven call sites used it — none of them passing a tenant, which is what
+        an optional scoping argument reliably produces. There was a second,
+        correctly scoped ``get_memory``; having both meant the unsafe
+        one was always a shorter name away. Now there is one, and the unscoped
+        call cannot be written rather than merely being discouraged.
 
         ``read=False`` routes to the WRITER. Pass it for a read-your-write — a
-        read-back of a row this request (or an event's producer) just wrote, where
-        replica lag would make the row or the freshly-PATCHed column invisible.
-        Same reasoning as the write-path dedup gate below, which passes it for the
-        same reason.
+        read-back of a row this request (or an event's producer) just wrote,
+        where replica lag would make the row or the freshly-PATCHed column
+        invisible. Same reasoning as the write-path dedup gate below.
         """
-        return await self._get(f"/memories/{memory_id}", read=read)
-
-    async def get_memory_for_tenant(self, tenant_id: str, memory_id: str) -> dict | None:
-        return await self._get(f"/memories/{memory_id}", tenant_id=tenant_id)
+        return await self._get(f"/memories/{memory_id}", tenant_id=tenant_id, read=read)
 
     async def update_memory(self, memory_id: str, tenant_id: str, data: dict) -> dict | None:
         # ``tenant_id`` (the row's home tenant) scopes the by-id UPDATE on

--- a/core-api/src/core_api/consumer.py
+++ b/core-api/src/core_api/consumer.py
@@ -84,7 +84,7 @@ async def handle_memory_enriched(event: Event) -> None:
     # typically sub-second, so a replica read races replication. On the replica the
     # miss lands in the ack-drop below, which never redelivers, and this handler is
     # one of only two contradiction-detection triggers on the deferred path.
-    memory = await sc.get_memory(str(payload.memory_id), read=False)
+    memory = await sc.get_memory(str(payload.memory_id), payload.tenant_id, read=False)
     if memory is None:
         # Genuinely deleted between the worker's PATCH and this handler — which the
         # writer read makes true. Read from the replica it was not: an unreplicated
@@ -193,7 +193,7 @@ async def handle_memory_embedded(event: Event) -> None:
     # event ever fires to cover for it, so a lagged read dropped detection
     # unconditionally. Contradictory memories then both stay ``active`` and recall
     # keeps returning the stale one.
-    memory = await sc.get_memory(str(payload.memory_id), read=False)
+    memory = await sc.get_memory(str(payload.memory_id), payload.tenant_id, read=False)
     if memory is None:
         # Genuinely deleted — true against the writer, not against a replica, where
         # an unreplicated row is indistinguishable from a deleted one.

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1329,7 +1329,7 @@ async def caura_manage(
                     t0,
                 )
             if op == "read":
-                memory = await sc.get_memory_for_tenant(tenant_id, str(uid))
+                memory = await sc.get_memory(str(uid), tenant_id)
                 if not memory:
                     return _with_latency(_error_response("NOT_FOUND", "Memory not found."), t0)
                 # Fleet/agent-scope authorization: honor the same scope_agent +
@@ -1380,7 +1380,7 @@ async def caura_manage(
                         t0,
                     )
                 # WRITE → home tenant only.
-                memory = await sc.get_memory_for_tenant(tenant_id, str(uid))
+                memory = await sc.get_memory(str(uid), tenant_id)
                 if not memory:
                     return _with_latency(_error_response("NOT_FOUND", "Memory not found."), t0)
                 # Cross-fleet / scope_agent authorization (write threshold).
@@ -1449,7 +1449,7 @@ async def caura_manage(
                 # Trust gate (>= 3) + cross-fleet / scope_agent row authorization,
                 # mirroring REST DELETE /memories/{id}.
                 await enforce_delete(tenant_id, caller_agent_id)
-                target = await sc.get_memory_for_tenant(tenant_id, str(uid))
+                target = await sc.get_memory(str(uid), tenant_id)
                 if target and not await authorize_memory_access(
                     tenant_id,
                     caller_agent_id,

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1499,9 +1499,9 @@ async def delete_memory(
     if auth.tenant_id and caller_agent_id:
         await enforce_delete(tenant_id, caller_agent_id)
         # Cross-fleet / scope_agent row authorization (write threshold).
-        # ``get_memory_for_tenant`` already filters out soft-deleted /
+        # ``get_memory`` already filters out soft-deleted /
         # cross-tenant rows server-side, so a returned row is live + owned.
-        target = await get_storage_client().get_memory_for_tenant(tenant_id, str(memory_id))
+        target = await get_storage_client().get_memory(str(memory_id), tenant_id)
         if target:
             allowed = await authorize_memory_access(
                 tenant_id,
@@ -1556,9 +1556,9 @@ async def update_memory_status(
             detail=f"Invalid status. Must be one of: {', '.join(MEMORY_STATUSES)}",
         )
     sc = get_storage_client()
-    # ``get_memory_for_tenant`` filters out soft-deleted / cross-tenant rows
+    # ``get_memory`` filters out soft-deleted / cross-tenant rows
     # server-side, so a returned row is live + owned.
-    memory = await sc.get_memory_for_tenant(tenant_id, str(memory_id))
+    memory = await sc.get_memory(str(memory_id), tenant_id)
     if not memory:
         raise HTTPException(status_code=404, detail="Memory not found")
     # Cross-fleet / scope_agent row authorization for the authenticated agent

--- a/core-api/src/core_api/routes/testing.py
+++ b/core-api/src/core_api/routes/testing.py
@@ -113,15 +113,23 @@ async def _handle_set_field(body: TimeWarpRequest, auth: AuthContext) -> TimeWar
 
     sc = get_storage_client()
     if body.table == "memories":
-        # Tenant isolation: verify the memory belongs to the caller's tenant
-        row = await sc.get_memory(body.id)
+        # Tenant isolation. This used to fetch the row unscoped and then compare
+        # ``row["tenant_id"] != auth.tenant_id`` in Python — a correct check, but
+        # one that pulled another tenant's row across the boundary to make it.
+        # The fetch is scoped now, so a row belonging to someone else is never
+        # read; the 404 below covers "no such memory" and "not yours" alike,
+        # which is also one less existence oracle for memory UUIDs.
+        if auth.tenant_id is None:
+            # Admin credentials carry no tenant. The old comparison rejected
+            # them here too — ``memories.tenant_id`` is NOT NULL, so it could
+            # never equal None — and there is no tenant to scope the fetch to.
+            raise HTTPException(status_code=403, detail="Tenant mismatch")
+        row = await sc.get_memory(body.id, auth.tenant_id)
         if not row:
             raise HTTPException(status_code=404, detail="Memory not found")
-        if row.get("tenant_id") != auth.tenant_id:
-            raise HTTPException(status_code=403, detail="Tenant mismatch")
-        # Pass the row's HOME tenant (verified == auth.tenant_id just above) so
-        # the storage-side guard scopes the write; row["tenant_id"] is a non-null
-        # column, unlike the Optional auth.tenant_id.
+        # Pass the row's HOME tenant so the storage-side guard scopes the write;
+        # row["tenant_id"] is a non-null column, unlike the Optional
+        # auth.tenant_id.
         result = await sc.update_memory(body.id, row["tenant_id"], {body.field: parsed_value.isoformat()})
         affected = 1 if result else 0
     else:

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -251,7 +251,7 @@ async def detect_contradictions_async(
     try:
         if new_memory is None:
             sc = get_storage_client()
-            new_memory = await sc.get_memory(str(memory_id))
+            new_memory = await sc.get_memory(str(memory_id), tenant_id)
         if not new_memory or new_memory.get("deleted_at") is not None:
             # Resolved before the lock is taken, so a gone row never holds one.
             return
@@ -1985,7 +1985,7 @@ async def _attempt_path_c_retraction(
     if not retraction_target_id:
         return False
 
-    candidate = await sc.get_memory(str(retraction_target_id))
+    candidate = await sc.get_memory(str(retraction_target_id), str(new_memory["tenant_id"]))
     if not candidate or candidate.get("deleted_at") is not None:
         return False
     # Only retract rows still in the conflicted state Path A produced.
@@ -2186,7 +2186,7 @@ async def detect_contradictions_by_entities_async(
         # work the lock protects, and fetching first also means a soft-deleted
         # row no longer burns a lock for the rest of the TTL.
         sc = get_storage_client()
-        new_memory = await sc.get_memory(str(memory_id))
+        new_memory = await sc.get_memory(str(memory_id), tenant_id)
         if not new_memory or new_memory.get("deleted_at") is not None:
             return
 
@@ -2217,7 +2217,7 @@ async def detect_contradictions_by_entities_async(
             n_retractions = 1
             # The new memory's ``supersedes_id`` was just cleared.
             # Re-fetch so the detection phase below sees the fresh state.
-            refreshed = await sc.get_memory(str(memory_id))
+            refreshed = await sc.get_memory(str(memory_id), tenant_id)
             if refreshed and refreshed.get("deleted_at") is None:
                 new_memory = refreshed
 

--- a/core-api/src/core_api/services/evolve_service.py
+++ b/core-api/src/core_api/services/evolve_service.py
@@ -459,7 +459,7 @@ async def _generate_rule(
     # originate from agent writes and can contain injection attempts.
     async def _fetch(mid_str: str) -> tuple[str, dict | None]:
         try:
-            return mid_str, await sc.get_memory_for_tenant(tenant_id, mid_str)
+            return mid_str, await sc.get_memory(mid_str, tenant_id)
         except Exception:
             logger.warning("evolve: fetch failed for memory %s", mid_str, exc_info=True)
             return mid_str, None

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2645,7 +2645,7 @@ async def _reembed_memory(
 
     try:
         sc = get_storage_client()
-        mem = await sc.get_memory(str(memory_id))
+        mem = await sc.get_memory(str(memory_id), tenant_id)
         if mem is None or mem.get("deleted_at") is not None:
             return
         # Race guard: _enrich_memory_background may have already written a
@@ -2823,7 +2823,7 @@ async def _reembed_memories_bulk(
     # storage p99 = 5s wall-clock before the first PATCH). gather with
     # return_exceptions=True so one failed read doesn't nuke the rest.
     mems = await asyncio.gather(
-        *[sc.get_memory(str(memory_id)) for (memory_id, _), _ in pairs],
+        *[sc.get_memory(str(memory_id), tenant_id) for (memory_id, _), _ in pairs],
         return_exceptions=True,
     )
 
@@ -3031,7 +3031,7 @@ async def _enrich_memory_background(
 
     try:
         sc = get_storage_client()
-        mem = await sc.get_memory(str(memory_id))
+        mem = await sc.get_memory(str(memory_id), tenant_id)
         if mem is None or mem.get("deleted_at") is not None:
             return None
 
@@ -3473,7 +3473,7 @@ async def _enrich_memory_background(
 
 async def soft_delete_memory(memory_id: UUID, tenant_id: str) -> None:
     sc = get_storage_client()
-    mem = await sc.get_memory_for_tenant(tenant_id, str(memory_id))
+    mem = await sc.get_memory(str(memory_id), tenant_id)
     if not mem:
         raise HTTPException(status_code=404, detail="Memory not found")
 
@@ -3503,7 +3503,7 @@ async def update_memory(
     from core_api.services.organization_settings import resolve_config
 
     sc = get_storage_client()
-    mem = await sc.get_memory_for_tenant(tenant_id, str(memory_id))
+    mem = await sc.get_memory(str(memory_id), tenant_id)
     if not mem:
         raise HTTPException(status_code=404, detail="Memory not found")
 
@@ -3783,7 +3783,7 @@ async def update_memory(
             logger.warning("Audit hook failed (non-critical)", exc_info=True)
 
     # Re-fetch updated memory
-    updated = await sc.get_memory(str(memory_id))
+    updated = await sc.get_memory(str(memory_id), tenant_id)
 
     # Post-commit async tasks for content changes
     if content_changed:

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1597,17 +1597,27 @@ async def get_memory_contradictions(memory_id: UUID, tenant_id: str) -> dict:
 
 
 @router.get("/{memory_id}")
-async def get_memory(memory_id: UUID, tenant_id: str | None = None) -> dict:
+async def get_memory(memory_id: UUID, tenant_id: str) -> dict:
+    """Fetch one memory by id, within ``tenant_id``.
+
+    ``tenant_id`` is a **required** query parameter. It used to default to
+    ``None``, and ``None`` meant "fetch by primary key with no tenant
+    predicate" — so a caller who knew a UUID got the row's full content
+    whichever tenant owned it, from a service that authenticates nothing. That
+    is GHSA-wgvw-28pq-jc36 in its single-row form; ``POST /memories/bulk-get``
+    was the batch one, and its optionality was justified in review as
+    "mirroring" this endpoint.
+
+    404 covers "no such memory" and "not yours" alike, so this does not become
+    an existence oracle for memory UUIDs.
+    """
     t_start = time.perf_counter()
     db_timer = None
     memory = None
     success = True
     try:
         with bind_timer() as db_timer:
-            if tenant_id is not None:
-                memory = await _svc.memory_get_by_id_for_tenant(memory_id, tenant_id)
-            else:
-                memory = await _svc.memory_get_by_id(memory_id)
+            memory = await _svc.memory_get_by_id_for_tenant(memory_id, tenant_id)
     except Exception:
         success = False
         raise

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -683,25 +683,35 @@ class PostgresService:
     # A) Core CRUD
     # ------------------------------------------------------------------
 
-    async def memory_get_by_id(self, memory_id: UUID) -> Memory | None:
-        # Wrap the full session block so db_ms includes connection-pool
-        # wait time — a saturated pool shows up as slow "DB" here, which
-        # is exactly how we want to see it in Cloud Logging.
-        with db_measure():
-            async with get_read_session() as session:
-                return await session.get(Memory, memory_id)
-
     async def memory_get_by_id_for_tenant(
         self,
         memory_id: UUID,
         tenant_id: str,
     ) -> Memory | None:
+        """Fetch one memory by id within one tenant, or None.
+
+        There was an unscoped sibling, ``memory_get_by_id``, that took an id
+        alone and returned whatever it matched. It is gone: it was the
+        single-row form of GHSA-wgvw-28pq-jc36's primitive, and the route above
+        reached it whenever ``tenant_id`` was omitted from the query string.
+
+        The predicate is in the statement rather than in Python after the fetch.
+        The previous version did ``session.get`` and then compared
+        ``memory.tenant_id != tenant_id`` — correct, but it let another tenant's
+        row cross the database boundary first, and the protection was a
+        comparison a later edit could drop with no test failing.
+        """
+        # Wrap the full session block so db_ms includes connection-pool
+        # wait time — a saturated pool shows up as slow "DB" here, which
+        # is exactly how we want to see it in Cloud Logging.
         with db_measure():
             async with get_read_session() as session:
-                memory = await session.get(Memory, memory_id)
-                if memory is None or memory.tenant_id != tenant_id or memory.deleted_at is not None:
-                    return None
-                return memory
+                stmt = select(Memory).where(
+                    Memory.id == memory_id,
+                    Memory.tenant_id == tenant_id,
+                    Memory.deleted_at.is_(None),
+                )
+                return (await session.execute(stmt)).scalar_one_or_none()
 
     @staticmethod
     def _filter_fields(model_cls, data: dict) -> dict:

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -147,7 +147,7 @@ class TestMemories:
         assert body["tenant_id"] == tenant_id
 
         # GET by id
-        resp2 = await client.get(f"{PREFIX}/memories/{memory_id}")
+        resp2 = await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})
         assert resp2.status_code == 200
         assert resp2.json()["id"] == memory_id
 
@@ -175,7 +175,9 @@ class TestMemories:
         assert created["is_inferred"] is True
         assert created["scope"] == {"role": "engineer", "location": "us"}
 
-        fetched = (await client.get(f"{PREFIX}/memories/{created['id']}")).json()
+        fetched = (
+            await client.get(f"{PREFIX}/memories/{created['id']}", params={"tenant_id": tenant_id})
+        ).json()
         assert fetched["confidence"] == 0.9
         assert fetched["is_inferred"] is True
         assert fetched["scope"] == {"role": "engineer", "location": "us"}
@@ -189,7 +191,9 @@ class TestMemories:
         """A write that omits the A55 fields gets the server defaults on read:
         ``confidence`` NULL, ``is_inferred`` false, ``scope`` ``{}``."""
         created = (await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))).json()
-        fetched = (await client.get(f"{PREFIX}/memories/{created['id']}")).json()
+        fetched = (
+            await client.get(f"{PREFIX}/memories/{created['id']}", params={"tenant_id": tenant_id})
+        ).json()
         assert fetched["confidence"] is None
         assert fetched["is_inferred"] is False
         assert fetched["scope"] == {}
@@ -270,7 +274,7 @@ class TestMemories:
         assert resp.json()["ok"] is True
 
         # Verify via GET
-        updated = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        updated = (await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})).json()
         assert updated["status"] == "archived"
 
     async def test_metadata_patch_jsonb_merge(
@@ -316,7 +320,7 @@ class TestMemories:
         )
         assert resp.status_code == 200, resp.text
 
-        updated = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        updated = (await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})).json()
         # Storage serialises the ORM attribute name verbatim, so the wire key
         # is ``metadata_`` (as the seed payload above already uses) — not the
         # ``metadata`` spelling core-api uses in its own internal field dicts.
@@ -365,7 +369,7 @@ class TestMemories:
         assert resp.status_code == 200, resp.text
         assert resp.json()["ok"] is True
 
-        updated = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        updated = (await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})).json()
         # Round-trips back as ISO strings on read; confirm the values
         # we sent landed at the right ORM columns.
         assert updated["ts_valid_start"].startswith("2026-09-14T00:00:00")
@@ -444,10 +448,23 @@ class TestMemories:
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
 
-        # Verify deleted_at is set
-        fetched = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
-        assert fetched["deleted_at"] is not None
-        assert fetched["status"] == "deleted"
+        # A soft-deleted row is gone as far as a tenant-scoped read is
+        # concerned. That was always true of the scoped path — this assertion
+        # used to reach the row only because the fetch went through the
+        # UNSCOPED one, which no longer exists.
+        fetched = await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})
+        assert fetched.status_code == 404, fetched.text
+
+        # The row is soft-deleted rather than gone: it still counts under an
+        # explicit include_deleted listing.
+        listed = await client.post(
+            f"{PREFIX}/memories/admin-list",
+            json={"tenant_id": tenant_id, "include_deleted": True},
+        )
+        assert listed.status_code == 200, listed.text
+        rows = {r["id"]: r for r in listed.json()}
+        assert memory_id in rows
+        assert rows[memory_id]["deleted_at"] is not None
 
     async def test_patch_after_delete_does_not_resurrect(
         self,
@@ -489,9 +506,20 @@ class TestMemories:
         )
         assert resp.status_code == 404, resp.text
 
-        # 3. Re-read: deleted_at is still set, status is still 'deleted',
-        # metadata is unchanged.
-        after = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        # 3. Re-read: still deleted, and the PATCH did not merge into it.
+        # Read through the include_deleted listing rather than the by-id GET —
+        # a tenant-scoped by-id read has always excluded soft-deleted rows, and
+        # this assertion previously reached one only via the UNSCOPED path,
+        # which no longer exists. The properties under test are unchanged.
+        assert (
+            await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})
+        ).status_code == 404
+        listed = await client.post(
+            f"{PREFIX}/memories/admin-list",
+            json={"tenant_id": tenant_id, "include_deleted": True},
+        )
+        assert listed.status_code == 200, listed.text
+        after = next(r for r in listed.json() if r["id"] == memory_id)
         assert after["deleted_at"] is not None
         assert after["status"] == "deleted"
         # ``metadata_``, not ``metadata`` — with the wrong key this assertion
@@ -712,7 +740,7 @@ class TestMemories:
         # ordering and prove nothing about the tie-break.
         stamps = set()
         for mid in inserted:
-            row = await client.get(f"{PREFIX}/memories/{mid}")
+            row = await client.get(f"{PREFIX}/memories/{mid}", params={"tenant_id": tenant_id})
             assert row.status_code == 200, row.text
             stamps.add(row.json()["created_at"])
         assert len(stamps) == 1, f"expected one shared created_at, got {stamps}"
@@ -822,9 +850,10 @@ class TestMemories:
     async def test_get_nonexistent_memory_returns_404(
         self,
         client: AsyncClient,
+        tenant_id: str,
     ) -> None:
         fake_id = str(uuid.uuid4())
-        resp = await client.get(f"{PREFIX}/memories/{fake_id}")
+        resp = await client.get(f"{PREFIX}/memories/{fake_id}", params={"tenant_id": tenant_id})
         assert resp.status_code == 404
 
     async def test_scored_search_rejects_a_payload_without_nested_search_params(

--- a/core-storage-api/tests/test_memory_get_tenant_scope.py
+++ b/core-storage-api/tests/test_memory_get_tenant_scope.py
@@ -1,0 +1,97 @@
+"""``GET /memories/{memory_id}`` must be told which tenant it is reading for.
+
+The single-row form of GHSA-wgvw-28pq-jc36. ``tenant_id`` was a query parameter
+defaulting to ``None``, and ``None`` meant "fetch by primary key with no tenant
+predicate" — so a caller who knew a UUID got the row's whole content, whichever
+tenant owned it, from a service that authenticates nothing.
+
+``POST /memories/bulk-get`` was the batch form of the same hole, and its own
+docstring justified being optional by "mirroring the single-row contract". This
+is that contract.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def _memory(client: AsyncClient, tenant_id: str, content: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "agent-a",
+            "content": content,
+            "memory_type": "fact",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+class TestMemoryGetTenantScope:
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """No tenant used to mean "any tenant"; it is now a 422 from FastAPI."""
+        tenant = f"get-{uuid.uuid4().hex[:8]}"
+        mem_id = await _memory(client, tenant, "a memory")
+
+        resp = await client.get(f"{PREFIX}/memories/{mem_id}")
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+
+    async def test_another_tenants_memory_is_not_readable(self, client: AsyncClient) -> None:
+        """The attack, stated as the request an attacker would send."""
+        victim = f"get-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"get-attacker-{uuid.uuid4().hex[:8]}"
+        victim_id = await _memory(client, victim, "victim's secret")
+
+        resp = await client.get(f"{PREFIX}/memories/{victim_id}", params={"tenant_id": attacker})
+
+        assert resp.status_code == 404, resp.text
+        assert "victim's secret" not in resp.text
+
+    async def test_a_foreign_id_is_indistinguishable_from_a_missing_one(self, client: AsyncClient) -> None:
+        """Both 404, so the endpoint is not an existence oracle for memory UUIDs."""
+        victim = f"get-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"get-attacker-{uuid.uuid4().hex[:8]}"
+        victim_id = await _memory(client, victim, "victim's secret")
+
+        foreign = await client.get(f"{PREFIX}/memories/{victim_id}", params={"tenant_id": attacker})
+        missing = await client.get(f"{PREFIX}/memories/{uuid.uuid4()}", params={"tenant_id": attacker})
+
+        assert foreign.status_code == missing.status_code == 404
+        assert foreign.json() == missing.json()
+
+    async def test_own_memory_is_returned(self, client: AsyncClient) -> None:
+        tenant = f"get-{uuid.uuid4().hex[:8]}"
+        mem_id = await _memory(client, tenant, "mine")
+
+        resp = await client.get(f"{PREFIX}/memories/{mem_id}", params={"tenant_id": tenant})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"] == mem_id
+        assert body["content"] == "mine"
+
+    async def test_a_soft_deleted_memory_is_not_returned(self, client: AsyncClient) -> None:
+        """Held by the same query now that the predicate moved into SQL.
+
+        The scoped read used to filter ``deleted_at`` in Python after the fetch;
+        this pins that the behaviour survived moving it into the statement.
+        """
+        tenant = f"get-{uuid.uuid4().hex[:8]}"
+        mem_id = await _memory(client, tenant, "doomed")
+
+        deleted = await client.delete(f"{PREFIX}/memories/{mem_id}", params={"tenant_id": tenant})
+        assert deleted.status_code == 200, deleted.text
+
+        resp = await client.get(f"{PREFIX}/memories/{mem_id}", params={"tenant_id": tenant})
+        assert resp.status_code == 404, resp.text

--- a/core-storage-api/tests/test_purge.py
+++ b/core-storage-api/tests/test_purge.py
@@ -51,7 +51,7 @@ class TestPurgeTenantData:
 
         # The memories are physically gone (not just soft-deleted).
         for memory_id in ids:
-            got = await client.get(f"{PREFIX}/memories/{memory_id}")
+            got = await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})
             assert got.status_code == 404
 
     async def test_purge_is_idempotent(self, client: AsyncClient) -> None:
@@ -72,7 +72,7 @@ class TestPurgeTenantData:
         await client.post(f"{PREFIX}/purge/tenant-data", json={"tenant_id": drop_tenant})
 
         # The other tenant's memory survives.
-        got = await client.get(f"{PREFIX}/memories/{keep['id']}")
+        got = await client.get(f"{PREFIX}/memories/{keep['id']}", params={"tenant_id": keep_tenant})
         assert got.status_code == 200
 
     async def test_purge_requires_tenant_id(self, client: AsyncClient) -> None:
@@ -147,10 +147,10 @@ class TestPurgeFleetData:
 
         # The purged fleet's memories are physically gone (not just soft-deleted).
         for memory_id in drop_ids:
-            got = await client.get(f"{PREFIX}/memories/{memory_id}")
+            got = await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})
             assert got.status_code == 404
         # The same tenant's OTHER fleet is untouched.
-        survivor = await client.get(f"{PREFIX}/memories/{keep['id']}")
+        survivor = await client.get(f"{PREFIX}/memories/{keep['id']}", params={"tenant_id": tenant_id})
         assert survivor.status_code == 200
 
     async def test_purge_fleet_is_idempotent(self, client: AsyncClient) -> None:
@@ -181,7 +181,7 @@ class TestPurgeFleetData:
             f"{PREFIX}/purge/fleet-data", json={"tenant_id": drop_tenant, "fleet_id": drop_fleet}
         )
 
-        got = await client.get(f"{PREFIX}/memories/{keep['id']}")
+        got = await client.get(f"{PREFIX}/memories/{keep['id']}", params={"tenant_id": keep_tenant})
         assert got.status_code == 200
 
     async def test_purge_fleet_requires_tenant_and_fleet(self, client: AsyncClient) -> None:

--- a/core-storage-api/tests/test_subject_writeback.py
+++ b/core-storage-api/tests/test_subject_writeback.py
@@ -78,7 +78,7 @@ class TestSubjectWriteback:
         assert resp.status_code == 200, resp.text
         assert resp.json() == {"updated": True}
 
-        row = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        row = (await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})).json()
         assert row["subject_entity_id"] == entity_id
 
     async def test_never_clobbers_an_existing_subject(
@@ -100,7 +100,7 @@ class TestSubjectWriteback:
         )
         assert r2.json() == {"updated": False}
 
-        row = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        row = (await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})).json()
         assert row["subject_entity_id"] == first
 
     async def test_foreign_tenant_matches_no_row(
@@ -116,5 +116,5 @@ class TestSubjectWriteback:
         assert resp.status_code == 200
         assert resp.json() == {"updated": False}
 
-        row = (await client.get(f"{PREFIX}/memories/{memory_id}")).json()
+        row = (await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})).json()
         assert row["subject_entity_id"] is None

--- a/tests/test_a10_evolve_rule_skipped_reason.py
+++ b/tests/test_a10_evolve_rule_skipped_reason.py
@@ -150,7 +150,7 @@ async def test_skip_reason_no_related_ids_on_partial_without_ids():
 
 @pytest.mark.asyncio
 async def test_skip_reason_no_memories_fetched_when_all_fetch_fail():
-    """All ``sc.get_memory_for_tenant`` calls failed → ``_generate_rule``
+    """All ``sc.get_memory`` calls failed → ``_generate_rule``
     returns ``None`` with reason."""
     result = await _run(
         "failure",

--- a/tests/test_a4_13_path_c_retraction.py
+++ b/tests/test_a4_13_path_c_retraction.py
@@ -113,7 +113,7 @@ def _mock_sc_with_retraction_setup(
         content="old statement that looked similar but is about subject Y",
     )
 
-    async def get_memory(mid: str) -> dict | None:
+    async def get_memory(mid: str, tenant_id: str, **_kw) -> dict | None:
         if mid == str(new_id):
             return new_mem
         if mid == str(cand_id):

--- a/tests/test_a4_status_retraction.py
+++ b/tests/test_a4_status_retraction.py
@@ -90,7 +90,7 @@ async def test_retraction_clears_supersedes_and_sets_status_active(sc):
     await _establish_conflicted(sc, conflicted=b, by=a)
 
     # Sanity: B is conflicted-by-A before retraction.
-    b_pre = await sc.get_memory(b["id"])
+    b_pre = await sc.get_memory(b["id"], TENANT_ID)
     assert b_pre["status"] == "conflicted"
     assert str(b_pre["supersedes_id"]) == str(a["id"])
 
@@ -105,7 +105,7 @@ async def test_retraction_clears_supersedes_and_sets_status_active(sc):
     assert result is not None  # PATCH succeeded
 
     # Assert: B is back to active and the supersedes pointer is cleared.
-    b_post = await sc.get_memory(b["id"])
+    b_post = await sc.get_memory(b["id"], TENANT_ID)
     assert b_post["status"] == "active", (
         f"Retraction must move status back to 'active'; got {b_post['status']!r}"
     )
@@ -147,7 +147,7 @@ async def test_retraction_rejects_when_supersedes_changed_under_us(sc):
     )
 
     # B unchanged.
-    b_post = await sc.get_memory(b["id"])
+    b_post = await sc.get_memory(b["id"], TENANT_ID)
     assert b_post["status"] == "conflicted"
     assert str(b_post["supersedes_id"]) == str(c["id"]), (
         f"Stale retraction must not touch the current supersedes_id; "
@@ -189,7 +189,7 @@ async def test_retraction_is_idempotent_on_already_cleared_row(sc):
     )
     assert result is not None
 
-    b_post = await sc.get_memory(b["id"])
+    b_post = await sc.get_memory(b["id"], TENANT_ID)
     assert b_post["status"] == "active"
     assert b_post["supersedes_id"] is None
 

--- a/tests/test_caura702_deprecated_memory_types.py
+++ b/tests/test_caura702_deprecated_memory_types.py
@@ -115,7 +115,7 @@ async def test_bulk_write_demotes_deprecated_semantic_to_fact():
     resp = await create_memories_bulk(req, bulk_attempt_id=uuid.uuid4().hex)
     assert resp.results[0].status == "created", resp.results[0]
 
-    mem = await get_storage_client().get_memory(resp.results[0].id)
+    mem = await get_storage_client().get_memory(resp.results[0].id, tenant)
     assert mem["memory_type"] == DEFAULT_MEMORY_TYPE  # "fact" — demoted from "semantic"
 
 
@@ -137,7 +137,7 @@ async def test_bulk_write_keeps_non_deprecated_type():
     resp = await create_memories_bulk(req, bulk_attempt_id=uuid.uuid4().hex)
     assert resp.results[0].status == "created", resp.results[0]
 
-    mem = await get_storage_client().get_memory(resp.results[0].id)
+    mem = await get_storage_client().get_memory(resp.results[0].id, tenant)
     assert mem["memory_type"] == "decision"
 
 
@@ -163,7 +163,7 @@ async def test_update_demotes_deprecated_semantic_to_fact():
     )
     assert updated.memory_type == DEFAULT_MEMORY_TYPE  # demoted from "semantic"
 
-    mem = await get_storage_client().get_memory(created.id)
+    mem = await get_storage_client().get_memory(created.id, tenant)
     assert mem["memory_type"] == DEFAULT_MEMORY_TYPE
 
 
@@ -187,5 +187,5 @@ async def test_update_semantic_on_fact_row_is_noop():
     )
     assert updated.memory_type == DEFAULT_MEMORY_TYPE  # unchanged — stays "fact"
 
-    mem = await get_storage_client().get_memory(created.id)
+    mem = await get_storage_client().get_memory(created.id, tenant)
     assert mem["memory_type"] == DEFAULT_MEMORY_TYPE

--- a/tests/test_caura717_new_deprecations.py
+++ b/tests/test_caura717_new_deprecations.py
@@ -172,7 +172,7 @@ async def test_bulk_write_demotes_new_deprecated_slug_to_default(slug: str) -> N
     resp = await create_memories_bulk(req, bulk_attempt_id=uuid.uuid4().hex)
     assert resp.results[0].status == "created", resp.results[0]
 
-    mem = await get_storage_client().get_memory(resp.results[0].id)
+    mem = await get_storage_client().get_memory(resp.results[0].id, tenant)
     assert mem["memory_type"] == DEFAULT_MEMORY_TYPE, (
         f"{slug!r} was stored verbatim instead of being demoted to "
         f"{DEFAULT_MEMORY_TYPE!r}"

--- a/tests/test_caura_130_path_c_safety.py
+++ b/tests/test_caura_130_path_c_safety.py
@@ -233,7 +233,7 @@ def _sc_for_forward_path(
     """
     sc = AsyncMock()
 
-    async def get_memory(mid: str):
+    async def get_memory(mid: str, tenant_id: str, **_kw):
         if mid == new_mem["id"]:
             return new_mem
         for c in candidates:

--- a/tests/test_caura_131_entity_aware_path_c_detection.py
+++ b/tests/test_caura_131_entity_aware_path_c_detection.py
@@ -75,7 +75,7 @@ def _sc(
 ) -> AsyncMock:
     sc = AsyncMock()
 
-    async def get_memory(mid: str):
+    async def get_memory(mid: str, tenant_id: str, **_kw):
         if mid == new_mem["id"]:
             return new_mem
         for c in candidates:

--- a/tests/test_consumer_enriched.py
+++ b/tests/test_consumer_enriched.py
@@ -104,7 +104,7 @@ async def test_handle_memory_enriched_invokes_contradiction_detection(
     # the worker PATCHes then publishes immediately, so a replica read races
     # replication and the miss ack-drops, killing one of only two
     # contradiction-detection triggers on the deferred path.
-    mock_storage_client.get_memory.assert_awaited_once_with(str(memory_id), read=False)
+    mock_storage_client.get_memory.assert_awaited_once_with(str(memory_id), "tenant-A", read=False)
     # ``new_memory`` is passed kwarg-only — threading the row through
     # eliminates the redundant second ``get_memory`` inside
     # ``detect_contradictions_async``.
@@ -337,7 +337,7 @@ async def test_embedded_handler_reads_the_writer_not_the_replica(
         _embedded_event(memory_id)
     )
 
-    mock_storage_client.get_memory.assert_awaited_once_with(str(memory_id), read=False)
+    mock_storage_client.get_memory.assert_awaited_once_with(str(memory_id), "tenant-A", read=False)
 
 
 @pytest.mark.asyncio

--- a/tests/test_contradiction_engine_golden.py
+++ b/tests/test_contradiction_engine_golden.py
@@ -181,7 +181,7 @@ def _sc_for_path_c(
     )
     sc = _base_sc()
 
-    async def get_memory(mid: str) -> dict | None:
+    async def get_memory(mid: str, tenant_id: str, **_kw) -> dict | None:
         return {NEW_ID: new_mem, CAND_ID: cand_mem}.get(mid)
 
     sc.get_memory = AsyncMock(side_effect=get_memory)

--- a/tests/test_dual_engine.py
+++ b/tests/test_dual_engine.py
@@ -48,7 +48,7 @@ async def test_read_engine_is_distinct_when_read_url_set():
 
 
 async def test_read_methods_use_read_session_factory(sc, tenant_id):
-    """Read methods (memory_get_by_id, memory_count_active, etc.) must
+    """Read methods (memory_get_by_id_for_tenant, memory_count_active, etc.) must
     consult the reader factory; spy both and assert the split."""
     import core_storage_api.services.postgres_service as pg_svc
 
@@ -74,7 +74,7 @@ async def test_read_methods_use_read_session_factory(sc, tenant_id):
     pg_svc._read_session_factory = _SpyFactory("reader", real_reader)  # type: ignore[assignment]
     try:
         svc = pg_svc.PostgresService()
-        await svc.memory_get_by_id(uuid4())
+        await svc.memory_get_by_id_for_tenant(uuid4(), tenant_id)
         await svc.memory_count_active(tenant_id=tenant_id)
     finally:
         pg_svc._session_factory = real_writer

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -455,7 +455,7 @@ async def test_bulk_reembed_preserves_batching() -> None:
 
     sc = MagicMock()
     sc.get_memory = AsyncMock(
-        side_effect=lambda mid: {"id": mid, "deleted_at": None, "fleet_id": "f"}
+        side_effect=lambda mid, tenant_id, **_kw: {"id": mid, "deleted_at": None, "fleet_id": "f"}
     )
     sc.update_embedding = AsyncMock()
 
@@ -767,7 +767,7 @@ async def test_bulk_reembed_reschedules_items_whose_get_memory_failed() -> None:
     mem_a_id = uuid.uuid4()
     mem_b_id = uuid.uuid4()
 
-    async def _get_memory(mid: str):
+    async def _get_memory(mid: str, tenant_id: str, **_kw):
         if mid == str(mem_a_id):
             raise RuntimeError("storage transient error for item A")
         return {"id": mid, "deleted_at": None, "fleet_id": "f", "embedding": None}
@@ -839,7 +839,7 @@ async def test_bulk_reembed_patch_failure_reschedules_item() -> None:
     mem_a_id = uuid.uuid4()
     mem_b_id = uuid.uuid4()
 
-    async def _get_memory(mid: str):
+    async def _get_memory(mid: str, tenant_id: str, **_kw):
         return {"id": mid, "deleted_at": None, "fleet_id": "f", "embedding": None}
 
     # Accepts ``embedded_content_hash``: the re-embed paths now record which
@@ -912,7 +912,7 @@ async def test_bulk_reembed_respects_existing_embedding_per_item() -> None:
     mem_a_id = uuid.uuid4()
     mem_b_id = uuid.uuid4()
 
-    def _get_memory(mid: str):
+    def _get_memory(mid: str, tenant_id: str, **_kw):
         if mid == str(mem_a_id):
             return {
                 "id": mid,

--- a/tests/test_enrich_agent_provided_fields.py
+++ b/tests/test_enrich_agent_provided_fields.py
@@ -59,7 +59,7 @@ def _enrichment(**over):
 
 
 def _row(**over):
-    """A stored row as ``get_memory_for_tenant`` returns it — all defaults."""
+    """A stored row as ``get_memory`` returns it — all defaults."""
     base = dict(
         id=str(uuid.uuid4()),
         memory_type="fact",  # schema default

--- a/tests/test_governance_e2e.py
+++ b/tests/test_governance_e2e.py
@@ -396,7 +396,7 @@ async def test_bulk_mask_redacts_stored_item():
     resp = await create_memories_bulk(_bulk(tenant, [dirty]), bulk_attempt_id=uuid.uuid4().hex
     )
     assert resp.results[0].status == "created"
-    mem = await get_storage_client().get_memory(resp.results[0].id)
+    mem = await get_storage_client().get_memory(resp.results[0].id, tenant)
     assert "jane.roe@example.com" not in mem["content"]  # stored masked
     rows = await _governance_audit_rows(tenant)
     assert any(
@@ -411,7 +411,7 @@ async def test_bulk_flag_marks_stored_metadata():
     resp = await create_memories_bulk(_bulk(tenant, [dirty]), bulk_attempt_id=uuid.uuid4().hex
     )
     assert resp.results[0].status == "created"
-    mem = await get_storage_client().get_memory(resp.results[0].id)
+    mem = await get_storage_client().get_memory(resp.results[0].id, tenant)
     md = mem.get("metadata_") or mem.get("metadata") or {}
     assert md.get("contains_pii") is True
     assert "jane.roe@example.com" in mem["content"]  # flag does not redact

--- a/tests/test_mcp_manage.py
+++ b/tests/test_mcp_manage.py
@@ -32,7 +32,7 @@ VALID_UID = str(uuid4())
 
 
 def _memory_dict(status="active", agent_id="alice", content="hello"):
-    """Storage-client memory row (Fix 2 Phase 4: ``sc.get_memory_for_tenant``
+    """Storage-client memory row (Fix 2 Phase 4: ``sc.get_memory``
     returns a plain dict, not an ORM row). ``caura_manage`` reads it via
     ``.get(...)`` so all the fields the read/transition shaping touches are
     present as dict keys."""
@@ -82,14 +82,14 @@ async def test_manage_invalid_uuid_errors(mcp_env):
 
 
 async def test_manage_read_not_found(mcp_env, monkeypatch):
-    stub_storage_client(monkeypatch, get_memory_for_tenant=None)
+    stub_storage_client(monkeypatch, get_memory=None)
     out = await mcp_server.caura_manage(op="read", memory_id=VALID_UID)
     assert "Memory not found" in strip_latency(out)
 
 
 async def test_manage_read_happy_path(mcp_env, monkeypatch):
     memory = _memory_dict()
-    stub_storage_client(monkeypatch, get_memory_for_tenant=memory)
+    stub_storage_client(monkeypatch, get_memory=memory)
     monkeypatch.setattr(mcp_server, "authorize_memory_access", _async_return(True))
     out = await mcp_server.caura_manage(op="read", memory_id=VALID_UID)
     payload = parse_envelope(out)
@@ -113,7 +113,7 @@ async def test_manage_transition_invalid_status_errors(mcp_env):
 
 
 async def test_manage_transition_not_found(mcp_env, monkeypatch):
-    stub_storage_client(monkeypatch, get_memory_for_tenant=None)
+    stub_storage_client(monkeypatch, get_memory=None)
     out = await mcp_server.caura_manage(
         op="transition", memory_id=VALID_UID, status="archived"
     )
@@ -124,7 +124,7 @@ async def test_manage_transition_happy_path(mcp_env, monkeypatch):
     memory = _memory_dict(status="active")
     sc = stub_storage_client(
         monkeypatch,
-        get_memory_for_tenant=memory,
+        get_memory=memory,
         update_memory_status=None,
     )
     monkeypatch.setattr(mcp_server, "authorize_memory_access", _async_return(True))

--- a/tests/test_memory_byid_authz.py
+++ b/tests/test_memory_byid_authz.py
@@ -125,7 +125,7 @@ async def test_unknown_agent_allowed(patch_lookup):
 
 def _fake_read_row(*, visibility, agent_id, fleet_id):
     # Fix 2 Phase 4: ``caura_manage`` op=read fetches via the storage client
-    # (``sc.get_memory_for_tenant``), which returns a plain dict — not an ORM
+    # (``sc.get_memory``), which returns a plain dict — not an ORM
     # row. The authz contract under test (``authorize_memory_access`` over the
     # row's visibility / owner / fleet) is unchanged; only the row SHAPE is.
     mid = uuid.uuid4()
@@ -155,7 +155,7 @@ async def _mcp_read(mcp_env, monkeypatch, *, caller, row):
     # Stub the storage client's by-id read; the real ``authorize_memory_access``
     # then runs over the returned row (``lookup_agent`` is controlled by
     # ``patch_lookup``), exactly as the pre-migration test exercised it.
-    stub_storage_client(monkeypatch, get_memory_for_tenant=mem)
+    stub_storage_client(monkeypatch, get_memory=mem)
     monkeypatch.setattr(mcp_server, "_get_agent_id", lambda: caller)
     return await mcp_server.caura_manage(op="read", memory_id=str(mid))
 

--- a/tests/test_memory_storage_phase2.py
+++ b/tests/test_memory_storage_phase2.py
@@ -250,8 +250,8 @@ async def test_soft_delete_by_ids(sc):
     # Re-deleting already-deleted rows is a no-op (deleted_at filter).
     assert await sc.soft_delete_by_ids(tid, [a["id"], b["id"]]) == 0
     # The untouched row is still live.
-    assert await sc.get_memory_for_tenant(tid, c["id"]) is not None
-    assert await sc.get_memory_for_tenant(tid, a["id"]) is None
+    assert await sc.get_memory(c["id"], tid) is not None
+    assert await sc.get_memory(a["id"], tid) is None
 
 
 async def test_soft_delete_by_ids_tenant_scoped(sc):
@@ -259,7 +259,7 @@ async def test_soft_delete_by_ids_tenant_scoped(sc):
     mem = await _write_memory(sc, tid_a)
     # Deleting under the wrong tenant matches nothing.
     assert await sc.soft_delete_by_ids(tid_b, [mem["id"]]) == 0
-    assert await sc.get_memory_for_tenant(tid_a, mem["id"]) is not None
+    assert await sc.get_memory(mem["id"], tid_a) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -276,8 +276,8 @@ async def test_soft_delete_by_filter_metadata_exact_match(sc):
         {"tenant_id": tid, "metadata_filter": {"run": "r2"}}
     )
     assert deleted == 1
-    assert await sc.get_memory_for_tenant(tid, drop["id"]) is None
-    assert await sc.get_memory_for_tenant(tid, keep["id"]) is not None
+    assert await sc.get_memory(drop["id"], tid) is None
+    assert await sc.get_memory(keep["id"], tid) is not None
 
 
 async def test_soft_delete_by_filter_multi_pair_and_semantics(sc):
@@ -292,8 +292,8 @@ async def test_soft_delete_by_filter_multi_pair_and_semantics(sc):
         {"tenant_id": tid, "metadata_filter": {"k1": "v1", "k2": "v2"}}
     )
     assert deleted == 1
-    assert await sc.get_memory_for_tenant(tid, match["id"]) is None
-    assert await sc.get_memory_for_tenant(tid, partial["id"]) is not None
+    assert await sc.get_memory(match["id"], tid) is None
+    assert await sc.get_memory(partial["id"], tid) is not None
 
 
 async def test_soft_delete_by_filter_exclude_ids(sc):
@@ -305,8 +305,8 @@ async def test_soft_delete_by_filter_exclude_ids(sc):
         {"tenant_id": tid, "agent_id": "ag", "exclude_ids": [a["id"]]}
     )
     assert deleted == 1
-    assert await sc.get_memory_for_tenant(tid, a["id"]) is not None
-    assert await sc.get_memory_for_tenant(tid, b["id"]) is None
+    assert await sc.get_memory(a["id"], tid) is not None
+    assert await sc.get_memory(b["id"], tid) is None
 
 
 # ---------------------------------------------------------------------------
@@ -326,9 +326,9 @@ async def test_soft_delete_by_run_requires_ingest_source(sc):
 
     deleted = await sc.soft_delete_by_run(tid, run, metadata_source="ingest")
     assert deleted == 1
-    assert await sc.get_memory_for_tenant(tid, ingest["id"]) is None
+    assert await sc.get_memory(ingest["id"], tid) is None
     # Same run_id but non-ingest source is untouched (belt-and-braces).
-    assert await sc.get_memory_for_tenant(tid, other["id"]) is not None
+    assert await sc.get_memory(other["id"], tid) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -355,11 +355,11 @@ async def test_redistribute_moves_promotes_skips_and_reports_not_found(sc):
     assert outcome["not_found"] == [ghost]
 
     # The scope_agent row was promoted and reassigned.
-    moved_private = await sc.get_memory_for_tenant(tid, private["id"])
+    moved_private = await sc.get_memory(private["id"], tid)
     assert moved_private["agent_id"] == "target"
     assert moved_private["visibility"] == "scope_team"
     # The scope_team row kept its visibility.
-    moved_team = await sc.get_memory_for_tenant(tid, team["id"])
+    moved_team = await sc.get_memory(team["id"], tid)
     assert moved_team["agent_id"] == "target"
     assert moved_team["visibility"] == "scope_team"
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -135,7 +135,7 @@ async def test_end_to_end_memory_get_404_emits_log_line(
     from uuid import uuid4
 
     caplog.set_level(logging.INFO, logger="caura.observability")
-    result = await sc.get_memory(uuid4())
+    result = await sc.get_memory(uuid4(), "t1")
     assert result is None
 
     obs_records = [r for r in caplog.records if r.name == "caura.observability"]

--- a/tests/test_p1_contradiction.py
+++ b/tests/test_p1_contradiction.py
@@ -534,7 +534,7 @@ class TestContradictionIntegration:
         assert str(contradictions[0].old_memory_id) == old["id"]
         assert contradictions[0].reason == "rdf_conflict"
         # Verify old memory was marked outdated via re-fetch
-        refreshed_old = await sc.get_memory(old["id"])
+        refreshed_old = await sc.get_memory(old["id"], tenant_id)
         assert refreshed_old["status"] == "outdated"
 
     async def test_semantic_contradiction_with_fake_llm(self, tenant_id):

--- a/tests/test_p5_crystallizer.py
+++ b/tests/test_p5_crystallizer.py
@@ -263,7 +263,7 @@ class TestBatchANNIntegration:
         await _check_near_duplicates(tenant_id, fleet_id)
 
         sc = get_storage_client()
-        refreshed = await sc.get_memory(mem["id"])
+        refreshed = await sc.get_memory(mem["id"], tenant_id)
         assert refreshed["last_dedup_checked_at"] is not None, (
             "last_dedup_checked_at should be set after processing"
         )

--- a/tests/test_ph4_status_tenant_guard.py
+++ b/tests/test_ph4_status_tenant_guard.py
@@ -104,13 +104,13 @@ async def test_route_status_update_cross_tenant_finds_no_row(sc):
     # Wrong tenant: guarded out → 404 → None, and the row is untouched.
     result = await sc.update_memory_status(mid, "archived", tenant_id=tenant_b)
     assert result is None
-    untouched = await sc.get_memory(mid)
+    untouched = await sc.get_memory(mid, tenant_a)
     assert untouched["status"] == "active"
 
     # Correct tenant succeeds.
     result = await sc.update_memory_status(mid, "archived", tenant_id=tenant_a)
     assert result is not None
-    post = await sc.get_memory(mid)
+    post = await sc.get_memory(mid, tenant_a)
     assert post["status"] == "archived"
 
 

--- a/tests/test_role_flag.py
+++ b/tests/test_role_flag.py
@@ -81,7 +81,7 @@ async def test_reader_allows_get(client_for_role) -> None:
     """GET /memories/{id} must reach the handler on reader — the handler
     then returns 404 (memory doesn't exist), not 405."""
     c = await client_for_role("reader")
-    r = await c.get(f"/api/v1/storage/memories/{uuid4()}")
+    r = await c.get(f"/api/v1/storage/memories/{uuid4()}", params={"tenant_id": "t1"})
     assert r.status_code == 404
 
 

--- a/tests/test_storage_bulk_endpoints.py
+++ b/tests/test_storage_bulk_endpoints.py
@@ -70,8 +70,8 @@ async def test_batch_update_status_backward_compat_2field_shape(sc):
     assert result["ok"] is True
     assert result["skipped"] == []
 
-    a_post = await sc.get_memory(a["id"])
-    b_post = await sc.get_memory(b["id"])
+    a_post = await sc.get_memory(a["id"], tid)
+    b_post = await sc.get_memory(b["id"], tid)
     assert a_post["status"] == "archived"
     assert b_post["status"] == "conflicted"
 
@@ -97,7 +97,7 @@ async def test_batch_update_status_sets_supersedes(sc):
     assert result["ok"] is True
     assert result["skipped"] == []
 
-    newer_post = await sc.get_memory(newer["id"])
+    newer_post = await sc.get_memory(newer["id"], tid)
     assert newer_post["status"] == "active"
     assert str(newer_post["supersedes_id"]) == str(older["id"])
 
@@ -126,7 +126,7 @@ async def test_batch_update_status_unset_supersedes(sc):
     )
     assert result["ok"] is True
 
-    newer_post = await sc.get_memory(newer["id"])
+    newer_post = await sc.get_memory(newer["id"], tid)
     assert newer_post["supersedes_id"] is None
 
 
@@ -158,7 +158,7 @@ async def test_batch_update_status_cas_skip_on_mismatch(sc):
     )
     # CAS gate fires: row reported as skipped, status untouched.
     assert newer["id"] in result["skipped"]
-    newer_post = await sc.get_memory(newer["id"])
+    newer_post = await sc.get_memory(newer["id"], tid)
     assert newer_post["status"] == "conflicted"
     assert str(newer_post["supersedes_id"]) == str(other["id"])
 
@@ -761,7 +761,7 @@ async def test_batch_update_status_partial_validation_failure_writes_nothing(sc)
     assert exc.value.response.status_code == 422
 
     # Critical: the valid row in position 0 must NOT have been committed.
-    post = await sc.get_memory(target["id"])
+    post = await sc.get_memory(target["id"], tid)
     assert post["status"] == original_status, (
         "validation pre-pass failed: status was committed before the "
         f"batch was rejected (expected {original_status!r}, got {post['status']!r})"

--- a/tests/test_storage_client_routing.py
+++ b/tests/test_storage_client_routing.py
@@ -63,7 +63,7 @@ async def test_get_goes_to_reader_when_read_url_set() -> None:
     client, writer, reader = await _fresh_client(
         writer_url="http://writer:8002", reader_url="http://reader:8002"
     )
-    await client.get_memory("11111111-1111-1111-1111-111111111111")
+    await client.get_memory("11111111-1111-1111-1111-111111111111", "t1")
     assert len(reader.requests) == 1
     assert len(writer.requests) == 0
     assert reader.requests[0].url.host == "reader"
@@ -269,7 +269,7 @@ async def test_authorization_header_attached_on_reader_calls() -> None:
         client, writer, reader = await _fresh_client(
             writer_url="https://writer:8002", reader_url="https://reader:8002"
         )
-        await client.get_memory("11111111-1111-1111-1111-111111111111")
+        await client.get_memory("11111111-1111-1111-1111-111111111111", "t1")
     assert reader.requests[0].headers["Authorization"] == "Bearer tok-reader"
     assert reader.requests[0].headers["X-Storage-Secret"] == "test-storage-secret"
 
@@ -320,7 +320,7 @@ async def test_http_audience_skips_token_fetch() -> None:
         client, writer, reader = await _fresh_client(
             writer_url="http://writer:8002", reader_url="http://reader:8002"
         )
-        await client.get_memory("11111111-1111-1111-1111-111111111111")
+        await client.get_memory("11111111-1111-1111-1111-111111111111", "t1")
     assert "Authorization" not in reader.requests[0].headers
     assert reader.requests[0].headers["X-Storage-Secret"] == "test-storage-secret"
 
@@ -334,7 +334,7 @@ async def test_no_authorization_header_when_no_credentials() -> None:
         client, writer, reader = await _fresh_client(
             writer_url="http://writer:8002", reader_url="http://reader:8002"
         )
-        await client.get_memory("11111111-1111-1111-1111-111111111111")
+        await client.get_memory("11111111-1111-1111-1111-111111111111", "t1")
     assert "Authorization" not in reader.requests[0].headers
     assert reader.requests[0].headers["X-Storage-Secret"] == "test-storage-secret"
 

--- a/tests/test_tenant_guard_byid_updates.py
+++ b/tests/test_tenant_guard_byid_updates.py
@@ -61,12 +61,12 @@ async def test_memory_update_wrong_tenant_is_noop(sc):
 
     applied = await svc.memory_update(mem_id, _t(), {"weight": 0.99})
     assert applied is False, "wrong-tenant update matches no row"
-    row = await svc.memory_get_by_id(mem_id)
+    row = await svc.memory_get_by_id_for_tenant(mem_id, owner)
     assert row is not None and row.weight == 0.5, "weight untouched by wrong tenant"
 
     applied_owner = await svc.memory_update(mem_id, owner, {"weight": 0.99})
     assert applied_owner is True
-    assert (await svc.memory_get_by_id(mem_id)).weight == 0.99
+    assert (await svc.memory_get_by_id_for_tenant(mem_id, owner)).weight == 0.99
 
 
 async def test_memory_update_metadata_patch_wrong_tenant_is_noop(sc):
@@ -75,12 +75,12 @@ async def test_memory_update_metadata_patch_wrong_tenant_is_noop(sc):
     mem_id = UUID(await _seed_memory(sc, owner, metadata={"k": "orig"}))
 
     await svc.memory_update(mem_id, _t(), {"metadata_patch": {"k": "hacked"}})
-    assert (await svc.memory_get_by_id(mem_id)).metadata_ == {"k": "orig"}, (
+    assert (await svc.memory_get_by_id_for_tenant(mem_id, owner)).metadata_ == {"k": "orig"}, (
         "metadata merge blocked for wrong tenant"
     )
 
     await svc.memory_update(mem_id, owner, {"metadata_patch": {"k": "new", "added": 1}})
-    assert (await svc.memory_get_by_id(mem_id)).metadata_ == {"k": "new", "added": 1}
+    assert (await svc.memory_get_by_id_for_tenant(mem_id, owner)).metadata_ == {"k": "new", "added": 1}
 
 
 async def test_update_memory_route_wrong_tenant_returns_none(sc):
@@ -90,11 +90,11 @@ async def test_update_memory_route_wrong_tenant_returns_none(sc):
 
     result = await sc.update_memory(mem_id, _t(), {"weight": 0.42})
     assert result is None, "wrong-tenant PATCH 404s -> client returns None"
-    assert (await PostgresService().memory_get_by_id(UUID(mem_id))).weight == 0.5
+    assert (await PostgresService().memory_get_by_id_for_tenant(UUID(mem_id), owner)).weight == 0.5
 
     ok = await sc.update_memory(mem_id, owner, {"weight": 0.42})
     assert ok == {"ok": True}
-    assert (await PostgresService().memory_get_by_id(UUID(mem_id))).weight == 0.42
+    assert (await PostgresService().memory_get_by_id_for_tenant(UUID(mem_id), owner)).weight == 0.42
 
 
 async def test_update_memory_route_requires_tenant(sc):
@@ -115,18 +115,18 @@ async def test_update_embedding_wrong_tenant_is_noop(sc):
     svc = PostgresService()
     owner = _t()
     mem_id = await _seed_memory(sc, owner)  # seeded without an embedding
-    assert (await svc.memory_get_by_id(UUID(mem_id))).embedding is None
+    assert (await svc.memory_get_by_id_for_tenant(UUID(mem_id), owner)).embedding is None
 
     # Wrong tenant matches no row -> route 404 -> client returns None, no write.
     wrong = await sc.update_embedding(mem_id, _t(), fake_embedding("vector"))
     assert wrong is None, "wrong-tenant embedding write 404s -> client None"
-    assert (await svc.memory_get_by_id(UUID(mem_id))).embedding is None, (
+    assert (await svc.memory_get_by_id_for_tenant(UUID(mem_id), owner)).embedding is None, (
         "wrong tenant must not write the embedding"
     )
 
     ok = await sc.update_embedding(mem_id, owner, fake_embedding("vector"))
     assert ok == {"ok": True}
-    assert (await svc.memory_get_by_id(UUID(mem_id))).embedding is not None
+    assert (await svc.memory_get_by_id_for_tenant(UUID(mem_id), owner)).embedding is not None
 
 
 async def test_update_embedding_requires_tenant(sc):
@@ -145,15 +145,15 @@ async def test_mark_dedup_checked_wrong_tenant_is_noop(sc):
     svc = PostgresService()
     owner = _t()
     mem_id = await _seed_memory(sc, owner)
-    assert (await svc.memory_get_by_id(UUID(mem_id))).last_dedup_checked_at is None
+    assert (await svc.memory_get_by_id_for_tenant(UUID(mem_id), owner)).last_dedup_checked_at is None
 
     await sc.mark_dedup_checked([mem_id], _t())
-    assert (await svc.memory_get_by_id(UUID(mem_id))).last_dedup_checked_at is None, (
+    assert (await svc.memory_get_by_id_for_tenant(UUID(mem_id), owner)).last_dedup_checked_at is None, (
         "wrong tenant must not stamp last_dedup_checked_at"
     )
 
     await sc.mark_dedup_checked([mem_id], owner)
-    assert (await svc.memory_get_by_id(UUID(mem_id))).last_dedup_checked_at is not None
+    assert (await svc.memory_get_by_id_for_tenant(UUID(mem_id), owner)).last_dedup_checked_at is not None
 
 
 async def test_mark_dedup_checked_requires_tenant(sc):

--- a/tests/test_update_memory_embedding.py
+++ b/tests/test_update_memory_embedding.py
@@ -68,7 +68,7 @@ async def test_content_change_with_failed_embedding_nulls_the_vector(
     assert resp.status_code == 200, resp.text
 
     # The content change must have landed...
-    got = await get_storage_client().get_memory_for_tenant(tenant_id, memory_id)
+    got = await get_storage_client().get_memory(memory_id, tenant_id)
     assert got is not None
     assert got["content"] == f"REPLACED content {tag}"
 


### PR DESCRIPTION
The single-row form of **GHSA-wgvw-28pq-jc36** — and the contract #1074's `bulk-get` optionality was justified by *"mirroring"*. Raised as a Critical on that PR's review; declined there because it is a much larger change, and promised as this one. Follows #1067 and #1074.

## What was wrong

```python
@router.get("/{memory_id}")
async def get_memory(memory_id: UUID, tenant_id: str | None = None) -> dict:
    if tenant_id is not None:
        memory = await _svc.memory_get_by_id_for_tenant(memory_id, tenant_id)
    else:
        memory = await _svc.memory_get_by_id(memory_id)   # bare session.get, no predicate
```

Omit the query parameter and you got the row's whole content, whichever tenant owned it.

## Why this took a whole PR

The client had **two** methods, and the unsafe one was the shorter name:

| | call sites | passing a tenant |
|---|---|---|
| `get_memory(memory_id)` | 11 | **1** |
| `get_memory_for_tenant(tenant_id, memory_id)` | 10 | 10 |

Ten of eleven callers of the unscoped method omitted the tenant. Not because anyone decided to — the argument simply wasn't there to forget. So this deletes the choice: there is now **one** method, `get_memory(memory_id, tenant_id, *, read=True)`, and the unscoped call cannot be written.

**Keeping the name and requiring the argument** — rather than keeping `get_memory_for_tenant` and deleting `get_memory` — was deliberate. The latter reads better in isolation, but `get_memory` is mocked *by name* in 31 test files; renaming it churns all of them, while requiring an argument leaves 54 plain attribute mocks untouched. The `_for_tenant` qualifier only ever existed to distinguish it from the unsafe sibling; with that gone it is noise. I tried it the other way first and measured.

Storage side: `memory_get_by_id` is deleted, and `memory_get_by_id_for_tenant` now filters **in SQL** rather than fetching by primary key and comparing `memory.tenant_id != tenant_id` in Python afterwards — same change #1074 made to `bulk-get`. A foreign row is never selected.

404 still covers "no such memory" and "not yours" alike, so this is not an existence oracle for memory UUIDs.

## Two behaviour changes worth reviewing

**`/testing/set-field`** fetched the row unscoped and compared tenants in Python to raise 403. It now scopes the fetch, so a foreign id is a **404** — one less oracle. Admin credentials (no tenant) still get 403; `memories.tenant_id` is NOT NULL and could never equal `None`, so they were rejected before too.

**A soft-deleted row is now absent from a by-id read.** That was *always* true of the scoped path — two integration tests reached one only because they went through the unscoped path. They now assert the 404 and read `deleted_at` from the `include_deleted` listing, which tests the same two properties (the row is soft-deleted, and a PATCH did not resurrect it).

## Tests

Five new; **one fails on the parent** (the omitted tenant — the vulnerability). The other four pin the contract: a foreign id reads as absent, is indistinguishable from a missing one, own rows return, and soft-deleted rows do not.

The wider churn is the interesting part. The first full run after the signature change gave **104 failures** — call sites and mock signatures that had been passing no tenant. Each was a place the old signature let a caller skip the scope, and every one now names its tenant. That number is the honest measure of what "optional" cost.

Verified after rebasing onto `d6fd10b9` (which includes #1066's storage authentication — no overlap with this change): 199 core-storage-api tests, 5550 root tests, `ruff check` / `ruff format --check` and `mypy src/` for both packages at CI's scopes, broker OpenAPI baseline current. `uv.lock` unchanged.

## Effect on #1069

Removes two more rows from the tenancy-gate allowlist — `route:GET /api/v1/storage/memories/{memory_id}` and `method:memory_get_by_id`, both `id-addressed`. That gate fails on stale rows until they are regenerated, so the shrink is enforced rather than remembered; it will be the fourth.