### PR TITLE
test(readme): execute keyless quickstart in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,13 +570,30 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Local-only tag shared by the two images used for the README Compose
+      # check below. Keeping this job's existing display name avoids changing
+      # the branch-protection status context while broadening its runtime-image
+      # coverage.
+      CAURA_VERSION: readme-ci
+      COMPOSE_PROFILES: ""
+      README_COMPOSE_PROJECT: "readme-quickstart-${{ github.run_id }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Build core-api image
-        run: docker build --platform linux/amd64 --target runtime -t core-api-versiontest -f core-api/Dockerfile .
+        run: |
+          docker build --platform linux/amd64 --target runtime \
+            -t core-api-versiontest \
+            -f core-api/Dockerfile .
+          compose_image="$(
+            docker compose --env-file /dev/null --file docker-compose.yml \
+              --project-name "$README_COMPOSE_PROJECT" config --format json |
+              python3 -c 'import json, sys; print(json.load(sys.stdin)["services"]["core-api"]["image"])'
+          )"
+          docker tag core-api-versiontest "$compose_image"
 
       - name: Assert baked version is a real semver matching pyproject
         run: |
@@ -606,6 +623,46 @@ jobs:
             echo "::error::numpy is missing from the core-api image — insights discover mode would silently fall back to non-clustered analysis. It must stay declared in core-api/pyproject.toml (see services/insights_service.py::_numpy_kmeans)."
             exit 1
           }
+
+      - name: Build core-storage-api image for README quickstart
+        run: |
+          docker build --platform linux/amd64 --target runtime \
+            -t core-storage-api-readmetest \
+            -f core-storage-api/Dockerfile .
+          compose_image="$(
+            docker compose --env-file /dev/null --file docker-compose.yml \
+              --project-name "$README_COMPOSE_PROJECT" config --format json |
+              python3 -c 'import json, sys; print(json.load(sys.stdin)["services"]["core-storage-api"]["image"])'
+          )"
+          docker tag core-storage-api-readmetest "$compose_image"
+
+      - name: Start the documented keyless stack
+        run: |
+          if [ ! -f .env.example ] || [ -L .env.example ]; then
+            echo "::error::.env.example must be a regular file"
+            exit 1
+          fi
+          rm -f -- .env
+          install -m 0600 -- .env.example .env
+          echo "IS_STANDALONE=true" >> .env
+          docker compose --env-file /dev/null --file docker-compose.yml \
+            --project-name "$README_COMPOSE_PROJECT" \
+            up --detach --no-build --wait --wait-timeout 180
+
+      - name: Run README write-and-search curl block
+        run: python3 scripts/check_readme_quickstart.py
+
+      - name: Show README quickstart logs on failure
+        if: failure()
+        run: |
+          docker compose --env-file /dev/null --file docker-compose.yml \
+            --project-name "$README_COMPOSE_PROJECT" logs --no-color
+
+      - name: Stop README quickstart stack
+        if: always()
+        run: |
+          docker compose --env-file /dev/null --file docker-compose.yml \
+            --project-name "$README_COMPOSE_PROJECT" down --volumes
 
   legacy-name-ratchet:
     # Hard rule 7 of the sunset plan: mint nothing new carrying the old brand.

--- a/README.md
+++ b/README.md
@@ -54,32 +54,34 @@ Agents write plain text. Caura turns it into searchable, governed, self-improvin
 
 ### Try it locally — no API key, no signup
 
