### PR TITLE
fix(usage): log counters stranded at shutdown

### DIFF
--- a/core-api/src/core_api/services/usage_meter.py
+++ b/core-api/src/core_api/services/usage_meter.py
@@ -175,6 +175,14 @@ class UsageMeter:
             self._task = None
         try:
             await asyncio.wait_for(self.flush(), timeout=timeout)
+            for (tenant_id, operation, period), count in self._counts.items():
+                logger.error(
+                    "usage meter counter row lost to shutdown: tenant=%s operation=%s period_start=%s count=%d",
+                    tenant_id,
+                    operation,
+                    period.isoformat(),
+                    count,
+                )
         except TimeoutError:
             logger.warning(
                 "usage meter final flush did not complete within %ss; %d counter rows are lost to shutdown",

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -14,6 +14,7 @@ that make buffered counting safe for billing, each pinned separately:
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
@@ -152,6 +153,25 @@ async def test_stop_flushes_what_is_buffered(sc):
     await meter.stop()
 
     assert _rows(sc)[0]["count"] == 4
+
+
+async def test_a_failed_final_flush_logs_the_stranded_counter(sc, caplog):
+    sc.increment_tenant_usage.side_effect = RuntimeError("storage down")
+    meter = UsageMeter()
+    await meter.record(tenant_id="tenant-a", operation="search", count=7)
+    period_start = next(iter(meter._counts))[2].isoformat()
+
+    with caplog.at_level(logging.ERROR, logger="core_api.services.usage_meter"):
+        await meter.stop()
+
+    stranded = [
+        record
+        for record in caplog.records
+        if f"tenant=tenant-a operation=search period_start={period_start} count=7"
+        in record.getMessage()
+    ]
+    assert len(stranded) == 1
+    assert stranded[0].levelno == logging.ERROR
 
 
 async def test_a_shutdown_landing_inside_a_flush_does_not_drop_the_batch(sc):


### PR DESCRIPTION
## What

- Log every usage counter row still buffered after `UsageMeter.stop()`'s final flush returns, at ERROR with tenant, operation, and count.
- Add a regression test for the exception-return path that previously made shutdown loss silent.

This is N1 only. It changes observability, not metering, retry, persistence, or the five-second shutdown budget.

## Why

The existing `counter rows are lost to shutdown` warning covers only a final-flush timeout. The incident's final flush raised an exception instead; `flush()` caught it, restored the batch, and returned normally, so `stop()` never reached that warning. The process then exited with the restored rows still in memory. Logging the row identity makes that narrow loss recoverable by hand because the increment endpoint already accepts an explicit `period_start`.

## Deliberately declined

- **N2 — bounded in-shutdown retry:** defensible, but not now. Any future version must remain inside the existing five-second budget; extending it would violate the sound Cloud Run grace-period tradeoff in `stop()` and could strand later shutdown steps.
- **N3 — persist the buffer outside the process:** not proportionate. It would put a durable write on the shutdown path to protect single-digit counts.

Both changes also amplify a latent double-count risk: `sent = True` is set only after `increment_tenant_usage()` returns. A `ReadTimeout` after storage commits therefore restores a batch that already landed, and a later flush counts it twice. More aggressive retry increases those odds. That is why the small recoverability-only N1 change is the right boundary here.

## No backfill

No backfill was performed. The three known lost counts were requests that returned 500, so restoring them would reintroduce an over-count.

## Regression proof

The new test was run before changing production code and failed on the missing log:

```text
FAILED tests/test_usage_meter.py::test_a_failed_final_flush_logs_the_stranded_counter
>       assert len(stranded) == 1
E       assert 0 == 1
Captured log: usage meter flush failed; 1 counter rows returned to the buffer
1 failed
```

After N1:

```text
tests/test_usage_meter.py: 15 passed
```

Additional verification:

- Exact CI Ruff check and format scopes: passed
- `core-api` mypy: 203 source files, no issues
- `core-api` sdist and wheel build: passed
- `/simplify`: clean
