### PR TITLE
fix(crystallizer): Type-II precision gates — 10% -> 80% on the same corpus (A59)

### DIFF
--- a/core-api/src/core_api/services/type_ii_materializer.py
+++ b/core-api/src/core_api/services/type_ii_materializer.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 from typing import Any
 
 from core_api.config import settings
@@ -59,6 +60,20 @@ MAX_SAMPLES = 20
 
 _LIVE_STATUSES = {"active", "confirmed"}
 
+# Rows that are raw conversation turns rather than distilled state claims.
+# Measured 2026-08-30: 9 of 13 accepted proposals in the first real sweep came
+# from consecutive dialogue turns, where "an earlier state and a later one" is
+# just the topic moving on. ``memory_type`` does NOT separate these — the false
+# positives were typed ``fact``/``preference`` exactly like the true ones — but
+# the content shape does. A turn is not a claim about the subject's current
+# state, so it can neither be a stale default nor evidence that one broke.
+_TURN_PREFIXES = ("user:", "assistant:", "system:", "human:", "ai:")
+# Jaccard overlap above which a "replacement" is really a restatement of the
+# stale claim. The dangerous failure mode: proposing "based in Seattle" as the
+# successor to "based in Seattle" after evidence of a move would enshrine the
+# error with a fresh timestamp — strictly worse than leaving the row alone.
+MAX_RESTATEMENT_OVERLAP = 0.6
+
 TYPE_II_PROMPT = """\
 Below are memories about ONE subject, oldest first, each with an id and date.
 
@@ -78,10 +93,13 @@ NOT stale: a fact that is merely older, merely related, or about a different \
 aspect that still holds. Most subjects have NOTHING stale — an empty list is \
 the common, correct answer.
 
-For each stale default, write the replacement the store should hold instead: \
-state what IS currently true, in the vocabulary of the stale memory, so a \
-question phrased like the stale memory still finds it. If the replacement \
-value is unknown, say so explicitly rather than inventing one.
+For each stale default, write the replacement the store should hold instead. \
+The replacement MUST say what is NO LONGER true, in the vocabulary of the stale \
+memory, so a question phrased like the stale memory still finds it. Never simply \
+restate the stale claim, and never assert the stale claim and the new evidence \
+together as if both still govern — deciding between them is the whole point. If \
+the value that replaces it is unknown, say the old one no longer holds and that \
+the current value is unknown, rather than inventing one.
 
 Return JSON only:
 {{"stale": [{{"stale_memory_id": "<id from the list>", \
@@ -102,6 +120,22 @@ def _parse_json(raw: Any) -> dict:
 
 def _created(m: dict) -> str:
     return str(m.get("created_at") or "")
+
+
+def is_transcript_turn(content: str) -> bool:
+    return (content or "").lstrip().lower().startswith(_TURN_PREFIXES)
+
+
+def _tokens(text: str) -> set[str]:
+    return {w for w in re.findall(r"[a-z0-9']+", (text or "").lower()) if len(w) > 3}
+
+
+def restates(replacement: str, stale: str) -> bool:
+    """True when the proposed replacement mostly repeats the stale claim."""
+    a, b = _tokens(replacement), _tokens(stale)
+    if not a or not b:
+        return False
+    return len(a & b) / len(a | b) >= MAX_RESTATEMENT_OVERLAP
 
 
 def proposal_key(subject_id: str, stale_id: str) -> str:
@@ -130,6 +164,8 @@ def group_subjects(memories: list[dict]) -> dict[str, list[dict]]:
         if (m.get("status") or "active") not in _LIVE_STATUSES:
             continue
         if m.get("deleted_at"):
+            continue
+        if is_transcript_turn(m.get("content") or ""):
             continue
         bundles.setdefault(str(subject), []).append(m)
     for subject, rows in bundles.items():
@@ -184,6 +220,10 @@ def validate_proposal(p: dict, subject_id: str, rows: list[dict]) -> tuple[dict 
     if confidence < MIN_CONFIDENCE:
         return None, "below_confidence_floor"
     stale_row = by_id[stale_id]
+    if restates(replacement, stale_row.get("content") or ""):
+        # Measured failure mode: the model returns the stale claim (or the
+        # stale claim merged with the new evidence) as its own successor.
+        return None, "replacement_restates_stale"
     return (
         {
             "key": proposal_key(subject_id, stale_id),

--- a/tests/test_a59_type_ii_materializer.py
+++ b/tests/test_a59_type_ii_materializer.py
@@ -186,3 +186,81 @@ def test_flag_defaults_off_and_phase_is_wired():
     # nested under hygiene on purpose: analysis_reports has fixed columns, so
     # a new top-level report key never reaches storage or the API
     assert 'hygiene["type_ii_staleness"] = type_ii' in src
+
+
+def test_transcript_turns_are_excluded_from_bundles():
+    """Raw dialogue turns are not state claims. Measured: 9 of 13 accepted
+    proposals in the first real sweep came from consecutive turns, and
+    memory_type does NOT separate them (false positives were typed
+    fact/preference exactly like the true ones) — the content shape does."""
+    rows = [
+        _m(
+            "t1",
+            "S1",
+            "2026-01-01",
+            content="User: I'm looking for book recommendations",
+        ),
+        _m(
+            "t2",
+            "S1",
+            "2026-02-01",
+            content="Assistant: Here are some historical fiction picks",
+        ),
+        _m("real", "S1", "2026-03-01", content="Robin commutes by bicycle every day"),
+    ]
+    b = tm.group_subjects(rows)
+    assert [m["id"] for m in b["S1"]] == ["real"]
+
+
+def test_restatement_is_rejected():
+    """The dangerous failure: proposing the stale claim as its own successor
+    would enshrine the error with a fresh timestamp."""
+    rows = [
+        _m(
+            "old",
+            "S1",
+            "2026-01-01",
+            content="Robin has been based in Seattle for the last few years",
+        ),
+        _m(
+            "new",
+            "S1",
+            "2026-06-01",
+            content="Robin switched their license and voter registration after the move",
+        ),
+    ]
+    accepted, reason = tm.validate_proposal(
+        {
+            "stale_memory_id": "old",
+            "supporting_memory_ids": ["new"],
+            # restates the stale claim instead of retiring it
+            "replacement_content": "Robin has been based in Seattle for the last few years, and completed the paperwork",
+            "confidence": 0.9,
+        },
+        "S1",
+        rows,
+    )
+    assert accepted is None and reason == "replacement_restates_stale"
+
+
+def test_genuine_replacement_still_passes():
+    rows = [
+        _m(
+            "old",
+            "S1",
+            "2026-01-01",
+            content="Robin sees friends twice a week and keeps those nights open",
+        ),
+        _m("new", "S1", "2026-06-01", content="Robin started a night-shift rotation"),
+    ]
+    accepted, _ = tm.validate_proposal(
+        {
+            "stale_memory_id": "old",
+            "supporting_memory_ids": ["new"],
+            "replacement_content": "Robin is no longer free two evenings a week; the night-shift rotation leaves only one",
+            "confidence": 0.8,
+        },
+        "S1",
+        rows,
+    )
+    assert accepted is not None


### PR DESCRIPTION
## Summary

The first real shadow sweep of the A59 materializer (#1077) scored **~10% precision** by hand — and two proposals were *actively harmful*: the "replacement" restated the stale claim ("based in Seattle" after evidence of a move) or asserted the old and new claims together. Written as successors, those would enshrine the error with fresh timestamps — worse than leaving the corpus alone.

This PR fixes that. Measured on the **identical six tenants**:

| | before | after |
|---|---|---|
| accepted proposals | 13 | 5 |
| correct on hand-scoring | 1–2 (~10%) | **4 of 5 (80%)** |
| harmful (restates/merges the stale claim) | **2** | **0** |

## Three changes

1. **Exclude raw transcript turns from subject bundles.** `memory_type` is *not* the discriminator — the nine false positives were typed `fact`/`preference` exactly like the true hits (verified against the DB). Content shape is: a dialogue turn ("User: …", "Assistant: …") is not a claim about the subject's current state, so it can be neither a stale default nor evidence that one broke.
2. **Prompt** now requires the replacement to state what is NO LONGER true, and forbids restating the stale claim or asserting both together.
3. **Deterministic restatement gate** — reject any replacement whose token overlap with the stale row is ≥0.6.

## What the surviving proposals look like

- *"works from home, office is here in the house"* + *"gave the landlord a move-out date, building is being converted"* → *"living situation is in transition; whether they will still be working from home is unknown"*
- *"on shift 4AM–noon every day"* + *"back home by nine most mornings"* → correctly **retires** the shift claim (before the fix, it asserted both)
- *"machine lacks the computing power"* + *"4K multi-angle edits stay smooth"* → correctly retires the limitation

Note the five LongMemEval tenants dropped to `subjects_scanned=0`: **every** subject-bearing row in them is a raw dialogue turn. That confirms the diagnosis rather than hiding it — those corpora contain nothing state-bearing for this mechanism to reason over.

## Still shadow-only

n=5 on one synthetic corpus justifies continuing and nothing more. The write gate is unchanged: sweep a **real** tenant corpus (distilled memories, not benchmark seeds) and score ~30 proposals. My standing reservation for that phase: demote sources to `conflicted`, not `outdated`, so a wrong call stays recoverable.

## Testing

12 unit tests (3 new: transcript exclusion, restatement rejection, genuine replacement still passes). Full suite **5565 passed**; ruff + mypy clean. Re-swept the same six tenants on a rebuilt image — the numbers above are from that live run, read back through `GET /crystallize/latest`.

Refs: A59; follows #1077; findings `benchmark/a57-recall-experiments-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
