### PR TITLE
fix(client-python): health() raises on HTTP errors instead of returning them as data

### DIFF
--- a/clients/python/src/caura_client/client.py
+++ b/clients/python/src/caura_client/client.py
@@ -113,6 +113,7 @@ class Caura:
     def health(self) -> dict[str, Any]:
         """Liveness probe (GET /api/v1/health)."""
         response = self._http.get("/api/v1/health")
+        self._raise_for_status(response)
         return response.json()
 
     def get_document(

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -163,6 +163,26 @@ def test_health():
     assert make_client(handler).health()["status"] == "ok"
 
 
+def test_health_raises_auth_error_on_401():
+    def handler(request):
+        assert request.url.path == "/api/v1/health"
+        return httpx.Response(401, json={"detail": "invalid api key"})
+
+    with pytest.raises(AuthError) as exc:
+        make_client(handler).health()
+    assert exc.value.status_code == 401
+
+
+def test_health_raises_api_error_on_503():
+    def handler(request):
+        assert request.url.path == "/api/v1/health"
+        return httpx.Response(503, json={"detail": "database unavailable"})
+
+    with pytest.raises(CauraAPIError) as exc:
+        make_client(handler).health()
+    assert exc.value.status_code == 503
+
+
 def test_auth_error_parses_envelope():
     def handler(request):
         return httpx.Response(403, json={"error": {"message": "cross-fleet", "details": {"x": 1}}})


### PR DESCRIPTION
Fixes #971。health() 补上缺失的 _raise_for_status,401/503 现在抛 AuthError/CauraAPIError,和其他方法及 TS 客户端行为一致。验证:cd clients/python && PYTHONPATH=src python -m pytest tests/ -q,137 passed(7 个失败是 Windows 上预存的 POSIX 专属测试,与本改动无关)。