### PR TITLE
docs(readme): split reference material

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -91,7 +91,9 @@ The OSS API supports three auth paths. Pick one:
 IS_STANDALONE=true
 ```
 
-Restart the server. All API calls work without `X-API-Key`. The MCP server still expects an `X-API-Key` header, so set any non-admin value (e.g. `X-API-Key: standalone`) — it's ignored in standalone mode.
+Restart the server. REST and MCP calls work without `X-API-Key`. Supplying a
+placeholder such as `X-API-Key: standalone` is harmless and can make the same
+client configuration easier to reuse with authenticated modes.
 
 **Path 2 — Admin key (multi-tenant, full access).** Set in your `.env`:
 
@@ -166,7 +168,7 @@ Use MCP if your agent supports it. Use the plugin if you're running on OpenClaw.
 ## Verify Your Connection
 
 ```bash
-# Example: standalone mode (tenant_id="default", any non-admin X-API-Key works)
+# Example: standalone mode (tenant_id="default"; the placeholder key is optional)
 CAURA_URL=http://localhost:8000
 KEY=standalone
 
@@ -252,6 +254,6 @@ If you see search latency materially above ~50 ms p50 after warm-up, the pgvecto
 ## Full Reference
 
 For complete tool documentation with parameters, examples, memory types, status lifecycle, best practices, and
