### PR TITLE
fix(search): preserve lexical matches through candidate limits

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -635,7 +635,7 @@ FTS_BOOST_MAX_TOKENS = 3  # queries with more meaningful tokens than this stay a
 FTS_BOOST_SPECIFICITY_RATIO = 0.4  # strict >; at N=2 this means >=1 specific token triggers boost
 SIMILARITY_BLEND = 0.85  # base_score = SIMILARITY_BLEND * similarity + (1 - SIMILARITY_BLEND) * weight (raised from 0.75 — LoCoMo sweep showed +13pp recall)
 SEARCH_OVERFETCH_FACTOR = 2  # fetch top_k * N candidates from storage, trim to top_k after min_similarity filter — gives post-filter headroom
-FTS_ONLY_RESERVED_RESULTS = 1  # #687: result slots held for rows that FTS-match but are not embedded yet (transient deferred-embed window); 0 restores the pre-#687 head-slice behaviour
+FTS_RESERVED_RESULTS = 1  # result slots held for full-text matches; includes #687's transient rows whose embedding is still pending
 # ``SQL_SCORING_PARAM_KEYS`` — the set both search-path builders project through
 # before sending ``search_params`` — is re-exported from ``common.constants``
 # above, because storage reads the same set and the drift that matters is

--- a/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
+++ b/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
@@ -193,6 +193,7 @@ class ExecuteScoredSearch:
                                 "recall_boost",
                                 "temporal_boost",
                                 "status_penalty",
+                                "fts_match",
                                 "entity_links",
                                 "has_embedding",
                             )
@@ -207,6 +208,7 @@ class ExecuteScoredSearch:
                     recall_boost=row.get("recall_boost"),
                     temporal_boost=row.get("temporal_boost"),
                     status_penalty=row.get("status_penalty"),
+                    fts_match=bool(row.get("fts_match", False)),
                     has_embedding=row.get("has_embedding", True),
                     entity_links=[],
                 )

--- a/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
+++ b/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
@@ -164,10 +164,12 @@ class LoadAndSerialize:
                 # ``score`` is the multiplicative ranking composite (similarity *
                 # freshness * entity/recall/temporal boosts) which routinely
                 # exceeds 1.0, so it's useless for client-side threshold gating.
-                # ``vec_sim`` is the 0..1 cosine and matches the ``min_similarity``
-                # gate in PostFilterResults. Rank order is unchanged (rows are
-                # already ordered by ``score`` upstream). None for FTS-only hits,
-                # which have no vector similarity.
+                # ``vec_sim`` is the raw cosine compared by ``min_similarity`` in
+                # PostFilterResults. An actual lexical hit may relax only the
+                # untuned global fallback; configured floors stay strict. Rank
+                # order is unchanged (rows are already ordered by ``score``
+                # upstream). None for FTS-only hits, which have no vector
+                # similarity.
                 similarity=(round(float(row.vec_sim), 4) if row.vec_sim is not None else None),
                 # D12 — the composite that ordered this row, and its factors.
                 # The storage SQL has always computed these per row; this is the

--- a/core-api/src/core_api/pipeline/steps/search/post_filter_results.py
+++ b/core-api/src/core_api/pipeline/steps/search/post_filter_results.py
@@ -1,11 +1,11 @@
-"""PostFilterResults — filter raw rows by min_similarity gate on vec_sim."""
+"""PostFilterResults — apply the similarity floor and final result limit."""
 
 from __future__ import annotations
 
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepOutcome, StepResult
 from core_api.pipeline.steps.search.retrieval_types import RetrievalStrategy
-from core_api.search_trim import trim_reserving_fts_only
+from core_api.search_trim import passes_relevance_filter, trim_reserving_fts_matches
 
 
 class PostFilterResults:
@@ -19,27 +19,22 @@ class PostFilterResults:
             return StepResult(outcome=StepOutcome.SKIPPED)
 
         min_similarity = ctx.data["search_params"]["min_similarity"]
-        # NULL-embedding rows reach this point only when storage admitted them
-        # via the FTS half of `embedding IS NOT NULL OR search_vector @@ query`
-        # (relaxed in CAURA-594 so writes deferred via EMBED_REQUESTED stay
-        # searchable during the embed-pending window). Storage coerces their
-        # missing cosine to a 0.0 sentinel and emits `has_embedding=False` to
-        # disambiguate that from a real orthogonal match — trust that flag
-        # here and bypass the vec_sim threshold for FTS-only rows. Without
-        # this, the entire FTS-fallback contract is silently broken for any
-        # row whose embedding hasn't been PATCHed yet by core-worker.
+        fts_enabled = float(ctx.data["search_params"].get("fts_weight", 0.0)) > 0.0
+        allow_fts_bypass = fts_enabled and bool(ctx.data.get("allow_fts_global_floor_bypass", False))
         filtered = [
             row
             for row in ctx.data["raw_rows"]
-            if (not getattr(row, "has_embedding", True))
-            or row.vec_sim is None
-            or float(row.vec_sim) >= min_similarity
+            if _passes_relevance_filter(row, min_similarity, allow_fts_bypass)
         ]
         below_floor = len(ctx.data["raw_rows"]) - len(filtered)
         # Trim to the user-requested top_k (storage returned top_k * overfetch_factor)
         final_top_k = ctx.data.get("final_top_k")
         if final_top_k is not None:
-            filtered = trim_reserving_fts_only(filtered, final_top_k, _is_fts_only)
+            filtered = trim_reserving_fts_matches(
+                filtered,
+                final_top_k,
+                lambda row: _is_reservable_fts_match(row, fts_enabled),
+            )
         ctx.data["filtered_rows"] = filtered
 
         # D12 — diagnostic trace: capture the FULL widened candidate set with