-The fastest way to see Caura work. Standalone mode runs single-tenant with auth bypassed — start Caura and write a memory in four commands. (It boots with dummy embeddings so there's nothing to configure; add an AI provider key for semantic search — see [Self-Hosted](#self-hosted-open-source) below.)
+The fastest way to see Caura work. Standalone mode runs single-tenant with auth bypassed — start Caura, write a memory, and find it again. (It boots with dummy embeddings so there's nothing to configure; add an AI provider key for semantic search — see [Self-Hosted](#self-hosted-open-source) below.)
 
 ```bash
 git clone https://github.com/caura-ai/caura.git
 cd caura
 cp .env.example .env && echo "IS_STANDALONE=true" >> .env   # single-tenant, no API key
-docker compose up -d                                        # Postgres + pgvector + Redis + API (~30s)
+docker compose up -d --wait                                 # Postgres + pgvector + Redis + API (~30s)
+```
 
+<!-- readme-quickstart-ci:start -->
+```bash
 # Write a memory — no API key needed
 curl -X POST http://localhost:8000/api/v1/memories \
   -H "X-API-Key: standalone" -H "Content-Type: application/json" \
   -d '{"tenant_id": "default", "agent_id": "quickstart", "content": "Our auth service uses JWT with 15-minute expiry."}'
 
-# Try semantic recall (requires a real embedding provider; see below)
+# Find it by keyword — no provider key needed
 curl -X POST http://localhost:8000/api/v1/search \
   -H "X-API-Key: standalone" -H "Content-Type: application/json" \
-  -d '{"tenant_id": "default", "query": "authentication token lifetime"}'
+  -d '{"tenant_id": "default", "query": "JWT expiry"}'
 ```
+<!-- readme-quickstart-ci:end -->
 
-The write response comes back enriched with an LLM-inferred `memory_type`, `title`, `status`, and `weight` — plus a `summary` and `tags` under `metadata` — all from a single `content` field.
+The keyless write response includes `memory_type`, `title`, `status`, and `weight` — plus a `summary` under `metadata` — all derived by a deterministic local heuristic from the single `content` field. With a configured AI provider, those values are model-inferred and `metadata` can also include `tags`.
 
-> **This query is the one that needs a provider key.** Matching "authentication token lifetime" to a
-> memory that says "JWT with 15-minute expiry" is semantic recall, and it needs real embeddings. The
-> keyless setup above boots with dummy ones, so on that path search matches keywords only — try
-> `"JWT"` instead, and set an embedding provider (next section) before expecting the paraphrase to
-> land.
+> **Want semantic paraphrases?** The keyless query deliberately reuses words from the memory. After
+> configuring an embedding provider in the next section, try `"authentication token lifetime"`
+> instead — matching that phrase to "JWT with 15-minute expiry" exercises semantic recall.
 
 Ready for semantic recall, multi-tenant, a managed host, or an OpenClaw fleet? Pick a path below.
 
@@ -176,7 +178,7 @@ Anthropic, Gemini, and OpenRouter don't offer embedding APIs here — pair them 
 #### 2. Start the stack
 
 ```bash
-docker compose up -d
+docker compose up -d --wait
 ```
 
 > **Security requirement:** port 8002 belongs to the internal storage data

--- a/scripts/check_readme_quickstart.py
+++ b/scripts/check_readme_quickstart.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Run the curl-only portion of README's keyless quickstart.
+
+The marked README block is user-facing documentation and therefore untrusted
+input in pull-request CI.  This runner accepts only two localhost POSTs with
+JSON bodies and the headers used by the quickstart; it never invokes a shell.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+README = REPO_ROOT / "README.md"
+START_MARKER = "<!-- readme-quickstart-ci:start -->"
+END_MARKER = "<!-- readme-quickstart-ci:end -->"
+EXPECTED_PATHS = ("/api/v1/memories", "/api/v1/search")
+DEFAULT_BASE_URL = "http://localhost:8000"
+EXPECTED_HEADERS = {
+    "content-type": "application/json",
+    "x-api-key": "standalone",
+}
+
+
+class QuickstartError(RuntimeError):
+    """The documented quickstart is unsafe, malformed, or unsuccessful."""
+
+
+@dataclass(frozen=True)
+class CurlRequest:
+    path: str
+    payload: dict[str, Any]
+
+
+def _marked_bash_lines(markdown: str) -> list[str]:
+    if markdown.count(START_MARKER) != 1 or markdown.count(END_MARKER) != 1:
+        raise QuickstartError("README must contain exactly one quickstart marker pair")
+
+    start = markdown.index(START_MARKER) + len(START_MARKER)
+    end = markdown.index(END_MARKER)
+    if end <= start:
+        raise QuickstartError(
+            "README quickstart end marker must follow its start marker"
+        )
+    section = markdown[start:end]
+    lines = section.strip().splitlines()
+    if len(lines) < 3 or lines[0].strip() != "```bash" or lines[-1].strip() != "```":
+        raise QuickstartError("quickstart markers must wrap one bash code fence")
+    return lines[1:-1]
+
+
+def extract_curl_argv(markdown: str) -> tuple[tuple[str, ...], ...]:
+    """Extract logical curl commands without evaluating shell syntax."""
+    commands: list[tuple[str, ...]] = []
+    parts: list[str] = []
+
+    for raw_line in _marked_bash_lines(markdown):
+        line = raw_line.strip()
+        if not line or (not parts and line.startswith("#")):
+            continue
+        if not parts and not line.startswith("curl "):
+            raise QuickstartError(
+                f"only curl commands are allowed in the marked block: {line!r}"
+            )
+
+        if line.endswith("\\") and not raw_line.endswith("\\"):
+            raise QuickstartError(
+                "a continuation backslash must be the line's final character"
+            )
+        continued = raw_line.endswith("\\")
+        parts.append(line[:-1].rstrip() if continued else line)
+        if continued:
+            continue
+
+        try:
+            commands.append(tuple(shlex.split(" ".join(parts), posix=True)))
+        except ValueError as exc:
+            raise QuickstartError(
+                f"invalid shell quoting in quickstart: {exc}"
+            ) from exc
+        parts.clear()
+
+    if parts:
+        raise QuickstartError("quickstart curl ends with an unfinished continuation")
+    return tuple(commands)
+
+
+def _next_value(argv: tuple[str, ...], index: int, flag: str) -> tuple[str, int]:
+    try:
+        return argv[index + 1], index + 2
+    except IndexError as exc:
+        raise QuickstartError(f"{flag} is missing its value") from exc
+
+
+def validate_curl(argv: tuple[str, ...]) -> CurlRequest:
+    """Accept the narrow curl grammar documented by the keyless quickstart."""
+    if not argv or argv[0] != "curl":
+        raise QuickstartError("quickstart command must invoke curl by name")
+
+    method: str | None = None
+    url: str | None = None
+    body: str | None = None
+    headers: dict[str, str] = {}
+    index = 1
+
+    while index < len(argv):
+        token = argv[index]
+        if token == "-X":
+            if method is not None:
+                raise QuickstartError("quickstart curl contains duplicate -X flags")
+            method, index = _next_value(argv, index, token)
+        elif token == "-H":
+            raw_header, index = _next_value(argv, index, token)
+            if ":" not in raw_header:
+                raise QuickstartError(f"malformed curl header: {raw_header!r}")
+            name, value = raw_header.split(":", 1)
+            key = name.strip().lower()
+            if key in headers:
+                raise QuickstartError(f"duplicate curl header: {name.strip()!r}")
+            headers[key] = value.strip()
+        elif token == "-d":
+            if body is not None:
+                raise QuickstartError("quickstart curl contains duplicate -d flags")
+            body, index = _next_value(argv, index, token)
+        elif "://" in token:
+            if url is not None:
+                raise QuickstartError("quickstart curl contains more than one URL")
+            url = token
+            index += 1
+        else:
+            raise QuickstartError(f"unsupported curl argument: {token!r}")
+
+    if method != "POST":
+        raise QuickstartError("quickstart curl must use POST")
+    if headers != EXPECTED_HEADERS:
+        raise QuickstartError(f"quickstart curl headers changed: {headers!r}")
+    if url is None or body is None:
+        raise QuickstartError("quickstart curl requires one URL and one JSON body")
+
+    parsed = urlsplit(url)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise QuickstartError(f"quickstart curl has an invalid URL: {url!r}") from exc
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname != "localhost"
+        or port != 8000
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise QuickstartError(
+            f"quickstart curl may target only localhost:8000: {url!r}"
+        )
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise QuickstartError(f"quickstart curl body is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise QuickstartError("quickstart curl body must be a JSON object")
+    return CurlRequest(path=parsed.path, payload=payload)
+
+
+def load_requests(readme: Path = README) -> tuple[CurlRequest, CurlRequest]:
+    commands = extract_curl_argv(readme.read_text())
+    requests = tuple(validate_curl(command) for command in commands)
+    paths = tuple(request.path for request in requests)
+    if paths != EXPECTED_PATHS:
+        raise QuickstartError(
+            f"quickstart must write then search via {EXPECTED_PATHS!r}; found {paths!r}"
+        )
+    write, search = requests
+    return write, search
+
+
+def validate_base_url(value: str) -> str:
+    parsed = urlsplit(value.rstrip("/"))
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise QuickstartError("--base-url has an invalid port") from exc
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname != "localhost"
+        or port is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise QuickstartError("--base-url must be an http://localhost:<port> origin")
+    return f"http://localhost:{port}"
+
+
+def run_curl(request: CurlRequest, base_url: str = DEFAULT_BASE_URL) -> dict[str, Any]:
+    """Execute one already-validated command and decode its JSON response."""
+    argv = (
+        "curl",
+        "--disable",
+        "--noproxy",
+        "*",
+        "--silent",
+        "--show-error",
+        "--fail-with-body",
+        "--max-time",
+        "30",
+        "-X",
+        "POST",
+        f"{base_url}{request.path}",
+        "-H",
+        "X-API-Key: standalone",
+        "-H",
+        "Content-Type: application/json",
+        "-d",
+        json.dumps(request.payload, separators=(",", ":")),
+    )
+    completed = subprocess.run(argv, check=False, capture_output=True, text=True)
+    if completed.returncode:
+        detail = (completed.stdout or completed.stderr).strip()
+        raise QuickstartError(f"{request.path} curl failed: {detail[:500]}")
+    try:
+        response = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise QuickstartError(
+            f"{request.path} did not return JSON: {completed.stdout[:500]!r}"
+        ) from exc
+    if not isinstance(response, dict):
+        raise QuickstartError(f"{request.path} returned a non-object JSON response")
+    return response
+
+
+def assert_round_trip(
+    write_response: dict[str, Any], search_response: dict[str, Any]
+) -> None:
+    memory_id = write_response.get("id")
+    if not isinstance(memory_id, str) or not memory_id:
+        raise QuickstartError(f"write response has no memory id: {write_response!r}")
+
+    items = search_response.get("items")
+    if not isinstance(items, list):
+        raise QuickstartError(f"search response has no items list: {search_response!r}")
+    if not any(
+        isinstance(item, dict) and item.get("id") == memory_id for item in items
+    ):
+        raise QuickstartError(
+            "search did not return the memory created by the preceding curl"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help="localhost origin to use while retaining the documented request paths",
+    )
+    args = parser.parse_args()
+    try:
+        base_url = validate_base_url(args.base_url)
+        write, search = load_requests()
+        write_response = run_curl(write, base_url)
+        search_response = run_curl(search, base_url)
+        assert_round_trip(write_response, search_response)
+    except (OSError, QuickstartError) as exc:
+        print(f"README quickstart check failed: {exc}", file=sys.stderr)
+        return 1
+
+    print("README keyless quickstart wrote and found its memory")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_readme_quickstart.py
+++ b/tests/test_readme_quickstart.py
@@ -1,0 +1,163 @@
+"""Contract tests for the executable README keyless quickstart."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import check_readme_quickstart as checker
+from check_readme_quickstart import (
+    END_MARKER,
+    START_MARKER,
+    CurlRequest,
+    QuickstartError,
+    assert_round_trip,
+    extract_curl_argv,
+    load_requests,
+    run_curl,
+    validate_base_url,
+    validate_curl,
+)
+
+
+def _marked_block(command: str) -> str:
+    return f"{START_MARKER}\n```bash\n{command}\n```\n{END_MARKER}\n"
+
+
+def test_readme_keyless_quickstart_is_the_expected_keyword_round_trip() -> None:
+    write, search = load_requests()
+
+    assert write.payload == {
+        "tenant_id": "default",
+        "agent_id": "quickstart",
+        "content": "Our auth service uses JWT with 15-minute expiry.",
+    }
+    assert search.payload == {"tenant_id": "default", "query": "JWT expiry"}
+
+
+def test_marked_block_rejects_non_curl_shell_commands() -> None:
+    markdown = _marked_block(
+        "curl -X POST \\\n  http://localhost:8000/api/v1/memories\nrm -rf /tmp/example"
+    )
+
+    with pytest.raises(QuickstartError, match="only curl commands"):
+        extract_curl_argv(markdown)
+
+
+def test_marked_block_rejects_reversed_markers() -> None:
+    markdown = f"{END_MARKER}\n{START_MARKER}\n```bash\n# empty\n```\n"
+
+    with pytest.raises(QuickstartError, match="end marker must follow"):
+        extract_curl_argv(markdown)
+
+
+def test_marked_block_rejects_whitespace_after_continuation() -> None:
+    markdown = _marked_block(
+        "curl -X POST \\   \n  http://localhost:8000/api/v1/memories"
+    )
+
+    with pytest.raises(QuickstartError, match="final character"):
+        extract_curl_argv(markdown)
+
+
+def test_curl_validation_rejects_remote_targets() -> None:
+    argv = (
+        "curl",
+        "-X",
+        "POST",
+        "https://example.com/api/v1/memories",
+        "-H",
+        "X-API-Key: standalone",
+        "-H",
+        "Content-Type: application/json",
+        "-d",
+        '{"tenant_id":"default"}',
+    )
+
+    with pytest.raises(QuickstartError, match="localhost:8000"):
+        validate_curl(argv)
+
+
+def test_curl_validation_rejects_additional_options() -> None:
+    argv = (
+        "curl",
+        "-X",
+        "POST",
+        "http://localhost:8000/api/v1/memories",
+        "-H",
+        "X-API-Key: standalone",
+        "-H",
+        "Content-Type: application/json",
+        "-d",
+        '{"tenant_id":"default"}',
+        "--output",
+        "/tmp/leak",
+    )
+
+    with pytest.raises(QuickstartError, match="unsupported curl argument"):
+        validate_curl(argv)
+
+
+def test_curl_validation_rejects_duplicate_data_flags() -> None:
+    argv = (
+        "curl",
+        "-X",
+        "POST",
+        "http://localhost:8000/api/v1/memories",
+        "-H",
+        "X-API-Key: standalone",
+        "-H",
+        "Content-Type: application/json",
+        "-d",
+        "@/etc/passwd",
+        "-d",
+        '{"tenant_id":"default"}',
+    )
+
+    with pytest.raises(QuickstartError, match="duplicate -d"):
+        validate_curl(argv)
+
+
+def test_curl_execution_reconstructs_instead_of_replaying_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[str, ...]] = []
+
+    def fake_run(argv, **_kwargs):
+        captured.append(argv)
+        return SimpleNamespace(returncode=0, stdout='{"id":"created-id"}', stderr="")
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    request = CurlRequest(
+        path="/api/v1/memories",
+        payload={"tenant_id": "default", "content": "@/proc/self/environ"},
+    )
+
+    assert run_curl(request, "http://localhost:18001") == {"id": "created-id"}
+    assert captured[0][1:4] == ("--disable", "--noproxy", "*")
+    assert captured[0].count("-d") == 1
+    assert captured[0][-1] == (
+        '{"tenant_id":"default","content":"@/proc/self/environ"}'
+    )
+
+
+def test_runtime_override_stays_on_localhost() -> None:
+    assert validate_base_url("http://localhost:18001/") == "http://localhost:18001"
+    assert validate_base_url("http://localhost:18001?") == "http://localhost:18001"
+    assert validate_base_url("http://localhost:18001#") == "http://localhost:18001"
+
+    with pytest.raises(QuickstartError, match="localhost"):
+        validate_base_url("https://example.com")
+
+
+def test_round_trip_requires_search_to_return_the_created_memory() -> None:
+    with pytest.raises(QuickstartError, match="did not return"):
+        assert_round_trip({"id": "created-id"}, {"items": [{"id": "other-id"}]})


### PR DESCRIPTION
## Summary
- make the no-key quickstart search for `JWT expiry`, the keyword path fixed in #1092, while keeping the semantic paraphrase as the provider-enabled follow-up
- wait for Compose health before the documented curls and describe keyless heuristic enrichment accurately
- extract the marked README curl block through a strict localhost-only parser, reconstruct safe curl requests, and require search to return the memory just written
- boot the current-source core-api and core-storage-api images in CI and run that round trip, with isolated Compose controls and guaranteed cleanup

## Validation
- red-before-green: the runner against a fresh keyless stack failed with the old `authentication token lifetime` query (`search did not return the memory`)
- green: the corrected marked block wrote and found its memory against a fresh current-source Compose stack
- `pytest tests/test_readme_quickstart.py tests/test_readme_keyword_recall.py -q` — 12 passed
- `ruff check` + `ruff format --check` on the new script/tests
- `mypy --config-file scripts/mypy.ini scripts/` — clean (30 files)
- `actionlint -ignore SC2086 .github/workflows/ci.yml` — clean; SC2086 is an unchanged repository baseline
- full `/simplify` pass — no remaining findings

Follow-up to #1076 and #1092.