-project structure, see the [README API reference](README.md#api-reference) and
-[README project structure](README.md#project-structure). For benchmark methodology and competitive context, see
+project structure, see the [API reference](docs/api-reference.md) and
+[project structure](docs/api-reference.md#project-structure). For benchmark methodology and competitive context, see
 [`docs/performance.md`](docs/performance.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ type drawn from this list:
 | `test`, `build`, `ci`, `chore` | Hidden from CHANGELOG, no release impact |
 
 Append `!` (`feat!: …`) or a `BREAKING CHANGE:` footer for changes
-that break the [Public API](README.md#public-api--stability) — these
+that break the [Public API](docs/public-api-stability.md) — these
 trigger a major bump once we ship 1.0.0. Before 1.0.0 they're treated
 as minor (`bump-minor-pre-major: true` in `release-please-config.json`).
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Three paths — pick the one that matches your setup:
 
 Get up and running in minutes — no infrastructure, automatic updates, usage analytics, and enterprise-grade security included.
 
-1. **[Sign up free on caura.ai](https://caura.ai)**
-2. Grab your API key from the dashboard
-3. Connect via MCP or REST:
+1. **[Sign up free on caura.ai](https://caura.ai).**
+2. Copy an API key from the dashboard.
+3. Connect through MCP or REST:
 
 ```json
 {
@@ -114,185 +114,64 @@ Get up and running in minutes — no infrastructure, automatic updates, usage an
 }
 ```
 
-> **Production / team use:** the quickstart key above is a **tenant-scoped credential** — fine for personal use, but a fleet of agents should bind each one to its own **agent-scoped credential** for trust gating, fleet membership, and per-agent keystones. Provision agent-scoped credentials atomically via [`POST /api/v1/admin/agent-keys/provision`](docs/integration-without-plugin.md), or through the dashboard at `/settings/organization/api-credentials`. Both kinds use the `mc_` prefix on the wire — scope is bound at mint time on the credential itself. The MCP server accepts the credential on either `X-API-Key: mc_…` or `Authorization: Bearer mc_…`. *(Pre-existing `mca_…` and `mci_…` keys continue to authenticate via back-compat.)*
->
-> Using a tenant-scoped credential? Pass an explicit `agent_id` on every MCP tool call — the gateway refuses the reserved default (`mcp-agent`) on the tenant-scoped path.
+For a production fleet, provision one agent-scoped credential per agent. See
+[Integrating without the OpenClaw plugin](docs/integration-without-plugin.md)
+for credential scopes, headers, and provisioning.
+
+Using the tenant-scoped dashboard key? Pass an explicit `agent_id` on every MCP
+tool call; the gateway rejects the reserved `mcp-agent` default on that path.
 
 ### Self-Hosted (Open Source)
 
-The fastest path is Docker Compose — one command brings up Postgres + pgvector + Redis + the API.
+Docker Compose starts PostgreSQL + pgvector, Redis, the storage service, and the
+REST/MCP API. The keyless example above is the shortest path; add a provider for
+semantic recall.
 
-> **Prefer not to use Docker?** Skip to [Manual deployment (without Docker)](#manual-deployment-without-docker) below for the bare-Python path.
->
-> **No cloud API key, no external calls?** v2.0+ supports a self-hosted local embedder (`BAAI/bge-m3` via HuggingFace TEI) — see [`docs/local-embedder.md`](docs/local-embedder.md). The setup below walks through the OpenAI default; the local-embedder doc walks through the alternative.
+<a id="prerequisites"></a>
+<a id="1-clone-and-configure"></a>
+<a id="2-start-the-stack"></a>
+<a id="what-the-stack-contains--and-what-it-doesnt"></a>
+<a id="3-verify"></a>
+<a id="4-write-and-search"></a>
 
-#### Prerequisites
+- [Complete self-hosting guide](docs/self-hosting.md) — providers, auth,
+  service topology, security, offline operation, and tests
+- [Local embedder](docs/local-embedder.md) — fully local semantic search with
+  no cloud API calls
+- [Manual deployment without Docker](#manual-deployment-without-docker)
 
-- **Docker Engine 24+** (Linux) or **Docker Desktop** (macOS / Windows). Confirm with `docker --version`.
-- **Docker Compose v2** (built into modern Docker). Confirm with `docker compose version`.
-- **Git** for cloning.
-- ~2 GB free disk for images + Postgres data volume.
+### OpenClaw Plugin
 
-#### 1. Clone and configure
+<a id="openclaw-plugin-1"></a>
 
-```bash
-git clone https://github.com/caura-ai/caura.git
-cd caura
-cp .env.example .env
-```
+Already running an OpenClaw fleet? Install Caura as a plugin against either the managed platform or your self-hosted stack:
 
-Set your AI provider in `.env` — minimal setup with OpenAI:
+The plugin claims OpenClaw's `memory` slot and exposes the same agent-facing
+memory tools. Use the
+[agent installer's one-line setup](AGENT-INSTALL.md#connect-via-openclaw-plugin-alternative-to-mcp),
+then see the [OpenClaw integration guide](static/docs/integration-guide.md) for
+agent prompts and trust levels.
 
-```env
-EMBEDDING_PROVIDER=openai
-ENTITY_EXTRACTION_PROVIDER=openai
-USE_LLM_FOR_MEMORY_CREATION=true
-OPENAI_API_KEY=sk-...
-```
+### Python client
 
-> Without any AI keys the stack still starts — dummy providers return non-semantic embeddings, useful for testing the API surface.
-
-> 💡 **Want zero cloud API calls?** v2.0+ ships a self-hosted embedder
-> profile (`BAAI/bge-m3` on a [HuggingFace TEI](https://github.com/huggingface/text-embeddings-inference)
-> sidecar). Bring up the stack with `docker compose --profile embed-local up -d`
-> and set the four `OPENAI_EMBEDDING_*` envs from `.env.example` — see
-> [`docs/local-embedder.md`](docs/local-embedder.md) for the full setup.
-> Combined with `IS_STANDALONE=true` (below) this is a fully self-contained
-> deployment with no external API calls.
-
-<details>
-<summary>Other providers (Gemini, Anthropic, OpenRouter, self-hosted)</summary>
-
-| Provider | `.env` settings | Required key |
-|---|---|---|
-| **OpenAI** (default) | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=openai` | `OPENAI_API_KEY` |
-| **Google Gemini** | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=gemini` | `GEMINI_API_KEY` + `OPENAI_API_KEY` |
-| **Anthropic** | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=anthropic` | `ANTHROPIC_API_KEY` + `OPENAI_API_KEY` |
-| **OpenRouter** | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=openrouter` | `OPENROUTER_API_KEY` + `OPENAI_API_KEY` |
-| **Self-hosted (TEI / bge-m3)** | `--profile embed-local` + `OPENAI_EMBEDDING_BASE_URL=http://tei:80/v1`<br>+ `OPENAI_EMBEDDING_MODEL=BAAI/bge-m3`<br>+ `OPENAI_EMBEDDING_SEND_DIMENSIONS=false` | none — runs locally |
-
-Anthropic, Gemini, and OpenRouter don't offer embedding APIs here — pair them with OpenAI (or with TEI) for embeddings. You can mix providers freely. Gemini uses the [Google AI Studio](https://aistudio.google.com/) key-auth Developer API (no GCP project/ADC required). The self-hosted TEI row keeps `EMBEDDING_PROVIDER=openai` because TEI speaks the same OpenAI-compatible API; see [`docs/local-embedder.md`](docs/local-embedder.md) for hardware sizing, GPU setup, and model swapping.
-
-</details>
-
-#### 2. Start the stack
+Talk to any managed or self-hosted Caura deployment from Python:
 
 ```bash
-docker compose up -d --wait
+pip install caura-client
 ```
 
-> **Security requirement:** port 8002 belongs to the internal storage data
-> plane and must never be exposed to the host or any untrusted network. The
-> shipped Compose file does not publish it; `core-api` reaches it only across
-> the private Compose network and authenticates with a random, per-installation
-> secret generated into a private Docker volume.
-> Do not add an `8002:8002` port mapping. If local debugging absolutely requires
-> host access, bind only `127.0.0.1:8002:8002` and keep the
-> `CORE_STORAGE_SHARED_SECRET` check enabled. Only exact `GET /healthz` and
-> `GET /readyz` probes are public; every storage data route requires the secret.
+See the [Python client guide](clients/python/) for examples and the full API.
 
-By default this **pulls the multi-arch images from `ghcr.io`** (`linux/amd64` + `linux/arm64`) on first run — takes ~30 seconds. Subsequent `up` commands re-use the cached image (no registry round-trip, works offline). To pin a specific version, set `CAURA_VERSION=v1.2.3` in your `.env`. To build from local source instead (e.g. when iterating on a fork), run `docker compose up --build --pull never`.
+### TypeScript client
 
-To upgrade to a newer image at the same tag (e.g. `:latest` after we cut a new release), run `docker compose pull && docker compose up -d`. Without an explicit `pull`, the local cache wins — there's no silent version drift.
-
-> **Offline / air-gapped operation**: depending on whether the image is already cached locally:
-> - **Image cached, no network**: `docker compose up -d` works as-is — `pull_policy: missing` doesn't try to pull when the image is present. Use `docker compose up -d --pull never` if you want to be explicit.
-> - **No local image, no network**: `docker compose up --build --pull never` (build from source, don't try to pull).
-> - **Strict no-network guarantee** (e.g. an air-gapped pipeline that should never reach `ghcr.io`): drop a `docker-compose.override.yml` setting `pull_policy: never` for both services — Compose then fails fast if the image is absent rather than attempting a pull.
-
-| Service | URL |
-|---|---|
-| Core API (REST + MCP) | http://localhost:8000 |
-| PostgreSQL (pgvector) | localhost:5432 |
-| Redis | localhost:6379 |
-
-`core-storage-api` is intentionally reachable only by other services on the
-Compose network; it has no host URL.
-
-#### What the stack contains — and what it doesn't
-
-`docker compose up` starts four long-running containers plus a one-shot
-`storage-secret-init` container that creates the internal credential:
-
-| Container | Role |
-|---|---|
-| `db` | PostgreSQL 16 + pgvector |
-| `redis` | Cache and rate limiting |
-| `core-storage-api` | Storage service (SQL + vector search) |
-| `core-api` | REST + MCP surface; embedding and enrichment run **in-process** (`deployment_mode=inline`, the default) |
-
-A fifth service, `tei` (the local embedder), is defined in the compose file but only starts with `--profile embed-local`. Components you may see referenced elsewhere in this repo — `core-worker`, the platform-tier services, the Google Pub/Sub event bus — run only in managed/enterprise deployments. The OSS stack uses the in-process event bus, and inline mode embeds and enriches inside `core-api` itself, so no worker service is needed.
-
-#### 3. Verify
+The Node 18+ client has no runtime dependencies:
 
 ```bash
-curl http://localhost:8000/api/v1/health
-# {"status":"ok","storage":"connected","redis":"connected","event_bus":"ok"}
+npm install @caura/client
 ```
 
-#### 4. Write and search
-
-```bash
-# Write a memory (standalone mode — no API key needed)
-curl -X POST http://localhost:8000/api/v1/memories \
-  -H "X-API-Key: standalone" \
-  -H "Content-Type: application/json" \
-  -d '{"tenant_id": "default", "agent_id": "quickstart", "content": "Our auth service uses JWT with 15-minute expiry."}'
-
-# Search for it — semantic, once an embedding provider is configured above
-curl -X POST http://localhost:8000/api/v1/search \
-  -H "X-API-Key: standalone" \
-  -H "Content-Type: application/json" \
-  -d '{"tenant_id": "default", "query": "authentication token lifetime"}'
-```
-
-`agent_id` names the writer, so every memory carries provenance. It's optional on the standalone path
-in current source — it defaults to `mcp-agent` — but published images through `v2.x` still require it,
-so the examples pass it explicitly and work against every version.
-
-A write body accepts only the fields the API declares. Send one it doesn't — a
-typo, or a plausible-looking key like `tags` — and you get a `422` naming it in
-`error.details.unknown_fields`, rather than a `201` with your data quietly
-dropped. Search and filter bodies still ignore unknown fields on purpose; the
-asymmetry is explained in
-[`docs/api-surfaces.md`](docs/api-surfaces.md#request-body-contract-writes-are-strict-searches-are-not).
-
-The write response carries an LLM-inferred `memory_type`, `title`, `status`, and a `weight` (the importance score) — all derived from a single `content` field. Two more inferred values, `summary` and `tags`, live under `metadata` rather than at the top level, so read them as `metadata.summary` and `metadata.tags`. On the default fast-write path, enrichment is applied asynchronously: the immediate response carries `metadata.enrichment_pending: true` and the inferred fields populate within moments.
-
-`POST /search` returns matches under an `items` array, each entry the full memory plus a `similarity` score:
-
-```json
-{
-  "items": [
-    {
-      "id": "…",
-      "agent_id": "mcp-agent",
-      "memory_type": "fact",
-      "title": "Auth service uses JWT with 15-minute expiry",
-      "similarity": 0.47,
-      "visibility": "scope_team",
-      "status": "active"
-    }
-  ]
-}
-```
-
-Embedding is asynchronous too, so a just-written memory may not surface in
-semantic `search` right after the write returns. The write response says so:
-`metadata.embedding_pending: true` means the row was stored without an embedding
-and a background backfill is scheduled. Until it lands the memory is already
-reachable by keyword and in the non-semantic `GET /memories` list — it just
-doesn't compete on semantic similarity yet. Budget ~15–20s in production; a
-slower backfill (staging, or a saturated worker) can take minutes, so treat the
-flag as the signal rather than assuming a fixed delay.
-
-If a caller has to search for what it just wrote, pass `write_mode: "strong"` on
-the write. That embeds inline — the response comes back with no
-`embedding_pending` and the memory is immediately searchable. The trade is an
-embedding provider call on the request path, which is precisely what fast mode's
-sub-2s p99 visibility target exists to avoid, so it's worth choosing per write
-rather than switching on globally. (A deployment configured to embed inline, the
-default for a local OSS install, never sets the flag at all.)
+See the [TypeScript client guide](clients/typescript/) for installation and
+package-name compatibility details.
 
 ---
 
@@ -300,119 +179,6 @@ default for a local OSS install, never sets the flag at all.)
 [star the repo](https://github.com/caura-ai/caura/stargazers)** —
 it's how other fleet builders find us, and it shapes how much time we can
 invest in the OSS edition.
-
----
-
-<details>
-<summary>Auth modes</summary>
-
-OSS supports three auth paths. Pick one and add it to your `.env`, then `docker compose up -d` to restart.
-
-**Standalone** — single-tenant (`tenant_id="default"`), simplest for local / self-install:
-```env
-IS_STANDALONE=true
-```
-No API key required for REST. MCP still expects a non-empty `X-API-Key` header — any value works.
-
-> Pair Standalone mode with `--profile embed-local` (see [`docs/local-embedder.md`](docs/local-embedder.md)) for a fully self-contained deployment: no admin keys, no external API calls, all embeddings computed locally. Useful for offline / air-gapped environments and personal-laptop installs.
-
-**Admin key** — multi-tenant with full access:
-```env
-ADMIN_API_KEY=your-long-random-admin-key
-```
-Pass `X-API-Key: your-long-random-admin-key` and include `tenant_id` in request bodies / query params.
-
-**Shared gate** — for network-exposed OSS deployments:
-```env
-CAURA_API_KEY=your-shared-key
-```
-Clients send `X-API-Key: your-shared-key` plus `X-Tenant-ID: <tenant>`.
-
-> See [AGENT-INSTALL.md](AGENT-INSTALL.md) for the full agent self-install walkthrough.
-
-</details>
-
-<details>
-<summary>Running tests</summary>
-
-```bash
-# Unit tests (no DB needed)
-pytest tests/ -m "unit"
-
-# All tests (requires PostgreSQL)
-docker compose up -d db
-pytest tests/ -m "not benchmark"
-
-# Smoke test against live API (~30s, auto-cleanup)
-python scripts/smoke_test.py --url http://localhost:8000 --api-key <admin-key>
-```
-
-</details>
-
-### OpenClaw Plugin
-
-Already running an OpenClaw fleet? Install Caura as a plugin against either the managed platform or your self-hosted stack:
-
-```bash
-# Point at whichever URL hosts your Caura API
-export CAURA_URL=https://caura.ai             # managed
-# or:  export CAURA_URL=http://localhost:8000  # self-hosted
-export CAURA_KEY=your-key                      # `standalone` works in self-hosted standalone mode
-export CAURA_FLEET=my-fleet
-
-curl -sf -H "X-API-Key: $CAURA_KEY" \
-  "$CAURA_URL/api/v1/install-plugin?fleet_id=$CAURA_FLEET&api_url=$CAURA_URL" | bash
-
-# Restart the gateway to load the plugin
-openclaw gateway restart
-```
-
-The plugin claims the OpenClaw `memory` slot (replacing `memory-core`) and exposes the same 12 MCP tools. Full setup, agent prompts, and trust levels: [static/docs/integration-guide.md](static/docs/integration-guide.md).
-
-### Python client
-
-Talk to any Caura deployment (managed or self-hosted) from Python:
-
-```bash
-pip install caura-client
-```
-
-```python
-from caura_client import Caura
-
-mc = Caura("mc_xxx", tenant_id="my-team", agent_id="my-agent")
-mc.write("Q3 revenue target is $4M, set on 2026-04-15.")
-print(mc.recall("Q3 revenue target").summary)
-```
-
-Formerly `memclaw-client` — the old package name, the `memclaw_client` <!-- legacy-name-ok: rule 3 keeps the client aliases working -->
-import, and the `MemClaw` class all keep working forever as aliases. <!-- legacy-name-ok: rule 3 keeps the client aliases working -->
-
-A thin wrapper over the REST API — see [`clients/python/`](clients/python/) for the full client.
-
-### TypeScript client
-
-Same, from TypeScript / JavaScript (Node 18+, no third-party dependencies):
-
-```bash
-npm install @caura/client
-```
-
-```ts
-import { Caura } from "@caura/client";
-
-const mc = new Caura("mc_xxx", { tenantId: "my-team", agentId: "my-agent" });
-await mc.write("Q3 revenue target is $4M, set on 2026-04-15.");
-console.log((await mc.recall("Q3 revenue target")).summary);
-```
-
-`MemClaw` remains a permanent alias of `Caura`. <!-- legacy-name-ok: rule 3 keeps the client aliases working -->
-
-The bare `caura` name on npm is held up by the registry's package-name
-similarity filter, so install the scoped package above. On the Python side,
-`pip install caura` works and pulls the same client.
-
-See [`clients/typescript/`](clients/typescript/) for the full client.
 
 ---
 
@@ -786,489 +552,68 @@ manual deployments must configure `CORE_STORAGE_SHARED_SECRET` (or
 
 ## Upgrading from v1.x
 
-> **⚠️ v2.0.0 ships a destructive schema migration.** If your installation is on
-> v1.x and has any memories already stored, follow this procedure carefully — the
-> migration NULLs every existing embedding to widen the pgvector column from
-> 768 → 1024 dim. The application is designed to refuse the migration
-> automatically; you must opt in.
+<!-- Preserve deep links from the former inline guide. -->
+<a id="what-changes"></a>
+<a id="procedure-oss-docker-compose"></a>
+<a id="what-if-i-skip-the-opt-in"></a>
+<a id="rolling-back"></a>
+<a id="v1x--v2x-compatibility-for-client-code"></a>
 
-### What changes
+Version 2.0 widened embeddings from 768 to 1024 dimensions. Existing
+installations must explicitly opt into the destructive migration, take a
+database snapshot, and re-embed stored data.
 
-- Default embedder model: `BAAI/bge-m3` (was: OpenAI `text-embedding-3-small`).
-  Self-hosted via the new `tei` profile in docker-compose; documented in
-  [`docs/local-embedder.md`](docs/local-embedder.md).
-- pgvector schema dim: `vector(1024)` (was: `vector(768)`).
-- Existing embeddings on `memories.embedding`, `entities.name_embedding`, and
-  `documents.embedding` are NULLed by alembic revision `012_vector_dim_1024`.
-  Re-embedding is required; until rows are re-embedded, semantic search returns
-  no results for those rows.
-
-### Procedure (OSS, docker-compose)
-
-1. **Stop the stack** so no writes happen during migration:
-   ```bash
-   docker compose down
-   ```
-
-2. **Snapshot the database.** A `pg_dump` is the safest fallback. Replace
-   `<container>` with the running PostgreSQL container name (typically
-   `caura-db-1`):
-   ```bash
-   docker compose up -d db    # bring just the DB back
-   docker exec <container> pg_dump -U memclaw memclaw > backup-pre-v2.sql
-   docker compose down
-   ```
-
-3. **Pull the new image** and start with the migration opt-in env set. The
-   gate enforces an explicit opt-in because the migration is destructive on
-   a populated DB:
-   ```bash
-   docker compose pull
-   CAURA_RUN_DESTRUCTIVE_MIGRATIONS=true docker compose up -d
-   ```
-   The `core-storage-api` container will run `alembic upgrade head` on
-   startup. The migration runs in seconds-to-minutes for typical OSS
-   workloads.
-
-4. **Verify migration completed.** Look for the line
-   `Database initialization complete` in the `core-storage-api` logs:
-   ```bash
-   docker compose logs core-storage-api | grep -i "alembic\|migration"
-   ```
-
-5. **Re-embed your data.** Two paths:
-   - **Lazy** (zero action): the application re-embeds rows on next read or
-     write that touches them. Search will return empty results for cold rows
-     until they are touched. Acceptable for low-traffic personal deployments.
-   - **Eager (recommended):** run the bundled backfill CLI. It walks every
-     memory and entity with a NULL embedding and re-embeds via the configured
-     provider. Idempotent — safe to re-run. First do a dry-run to estimate
-     scope:
-     ```bash
-     docker compose run --rm core-storage-api \
-       python -m core_storage_api.scripts.backfill_embeddings --dry-run
-     ```
-     Then the real run:
-     ```bash
-     docker compose run --rm core-storage-api \
-       python -m core_storage_api.scripts.backfill_embeddings
-     ```
-     Optional knobs: `--tenant-id <id>` (per-tenant cutover), `--batch-size N`,
-     `--max-inflight N`, `--only-table memories|entities`. Documents are NOT
-     covered (their embed-source field is per-row JSON, not a fixed column);
-     re-write any embedded documents to refresh them.
-   - **Eager (event-driven, recommended for multi-tenant production):** if you
-     run the `core-worker` service, drive the existing `EMBED_REQUESTED`
-     consumer instead. The CLI scans `WHERE embedding IS NULL` and publishes
-     one event per row, inheriting per-tenant concurrency + retry + DLQ:
-     ```bash
-     docker compose run --rm core-worker \
-       python -m core_worker.cli backfill-embeddings --dry-run
-     docker compose run --rm core-worker \
-       python -m core_worker.cli backfill-embeddings
-     ```
-     Same knobs as the standalone script (`--tenant-id`, `--batch-size`,
-     `--max-inflight`, `--dry-run`). Currently covers `memories` only.
-     Note the shipped compose stack does **not** include a `core-worker`
-     service — it's a managed/deferred-mode component (`deployment_mode=deferred`),
-     so self-hosters on the stock stack should use the `core-storage-api`
-     variant above, which works as documented.
-
-6. **Once stable, unset `CAURA_RUN_DESTRUCTIVE_MIGRATIONS`** so subsequent
-   `up` commands don't carry the opt-in:
-   ```bash
-   unset CAURA_RUN_DESTRUCTIVE_MIGRATIONS  # if exported in the shell
-   # or remove the line from your .env file
-   ```
-
-### What if I skip the opt-in?
-
-`core-storage-api` will refuse to start, with a clear error message reporting
-how many rows would be NULLed. The container exits non-zero; the rest of the
-stack stays healthy. No data is touched. Set the env var and retry.
-
-### Rolling back
-
-The migration has a symmetric `downgrade()`. To revert, set the env var and
-explicitly downgrade:
-
-```bash
-docker compose run --rm \
-  -e CAURA_RUN_DESTRUCTIVE_MIGRATIONS=true \
-  core-storage-api alembic downgrade 011
-```
-
-This NULLs any 1024-dim embeddings written since the upgrade and widens the
-columns back to `vector(768)`. The same data-loss tradeoff applies in reverse.
-For untouched-since-upgrade installations, the simpler recovery is to restore
-the snapshot from step 2.
-
-### v1.x → v2.x compatibility for client code
-
-No public API changes. Code that reads memory embeddings via the search/recall
-endpoints is unaffected. Client code that hardcodes `768` for vector lengths
-should be updated to read `VECTOR_DIM` from `common.constants`.
+Follow the complete [v1.x → v2.x upgrade guide](docs/upgrading-from-v1.md)
+before pulling a v2 image.
 
 ---
 
 ## API Reference
 
-All routes are versioned under `/api/v1/`. Interactive Swagger docs at `/api/docs`.
-
-<details>
-<summary>Memory endpoints</summary>
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/memories` | POST | Write a memory. LLM enrichment + embedding + entity extraction + contradiction detection. `"persist": false` for extract-only preview |
-| `/memories/bulk` | POST | Write up to 100 memories. Batches embeddings, parallelizes enrichment, single transaction. Requires `X-Bulk-Attempt-Id` header (per-attempt idempotency); a retry with the same id resolves committed rows as `duplicate_attempt` instead of duplicating. Returns 200 (clean / all-error) or 207 Multi-Status (mixed) — read per-item `status` |
-| `/memories` | GET | List memories (filter by type, status, agent; paginate) |
-| `/memories/{id}` | GET | Full memory detail (embedding stats, entity links, RDF triple, temporal bounds) |
-| `/memories/{id}` | PATCH | Update content or metadata. Re-embeds if content changes |
-| `/memories/{id}` | DELETE | Soft delete (sets status to `deleted`) |
-| `/memories/{id}/status` | PATCH | Update lifecycle status |
-| `/memories/{id}/contradictions` | GET | View contradiction chain |
-| `/memories` | DELETE | Bulk soft-delete |
-| `/memories/stats` | GET | Counts by type, agent, and status |
-| `/search` | POST | Hybrid semantic + keyword search with graph-enhanced retrieval |
-| `/recall` | POST | Search + LLM synthesis — `summary` is the answer to the query (the model reasons step by step internally; only its final answer is surfaced), alongside the source memories under both `memories` and `items` |
-| `/ingest/preview` | POST | Extract 5-20 atomic facts from a URL or text (no writes) |
-| `/ingest/commit` | POST | Write previewed facts as memories |
-
-</details>
-
-<details>
-<summary>Knowledge graph endpoints</summary>
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/entities` | GET | List entities (filter by type, search) |
-| `/entities/upsert` | POST | Create or update entity |
-| `/entities/{id}` | GET | Entity detail with relations and linked memories |
-| `/relations/upsert` | POST | Create or update relation |
-| `/graph` | GET | Full knowledge graph (entities + relations) |
-
-</details>
-
-<details>
-<summary>Evolve, Insights, Agents, Crystallizer, Documents, Fleet, Admin</summary>
-
-**Karpathy Loop / Evolve**
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/evolve/report` | POST | Report an outcome (success/failure/partial) against recalled memories |
-
-**Insights**
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/insights/generate` | POST | LLM-powered analysis. Focus: `contradictions`, `failures`, `stale`, `divergence`, `patterns`, `discover` |
-
-**Agents**
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/agents` | GET | List registered agents with trust levels |
-| `/agents/{id}` | GET | Single agent detail |
-| `/agents/{id}/trust` | PATCH | Set trust level (0-3) |
-
-**Memory Crystallizer**
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/crystallize` | POST | Trigger crystallization for a tenant |
-| `/crystallize/all` | POST | Trigger for all tenants (admin key, nightly) |
-| `/crystallize/reports` | GET | List crystallization reports |
-| `/crystallize/latest` | GET | Most recent completed report |
-
-**Documents**
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/documents` | POST | Store or update a structured JSON document |
-| `/documents/{id}` | GET | Retrieve document by ID |
-| `/documents/query` | POST | Query by field equality filters |
-| `/documents/{id}` | DELETE | Delete a document |
-
-**Fleet**
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/fleet/heartbeat` | POST | Plugin heartbeat — upserts node status, returns pending commands |
-| `/fleet/nodes` | GET | List fleet nodes with status (online/stale/offline) |
-| `/fleet/commands` | POST | Queue a command for a node |
-| `/fleet/commands` | GET | List command history |
-
-**Admin + System**
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/health` | GET | Liveness check |
-| `/version` | GET | Current version |
-| `/tool-descriptions` | GET | Canonical MCP tool descriptions |
-| `/admin/tenants` | GET | List all tenants (admin key) |
-| `/admin/fleets` | GET | List fleets across all tenants (admin key) |
-| `/admin/memories` | GET | List memories across all tenants with filters (admin key) |
-| `/admin/memories/stats` | GET | Memory counts by tenant/type/status (admin key) |
-| `/settings` | GET / PUT | Per-tenant configuration |
-| `/audit-log` | GET | Audit log entries |
-| `/mcp` | POST | MCP Streamable HTTP endpoint (mounted at app root, NOT under `/api/v1`) |
-
-**Auth:** `X-API-Key` header for all endpoints. Admin endpoints require the admin key. Public (no auth): `/api/v1/health`, `/api/v1/version`, `/api/v1/tool-descriptions`.
-
-**Gateway-injected headers** (trusted only behind the enterprise gateway):
-
-| Header | Effect |
-|---|---|
-| `X-Agent-ID` | Scopes the request to this agent |
-| `X-Org-Read-Only: true` | Read-only mode — creates/updates return 403 |
-| `X-Tenant-ID` | Tenant identity when using the shared `CAURA_API_KEY` gate |
-
-These headers are honored unconditionally — `core-api` must not be network-exposed without a gateway that strips them from untrusted callers.
-
-**Rate limiting (managed platform)**
-
-These limits apply to the managed platform at `caura.ai`. A self-hosted deployment enforces its own, looser per-route limits out of the box — see the [Rate limiting](#rate-limiting) section below.
-
-| Scope | Limit |
-|---|---|
-| Memory writes | 60 req/min per API key |
-| Memory searches | 120 req/min per API key |
-| General reads | 300 req/min per API key |
-| Auth endpoints | 10 req/min per IP |
-| Global DDoS floor | 1000 req/min per IP |
-
-Exceeded limits return HTTP 429 with a `Retry-After` header. Rate-limited routes also carry `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` on **successful** responses, so a client can back off before it is throttled rather than after.
-
-</details>
-
----
-
-<details>
-<summary>Configuration</summary>
-
-All configuration is via environment variables or `.env`. See `.env.example` for the full list.
-
-> **Migrating from a pre-1.0 deploy?** The legacy `ALLOYDB_*` env var names are still accepted as aliases — `POSTGRES_HOST` falls back to `ALLOYDB_HOST`, etc. Aliases will be dropped in a future major release.
-
-| Variable | Default | Description |
-|---|---|---|
-| `POSTGRES_HOST` | `127.0.0.1` | Database host |
-| `POSTGRES_PORT` | `5432` | Database port |
-| `POSTGRES_USER` | `memclaw` | Database user |
-| `POSTGRES_PASSWORD` | `changeme` | Database password |
-| `POSTGRES_DB` | `memclaw` | Database name |
-| `POSTGRES_USE_IAM_AUTH` | `false` | Use GCP IAM for DB auth (managed Postgres on GCP only) |
-| `ADMIN_API_KEY` | *(empty)* | Admin API key — bypasses tenant enforcement |
-| `EMBEDDING_PROVIDER` | `openai` | `openai`, `local`, or `fake` |
-| `ENTITY_EXTRACTION_PROVIDER` | `openai` | `openai`, `gemini`, `anthropic`, `openrouter`, `fake`, or `none` |
-| `ENTITY_EXTRACTION_MODEL` | `gpt-5.4-nano` | LLM model for enrichment and entity extraction |
-| `OPENAI_API_KEY` | — | Required for OpenAI embeddings and enrichment |
-| `USE_LLM_FOR_MEMORY_CREATION` | `true` | LLM auto-classifies type, weight, title, summary, tags on write |
-| `ANTHROPIC_API_KEY` | — | Required for Anthropic |
-| `OPENROUTER_API_KEY` | — | Required for OpenRouter |
-| `GEMINI_API_KEY` | — | Required for Gemini (Developer API, from AI Studio) |
-| `CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed CORS origins |
-| `ENVIRONMENT` | `development` | `development` or `production` |
-| `SETTINGS_ENCRYPTION_KEY` | — | Fernet key for encrypting tenant settings. Required in production |
-| `PLATFORM_LLM_PROVIDER` | *(empty)* | Platform-default LLM: `openai`, `vertex`, or empty to disable |
-| `PLATFORM_LLM_MODEL` | *(empty)* | Model override (e.g. `gpt-5.4-nano`, `gemini-3.1-flash-lite-preview`) |
-| `PLATFORM_LLM_API_KEY` | — | OpenAI API key for the platform LLM singleton |
-| `PLATFORM_LLM_GCP_PROJECT_ID` | — | GCP project for platform Vertex LLM |
-| `PLATFORM_LLM_GCP_LOCATION` | `us-central1` | GCP region for platform Vertex LLM |
-| `PLATFORM_EMBEDDING_PROVIDER` | *(empty)* | Platform-default embeddings: `openai` or empty to disable |
-| `PLATFORM_EMBEDDING_MODEL` | *(empty)* | Embedding model override (e.g. `text-embedding-3-small`) |
-| `PLATFORM_EMBEDDING_API_KEY` | — | OpenAI API key for platform embeddings |
-
-</details>
-
 <a id="project-structure"></a>
-<details>
-<summary>Project structure</summary>
 
-```
-caura/
-├── core-api/                      # Main FastAPI service
-│   └── src/core_api/
-│       ├── app.py                 # FastAPI app, lifespan, middleware
-│       ├── mcp_server.py          # MCP server (Streamable HTTP, 12 tools)
-│       ├── constants.py           # Tool descriptions, limits, ranking params
-│       ├── config.py              # Settings (env vars)
-│       ├── auth.py                # API key + JWT auth, tenant enforcement
-│       ├── routes/                # Route handlers
-│       ├── services/              # Business logic
-│       ├── providers/             # LLM/embedding abstraction + fallback
-│       ├── pipeline/              # Composable write/search pipelines
-│       └── tools/                 # MCP tool implementations
-│
-├── core-storage-api/              # PostgreSQL CRUD microservice
-│   └── src/core_storage_api/
-│       ├── routers/               # Memory, entity, document, fleet CRUD
-│       ├── services/              # ORM operations
-│       └── database/              # SQLAlchemy models, Alembic migrations
-│
-├── plugin/                        # OpenClaw plugin (TypeScript)
-│   └── src/
-│       ├── tools.ts               # Tool implementations
-│       ├── agent-auth.ts          # Per-agent credentials (agent-scoped mc_ keys)
-│       ├── context-engine.ts      # Auto-read/write lifecycle
-│       ├── heartbeat.ts           # 60s heartbeat → Caura API
-│       └── educate.ts             # Agent education delivery
-│
-├── common/                        # Shared SQLAlchemy ORM models and constants
-├── tests/                         # Test suite
-├── scripts/                       # Smoke tests, benchmarks, export tools
-├── docker-compose.yml             # Production-like stack
-├── docker-compose.dev.yml         # Dev stack
-└── .env.example                   # Full configuration reference
-```
+Versioned REST routes live under `/api/v1/`; MCP is mounted separately at
+`/mcp`. A running deployment serves its authoritative OpenAPI schema at
+`/api/openapi.json` and interactive Swagger docs at `/api/docs`.
 
-</details>
-
-<details>
-<summary>Latency benchmarks</summary>
-
-Typical results on a single-instance deployment (OpenAI embeddings + GPT-5.4 Nano):
-
-| Operation | Mean | P50 | P95 |
-|---|---|---|---|
-| `caura_write` | ~2000ms | ~2000ms | ~2300ms |
-| `caura_recall` | ~650ms | ~640ms | ~670ms |
-| `caura_recall` (with `include_brief=true`) | ~1300ms | ~1200ms | ~2100ms |
-
-Write latency is dominated by LLM enrichment. Recall latency by the embedding API call.
-
-```bash
-python scripts/latency_test.py --url http://localhost:8000 --api-key <admin-key> --runs 20
-```
-
-</details>
+Use the [curated API reference](docs/api-reference.md) for endpoint groups,
+authentication, configuration, and repository structure. The
+[API surface ownership charter](docs/api-surfaces.md) explains which operations
+belong on REST, MCP, or the OpenClaw plugin.
 
 ---
 
 ## Public API & Stability
 
-Caura v1.x follows [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html). The surfaces below are stable; everything else is internal and may change in any release.
+<!-- Preserve deep links from the former inline contract. -->
+<a id="stable-surfaces"></a>
+<a id="mcp-tools-12"></a>
+<a id="rest-endpoints"></a>
+<a id="plugin-environment-variables"></a>
+<a id="server-environment-variables"></a>
+<a id="auth-modes"></a>
+<a id="internal-not-covered-by-semver"></a>
+<a id="reporting-breaking-changes"></a>
 
-### Stable surfaces
-
-#### MCP tools (12)
-
-The MCP server is mounted at `/mcp`. Tool names, parameter names, and the documented op-dispatch values are stable.
-
-| Tool | Purpose |
-|---|---|
-| `caura_recall` | Hybrid semantic + keyword search over memories, with optional LLM-summarised brief. |
-| `caura_write` | Single or batch (≤100) memory write; auto-enriched with type, title, summary, tags. |
-| `caura_manage` | Per-memory lifecycle, op-dispatched: `read` \| `update` \| `transition` \| `delete` \| `bulk_delete` \| `lineage`. |
-| `caura_list` | Non-semantic enumeration with filters, sort, cursor pagination. |
-| `caura_doc` | Structured-document CRUD, op-dispatched: `write` \| `read` \| `query` \| `delete` \| `list_collections` \| `search`. |
-| `caura_entity_get` | Look up a knowledge-graph entity by UUID. |
-| `caura_tune` | Read/update an agent's per-search profile (top_k, fts_weight, freshness, blend, …). |
-| `caura_insights` | Karpathy-Loop reflection: contradictions, failures, stale, divergence, patterns, discover. |
-| `caura_evolve` | Karpathy-Loop feedback: record an outcome (`success` \| `failure` \| `partial`) against memories. |
-| `caura_stats` | Aggregate counts: total + breakdowns by `type` / `agent` / `status`. Read-only. |
-| `caura_keystones` | Read mandatory governance rules for the current scope (tenant + fleet + agent merged). Call once per session. |
-| `caura_keystones_set` | Author/remove keystone rules, op-dispatched: `set` \| `delete`. Trust ≥ 1 for self-authored `scope=agent` (requires an explicit `agent_id` equal to the caller); ≥ 2 otherwise, including `scope=agent` with `agent_id` omitted. |
-
-> Skill sharing uses the generic `caura_doc` surface — write/read/query/search/delete on `collection="skills"`. The server validates the slug and embeds `data["summary"]` for semantic discovery (with a back-compat fallback to `data["description"]` for skills).
-
-#### REST endpoints
-
-All paths are prefixed with `/api/v1` unless noted. Request and response shapes documented in the OpenAPI schema at `/openapi.json` are part of the contract.
-
-| Area | Endpoints |
-|---|---|
-| Memory | `GET/POST /memories`, `PATCH /memories/{id}`, `DELETE /memories/{id}`, `PATCH /memories/{id}/status`, `POST /memories/bulk`, `POST /memories/bulk-delete`, `GET /memories/stats`, `GET /memories/{id}`, `GET /memories/{id}/contradictions`, `POST /search`, `POST /recall`, `POST /ingest/preview`, `POST /ingest/commit` |
-| Knowledge graph | `GET /entities`, `GET /entities/{id}`, `POST /entities/upsert`, `GET /graph`, `POST /relations/upsert` |
-| Documents | `POST /documents`, `GET /documents`, `GET /documents/{id}`, `POST /documents/query`, `DELETE /documents/{id}` |
-| Keystones | `GET /keystones`, `POST /keystones`, `DELETE /keystones/{doc_id}` (permanent legacy alias: `/memclaw/keystones`) | <!-- legacy-name-ok: taught as legacy alias -->
-| Fleet | `POST /fleet/heartbeat`, `GET /fleet/nodes`, `POST /fleet/commands`, `GET /fleet/commands` |
-| Agents | `GET /agents`, `GET /agents/{id}`, `PATCH /agents/{id}/trust`, `POST /admin/agent-keys/provision` (atomic key + row + trust + fleet), `GET /whoami` (identity probe) |
-| Insights | `POST /insights/generate` |
-| Evolve | `POST /evolve/report` |
-| Crystallizer | `POST /crystallize`, `POST /crystallize/all`, `GET /crystallize/reports`, `GET /crystallize/latest` |
-| Settings | `GET/PUT /settings` |
-| System | `GET /health`, `GET /version`, `GET /tool-descriptions`, `GET /audit-log` |
-| MCP | `POST /mcp` (Streamable HTTP transport, mounted at app root) |
-| Bootstrap (plugin) | `GET /plugin-source`, `GET /plugin-source-hash`, `GET/POST /install-plugin`, `GET /install-skill[?skill=memclaw\|company-brain]`, `GET /skill/{memclaw\|company-brain}`. Aliased under `/api` (no `/v1`) for one-line installers. |
-
-#### Plugin environment variables
-
-Read by the OpenClaw plugin. The plugin's published name (`memclaw`) and these variables are the public contract; the plugin's TypeScript module structure is internal.
-
-| Var | Purpose |
-|---|---|
-| `CAURA_API_URL` | Base URL of the core-api server. |
-| `CAURA_API_KEY` | Tenant or admin API key sent in `X-API-Key`. |
-| `CAURA_TENANT_ID` | Optional pre-resolved tenant id; bypasses lookup. |
-| `CAURA_FLEET_ID` | Default fleet id for writes/heartbeat. |
-| `CAURA_NODE_NAME` | Fleet node identifier reported on heartbeat. |
-| `CAURA_AUTO_WRITE_TURNS` | Auto-write turn summaries (default `true`). |
-
-**Legacy spellings.** Every `CAURA_*` variable in this document — the table above, the `CAURA_API_KEY` server gate, and `CAURA_VERSION` in compose — also answers to its pre-rename `MEMCLAW_*` name and will keep doing so: swap the prefix, and the rest of the name is unchanged (`CAURA_API_URL` ⇄ `MEMCLAW_API_URL`). Where both are set the first **non-empty** value wins — deliberately, rather than the first one *defined* — so an unfilled `CAURA_FOO=` in a deploy template cannot blank out a working `MEMCLAW_FOO`. <!-- legacy-name-ok: rule 3 dual-read alias — the one surviving alias table -->
-
-New installs are written with the `CAURA_*` names. Variables without the prefix
-(`ADMIN_API_KEY`, `POSTGRES_*`, `IS_STANDALONE`, …) never had a branded spelling.
-
-#### Server environment variables
-
-These mirror the Configuration table above. See it for defaults.
-
-| Group | Vars |
-|---|---|
-| Database | `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_USE_IAM_AUTH`, `POSTGRES_REQUIRE_SSL` |
-| Auth | `ADMIN_API_KEY`, `CAURA_API_KEY`, `CORE_STORAGE_SHARED_SECRET`, `CORE_STORAGE_SHARED_SECRET_FILE`, `IS_STANDALONE` |
-| Providers | `EMBEDDING_PROVIDER`, `ENTITY_EXTRACTION_PROVIDER`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `USE_LLM_FOR_MEMORY_CREATION` |
-| Runtime | `CORS_ORIGINS`, `ENVIRONMENT`, `SETTINGS_ENCRYPTION_KEY`, `REDIS_URL` |
-
-#### Auth modes
-
-| Mode | Activated by | Use case |
-|---|---|---|
-| Standalone | `IS_STANDALONE=true` | Single-tenant self-host; auth bypassed. |
-| Multi-tenant admin | `ADMIN_API_KEY=…` | Operator key for multi-tenant deployments. |
-| Shared gate | `CAURA_API_KEY=…` | Optional shared secret required on every non-admin request. |
-
-See [AGENT-INSTALL.md](AGENT-INSTALL.md) for installation flows that exercise each mode.
-
-### Internal (not covered by SemVer)
-
-Anything not listed above is internal and may change in any release without a major version bump:
-
-- Python module layout (`core_api.middleware.*`, `core_api.providers.*`, `core_api.pipeline.*`, `core_api.services.*`, `common/*`)
-- Database schema, table names, migration paths
-- Gateway-injected HTTP headers (`X-Gateway-Secret`, `X-Tenant-ID`, `X-Agent-ID`, `X-Org-Read-Only`)
-- Most `/api/v1/admin/*` and all `/api/v1/testing/*` routes (the documented exception is `POST /admin/agent-keys/provision`, which is part of the stable identity-bootstrap surface — see the Agents row above)
-- The `core-storage-api` microservice (internal, not user-facing)
-- The plugin's TypeScript module structure
-- API-key prefix formats — currently unified on `mc_…` (with legacy `mca_…` / `mci_…` aliases still accepted via back-compat); formats may continue to evolve
-
-### Reporting breaking changes
-
-Contributors who introduce a breaking change to a stable surface must:
-
-- Add a `BREAKING CHANGE:` trailer to the commit message describing the impact and any migration steps.
-- Apply the `kind/breaking` label to the pull request.
-
-Reviewers will block merges to `dev` that touch a stable surface without these markers. If you are unsure whether a change is breaking, open the PR with the label and let review decide — better to over-label than ship a silent break.
+Caura follows SemVer. The stable MCP tools, REST endpoints, plugin variables,
+auth modes, and contributor requirements live in the
+[public API stability contract](docs/public-api-stability.md).
 
 ---
 
-## Telemetry and error tracking
+<a id="telemetry-and-error-tracking"></a>
 
-Caura supports optional [Sentry](https://sentry.io) integration for error tracking and performance monitoring:
+## Telemetry
+
+The self-hosted OSS runtime supports optional [Sentry](https://sentry.io)
+integration for error tracking and performance monitoring:
 
 - **Opt-in only** — set the `SENTRY_DSN` environment variable to enable. No errors are reported unless you explicitly configure a DSN.
-- **No usage analytics** — Caura does not collect usage statistics, feature flags, or behavioral data.
-- **No phone-home** — the application makes zero outbound calls unless you configure a Sentry DSN or an LLM/embedding provider.
+- **No built-in usage analytics** — a self-hosted deployment does not collect usage statistics, feature flags, or behavioral data.
+- **No phone-home** — the self-hosted application makes zero outbound calls unless you configure a Sentry DSN or an LLM/embedding provider.
 
----
-
-## OpenClaw Plugin
-
-See [static/docs/integration-guide.md](static/docs/integration-guide.md) for full plugin setup, agent system prompts, and usage examples.
+The managed platform's usage analytics are a hosted-service feature; they are
+not part of the self-hosted runtime.
 
 ---
 
@@ -1292,15 +637,6 @@ outage fails open: requests pass through un-throttled rather than erroring.
 
 Add limiting at your reverse proxy (nginx, Caddy, Cloudflare) as well if you need per-IP DDoS
 floors or limits the application layer can't see.
-
-## Telemetry
-
-Caura **does not phone home** by default. No usage data, analytics, or tracking of any kind.
-
-If you set the `SENTRY_DSN` environment variable, [Sentry](https://sentry.io) error tracking
-is enabled — crash reports and performance traces are sent to your configured Sentry project.
-When `SENTRY_DSN` is empty (the default), Sentry is not initialized and no data leaves the
-server.
 
 ## Contributing
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,7 +12,7 @@ Open a [Bug report](https://github.com/caura-ai/caura/issues/new?template=bug_re
 
 Before filing:
 - Search existing issues and Discussions for duplicates.
-- Confirm the behavior contradicts the [Public API & Stability](README.md#public-api--stability) section. Behavior of internal surfaces (e.g. database schema, gateway-injected headers, `/admin/*` routes) can change without notice and isn't tracked as a bug.
+- Confirm the behavior contradicts the [Public API & Stability](docs/public-api-stability.md) contract. Behavior of internal surfaces (e.g. database schema, gateway-injected headers, `/admin/*` routes) can change without notice and isn't tracked as a bug.
 
 ## Feature requests
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,247 @@
+# API reference
+
+Versioned REST routes live under `/api/v1/`; MCP is mounted separately at
+`/mcp`. A running deployment serves its authoritative OpenAPI schema at
+`/api/openapi.json` and interactive Swagger docs at `/api/docs`. The tables below
+are a curated map; use the schema for exact request and response shapes.
+
+See also the [public API stability contract](public-api-stability.md) and the
+[API surface ownership charter](api-surfaces.md).
+
+<details>
+<summary>Memory endpoints</summary>
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/memories` | POST | Write a memory. LLM enrichment + embedding + entity extraction + contradiction detection. `"persist": false` for extract-only preview |
+| `/memories/bulk` | POST | Write up to 100 memories. Batches embeddings, parallelizes enrichment, single transaction. Requires `X-Bulk-Attempt-Id` header (per-attempt idempotency); a retry with the same id resolves committed rows as `duplicate_attempt` instead of duplicating. Returns 200 (clean / all-error) or 207 Multi-Status (mixed) — read per-item `status` |
+| `/memories` | GET | List memories (filter by type, status, agent; paginate) |
+| `/memories/{id}` | GET | Full memory detail (embedding stats, entity links, RDF triple, temporal bounds) |
+| `/memories/{id}` | PATCH | Update content or metadata. Re-embeds if content changes |
+| `/memories/{id}` | DELETE | Soft delete (sets status to `deleted`) |
+| `/memories/{id}/status` | PATCH | Update lifecycle status |
+| `/memories/{id}/contradictions` | GET | View contradiction chain |
+| `/memories` | DELETE | Bulk soft-delete |
+| `/memories/stats` | GET | Counts by type, agent, and status |
+| `/search` | POST | Hybrid semantic + keyword search with graph-enhanced retrieval |
+| `/recall` | POST | Search + LLM synthesis — `summary` is the answer to the query (the model reasons step by step internally; only its final answer is surfaced), alongside the source memories under both `memories` and `items` |
+| `/ingest/preview` | POST | Extract 5-20 atomic facts from a URL or text (no writes) |
+| `/ingest/commit` | POST | Write previewed facts as memories |
+
+</details>
+
+<details>
+<summary>Knowledge graph endpoints</summary>
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/entities` | GET | List entities (filter by type, search) |
+| `/entities/upsert` | POST | Create or update entity |
+| `/entities/{id}` | GET | Entity detail with relations and linked memories |
+| `/relations/upsert` | POST | Create or update relation |
+| `/graph` | GET | Full knowledge graph (entities + relations) |
+
+</details>
+
+<details>
+<summary>Evolve, Insights, Agents, Crystallizer, Documents, Fleet, Admin</summary>
+
+**Karpathy Loop / Evolve**
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/evolve/report` | POST | Report an outcome (success/failure/partial) against recalled memories |
+
+**Insights**
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/insights/generate` | POST | LLM-powered analysis. Focus: `contradictions`, `failures`, `stale`, `divergence`, `patterns`, `discover` |
+
+**Agents**
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/agents` | GET | List registered agents with trust levels |
+| `/agents/{id}` | GET | Single agent detail |
+| `/agents/{id}/trust` | PATCH | Set trust level (0-3) |
+
+**Memory Crystallizer**
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/crystallize` | POST | Trigger crystallization for a tenant |
+| `/crystallize/all` | POST | Trigger for all tenants (admin key, nightly) |
+| `/crystallize/reports` | GET | List crystallization reports |
+| `/crystallize/latest` | GET | Most recent completed report |
+
+**Documents**
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/documents` | POST | Store or update a structured JSON document |
+| `/documents/{id}` | GET | Retrieve document by ID |
+| `/documents/query` | POST | Query by field equality filters |
+| `/documents/{id}` | DELETE | Delete a document |
+
+**Fleet**
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/fleet/heartbeat` | POST | Plugin heartbeat — upserts node status, returns pending commands |
+| `/fleet/nodes` | GET | List fleet nodes with status (online/stale/offline) |
+| `/fleet/commands` | POST | Queue a command for a node |
+| `/fleet/commands` | GET | List command history |
+
+**Admin + System**
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/health` | GET | Liveness check |
+| `/version` | GET | Current version |
+| `/tool-descriptions` | GET | Canonical MCP tool descriptions |
+| `/admin/tenants` | GET | List all tenants (admin key) |
+| `/admin/fleets` | GET | List fleets across all tenants (admin key) |
+| `/admin/memories` | GET | List memories across all tenants with filters (admin key) |
+| `/admin/memories/stats` | GET | Memory counts by tenant/type/status (admin key) |
+| `/settings` | GET / PUT | Per-tenant configuration |
+| `/audit-log` | GET | Audit log entries |
+| `/mcp` | POST | MCP Streamable HTTP endpoint (mounted at app root, NOT under `/api/v1`) |
+
+**Auth:** Most data endpoints require an `X-API-Key`; admin endpoints require
+the admin key. Intentional public exceptions include the health/version/tool
+description probes, `/api/v1/whoami`, and the plugin/skill bootstrap routes
+(`/api/v1/plugin-*`, `/api/v1/install-*`, and `/api/v1/skill/*`). These public
+routes expose generic software or identity-probe data, not tenant data.
+
+**Gateway-injected headers** (trusted only behind the enterprise gateway):
+
+| Header | Effect |
+|---|---|
+| `X-Agent-ID` | Scopes the request to this agent |
+| `X-Org-Read-Only: true` | Read-only mode — creates/updates return 403 |
+| `X-Tenant-ID` | Tenant identity when using the shared `CAURA_API_KEY` gate |
+
+The identity headers are trusted on the gateway-header auth path. Set
+`GATEWAY_SHARED_SECRET` so that path also requires a matching
+`X-Gateway-Secret`. A network-exposed OSS deployment without a gateway should
+set `CAURA_API_KEY`; that shared-key path authenticates first and prevents the
+header-trust path from being reached.
+
+**Rate limiting (managed platform)**
+
+These limits apply to the managed platform at `caura.ai`. A self-hosted deployment enforces its own, looser per-route limits out of the box — see the [self-hosted rate limiting](../README.md#rate-limiting) section.
+
+| Scope | Limit |
+|---|---|
+| Memory writes | 60 req/min per API key |
+| Memory searches | 120 req/min per API key |
+| General reads | 300 req/min per API key |
+| Auth endpoints | 10 req/min per IP |
+| Global DDoS floor | 1000 req/min per IP |
+
+Exceeded limits return HTTP 429 with a `Retry-After` header. Rate-limited routes also carry `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` on **successful** responses, so a client can back off before it is throttled rather than after.
+
+</details>
+
+## Configuration
+
+Configuration is supplied through environment variables or `.env`. See
+[`.env.example`](../.env.example) for the common OSS settings; the table below
+also includes production-only safety controls.
+
+The stock Compose file sets the storage service's `DATABASE_URL` to its bundled
+PostgreSQL service. A custom storage deployment should set `DATABASE_URL`
+directly. A complete `ALLOYDB_HOST`, `ALLOYDB_USER`, `ALLOYDB_PASSWORD`, and
+`ALLOYDB_DATABASE` set (plus optional `ALLOYDB_PORT`) is also supported when
+`DATABASE_URL` is absent; these are storage-service inputs, not aliases for the
+`POSTGRES_*` fields.
+
+| Variable | Default | Description |
+|---|---|---|
+| `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` | local PostgreSQL defaults | Inputs used by migration/dev helpers; the stock Compose file hardcodes its container connection values |
+| `DATABASE_URL` | local PostgreSQL URL | Storage-service primary connection URL; set directly outside the stock Compose deployment |
+| `READ_DATABASE_URL` | *(empty)* | Optional storage-service read-replica URL |
+| `ADMIN_API_KEY` | *(empty)* | Admin API key — bypasses tenant enforcement |
+| `CAURA_API_KEY` | *(empty)* | Shared perimeter key for a network-exposed OSS deployment |
+| `GATEWAY_SHARED_SECRET` | *(empty)* | Secret required in `X-Gateway-Secret` before gateway identity headers are trusted |
+| `JWT_SECRET` | `change-me-in-production` | JWT signing secret; must be changed in production |
+| `EMBEDDING_PROVIDER` | `openai` | `openai`, `local`, or `fake` |
+| `ENTITY_EXTRACTION_PROVIDER` | `openai` | `openai`, `gemini`, `anthropic`, `openrouter`, `fake`, or `none` |
+| `ENTITY_EXTRACTION_MODEL` | `gpt-5.4-nano` | LLM model for enrichment and entity extraction |
+| `OPENAI_API_KEY` | — | Required for OpenAI embeddings and enrichment |
+| `USE_LLM_FOR_MEMORY_CREATION` | `true` | LLM auto-classifies type, weight, title, summary, tags on write |
+| `ANTHROPIC_API_KEY` | — | Required for Anthropic |
+| `OPENROUTER_API_KEY` | — | Required for OpenRouter |
+| `GEMINI_API_KEY` | — | Required for Gemini (Developer API, from AI Studio) |
+| `CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed CORS origins |
+| `ENVIRONMENT` | `development` | `development` or `production` |
+| `SETTINGS_ENCRYPTION_KEY` | — | Fernet key for encrypting tenant settings. Required in production |
+| `PLATFORM_LLM_PROVIDER` | *(empty)* | Platform-default LLM: `openai`, `vertex`, or empty to disable |
+| `PLATFORM_LLM_MODEL` | *(empty)* | Model override (e.g. `gpt-5.4-nano`, `gemini-3.1-flash-lite-preview`) |
+| `PLATFORM_LLM_API_KEY` | — | OpenAI API key for the platform LLM singleton |
+| `PLATFORM_LLM_GCP_PROJECT_ID` | — | GCP project for platform Vertex LLM |
+| `PLATFORM_LLM_GCP_LOCATION` | `us-central1` | GCP region for platform Vertex LLM |
+| `PLATFORM_EMBEDDING_PROVIDER` | *(empty)* | Platform-default embeddings: `openai` or empty to disable |
+| `PLATFORM_EMBEDDING_MODEL` | *(empty)* | Embedding model override (e.g. `text-embedding-3-small`) |
+| `PLATFORM_EMBEDDING_API_KEY` | — | OpenAI API key for platform embeddings |
+
+With `ENVIRONMENT=production`, startup additionally requires
+`ADMIN_API_KEY`, a non-default `JWT_SECRET`, `SETTINGS_ENCRYPTION_KEY`, and
+either `GATEWAY_SHARED_SECRET` or `CAURA_API_KEY`. Standalone mode is rejected
+in production.
+
+## Project structure
+
+```text
+caura/
+├── core-api/                      # Main FastAPI service
+│   └── src/core_api/
+│       ├── app.py                 # FastAPI app, lifespan, middleware
+│       ├── mcp_server.py          # MCP server (Streamable HTTP, 12 tools)
+│       ├── constants.py           # Limits and ranking parameters
+│       ├── config.py              # Settings (env vars)
+│       ├── auth.py                # API key + JWT auth, tenant enforcement
+│       ├── routes/                # Route handlers
+│       ├── services/              # Business logic
+│       ├── providers/             # LLM/embedding abstraction + fallback
+│       ├── pipeline/              # Composable write/search pipelines
+│       └── tools/                 # MCP tool implementations
+│
+├── core-storage-api/              # PostgreSQL CRUD microservice
+│   └── src/core_storage_api/
+│       ├── routers/               # Memory, entity, document, fleet CRUD
+│       ├── services/              # ORM operations
+│       └── database/              # Engine initialization and Alembic migrations
+│
+├── plugin/                        # OpenClaw plugin (TypeScript)
+│   └── src/
+│       ├── tools.ts               # Tool implementations
+│       ├── agent-auth.ts          # Per-agent credentials (agent-scoped mc_ keys)
+│       ├── context-engine.ts      # Auto-read/write lifecycle
+│       ├── heartbeat.ts           # 60s heartbeat → Caura API
+│       └── educate.ts             # Agent education delivery
+│
+├── common/                        # Shared SQLAlchemy ORM models and constants
+├── tests/                         # Test suite
+├── scripts/                       # Smoke tests, benchmarks, export tools
+├── docker-compose.yml             # Production-like stack
+├── docker-compose.dev.yml         # Dev stack
+└── .env.example                   # Common OSS configuration template
+```
+
+## Latency benchmarks
+
+Typical results on a single-instance deployment (OpenAI embeddings + GPT-5.4 Nano):
+
+| Operation | Mean | P50 | P95 |
+|---|---|---|---|
+| `caura_write` | ~2000ms | ~2000ms | ~2300ms |
+| `caura_recall` | ~650ms | ~640ms | ~670ms |
+| `caura_recall` (with `include_brief=true`) | ~1300ms | ~1200ms | ~2100ms |
+
+Write latency is dominated by LLM enrichment. Recall latency by the embedding API call.
+
+See [`BENCHMARKS.md`](../BENCHMARKS.md) and the
+[performance guide](performance.md) for current methodology and reproducible
+benchmarks.

--- a/docs/local-embedder.md
+++ b/docs/local-embedder.md
@@ -38,8 +38,8 @@ docker compose --profile embed-local logs -f tei
 
 In another terminal, fire one write → search round-trip:
 
-> These examples assume `IS_STANDALONE=true` in `.env` (see the
-> [Auth modes](../README.md#self-hosted-open-source) section in README).
+> These examples assume `IS_STANDALONE=true` in `.env` (see
+> [Authentication modes](self-hosting.md#authentication-modes)).
 > Replace `standalone` with your actual API key if you're using `ADMIN_API_KEY`
 > or `CAURA_API_KEY` instead, and add `tenant_id` matching your setup.
 
@@ -278,15 +278,15 @@ container start. Just bring the stack up per the [TL;DR](#tldr) above.
 
 **Upgrading from v1.x.** This is destructive — every existing 768-dim
 embedding is set to `NULL` so the column can be widened to 1024-dim.
-**Follow the canonical procedure in the README's
-[Upgrading from v1.x](../README.md#upgrading-from-v1x) section** — it
+**Follow the canonical procedure in the
+[Upgrading from v1.x](upgrading-from-v1.md) guide** — it
 sequences DB snapshot, opt-in env var, migration trigger, and re-embed in
 the order that won't lose data.
 
 The procedure expects you to run a stand-alone backfill CLI to re-embed
 existing rows (`python -m core_storage_api.scripts.backfill_embeddings`)
 after the migration completes. Both the OSS standalone CLI and the
-event-driven `core-worker` task work; the README documents both. For
+event-driven `core-worker` task work; the upgrade guide documents both. For
 multi-tenant production cutovers prefer the event-driven path.
 
 ## Switching back to OpenAI hosted

--- a/docs/public-api-stability.md
+++ b/docs/public-api-stability.md
@@ -1,0 +1,116 @@
+# Public API and stability
+
+Caura follows [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html). The surfaces
+below are stable; everything else is internal and may change in any release.
+
+For exact REST request and response shapes, use the OpenAPI schema served at
+`/api/openapi.json`. See the [API reference](api-reference.md) for a curated map.
+
+## Stable surfaces
+
+### MCP tools (12)
+
+The MCP server is mounted at `/mcp`. Tool names, parameter names, and the documented op-dispatch values are stable.
+
+| Tool | Purpose |
+|---|---|
+| `caura_recall` | Hybrid semantic + keyword search over memories, with optional LLM-summarised brief. |
+| `caura_write` | Single or batch (≤100) memory write; configured enrichment providers can infer type, title, summary, and tags. |
+| `caura_manage` | Per-memory lifecycle, op-dispatched: `read` \| `update` \| `transition` \| `delete` \| `bulk_delete` \| `lineage`. |
+| `caura_list` | Non-semantic enumeration with filters, sort, cursor pagination. |
+| `caura_doc` | Structured-document CRUD, op-dispatched: `write` \| `read` \| `query` \| `delete` \| `list_collections` \| `search`. |
+| `caura_entity_get` | Look up a knowledge-graph entity by UUID. |
+| `caura_tune` | Read/update an agent's per-search profile (top_k, fts_weight, freshness, blend, …). |
+| `caura_insights` | Karpathy-Loop reflection: contradictions, failures, stale, divergence, patterns, discover. |
+| `caura_evolve` | Karpathy-Loop feedback: record an outcome (`success` \| `failure` \| `partial`) against memories. |
+| `caura_stats` | Aggregate counts: total + breakdowns by `type` / `agent` / `status`. Read-only. |
+| `caura_keystones` | Read mandatory governance rules for the current scope (tenant + fleet + agent merged). Call once per session. |
+| `caura_keystones_set` | Author/remove keystone rules, op-dispatched: `set` \| `delete`. Trust ≥ 1 for self-authored `scope=agent` (requires an explicit `agent_id` equal to the caller); ≥ 2 otherwise, including `scope=agent` with `agent_id` omitted. |
+
+> Skill sharing uses the generic `caura_doc` surface — write/read/query/search/delete on `collection="skills"`. The server validates the slug and embeds `data["summary"]` for semantic discovery (with a back-compat fallback to `data["description"]` for skills).
+
+### REST endpoints
+
+All paths are prefixed with `/api/v1` unless noted. Request and response shapes documented in the OpenAPI schema at `/api/openapi.json` are part of the contract.
+
+| Area | Endpoints |
+|---|---|
+| Memory | `GET/POST /memories`, `PATCH /memories/{id}`, `DELETE /memories/{id}`, `PATCH /memories/{id}/status`, `POST /memories/bulk`, `POST /memories/bulk-delete`, `GET /memories/stats`, `GET /memories/{id}`, `GET /memories/{id}/contradictions`, `POST /search`, `POST /recall`, `POST /ingest/preview`, `POST /ingest/commit` |
+| Knowledge graph | `GET /entities`, `GET /entities/{id}`, `POST /entities/upsert`, `GET /graph`, `POST /relations/upsert` |
+| Documents | `POST /documents`, `GET /documents`, `GET /documents/{id}`, `POST /documents/query`, `DELETE /documents/{id}` |
+| Keystones | `GET /keystones`, `POST /keystones`, `DELETE /keystones/{doc_id}` (permanent legacy alias: `/memclaw/keystones`) | <!-- legacy-name-ok: taught as legacy alias -->
+| Fleet | `POST /fleet/heartbeat`, `GET /fleet/nodes`, `POST /fleet/commands`, `GET /fleet/commands` |
+| Agents | `GET /agents`, `GET /agents/{id}`, `PATCH /agents/{id}/trust`, `POST /admin/agent-keys/provision` (atomic key + row + trust + fleet), `GET /whoami` (identity probe) |
+| Insights | `POST /insights/generate` |
+| Evolve | `POST /evolve/report` |
+| Crystallizer | `POST /crystallize`, `POST /crystallize/all`, `GET /crystallize/reports`, `GET /crystallize/latest` |
+| Settings | `GET/PUT /settings` |
+| System | `GET /health`, `GET /version`, `GET /tool-descriptions`, `GET /audit-log` |
+| MCP | `POST /mcp` (Streamable HTTP transport, mounted at app root) |
+| Bootstrap (plugin) | `GET /plugin-source`, `GET /plugin-source-hash`, `GET /plugin-manifest`, `GET/POST /install-plugin`, `GET /install-skill[?skill=memclaw\|company-brain]`, `GET /skill/{memclaw\|company-brain}`. `/plugin-source`, `/plugin-manifest`, and `GET/POST /install-plugin` are also aliased under `/api` (no `/v1`) for the generated installer. | <!-- legacy-name-floor: published skill query parameter and route -->
+
+### Plugin environment variables
+
+Read by the OpenClaw plugin. The plugin's published name (`memclaw`) and these variables are the public contract; the plugin's TypeScript module structure is internal.
+
+| Var | Purpose |
+|---|---|
+| `CAURA_API_URL` | Base URL of the core-api server. |
+| `CAURA_API_KEY` | Tenant or admin API key sent in `X-API-Key`. |
+| `CAURA_TENANT_ID` | Optional pre-resolved tenant id; bypasses lookup. |
+| `CAURA_FLEET_ID` | Default fleet id for writes/heartbeat. |
+| `CAURA_NODE_NAME` | Fleet node identifier reported on heartbeat. |
+| `CAURA_AUTO_WRITE_TURNS` | Auto-write turn summaries (default `true`). |
+
+**Legacy spellings.** Every `CAURA_*` variable in this document — the table above, the `CAURA_API_KEY` server gate, and `CAURA_VERSION` in compose — also answers to its pre-rename `MEMCLAW_*` name and will keep doing so: swap the prefix, and the rest of the name is unchanged (`CAURA_API_URL` ⇄ `MEMCLAW_API_URL`). Where both are set the first **non-empty** value wins — deliberately, rather than the first one *defined* — so an unfilled `CAURA_FOO=` in a deploy template cannot blank out a working `MEMCLAW_FOO`. <!-- legacy-name-ok: rule 3 dual-read alias — the one surviving alias table -->
+
+New installs are written with the `CAURA_*` names. Variables without the prefix
+(`ADMIN_API_KEY`, `POSTGRES_*`, `IS_STANDALONE`, …) never had a branded spelling.
+
+### Server environment variables
+
+These mirror the [configuration reference](api-reference.md#configuration).
+
+| Group | Vars |
+|---|---|
+| Database | Storage service: `DATABASE_URL`, `READ_DATABASE_URL` or a complete `ALLOYDB_*` connection set; migration/dev helpers: `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` (stock Compose hardcodes its container connection values) |
+| Auth | `ADMIN_API_KEY`, `CAURA_API_KEY`, `GATEWAY_SHARED_SECRET`, `JWT_SECRET`, `CORE_STORAGE_SHARED_SECRET`, `CORE_STORAGE_SHARED_SECRET_FILE`, `IS_STANDALONE` |
+| Providers | `EMBEDDING_PROVIDER`, `ENTITY_EXTRACTION_PROVIDER`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `USE_LLM_FOR_MEMORY_CREATION` |
+| Runtime | `CORS_ORIGINS`, `ENVIRONMENT`, `SETTINGS_ENCRYPTION_KEY`, `REDIS_URL` |
+
+Production startup requires `ADMIN_API_KEY`, a non-default `JWT_SECRET`,
+`SETTINGS_ENCRYPTION_KEY`, and either `GATEWAY_SHARED_SECRET` or
+`CAURA_API_KEY`; `IS_STANDALONE=true` is not allowed.
+
+### Auth modes
+
+| Mode | Activated by | Use case |
+|---|---|---|
+| Standalone | `IS_STANDALONE=true` | Single-tenant self-host; auth bypassed. |
+| Multi-tenant admin | `ADMIN_API_KEY=…` | Operator key for multi-tenant deployments. |
+| Shared gate | `CAURA_API_KEY=…` | Optional shared secret required on authenticated non-admin routes. |
+
+See [AGENT-INSTALL.md](../AGENT-INSTALL.md) for installation flows that exercise each mode.
+
+## Internal (not covered by SemVer)
+
+Anything not listed above is internal and may change in any release without a major version bump:
+
+- Python module layout (`core_api.middleware.*`, `core_api.providers.*`, `core_api.pipeline.*`, `core_api.services.*`, `common/*`)
+- Database schema, table names, migration paths
+- Gateway-injected HTTP headers (`X-Gateway-Secret`, `X-Tenant-ID`, `X-Agent-ID`, `X-Org-Read-Only`)
+- Most `/api/v1/admin/*` and all `/api/v1/testing/*` routes (the documented exception is `POST /admin/agent-keys/provision`, which is part of the stable identity-bootstrap surface — see the Agents row above)
+- The `core-storage-api` microservice (internal, not user-facing)
+- The plugin's TypeScript module structure
+- API-key prefix formats — currently unified on `mc_…` (with legacy `mca_…` / `mci_…` aliases still accepted via back-compat); formats may continue to evolve
+
+## Reporting breaking changes
+
+Contributors who introduce a breaking change to a stable surface must:
+
+- Add a `BREAKING CHANGE:` trailer to the commit message describing the impact and any migration steps.
+- Apply the `kind/breaking` label to the pull request.
+
+Reviewers will block changes to a stable surface without these markers. If you
+are unsure whether a change is breaking, open the PR with the label and let
+review decide — better to over-label than ship a silent break.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,242 @@
+# Self-hosting Caura
+
+The fastest self-hosted path is Docker Compose. It starts PostgreSQL with
+pgvector, Redis, the storage service, and the public REST/MCP API.
+
+For a keyless first run, use the executable example in the
+[README quick start](../README.md#quick-start). This
+guide covers provider configuration, production-minded deployment details,
+authentication modes, and tests.
+
+> **Prefer not to use Docker?** See
+> [Manual deployment (without Docker)](../README.md#manual-deployment-without-docker)
+> for the bare-Python path.
+>
+> **No cloud API key or external calls?** Use the
+> [local embedder](local-embedder.md) (`BAAI/bge-m3` through HuggingFace TEI).
+
+## Prerequisites
+
+- **Docker Engine 24+** (Linux) or **Docker Desktop** (macOS / Windows). Confirm with `docker --version`.
+- **Docker Compose v2** (built into current Docker Desktop releases). Confirm with `docker compose version`.
+- **Git** for cloning.
+- About 2 GB free disk for images and the PostgreSQL data volume.
+
+## 1. Clone and configure
+
+```bash
+git clone https://github.com/caura-ai/caura.git
+cd caura
+cp .env.example .env
+```
+
+Set your AI provider in `.env`. Minimal OpenAI configuration:
+
+```env
+EMBEDDING_PROVIDER=openai
+ENTITY_EXTRACTION_PROVIDER=openai
+USE_LLM_FOR_MEMORY_CREATION=true
+OPENAI_API_KEY=sk-...
+```
+
+Without AI keys the stack still starts. Its dummy providers return
+non-semantic embeddings, which are useful for exercising the API surface but
+not for evaluating semantic recall.
+
+> **Want zero cloud API calls?** v2.0+ includes a self-hosted embedder profile
+> (`BAAI/bge-m3` on a
+> [HuggingFace TEI](https://github.com/huggingface/text-embeddings-inference)
+> sidecar). Start it with `docker compose --profile embed-local up -d --wait`
+> and set the three `OPENAI_EMBEDDING_*` values documented in `.env.example`.
+> See the [local-embedder guide](local-embedder.md) for the complete setup. Combined
+> with `IS_STANDALONE=true`, this makes the deployment fully self-contained.
+
+<details>
+<summary>Provider matrix</summary>
+
+| Provider | `.env` settings | Required key |
+|---|---|---|
+| **OpenAI** (default) | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=openai` | `OPENAI_API_KEY` |
+| **Google Gemini** | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=gemini` | `GEMINI_API_KEY` + `OPENAI_API_KEY` |
+| **Anthropic** | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=anthropic` | `ANTHROPIC_API_KEY` + `OPENAI_API_KEY` |
+| **OpenRouter** | `EMBEDDING_PROVIDER=openai`<br>`ENTITY_EXTRACTION_PROVIDER=openrouter` | `OPENROUTER_API_KEY` + `OPENAI_API_KEY` |
+| **Self-hosted (TEI / bge-m3)** | `--profile embed-local` + `OPENAI_EMBEDDING_BASE_URL=http://tei:80/v1`<br>+ `OPENAI_EMBEDDING_MODEL=BAAI/bge-m3`<br>+ `OPENAI_EMBEDDING_SEND_DIMENSIONS=false` | none — runs locally |
+
+Anthropic, Gemini, and OpenRouter do not provide embedding APIs here, so pair
+them with OpenAI or TEI for embeddings. Gemini uses the Google AI Studio
+key-auth Developer API; it does not require a GCP project or application
+default credentials. TEI keeps `EMBEDDING_PROVIDER=openai` because it exposes
+an OpenAI-compatible API.
+
+</details>
+
+## 2. Start the stack
+
+```bash
+docker compose up -d --wait
+```
+
+> **Security requirement:** port 8002 belongs to the internal storage data
+> plane and must never be exposed to the host or an untrusted network. The
+> shipped Compose file does not publish it. `core-api` reaches it only on the
+> private Compose network and authenticates with a random per-installation
+> secret generated in a private Docker volume. Do not add an `8002:8002` port
+> mapping. For local debugging, bind only `127.0.0.1:8002:8002` and keep the
+> `CORE_STORAGE_SHARED_SECRET` check enabled. Only exact `GET /healthz` and
+> `GET /readyz` probes are public; every storage data route requires the secret.
+
+The first run pulls multi-architecture images from `ghcr.io` for `linux/amd64`
+and `linux/arm64`. Later runs reuse the cached image. Set `CAURA_VERSION` to a
+concrete v2 release tag in `.env` to pin a release. To build from a local
+checkout, run:
+
+```bash
+docker compose up --build --pull never
+```
+
+To refresh an image at the same tag:
+
+```bash
+docker compose pull
+docker compose up -d --wait
+```
+
+There is no silent version drift: without an explicit pull, the local cache
+wins.
+
+### Offline and air-gapped operation
+
+- If the image is cached, `docker compose up -d --pull never` starts without a registry request.
+- If no image is cached, `docker compose up --build --pull never` builds from source.
+- For a strict no-network guarantee, add a `docker-compose.override.yml` that sets `pull_policy: never` for both application services. Compose then fails fast when an image is absent.
+
+### Service URLs
+
+| Service | URL |
+|---|---|
+| Core API (REST + MCP) | http://localhost:8000 |
+| PostgreSQL (pgvector) | localhost:5432 |
+| Redis | localhost:6379 |
+
+`core-storage-api` is intentionally reachable only by services on the Compose
+network; it has no host URL.
+
+### What the stack contains
+
+`docker compose up` starts four long-running containers and a one-shot
+`storage-secret-init` container:
+
+| Container | Role |
+|---|---|
+| `db` | PostgreSQL 16 + pgvector |
+| `redis` | Cache and rate limiting |
+| `core-storage-api` | Storage service (SQL + vector search) |
+| `core-api` | REST + MCP surface; embedding and enrichment run in-process (`deployment_mode=inline`) |
+
+The optional `tei` service starts only with `--profile embed-local`.
+`core-worker`, platform-tier services, and the Google Pub/Sub event bus are
+managed/enterprise components. The OSS stack uses the in-process event bus and
+performs embedding and enrichment inside `core-api`, so it needs no worker.
+
+## 3. Verify
+
+```bash
+curl http://localhost:8000/api/v1/health
+# {"status":"ok","storage":"connected","redis":"connected","event_bus":"ok"}
+```
+
+## 4. Write and search
+
+```bash
+# Write a memory (standalone mode — no API key needed)
+curl -X POST http://localhost:8000/api/v1/memories \
+  -H "X-API-Key: standalone" \
+  -H "Content-Type: application/json" \
+  -d '{"tenant_id": "default", "agent_id": "quickstart", "content": "Our auth service uses JWT with 15-minute expiry."}'
+
+# Search for it semantically after configuring an embedding provider
+curl -X POST http://localhost:8000/api/v1/search \
+  -H "X-API-Key: standalone" \
+  -H "Content-Type: application/json" \
+  -d '{"tenant_id": "default", "query": "authentication token lifetime"}'
+```
+
+`agent_id` names the writer, so every memory carries provenance. It is optional
+for a standalone deployment in current source and defaults to `mcp-agent`, but
+published v2.x images still require it. Passing it explicitly works everywhere.
+
+Write bodies reject undeclared fields with a `422` response and name them in
+`error.details.unknown_fields`. Put caller-owned values under `metadata`.
+Search and filter bodies deliberately ignore unknown fields. See
+[API surface contracts](api-surfaces.md#request-body-contract-writes-are-strict-searches-are-not).
+
+The write response contains inferred `memory_type`, `title`, `status`, and
+`weight`. `summary` and `tags` live under `metadata`. On a deferred fast-write
+deployment, enrichment is asynchronous and the immediate response may contain
+`metadata.enrichment_pending: true`.
+
+Semantic embedding can also be asynchronous. While
+`metadata.embedding_pending: true`, the memory is available through keyword
+search and `GET /memories`, but does not compete on semantic similarity. If a
+caller must immediately search what it wrote, pass `write_mode: "strong"` to
+embed inline. This adds a provider call to the write request, so choose it per
+write rather than globally.
+
+`POST /search` returns matches in an `items` array. Each item contains the full
+memory plus its `similarity` score.
+
+## Authentication modes
+
+Choose one mode in `.env`, then restart with `docker compose up -d`.
+
+### Standalone
+
+Single-tenant (`tenant_id="default"`), intended for local or personal installs:
+
+```env
+IS_STANDALONE=true
+```
+
+REST and MCP need no API key in standalone mode. Pair this mode with the
+[local embedder](local-embedder.md) for a fully self-contained deployment.
+
+### Admin key
+
+Multi-tenant with full access:
+
+```env
+ADMIN_API_KEY=your-long-random-admin-key
+```
+
+Send the key in `X-API-Key` and include `tenant_id` in request bodies or query
+parameters.
+
+### Shared gate
+
+For network-exposed OSS deployments:
+
+```env
+CAURA_API_KEY=your-shared-key
+```
+
+Clients send `X-API-Key: your-shared-key` and `X-Tenant-ID: <tenant>`.
+
+See the [agent installation guide](../AGENT-INSTALL.md) for the complete
+self-install flow.
+
+## Running tests
+
+```bash
+# Root unit tests (no database needed)
+pytest tests/ -m "unit"
+
+# Root integration suite (requires PostgreSQL)
+docker compose up -d db
+pytest tests/ -m "not benchmark"
+
+# Smoke test against a live API (~30s, auto-cleanup)
+python scripts/smoke_test.py --url http://localhost:8000 --api-key <admin-key>
+```
+
+CI also runs service-, worker-, operations-, client-, and plugin-specific
+suites from their respective directories.

--- a/docs/upgrading-from-v1.md
+++ b/docs/upgrading-from-v1.md
@@ -1,0 +1,138 @@
+# Upgrading from v1.x
+
+> **⚠️ v2.0.0 ships a destructive schema migration.** If your installation is on
+> v1.x and has any memories already stored, follow this procedure carefully — the
+> migration NULLs every existing embedding to widen the pgvector column from
+> 768 → 1024 dim. The application is designed to refuse the migration
+> automatically; you must opt in.
+
+## What changes
+
+- The supported vector width changes from 768 to 1024 dimensions. Hosted
+  OpenAI `text-embedding-3-small` remains the default; `BAAI/bge-m3` is an
+  optional self-hosted provider through the new `tei` Compose profile. See
+  [`local-embedder.md`](local-embedder.md).
+- pgvector schema dim: `vector(1024)` (was: `vector(768)`).
+- Existing embeddings on `memories.embedding`, `entities.name_embedding`, and
+  `documents.embedding` are NULLed by alembic revision `012_vector_dim_1024`.
+  Re-embedding is required for full semantic recall. Until then, NULL-vector
+  rows can still surface through full-text keyword matching, but they do not
+  contribute a vector-similarity score.
+
+## Procedure (OSS, docker-compose)
+
+1. **Stop the stack** so no writes happen during migration:
+
+   ```bash
+   docker compose down
+   ```
+
+2. **Snapshot the database.** A `pg_dump` is the safest fallback. Replace
+   `<container>` with the running PostgreSQL container name (typically
+   `caura-db-1`):
+
+   ```bash
+   docker compose up -d db    # bring just the DB back
+   docker exec <container> pg_dump -U memclaw memclaw > backup-pre-v2.sql
+   docker compose down
+   ```
+
+3. **Select a v2 image, pull it, and run the migration explicitly.** If `.env`
+   pins `CAURA_VERSION` to a v1 tag, update it to the v2 release you are
+   installing first; otherwise `docker compose pull` will fetch v1 again. The
+   stock Compose service does not forward arbitrary shell variables into the
+   container, so pass the opt-in on the one-off migration command itself:
+
+   ```bash
+   docker compose pull
+   docker compose run --rm \
+     -e CAURA_RUN_DESTRUCTIVE_MIGRATIONS=true \
+     core-storage-api \
+     python -c 'import asyncio; from core_storage_api.database.init import init_database; asyncio.run(init_database())'
+   docker compose up -d --wait
+   ```
+
+   `init_database()` runs `alembic upgrade head` through the same advisory-lock
+   path used at normal service startup. The migration runs in
+   seconds-to-minutes for typical OSS workloads.
+
+4. **Verify the restarted service is at the current schema head.** The
+   `--wait` command above checks readiness; the storage log should also show
+   that no migration remains:
+
+   ```bash
+   docker compose logs core-storage-api | \
+     grep -i "schema already at head\|database initialization complete"
+   ```
+
+5. **Re-embed your data.** Three paths are available:
+
+   - **Keyword-only while waiting:** no automatic read-time re-embedding occurs.
+     NULL-vector rows may still appear through full-text matching, but semantic
+     paraphrases will miss them. Run one of the eager paths below to restore
+     full semantic recall.
+   - **Eager (recommended for the stock OSS stack):** run the bundled backfill CLI. It walks every
+     memory and entity with a NULL embedding and re-embeds via the configured
+     provider. Idempotent — safe to re-run. First do a dry-run to estimate
+     scope. The `--env-from-file` option requires Docker Compose 2.34+; if
+     `docker compose run --help` does not list it, upgrade Compose first:
+
+     ```bash
+     docker compose run --rm --env-from-file .env core-storage-api \
+       python -m core_storage_api.scripts.backfill_embeddings --dry-run
+     ```
+
+     Then the real run:
+
+     ```bash
+     docker compose run --rm --env-from-file .env core-storage-api \
+       python -m core_storage_api.scripts.backfill_embeddings
+     ```
+
+     `--env-from-file .env` is required: unlike `core-api`, the stock
+     `core-storage-api` service does not load provider settings from `.env`.
+     Without it, the CLI falls back to fake embeddings.
+
+     Optional knobs: `--tenant-id <id>` (per-tenant cutover), `--batch-size N`,
+     `--max-inflight N`, `--only-table memories|entities`. Documents are NOT
+     covered (their embed-source field is per-row JSON, not a fixed column);
+     re-write any embedded documents to refresh them.
+   - **Eager (event-driven, recommended for multi-tenant production):** if you
+     run the `core-worker` service, drive the existing `EMBED_REQUESTED`
+     consumer instead. The CLI scans `WHERE embedding IS NULL` and publishes
+     one event per row, inheriting per-tenant concurrency + retry + DLQ:
+
+     Run these commands inside an already configured `core-worker` runtime;
+     the stock Compose stack does **not** define a `core-worker` service:
+
+     ```bash
+     python -m core_worker.cli backfill-embeddings \
+       --tenant-id <tenant-id> --dry-run
+     python -m core_worker.cli backfill-embeddings \
+       --tenant-id <tenant-id>
+     ```
+
+     `--tenant-id` is required; repeat the command once per tenant for a full
+     deployment cutover. The other knobs are `--batch-size`, `--max-inflight`,
+     and `--dry-run`. This path currently covers `memories` only. Self-hosters
+     on the stock stack should use the `core-storage-api` variant above.
+
+## What if I skip the opt-in?
+
+The one-off migration command exits non-zero with a clear error reporting how
+many rows would be NULLed. No data is touched. Add the explicit opt-in and
+retry.
+
+## Rolling back
+
+Restore the `pg_dump` snapshot from step 2. Migration 012 has a symmetric
+`downgrade()`, but it NULLs every 1024-dim embedding written since the upgrade
+before restoring `vector(768)`, so restoring the pre-upgrade snapshot is the
+safer and simpler recovery path.
+
+## v1.x → v2.x compatibility for client code
+
+No public API changes. Code that reads memory embeddings via the search/recall
+endpoints is unaffected. External clients should not assume a vector width;
+custom integrations that directly handle the internal storage schema must
+migrate from 768 to 1024 dimensions with the database.


### PR DESCRIPTION
## Summary

Split the long README into focused operator/reference guides and reduce the README from 1,366 to 702 lines. The executable keyless quick start remains in place, while self-hosting, v1 migration, API reference, and public stability details move under `docs/` with legacy anchors preserved.

This also consolidates the duplicate telemetry sections and corrects stale inherited guidance around v2 migration/backfill commands, storage configuration, auth headers, bootstrap aliases, production startup requirements, and OpenAPI URLs.

## Type of Change

- [x] Documentation update
- [x] Refactor / internal cleanup

## How Has This Been Tested?

- `pre-commit run --files README.md AGENT-INSTALL.md CONTRIBUTING.md SUPPORT.md docs/local-embedder.md docs/api-reference.md docs/public-api-stability.md docs/self-hosting.md docs/upgrading-from-v1.md`
- `pytest tests/test_readme_quickstart.py -q` — 10 passed
- `python3 scripts/legacy_name_ratchet.py --base origin/main`
- `docker compose config --quiet`
- Local Markdown path and anchor validation across all changed docs
- Current FastAPI route/OpenAPI introspection for documented paths

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I have added tests that cover my changes (existing README contract tests cover the retained executable block; this change adds no runtime behavior)
- [x] `ruff check` and `ruff format --check` pass (no Python files changed; pre-commit passed)
- [x] `mypy` passes (not applicable; no typed source changed)
- [x] `pytest` passes locally
- [x] I have updated relevant documentation
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (not applicable: documentation reorganization only)

## Additional Notes

The `/simplify` review completed with no remaining findings. Follow-up work will improve the demo's cross-agent/fleet story and verify remaining published-image/provider parity separately so this PR stays focused on information architecture.
