### PR TITLE
fix(storage): require a binding tenant on quality-metrics

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1370,10 +1370,20 @@ async def quality_metrics(request: Request) -> dict:
     readable_tenant_ids?}``. Returns ``{total, reused, total_recalls,
     top_recalls, by_type:{type:{total,reused}}}``. Same scope/visibility as
     ``/stats-breakdown``; read-only.
+
+    ``tenant_id`` is required, and ``readable_tenant_ids`` does not substitute
+    for it. The guard used to accept either, which made this the only one of
+    the eight ``readable_tenant_ids`` routes where a caller could name its own
+    scope and supply no home tenant: the grant is read verbatim from the body
+    by a service that authenticates nothing, so accepting it in place of a
+    tenant is strictly weaker than requiring one. The error message already
+    said ``tenant_id is required`` while the condition did not enforce it.
+    With a tenant always present, omitting the grant narrows to that tenant —
+    fail-closed — which is what the other seven sites have always done.
     """
     body: dict = await request.json()
     tenant_id = body.get("tenant_id")
-    if not tenant_id and not body.get("readable_tenant_ids"):
+    if not tenant_id:
         raise HTTPException(status_code=422, detail="tenant_id is required")
     ca = body.get("created_after")
     try:

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -731,13 +731,6 @@
       "note": "Tracked in #1088."
     },
     {
-      "id": "route:POST /api/v1/storage/memories/quality-metrics",
-      "verdict": "OPTIONAL",
-      "evidence": "reads tenant_id with .get() and never rejects a missing one",
-      "category": "grant-in-lieu-of-tenant",
-      "note": "Accepts a caller-supplied readable_tenant_ids in place of a binding tenant: 'if not tenant_id and not readable_tenant_ids: raise'. Its three sibling stats routes (stats-breakdown, daily-durable-counts, list) all require tenant_id outright, and this one's own docstring lists tenant_id as non-optional. Tracked in #1096."
-    },
-    {
       "id": "route:POST /api/v1/storage/reports",
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",

--- a/core-storage-api/tests/test_quality_metrics_tenant_scope.py
+++ b/core-storage-api/tests/test_quality_metrics_tenant_scope.py
@@ -1,0 +1,118 @@
+"""``POST /memories/quality-metrics`` requires a binding tenant.
+
+The guard was ``if not tenant_id and not readable_tenant_ids``, so a request
+carrying only a ``readable_tenant_ids`` list passed it. That grant is read
+verbatim from the request body by a service that authenticates nothing
+(GHSA-wgvw-28pq-jc36), so accepting it in place of a home tenant let the caller
+name its own scope.
+
+This was the only one of the eight ``readable_tenant_ids`` routes shaped that
+way — the other seven require ``tenant_id`` and treat the grant as a widening
+on top of it, so omitting the grant narrows to the home tenant rather than
+opening up. The route's own error message already read ``tenant_id is
+required``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def _memory(client: AsyncClient, tenant_id: str, content: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "agent-a",
+            "content": content,
+            "memory_type": "fact",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+class TestQualityMetricsTenantScope:
+    async def test_a_grant_alone_is_rejected(self, client: AsyncClient) -> None:
+        """The defect, stated as the request an attacker would send.
+
+        No ``tenant_id``, only a list of tenants the caller nominated. This used
+        to reach the query.
+        """
+        victim = f"qm-victim-{uuid.uuid4().hex[:8]}"
+        await _memory(client, victim, "victim's secret")
+
+        resp = await client.post(
+            f"{PREFIX}/memories/quality-metrics",
+            json={"readable_tenant_ids": [victim]},
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+
+    async def test_no_scope_at_all_is_rejected(self, client: AsyncClient) -> None:
+        resp = await client.post(f"{PREFIX}/memories/quality-metrics", json={})
+        assert resp.status_code == 422, resp.text
+
+    async def test_own_tenant_is_returned(self, client: AsyncClient) -> None:
+        """The supported call still works."""
+        tenant = f"qm-{uuid.uuid4().hex[:8]}"
+        await _memory(client, tenant, "mine")
+
+        resp = await client.post(
+            f"{PREFIX}/memories/quality-metrics",
+            json={"tenant_id": tenant},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["total"] >= 1
+
+    async def test_the_grant_still_widens_on_top_of_a_tenant(self, client: AsyncClient) -> None:
+        """The grant is not removed — it is only stopped from standing alone.
+
+        With a binding tenant present it still widens the read across the named
+        siblings, which is what the other seven routes do and what this change
+        must not break.
+        """
+        home = f"qm-home-{uuid.uuid4().hex[:8]}"
+        sibling = f"qm-sib-{uuid.uuid4().hex[:8]}"
+        await _memory(client, home, "home memory")
+        await _memory(client, sibling, "sibling memory")
+
+        narrow = await client.post(
+            f"{PREFIX}/memories/quality-metrics",
+            json={"tenant_id": home},
+        )
+        widened = await client.post(
+            f"{PREFIX}/memories/quality-metrics",
+            json={"tenant_id": home, "readable_tenant_ids": [home, sibling]},
+        )
+
+        assert narrow.status_code == widened.status_code == 200, widened.text
+        assert widened.json()["total"] > narrow.json()["total"]
+
+    async def test_omitting_the_grant_narrows_to_the_home_tenant(self, client: AsyncClient) -> None:
+        """Fail-closed: forgetting the grant must not widen the read.
+
+        This is the property that makes the grant safe to omit, and it only
+        holds because a binding tenant is now always present.
+        """
+        home = f"qm-home-{uuid.uuid4().hex[:8]}"
+        other = f"qm-other-{uuid.uuid4().hex[:8]}"
+        await _memory(client, home, "home memory")
+        await _memory(client, other, "other tenant's memory")
+
+        resp = await client.post(
+            f"{PREFIX}/memories/quality-metrics",
+            json={"tenant_id": home},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["total"] == 1


### PR DESCRIPTION
Closes #1096.

`POST /memories/quality-metrics` guarded with:

```python
if not tenant_id and not body.get("readable_tenant_ids"):
    raise HTTPException(status_code=422, detail="tenant_id is required")
```

so a request carrying **only** a `readable_tenant_ids` list passed it, and the caller named its own scope. `core-storage-api` authenticates no request (GHSA-wgvw-28pq-jc36) and reads that list verbatim from the body, so accepting it in place of a home tenant is strictly weaker than requiring one.

The error message already said `tenant_id is required` while the condition did not enforce it.

### Why this is a defect rather than a design

Measured across the router: of the **eight** routes that forward `readable_tenant_ids` to the service layer, this was the **only** one with that guard shape. The other seven — `stats-breakdown` and `daily-durable-counts` among them — all use `if not tenant_id: raise 422`, treating the grant as a widening *on top of* a binding tenant.

That difference is what makes the grant safe everywhere else: with a tenant always present, forgetting the grant narrows to the home tenant. Fail-closed. Here there was nothing to narrow to.

### The change

One line. `readable_tenant_ids` is untouched and still widens the read across the named siblings.

### Tests

Five, in `core-storage-api/tests/test_quality_metrics_tenant_scope.py`. Deliberately only **one** fails on the parent commit:

| test | on parent |
|---|---|
| `test_a_grant_alone_is_rejected` | ✅ **fails** — this is the defect |
| `test_no_scope_at_all_is_rejected` | passes |
| `test_own_tenant_is_returned` | passes |
| `test_the_grant_still_widens_on_top_of_a_tenant` | passes |
| `test_omitting_the_grant_narrows_to_the_home_tenant` | passes |

The four that pass either way are there on purpose: the cheap way to satisfy the first test is to break the grant, and those four make that impossible to do quietly. Stating it explicitly so the ratio does not read as four tests that forgot to assert anything.

### Verification

`core-storage-api` suite: 10 failed / **194** passed / 7 errors — byte-identical failures and errors to pristine `origin/main` (10 / **189** / 7), so the delta is exactly the five new tests and nothing regressed. The pre-existing 10+7 are environmental in my local setup and reproduce unmodified on `main`.

`ruff check` and `ruff format --check` at CI's exact scopes (`src/`, `tests/`, run separately, discovery-based, no `--config`) — clean at ruff 0.16.5, matching the pinned `>=0.16.2`. `mypy src/` from `core-storage-api/` — clean, 84 files. `uv.lock` untouched. Rebased onto `01780eac` and re-run there.

### Relationship to #1069

#1069 adds the CI gate that found this. This path is on its allowlist under `grant-in-lieu-of-tenant`; once this merges, that entry becomes stale and #1069's own ratchet will fail until it is regenerated away — the fifth time that mechanism has forced a shrink to be recorded rather than remembered.

Its sibling issue #1095 (`POST /tenant-usage/query`) is **not** fixed here, and on investigation is not fixable the way I described when filing it — see the note I am adding to that issue.