@@ -50,11 +45,7 @@ class PostFilterResults:
             kept_ids = {id(row) for row in filtered}
             passed_floor_ids = set()
             for row in ctx.data["raw_rows"]:
-                if (
-                    (not getattr(row, "has_embedding", True))
-                    or row.vec_sim is None
-                    or float(row.vec_sim) >= min_similarity
-                ):
+                if _passes_relevance_filter(row, min_similarity, allow_fts_bypass):
                     passed_floor_ids.add(id(row))
             candidates = []
             for row in ctx.data["raw_rows"]:
@@ -73,6 +64,12 @@ class PostFilterResults:
                         "score": _f(getattr(row, "score", None)),
                         "vec_sim": _f(getattr(row, "vec_sim", None)),
                         "fts_score": _f(getattr(row, "fts_score", None)),
+                        "fts_match": bool(getattr(row, "fts_match", False)),
+                        "fts_global_floor_bypass": _used_fts_global_floor_bypass(
+                            row,
+                            min_similarity,
+                            allow_fts_bypass,
+                        ),
                         "freshness": _f(getattr(row, "freshness", None)),
                         "entity_boost": _f(getattr(row, "entity_boost", None)),
                         "recall_boost": _f(getattr(row, "recall_boost", None)),
@@ -97,19 +94,37 @@ def _f(v) -> float | None:
     return round(float(v), 4) if v is not None else None
 
 
-def _is_fts_only(row) -> bool:
-    """True for a row storage admitted on FTS alone, with no embedding yet.
+def _passes_relevance_filter(
+    row,
+    min_similarity: float,
+    allow_fts_global_floor_bypass: bool,
+) -> bool:
+    return passes_relevance_filter(
+        has_embedding=getattr(row, "has_embedding", True),
+        vec_sim=row.vec_sim,
+        min_similarity=min_similarity,
+        fts_match=bool(getattr(row, "fts_match", False)),
+        allow_fts_global_floor_bypass=allow_fts_global_floor_bypass,
+    )
 
-    Same test as the cosine-gate exemption above, which has used this form since
-    CAURA-679 — kept identical so the gate and the reservation cannot disagree
-    about what "FTS-only" means.
 
-    ``row`` is a ``SimpleNamespace``, hence ``getattr``; the legacy path in
-    ``memory_service`` holds dicts and reads the same field with ``.get``. The
-    value is always a real ``bool``, never ``None``: storage computes it as
-    ``Memory.embedding.is_not(None)`` — a non-nullable SQL boolean — and
-    ``execute_scored_search`` carries it onto the namespace with a ``True``
-    default. So truthiness and ``is False`` cannot diverge on any reachable
-    input here.
-    """
-    return not getattr(row, "has_embedding", True)
+def _used_fts_global_floor_bypass(
+    row,
+    min_similarity: float,
+    allow_fts_global_floor_bypass: bool,
+) -> bool:
+    vec_sim = getattr(row, "vec_sim", None)
+    return bool(
+        allow_fts_global_floor_bypass
+        and getattr(row, "has_embedding", True)
+        and getattr(row, "fts_match", False)
+        and vec_sim is not None
+        and float(vec_sim) < min_similarity
+    )
+
+
+def _is_reservable_fts_match(row, fts_enabled: bool) -> bool:
+    """Include embedded matches only while keyword scoring is enabled."""
+    return (not getattr(row, "has_embedding", True)) or (
+        fts_enabled and bool(getattr(row, "fts_match", False))
+    )

--- a/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
+++ b/core-api/src/core_api/pipeline/steps/search/resolve_search_profile.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
-from core_api.services.memory_service import resolve_search_params
+from core_api.services.memory_service import _uses_global_min_similarity, resolve_search_params
 
 
 class ResolveSearchProfile:
@@ -32,4 +32,12 @@ class ResolveSearchProfile:
         override = ctx.data.get("min_similarity_override")
         if override is not None:
             ctx.data["search_params"]["min_similarity"] = float(override)
+        # An actual lexical hit may relax only the untuned global fallback.
+        # Keep this provenance outside search_params: it is core filtering state,
+        # not a storage scoring knob.
+        ctx.data["allow_fts_global_floor_bypass"] = _uses_global_min_similarity(
+            ctx.data.get("search_profile"),
+            ctx.tenant_config,
+            override,
+        )
         return None

--- a/core-api/src/core_api/search_trim.py
+++ b/core-api/src/core_api/search_trim.py
@@ -1,9 +1,8 @@
-"""Head-slice trim that reserves result slots for FTS-only rows (#687).
+"""Shared post-processing helpers for scored search results.
 
 Lives at the package root, importing only :mod:`core_api.constants`, so both the
 pipeline post-filter step and the legacy search path can use it without an import
-cycle. One implementation on purpose: the two paths trim independently, and when
-this logic was duplicated a boundary bug had to be fixed in both copies.
+cycle.
 """
 
 from __future__ import annotations
@@ -11,30 +10,51 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from core_api.constants import FTS_ONLY_RESERVED_RESULTS
+from core_api.constants import FTS_RESERVED_RESULTS
 
 
-def trim_reserving_fts_only(
+def passes_relevance_filter(
+    *,
+    has_embedding: bool | None,
+    vec_sim: float | None,
+    min_similarity: float,
+    fts_match: bool = False,
+    allow_fts_global_floor_bypass: bool = False,
+) -> bool:
+    """Apply the relevance floor, including its two lexical exceptions.
+
+    Storage admits an unembedded row only through full-text search and represents
+    its missing cosine as ``0.0``. ``has_embedding`` distinguishes that sentinel
+    from a real orthogonal vector. An embedded full-text match may bypass only
+    the untuned global fallback; request, agent, and tenant floors remain strict.
+    """
+    return (
+        has_embedding is False
+        or vec_sim is None
+        or float(vec_sim) >= min_similarity
+        or (allow_fts_global_floor_bypass and fts_match)
+    )
+
+
+def trim_reserving_fts_matches(
     rows: list[Any],
     top_k: int,
-    is_fts_only: Callable[[Any], bool],
+    is_fts_match: Callable[[Any], bool],
 ) -> list[Any]:
-    """Trim ``rows`` to ``top_k``, keeping one FTS-only row if any exist.
+    """Trim ``rows`` to ``top_k``, keeping one full-text match if available.
 
-    #687: exempting FTS-only rows from the cosine gate is not enough to make them
-    reachable. They score on ``fts_score`` alone — single digits of a percent for
-    one term — so with enough embedded rows above them a plain head slice drops
-    them, having already survived storage's candidate LIMIT only because that
-    reserves slots for them too.
+    A full-text match can rank below vector-only candidates and fall outside a
+    plain head slice. Storage reserves matching candidates for the same reason;
+    this final trim makes one of those candidates visible without changing the
+    ordering of the remaining results. It also preserves #687's guarantee for a
+    matching row whose embedding backfill has not landed yet.
 
     The reservation is deliberately minimal: it promotes at most
-    ``FTS_ONLY_RESERVED_RESULTS`` rows, displacing the same number from the tail
+    ``FTS_RESERVED_RESULTS`` rows, displacing the same number from the tail
     of the head — the weakest results — and only when the head contains none
-    already. It never reorders anything. The population is transient: a row is
-    FTS-only just until the deferred embed backfill lands, after which it competes
-    on cosine normally.
+    already. It never reorders anything.
 
-    ``is_fts_only`` is passed in because the two callers hold different row
+    ``is_fts_match`` is passed in because the two callers hold different row
     shapes: the pipeline has objects (attribute access), the legacy path dicts.
 
     Never consumes the whole head. A ``top_k=1`` caller (valid input —
@@ -45,17 +65,17 @@ def trim_reserving_fts_only(
     never that the row outranks the best result.
     """
     head = rows[:top_k]
-    if FTS_ONLY_RESERVED_RESULTS <= 0 or top_k <= 0:
+    if FTS_RESERVED_RESULTS <= 0 or top_k <= 0:
         return head
-    if any(is_fts_only(r) for r in head):
+    if any(is_fts_match(r) for r in head):
         return head
     # The ``- 1`` is what stops the promotion taking every slot: it keeps
     # ``top_k - len(promoted)`` in the slice below at 1 or more, so at least one
     # row that earned its place on score always survives.
-    budget = min(FTS_ONLY_RESERVED_RESULTS, top_k - 1)
+    budget = min(FTS_RESERVED_RESULTS, top_k - 1)
     if budget <= 0:
         return head
-    promoted = [r for r in rows[top_k:] if is_fts_only(r)][:budget]
+    promoted = [r for r in rows[top_k:] if is_fts_match(r)][:budget]
     if not promoted:
         return head
     return head[: top_k - len(promoted)] + promoted

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -91,7 +91,7 @@ from core_api.schemas import (
     MemoryUpdate,
     ScoreParts,
 )
-from core_api.search_trim import trim_reserving_fts_only
+from core_api.search_trim import passes_relevance_filter, trim_reserving_fts_matches
 from core_api.services.entity_extraction_worker import process_entity_extraction
 from core_api.services.entity_tokens import extract_entity_tokens
 from core_api.services.governance_gate import (
@@ -3978,6 +3978,20 @@ def resolve_search_params(
     }
 
 
+def _uses_global_min_similarity(
+    search_profile: dict | None,
+    tenant_config,
+    request_override: float | None,
+) -> bool:
+    """Return whether search fell through to the untuned global floor."""
+    if request_override is not None or (search_profile and "min_similarity" in search_profile):
+        return False
+    if tenant_config is None:
+        return True
+    tenant_default = getattr(tenant_config, "default_search_profile", {}) or {}
+    return "min_similarity" not in tenant_default
+
+
 def _normalize_query_for_cache(query: str) -> str:
     """Normalize query for cache key: lowercase, strip, collapse whitespace."""
     return re.sub(r"\s+", " ", query.strip().lower())
@@ -4605,6 +4619,14 @@ async def _search_memories_legacy(
     # D12 — per-request floor beats the resolved profile, same precedence as
     # ResolveSearchProfile applies on the pipeline path.
     _min_similarity = min_similarity if min_similarity is not None else sp["min_similarity"]
+    fts_enabled = float(sp["fts_weight"]) > 0.0
+    # Match the pipeline's provenance-aware exception: only the global fallback
+    # can yield to lexical evidence, never a request/agent/tenant floor.
+    allow_fts_bypass = fts_enabled and _uses_global_min_similarity(
+        search_profile,
+        tenant_config,
+        min_similarity,
+    )
 
     # Temporal hint
     temporal_window = _extract_temporal_hint(query)
@@ -4690,33 +4712,22 @@ async def _search_memories_legacy(
         rows = await sc.scored_search(search_data)
 
     # Post-filter by min_similarity, then trim to top_k.
-    #
-    # `has_embedding is False` is the clause that matters, and it was missing:
-    # the invariant the old comment here relied on ("the scored_search SQL
-    # enforces `Memory.embedding IS NOT NULL`") stopped holding at CAURA-594,
-    # which admits NULL-embedding rows that FTS-match via
-    # `or_(embedding IS NOT NULL, fts_guard)`. The storage layer coerces those
-    # rows' cosine to 0.0 rather than NULL — as that comment itself noted — so
-    # the `vec_sim is None` branch never fires for them and `0.0 >= threshold`
-    # gated out exactly the FTS-only rows CAURA-679 exists to keep discoverable
-    # during the deferred-embed window. `has_embedding` is the authoritative
-    # NULL signal for precisely this reason. Now genuinely mirrors the
-    # pipeline's post_filter step, which has carried this clause since CAURA-679.
     rows = [
         r
         for r in rows
-        if r.get("has_embedding") is False
-        or r.get("vec_sim") is None
-        or float(r["vec_sim"]) >= _min_similarity
+        if passes_relevance_filter(
+            has_embedding=r.get("has_embedding", True),
+            vec_sim=r.get("vec_sim"),
+            min_similarity=_min_similarity,
+            fts_match=bool(r.get("fts_match", False)),
+            allow_fts_global_floor_bypass=allow_fts_bypass,
+        )
     ]
-    # #687: the same reservation the pipeline post-filter applies — exempting
-    # FTS-only rows from the cosine gate above does not make them reachable,
-    # because they score on fts_score alone and a plain head slice drops them once
-    # enough embedded rows sit above. Shared with that path via
-    # `trim_reserving_fts_only` so the two cannot drift; rows here are dicts, so
-    # the predicate reads `has_embedding` with `.get` (matching the gate above)
-    # where the pipeline uses attribute access.
-    rows = trim_reserving_fts_only(rows, _top_k, lambda r: r.get("has_embedding") is False)
+    rows = trim_reserving_fts_matches(
+        rows,
+        _top_k,
+        lambda r: r.get("has_embedding") is False or (fts_enabled and bool(r.get("fts_match", False))),
+    )
 
     # Build results from storage API response
     memory_ids = [row.get("id") for row in rows if row.get("id")]

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -224,6 +224,7 @@ async def scored_search(request: Request) -> list[dict]:
             row["score"] = float(r.score) if r.score is not None else 0.0
             row["similarity"] = float(r.similarity) if r.similarity is not None else 0.0
             row["vec_sim"] = float(r.vec_sim) if r.vec_sim is not None else 0.0
+            row["fts_match"] = bool(getattr(r, "fts_match", False))
             # CAURA-594: authoritative signal for async-embed callers;
             # `vec_sim == 0.0` is ambiguous with an orthogonal embedding.
             # Default to False on missing attribute — the only readers

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -265,20 +265,17 @@ def _entity_uf_union(parent: dict[UUID, UUID], rank: dict[UUID, int], a: UUID, b
         rank[ra] += 1
 
 
-# #687: how many candidate slots the scored search reserves for rows that
-# FTS-match but have no embedding yet. Deliberately small: the guarantee needed
-# is "discoverable", not "ranked highly", and the population is transient — rows
-# carry a NULL embedding only until the deferred backfill lands. Set to 0 to
-# restore the pre-#687 behaviour where such rows are cut by the candidate LIMIT.
+# How many candidate slots scored search reserves for full-text matches. The
+# lexical scoring path needs this before the candidate LIMIT: a strong vector-only
+# cohort can otherwise cut every lexical hit before core-api sees it. When
+# keyword scoring is disabled, the reservation narrows to #687's transient
+# NULL-embedding fallback.
 #
 # This also floors what the result layer can promote: core-api's
-# ``FTS_ONLY_RESERVED_RESULTS`` (currently 1) reserves result slots only among
-# rows that already reached it, and this branch is the only supply it is
-# guaranteed — the main branch carries FTS-only rows just when they earn a slot
-# on score. So keep this >= that constant; above it, the extra promotions are
-# satisfied only incidentally. core-storage-api must not import core-api, so the
-# coupling is documented here rather than enforced.
-_FTS_ONLY_RESERVED_CANDIDATES = 3
+# ``FTS_RESERVED_RESULTS`` (currently 1) reserves result slots only among rows
+# that already reached it. Keep this >= that constant. core-storage-api must not
+# import core-api, so the coupling is documented here rather than enforced.
+_FTS_RESERVED_CANDIDATES = 3
 
 
 def _saturate_rank(scaled_rank: Any) -> Any:
@@ -2087,12 +2084,14 @@ class PostgresService:
         # weight bug. Gate on the Python-side query string so the
         # operator is only emitted when there's actual text to match.
         _fts_guard = Memory.search_vector.op("@@")(ts_query) if query and query.strip() else false()
+        fts_match = _fts_guard.label("fts_match")
         scored_stmt = (
             select(
                 Memory.id.label("mem_id"),
                 score,
                 similarity,
                 vec_sim,
+                fts_match,
                 has_embedding,
                 status_penalty,
             )
@@ -2233,27 +2232,22 @@ class PostgresService:
             # always meant to ask for.
             main_stmt = scored_stmt.order_by(score.desc(), Memory.created_at.desc()).limit(top_k)
 
-        # #687: reserve candidate slots for FTS-only rows.
+        # Reserve candidate slots for full-text matches.
         #
-        # CAURA-594 admits a NULL-embedding row when it FTS-matches, and CAURA-679
-        # scores it on ``fts_score`` alone so the blend's haircut can't bury it —
-        # both so a memory stays discoverable during the deferred-embed window.
-        # Neither helps it survive the LIMIT above: ``fts_score`` is
-        # ``ts_rank_cd/(1+ts_rank_cd)``, single digits of a percent for one term,
-        # while embedded rows near the query score far higher. Measured on prod
-        # (#687): embedded rows 0.35-0.39, the FTS-only row 0, a 10-row window —
-        # so the row was cut here, upstream of every exemption downstream of it.
+        # A lexical hit can score below enough strong vector-only candidates to
+        # miss the LIMIT above. That is fatal because core-api can only reserve
+        # rows storage returns. With lexical scoring enabled, reserve any FTS match;
+        # otherwise preserve #687's narrower NULL-embedding fallback only.
         #
-        # A small dedicated branch, ordered by FTS relevance and separately capped,
-        # guarantees such rows reach the caller without touching how anything else
-        # ranks: they enter the pool at their own true (low) score and the outer
-        # ORDER BY still places them last. Bounded twice over — the cap, and the
-        # fact that NULL-embedding rows exist only until the backfill lands.
-        if _FTS_ONLY_RESERVED_CANDIDATES > 0 and query and query.strip():
+        # The dedicated branch is separately capped and the outer ORDER BY keeps
+        # every row at its true score, so this changes candidate admission rather
+        # than the ranking formula.
+        if _FTS_RESERVED_CANDIDATES > 0 and query and query.strip():
+            reserve_filter = _fts_guard if _fts_weight > 0.0 else and_(Memory.embedding.is_(None), _fts_guard)
             reserved_stmt = (
-                scored_stmt.where(and_(Memory.embedding.is_(None), _fts_guard))
+                scored_stmt.where(reserve_filter)
                 .order_by(fts_score.desc(), Memory.created_at.desc())
-                .limit(_FTS_ONLY_RESERVED_CANDIDATES)
+                .limit(_FTS_RESERVED_CANDIDATES)
             )
             # Each operand is wrapped in its own subquery so its ORDER BY/LIMIT is
             # applied BEFORE the union, not hoisted to the compound statement — the
@@ -2269,6 +2263,7 @@ class PostgresService:
                 scored_cte.c.score,
                 scored_cte.c.similarity,
                 scored_cte.c.vec_sim,
+                scored_cte.c.fts_match,
                 scored_cte.c.has_embedding,
                 scored_cte.c.status_penalty,
                 MemoryEntityLink.entity_id,
@@ -2300,6 +2295,7 @@ class PostgresService:
                     score=row.score,
                     similarity=row.similarity,
                     vec_sim=row.vec_sim,
+                    fts_match=row.fts_match,
                     has_embedding=row.has_embedding,
                     status_penalty=row.status_penalty,
                     entity_links=[],

--- a/core-storage-api/tests/test_fts_score_single_render.py
+++ b/core-storage-api/tests/test_fts_score_single_render.py
@@ -32,7 +32,10 @@ from core_storage_api.services.postgres_service import _saturate_rank
 # cost back, a fall means the inner-projection work landed. Either way,
 # re-measure and move the number deliberately rather than loosening the check.
 _EXPECTED_TS_RANK_CD_RENDERS = 9
-_EXPECTED_TSQUERY_RENDERS = 18
+# The main and reserved candidate branches each carry ``fts_match`` into the
+# candidate CTE. Projecting it there keeps the expression ahead of entity-link
+# fanout, where an outer render would evaluate it once per joined row.
+_EXPECTED_TSQUERY_RENDERS = 20
 
 
 def _scaled_rank():

--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -167,10 +167,9 @@ async def test_extract_temporal_hint_uses_valid_at_as_reference():
 
 
 @pytest.mark.asyncio
-async def test_post_filter_results():
-    """PostFilterResults filters rows below min_similarity."""
+async def test_post_filter_results_keeps_configured_cosine_floor_strict():
+    """PostFilterResults keeps an explicit cosine floor strict."""
     from types import SimpleNamespace
-    from unittest.mock import AsyncMock
 
     from core_api.pipeline.context import PipelineContext
     from core_api.pipeline.steps.search.post_filter_results import PostFilterResults
@@ -180,7 +179,12 @@ async def test_post_filter_results():
             vec_sim=0.8, Memory=None, score=0.7, similarity=0.7, entity_links=[]
         ),
         SimpleNamespace(
-            vec_sim=0.3, Memory=None, score=0.2, similarity=0.2, entity_links=[]
+            vec_sim=0.3,
+            fts_match=True,
+            Memory=None,
+            score=0.2,
+            similarity=0.2,
+            entity_links=[],
         ),
         SimpleNamespace(
             vec_sim=0.6, Memory=None, score=0.5, similarity=0.5, entity_links=[]
@@ -197,6 +201,54 @@ async def test_post_filter_results():
 
     assert len(ctx.data["filtered_rows"]) == 2
     assert all(float(r.vec_sim) >= 0.5 for r in ctx.data["filtered_rows"])
+
+
+@pytest.mark.asyncio
+async def test_post_filter_results_allows_fts_match_past_global_default_floor():
+    """Only a lexical hit may bypass the untuned global fallback."""
+    from types import SimpleNamespace
+
+    from core_api.pipeline.context import PipelineContext
+    from core_api.pipeline.steps.search.post_filter_results import PostFilterResults
+
+    lexical = SimpleNamespace(
+        vec_sim=0.1,
+        fts_match=True,
+        has_embedding=True,
+        Memory=None,
+        score=0.2,
+    )
+    unrelated = SimpleNamespace(
+        vec_sim=0.1,
+        fts_match=False,
+        has_embedding=True,
+        Memory=None,
+        score=0.2,
+    )
+    ctx = PipelineContext(
+        data={
+            "raw_rows": [lexical, unrelated],
+            "search_params": {"min_similarity": 0.3, "fts_weight": 0.6},
+            "allow_fts_global_floor_bypass": True,
+            "diagnostic": True,
+        },
+    )
+
+    await PostFilterResults().execute(ctx)
+
+    assert ctx.data["filtered_rows"] == [lexical]
+    assert ctx.data["diagnostic_results"][0]["fts_global_floor_bypass"] is True
+    assert ctx.data["diagnostic_results"][1]["excluded"] == "below_min_similarity"
+
+    disabled_ctx = PipelineContext(
+        data={
+            "raw_rows": [lexical, unrelated],
+            "search_params": {"min_similarity": 0.3, "fts_weight": 0.0},
+            "allow_fts_global_floor_bypass": True,
+        },
+    )
+    await PostFilterResults().execute(disabled_ctx)
+    assert disabled_ctx.data["filtered_rows"] == []
 
 
 @pytest.mark.asyncio
@@ -668,59 +720,74 @@ async def test_recall_returns_memory_with_pending_embedding(db, monkeypatch, use
 
 
 # ---------------------------------------------------------------------------
-# Bounds of the FTS-only result reservation (#687)
+# Bounds of the full-text result reservation
 # ---------------------------------------------------------------------------
 
 
 class _Row:
-    """Minimal stand-in for a scored row: the reservation reads has_embedding only."""
+    """Minimal stand-in for a scored row used by the reservation helper."""
 
-    def __init__(self, rid, has_embedding):
+    def __init__(self, rid, *, fts_match=False, has_embedding=True):
         self.id = rid
+        self.fts_match = fts_match
         self.has_embedding = has_embedding
 
 
-def test_fts_only_reservation_is_bounded_and_only_fires_when_needed():
-    """The #687 reservation must be a floor of one, not a general reordering.
+def test_fts_reservation_is_bounded_and_only_fires_when_needed():
+    """The lexical reservation must be a floor of one, not a reordering.
 
-    It exists so a row that FTS-matches while its embedding is still pending
-    stays reachable. It must not become a licence to displace good results, so
-    this pins the three boundaries: it promotes at most
-    FTS_ONLY_RESERVED_RESULTS, it stays out of the way when the head already
-    contains such a row, and it does nothing at all to an ordinary result set.
+    It promotes at most ``FTS_RESERVED_RESULTS``, stays out of the way when the
+    head already contains a lexical match, and preserves #687's NULL-embedding
+    fallback when keyword scoring is disabled.
     """
-    from core_api.constants import FTS_ONLY_RESERVED_RESULTS
-    from core_api.pipeline.steps.search.post_filter_results import _is_fts_only
-    from core_api.search_trim import trim_reserving_fts_only
+    from core_api.constants import FTS_RESERVED_RESULTS
+    from core_api.pipeline.steps.search.post_filter_results import (
+        _is_reservable_fts_match,
+    )
+    from core_api.search_trim import trim_reserving_fts_matches
 
-    def _trim(rows, top_k):
-        return trim_reserving_fts_only(rows, top_k, _is_fts_only)
+    def _trim(rows, top_k, *, fts_enabled=True):
+        return trim_reserving_fts_matches(
+            rows,
+            top_k,
+            lambda row: _is_reservable_fts_match(row, fts_enabled),
+        )
 
-    # No FTS-only rows anywhere → identical to a plain head slice.
-    embedded = [_Row(i, True) for i in range(10)]
+    # No FTS matches anywhere → identical to a plain head slice.
+    embedded = [_Row(i) for i in range(10)]
     assert [r.id for r in _trim(embedded, 5)] == [0, 1, 2, 3, 4]
 
-    # An FTS-only row already inside the head → untouched, nothing promoted.
-    head_has_one = [_Row(0, True), _Row(1, False)] + [_Row(i, True) for i in range(2, 10)]
+    # An FTS match already inside the head → untouched, nothing promoted.
+    head_has_one = [_Row(0), _Row(1, fts_match=True)] + [_Row(i) for i in range(2, 10)]
     assert [r.id for r in _trim(head_has_one, 5)] == [0, 1, 2, 3, 4]
 
-    # FTS-only rows only beyond the cutoff → exactly the reserved count is
+    # Lexical matches only beyond the cutoff → exactly the reserved count is
     # promoted, displacing the same number from the tail of the head, and the
     # result length is unchanged.
-    beyond = [_Row(i, True) for i in range(5)] + [_Row(100 + i, False) for i in range(4)]
+    beyond = [_Row(i) for i in range(5)] + [
+        _Row(100 + i, fts_match=True) for i in range(4)
+    ]
     out = _trim(beyond, 5)
     assert len(out) == 5, "the reservation must not change how many rows are returned"
-    promoted = [r.id for r in out if not r.has_embedding]
-    assert len(promoted) == FTS_ONLY_RESERVED_RESULTS, (
-        f"promoted {len(promoted)} FTS-only rows, expected exactly "
-        f"FTS_ONLY_RESERVED_RESULTS={FTS_ONLY_RESERVED_RESULTS} — an unbounded "
-        f"promotion would let a bulk import of unembedded rows flood results"
+    promoted = [r.id for r in out if r.fts_match]
+    assert len(promoted) == FTS_RESERVED_RESULTS, (
+        f"promoted {len(promoted)} FTS matches, expected exactly "
+        f"FTS_RESERVED_RESULTS={FTS_RESERVED_RESULTS} — an unbounded "
+        f"promotion would let lexical matches flood results"
     )
     # The strongest results survive; only the weakest are displaced.
-    assert [r.id for r in out][0] == 0
+    assert out[0].id == 0
+
+    # Embedded lexical matches are not promoted if keyword scoring is disabled,
+    # but #687's pending-embedding fallback remains discoverable.
+    assert [r.id for r in _trim(beyond, 5, fts_enabled=False)] == [0, 1, 2, 3, 4]
+    pending = [_Row(i) for i in range(5)] + [
+        _Row(100, fts_match=True, has_embedding=False)
+    ]
+    assert [r.id for r in _trim(pending, 5, fts_enabled=False)] == [0, 1, 2, 3, 100]
 
     # Fewer rows than top_k → head slice semantics preserved.
-    assert len(_trim([_Row(0, True)], 5)) == 1
+    assert len(_trim([_Row(0)], 5)) == 1
 
     # The reservation must never consume the ENTIRE head. top_k=1 is a valid
     # input (schemas.py: ge=1), and answering a "give me your single best match"
@@ -728,30 +795,25 @@ def test_fts_only_reservation_is_bounded_and_only_fires_when_needed():
     # result — is a worse answer than not surfacing the stub at all. #687
     # promises such a row is discoverable, not that it outranks the best match;
     # storage's candidate reservation is what keeps that promise here.
-    best_then_stub = [_Row(0, True), _Row(100, False)]
+    best_then_stub = [_Row(0), _Row(100, fts_match=True, has_embedding=False)]
     assert [r.id for r in _trim(best_then_stub, 1)] == [0], (
         "a top_k=1 caller must keep their true best match; promoting into the "
         "only slot displaces it entirely rather than displacing the weakest"
     )
     # One slot above the reserved count is the first size that can promote.
-    assert [r.id for r in _trim(best_then_stub, FTS_ONLY_RESERVED_RESULTS + 1)] == [0, 100]
+    assert [r.id for r in _trim(best_then_stub, FTS_RESERVED_RESULTS + 1)] == [0, 100]
 
 
-def test_fts_only_reservation_constants_stay_in_step_across_services():
+def test_fts_reservation_constants_stay_in_step_across_services():
     """core-api can only reserve result slots among rows storage sent it.
 
-    ``_FTS_ONLY_RESERVED_CANDIDATES`` (core-storage-api) is the only supply of
-    FTS-only candidates the result layer is *guaranteed* — the main branch
-    carries such rows just when they earn a slot on score. The two constants sit
-    in separately deployed packages and core-storage-api must not import
-    core-api, so nothing but this test stops them drifting apart.
+    The two constants sit in separately deployed packages and core-storage-api
+    must not import core-api, so nothing but this test stops them drifting apart.
     """
-    from core_api.constants import FTS_ONLY_RESERVED_RESULTS
-    from core_storage_api.services.postgres_service import _FTS_ONLY_RESERVED_CANDIDATES
+    from core_api.constants import FTS_RESERVED_RESULTS
+    from core_storage_api.services.postgres_service import _FTS_RESERVED_CANDIDATES
 
-    assert _FTS_ONLY_RESERVED_CANDIDATES >= FTS_ONLY_RESERVED_RESULTS, (
-        f"storage reserves {_FTS_ONLY_RESERVED_CANDIDATES} FTS-only candidate "
-        f"slots but core-api tries to reserve {FTS_ONLY_RESERVED_RESULTS} result "
-        f"slots — the surplus can only be filled incidentally, so the #687 "
-        f"discoverability guarantee silently weakens"
+    assert _FTS_RESERVED_CANDIDATES >= FTS_RESERVED_RESULTS, (
+        f"storage reserves {_FTS_RESERVED_CANDIDATES} FTS candidate slots but "
+        f"core-api tries to reserve {FTS_RESERVED_RESULTS} result slots"
     )

--- a/tests/test_d12_search_diagnostics.py
+++ b/tests/test_d12_search_diagnostics.py
@@ -18,7 +18,10 @@ from uuid import uuid4
 
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.steps.search import track_recalls as tr
-from core_api.pipeline.steps.search.load_and_serialize import LoadAndSerialize, _score_parts
+from core_api.pipeline.steps.search.load_and_serialize import (
+    LoadAndSerialize,
+    _score_parts,
+)
 from core_api.pipeline.steps.search.post_filter_results import PostFilterResults
 from core_api.pipeline.steps.search.resolve_search_profile import ResolveSearchProfile
 
@@ -80,6 +83,7 @@ async def test_min_similarity_override_beats_profile():
     )
     await ResolveSearchProfile().execute(ctx)
     assert ctx.data["search_params"]["min_similarity"] == 0.9
+    assert ctx.data["allow_fts_global_floor_bypass"] is False
 
 
 async def test_profile_min_similarity_kept_without_override():
@@ -94,6 +98,7 @@ async def test_profile_min_similarity_kept_without_override():
     )
     await ResolveSearchProfile().execute(ctx)
     assert ctx.data["search_params"]["min_similarity"] == 0.5
+    assert ctx.data["allow_fts_global_floor_bypass"] is False
 
 
 # --- PostFilterResults: diagnostic trace --------------------------------------

--- a/tests/test_readme_keyword_recall.py
+++ b/tests/test_readme_keyword_recall.py
@@ -1,0 +1,130 @@
+"""Regression coverage for the keyless README write-and-search flow."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+import pytest
+from core_api.clients.storage_client import get_storage_client
+from core_api.constants import MIN_SEARCH_SIMILARITY, SEARCH_OVERFETCH_FACTOR
+from core_api.services import memory_service
+from core_storage_api.services.postgres_service import get_session
+from sqlalchemy import text
+
+from common.embedding import fake_embedding
+from tests.conftest import get_test_auth
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_pipeline", [True, False], ids=["pipeline", "legacy"])
+async def test_readme_keyword_match_survives_candidate_cutoff(
+    client,
+    monkeypatch,
+    use_pipeline,
+):
+    """The README memory must survive storage and result candidate cuts.
+
+    This reproduces R1's exact query and zero-floor retry. The keyless
+    quickstart's local vectors give the target a low cosine, while enough
+    stronger vector-only distractors fill storage's overfetched candidate
+    window. The target still has independent full-text evidence: PostgreSQL
+    matched every query term.
+    """
+    monkeypatch.setattr(memory_service, "_USE_PIPELINE_SEARCH", use_pipeline)
+
+    tenant_id = f"test-tenant-readme-recall-{uuid.uuid4().hex[:8]}"
+    headers = get_test_auth(tenant_id)[1]
+    content = "Our auth service uses JWT with 15-minute expiry."
+    query = "JWT expiry"
+    write_response = await client.post(
+        "/api/v1/memories",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "quickstart",
+            "content": content,
+        },
+    )
+    assert write_response.status_code == 201, write_response.text
+    memory_id = write_response.json()["id"]
+
+    content_embedding = fake_embedding(content)
+    query_embedding = fake_embedding(query)
+    cosine = sum(a * b for a, b in zip(content_embedding, query_embedding, strict=True))
+    assert 0.0 <= cosine < MIN_SEARCH_SIMILARITY, (
+        "the regression requires a full-text match that clears an explicit zero "
+        "floor but not the default floor; "
+        f"got cosine={cosine:.3f}, default={MIN_SEARCH_SIMILARITY:.3f}"
+    )
+
+    async with get_session() as session:
+        row = (
+            await session.execute(
+                text(
+                    "SELECT embedding IS NOT NULL AS embedded, "
+                    "search_vector @@ plainto_tsquery('english', :query) AS fts_matches "
+                    "FROM memories WHERE id = CAST(:id AS uuid)"
+                ),
+                {"query": query, "id": memory_id},
+            )
+        ).one()
+    assert row.embedded is True, "the regression concerns an embedded row"
+    assert row.fts_matches is True, "the regression requires a full-text match"
+
+    top_k = 5
+    distractor_count = top_k * SEARCH_OVERFETCH_FACTOR + 2
+    storage = get_storage_client()
+    for index in range(distractor_count):
+        distractor = f"Unrelated high-cosine candidate {index} {uuid.uuid4().hex}"
+        await storage.create_memory(
+            {
+                "tenant_id": tenant_id,
+                "fleet_id": None,
+                "agent_id": "retrieval-pressure",
+                "memory_type": "fact",
+                "content": distractor,
+                "weight": 1.0,
+                "embedding": query_embedding,
+                "content_hash": hashlib.sha256(
+                    f"{tenant_id}:None:{distractor}".encode()
+                ).hexdigest(),
+                "status": "active",
+                "recall_count": 0,
+                "visibility": "scope_team",
+            }
+        )
+
+    for floor in (0.0, None):
+        search_body = {"tenant_id": tenant_id, "query": query, "top_k": top_k}
+        if floor is not None:
+            search_body["min_similarity"] = floor
+        search_response = await client.post(
+            "/api/v1/search",
+            headers=headers,
+            json=search_body,
+        )
+        assert search_response.status_code == 200, search_response.text
+
+        result_ids = {item["id"] for item in search_response.json()["items"]}
+        applied_floor = MIN_SEARCH_SIMILARITY if floor is None else floor
+        assert memory_id in result_ids, (
+            f"the {('pipeline' if use_pipeline else 'legacy')} search path discarded "
+            "the README's full-text match under candidate pressure with "
+            f"min_similarity={applied_floor:.1f}"
+        )
+
+    strict_response = await client.post(
+        "/api/v1/search",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "query": query,
+            "top_k": top_k,
+            "min_similarity": MIN_SEARCH_SIMILARITY,
+        },
+    )
+    assert strict_response.status_code == 200, strict_response.text
+    assert memory_id not in {item["id"] for item in strict_response.json()["items"]}, (
+        "an explicit similarity floor must remain strict even for a full-text match"
+    )

--- a/tests/test_search_default_profile.py
+++ b/tests/test_search_default_profile.py
@@ -137,6 +137,51 @@ async def test_precedence_empty_tenant_default_is_neutral():
     assert params["min_similarity"] == MIN_SEARCH_SIMILARITY
 
 
+async def test_keyword_strategy_keeps_the_global_semantic_floor():
+    step = ResolveSearchProfile()
+    ctx = PipelineContext(
+        data={"query": "JWT expiry", "top_k": 5, "search_profile": None},
+        tenant_config=None,
+    )
+
+    await step.execute(ctx)
+
+    assert ctx.data["search_params"]["min_similarity"] == MIN_SEARCH_SIMILARITY
+    assert ctx.data["allow_fts_global_floor_bypass"] is True
+
+
+async def test_keyword_strategy_keeps_a_tuned_floor():
+    step = ResolveSearchProfile()
+    ctx = PipelineContext(
+        data={
+            "query": "JWT expiry",
+            "top_k": 5,
+            "search_profile": {"min_similarity": 0.55},
+        },
+        tenant_config=None,
+    )
+
+    await step.execute(ctx)
+
+    assert ctx.data["search_params"]["min_similarity"] == 0.55
+    assert ctx.data["allow_fts_global_floor_bypass"] is False
+
+
+async def test_keyword_strategy_keeps_a_tenant_floor_strict():
+    step = ResolveSearchProfile()
+    ctx = PipelineContext(
+        data={"query": "JWT expiry", "top_k": 5, "search_profile": None},
+        tenant_config=ResolvedConfig(
+            {"search": {"default_profile": {"min_similarity": 0.42}}}
+        ),
+    )
+
+    await step.execute(ctx)
+
+    assert ctx.data["search_params"]["min_similarity"] == 0.42
+    assert ctx.data["allow_fts_global_floor_bypass"] is False
+
+
 # ── fts_rank_scale (#687) ──
 
 


### PR DESCRIPTION
## Why

Follow-up to #1076. The README probe exposed a real retrieval failure: an embedded memory that full-text matched JWT expiry still returned zero results, including with min_similarity 0.0. Strong vector-only rows filled the storage candidate window before core-api could apply its hybrid ranking policy.

## What changed

- Reserve a small, bounded supply of full-text matches before the storage candidate limit, while preserving the existing pending-embedding fallback when lexical scoring is disabled.
- Carry the full-text match signal through storage and both core search implementations, then reserve at most one lexical result at the final trim.
- Allow lexical evidence to relax only the untuned global similarity fallback. Per-request, agent, and tenant similarity floors remain strict.
- Add diagnostics for full-text matches and global-floor bypasses.
- Add an end-to-end regression for the exact README write and JWT expiry query under a saturated candidate window, covering both pipeline and legacy search paths and an explicit strict-floor control.

## Validation

The new end-to-end regression failed on the pre-fix code in both search paths, including the explicit 0.0 retry.

- API retrieval/recall slice: 194 passed
- core-storage-api suite: 199 passed
- core-api mypy: 203 source files clean
- core-storage-api mypy: 84 source files clean
- Ruff check and format: clean for changed production and new test files

One DCO-signed commit, rebased onto current main.