### PR TITLE
fix(ratchet): separate annotations from removals

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -99,7 +99,7 @@ Usage::
 
     scripts/legacy_name_ratchet.py                     # compare against origin/main
     scripts/legacy_name_ratchet.py --base <tree-ish>
-    scripts/legacy_name_ratchet.py --report            # counts only, never fails
+    scripts/legacy_name_ratchet.py --report            # counts + change split; never fails
 """
 
 from __future__ import annotations
@@ -110,7 +110,7 @@ import re
 import subprocess
 import sys
 from collections import Counter
-from typing import NamedTuple
+from typing import NamedTuple, overload
 
 # The legacy brand. Matched case-insensitively, so every casing in the tree
 # counts — prose, identifiers and SCREAMING_SNAKE env names alike. This is the
@@ -330,7 +330,7 @@ def _git(args: list[str]) -> str:
 
 
 def _grep(
-    tree: str | None, pathspec: str = ":/"
+    tree: str | None, pathspec: str | list[str] = ":/"
 ) -> list[tuple[str, str, str, str | None]]:
     """``(path, lineno, text, kind)`` for every matching line.
 
@@ -357,7 +357,8 @@ def _grep(
     args = ["git", "grep", "-I", "-i", "-n", "-z", "--full-name", "-e", LEGACY_NAME]
     if tree is not None:
         args.append(tree)
-    args += ["--", pathspec]
+    args.append("--")
+    args += [pathspec] if isinstance(pathspec, str) else pathspec
 
     prefix = f"{tree}:" if tree is not None else ""
 
@@ -520,7 +521,7 @@ class Scan(NamedTuple):
         )
 
 
-def scan(tree: str | None) -> Scan:
+def scan(tree: str | None, pathspec: str | list[str] = ":/") -> Scan:
     """Read a tree once. ``tree=None`` is the working tree."""
     by_file: dict[str, Counter[str]] = {}
     total: Counter[str] = Counter()
@@ -530,7 +531,7 @@ def scan(tree: str | None) -> Scan:
     # so the kind is recoverable from the key. Splitting would be a second
     # definition of the same fact.
     exempt_by_file: dict[str, Counter[str]] = {}
-    for path, _, text, kind in _grep(tree):
+    for path, _, text, kind in _grep(tree, pathspec):
         stripped = text.strip()
         if kind is not None:
             exempt_by_file.setdefault(path, Counter())[stripped] += 1
@@ -538,6 +539,216 @@ def scan(tree: str | None) -> Scan:
         by_file.setdefault(path, Counter())[stripped] += 1
         total[stripped] += 1
     return Scan(by_file, total, exempt_by_file)
+
+
+def _updated_scan(before: Scan, tree: str, paths: list[str]) -> Scan:
+    """Apply one commit by rescanning only its changed paths."""
+    if not paths:
+        return before
+
+    by_file = before.by_file.copy()
+    exempt_by_file = before.exempt_by_file.copy()
+    total = before.total.copy()
+    for path in paths:
+        total.subtract(by_file.pop(path, Counter()))
+        exempt_by_file.pop(path, None)
+
+    changed = scan(tree, [_literal(path) for path in paths])
+    by_file.update(changed.by_file)
+    exempt_by_file.update(changed.exempt_by_file)
+    total.update(changed.total)
+    return Scan(by_file, +total, exempt_by_file)
+
+
+def _transition_paths(before: str, after: str | None = None) -> list[str]:
+    """Tracked paths changed between two trees, or from before to worktree."""
+    args = ["git", "diff", "--name-only", "-z", "--no-renames", before]
+    if after is not None:
+        args.append(after)
+    args.append("--")
+    return [path for path in _git(args).split("\0") if path]
+
+
+class _ChangeSummary(NamedTuple):
+    """Gross causes behind the non-exempt count's net movement."""
+
+    added: int
+    annotated: int
+    removed: int
+    moved: int
+    net: int
+
+
+# Ordinary gate runs must stay bounded. A caller asking for --report is
+# explicitly asking for the archaeology and remains uncapped.
+_GATE_REPLAY_LIMIT = 64
+
+
+def _only_inserts(before: str, after: str) -> bool:
+    """Whether deleting one contiguous insertion from ``after`` yields ``before``."""
+    inserted = len(after) - len(before)
+    if inserted <= 0:
+        return False
+    mismatch = next(
+        (
+            i
+            for i, (old, new) in enumerate(zip(before, after, strict=False))
+            if old != new
+        ),
+        len(before),
+    )
+    return after[mismatch + inserted :] == before[mismatch:]
+
+
+def _transition_summary(base: Scan, head: Scan) -> _ChangeSummary:
+    """Classify one tree-to-tree transition without affecting the gate."""
+    lost = {
+        (path, text): n
+        for path, lines in base.by_file.items()
+        for text, n in (lines - head.by_file.get(path, Counter())).items()
+    }
+    gained = {
+        (path, text): n
+        for path, lines in head.by_file.items()
+        for text, n in (lines - base.by_file.get(path, Counter())).items()
+    }
+    gained_exempt = {
+        (path, text): n
+        for path, lines in head.exempt_by_file.items()
+        for text, n in (lines - base.exempt_by_file.get(path, Counter())).items()
+    }
+
+    annotated = 0
+    for (destination, marked), available in sorted(gained_exempt.items()):
+        candidates = sorted(
+            (key for key, n in lost.items() if n and _only_inserts(key[1], marked)),
+            key=lambda key: (key[0] != destination, len(marked) - len(key[1]), key),
+        )
+        for key in candidates:
+            matched = min(available, lost[key])
+            annotated += matched
+            available -= matched
+            lost[key] -= matched
+            if not available:
+                break
+
+    moved = 0
+    for (destination, text), available in sorted(gained.items()):
+        sources = sorted(
+            key
+            for key, n in lost.items()
+            if n and key[0] != destination and key[1] == text
+        )
+        for key in sources:
+            matched = min(available, lost[key])
+            moved += matched
+            available -= matched
+            lost[key] -= matched
+            gained[(destination, text)] -= matched
+            if not available:
+                break
+
+    return _ChangeSummary(
+        added=sum(gained.values()),
+        annotated=annotated,
+        removed=sum(lost.values()),
+        moved=moved,
+        net=sum(head.counts().values()) - sum(base.counts().values()),
+    )
+
+
+@overload
+def _change_summary(
+    base_ref: str,
+    base: Scan,
+    head: Scan,
+    *,
+    max_commits: None = None,
+) -> _ChangeSummary: ...
+
+
+@overload
+def _change_summary(
+    base_ref: str,
+    base: Scan,
+    head: Scan,
+    *,
+    max_commits: int,
+) -> _ChangeSummary | None: ...
+
+
+def _change_summary(
+    base_ref: str,
+    base: Scan,
+    head: Scan,
+    *,
+    max_commits: int | None = None,
+) -> _ChangeSummary | None:
+    """Classify each first-parent step, falling back to the two endpoints.
+
+    Replaying matters when a line is annotated and a later commit removes it:
+    by then it is exempt, so that later edit is exemption churn rather than a
+    removal from the ratcheted population. Endpoint arithmetic loses that order.
+
+    Intermediate states are updated by scanning only the paths each commit
+    changed. This retains exact chronology without re-grepping the whole tree
+    per commit. A range with at most one non-empty transition has no intermediate
+    state to recover and reuses the endpoint scans.
+
+    None means a bounded caller exceeded max_commits. It must omit the split
+    rather than print the cheaper endpoint classification as exact.
+    """
+    endpoint = _transition_summary(base, head)
+    try:
+        base_oid = _git(["git", "rev-parse", f"{base_ref}^{{commit}}"]).strip()
+        head_oid = _git(["git", "rev-parse", "HEAD^{commit}"]).strip()
+        rev_list_args = ["git", "rev-list", "--first-parent", "--reverse"]
+        if max_commits is not None:
+            rev_list_args.append(f"--max-count={max_commits + 1}")
+        rev_list_args.append(f"{base_oid}..{head_oid}")
+        commits = _git(rev_list_args).splitlines()
+        if max_commits is not None and len(commits) > max_commits:
+            return None
+        transitions: list[tuple[str, list[str]]] = []
+        previous = base_oid
+        for commit in commits:
+            parent = _git(["git", "rev-parse", f"{commit}^1"]).strip()
+            if parent != previous:
+                return endpoint
+            transitions.append((commit, _transition_paths(previous, commit)))
+            previous = commit
+        if previous != head_oid:
+            return endpoint
+
+        worktree_paths = _transition_paths("HEAD")
+        if sum(bool(paths) for _, paths in transitions) + bool(worktree_paths) <= 1:
+            return endpoint
+
+        parts: list[_ChangeSummary] = []
+        current = base
+        for index, (commit, paths) in enumerate(transitions):
+            if index == len(transitions) - 1 and not worktree_paths:
+                following = head
+            else:
+                following = _updated_scan(current, commit, paths)
+            parts.append(_transition_summary(current, following))
+            current = following
+        if worktree_paths:
+            parts.append(_transition_summary(current, head))
+    except RuntimeError:
+        return endpoint
+
+    return _ChangeSummary(
+        added=sum(part.added for part in parts),
+        annotated=sum(part.annotated for part in parts),
+        removed=sum(part.removed for part in parts),
+        moved=sum(part.moved for part in parts),
+        net=sum(part.net for part in parts),
+    )
+
+
+def _move_label(n: int) -> str:
+    return "excused move" if n == 1 else "excused moves"
 
 
 def _mint_budget(head_total: Counter[str], base_total: Counter[str]) -> Counter[str]:
@@ -971,28 +1182,48 @@ def main() -> int:
     parser.add_argument(
         "--base", default="origin/main", help="tree-ish to compare against"
     )
-    parser.add_argument("--report", action="store_true", help="print counts and exit 0")
+    parser.add_argument(
+        "--report", action="store_true", help="print counts and change split; exit 0"
+    )
     args = parser.parse_args()
 
-    # Both scans under one guard. A bad ``--base`` is the likely cause, but the
-    # working-tree scan reaches git the same way and can fail the same way, and
-    # leaving it bare would surface that as a traceback and exit 1 — which in this
-    # script means "ran, found new names". A gate that cannot run must never be
-    # mistaken for a gate that failed you. Exit 2 says it could not run.
+    # Scan the working tree first so report mode can retain its "counts never
+    # fail" contract even when its optional comparison base is unreadable.
     try:
         head_scan = scan(None)
-        if args.report:
-            head = head_scan.counts()
-            print(f"{sum(head.values())} lines across {len(head)} files")
-            for path, n in sorted(head.items(), key=lambda kv: (-kv[1], kv[0])):
-                print(f"  {n:>4}  {path}")
-            return 0
-        base_scan = scan(args.base)
     except RuntimeError as exc:
         print(exc, file=sys.stderr)
         return 2
 
-    head, base = head_scan.counts(), base_scan.counts()
+    head = head_scan.counts()
+    if args.report:
+        print(f"{sum(head.values())} lines across {len(head)} files")
+        for path, n in sorted(head.items(), key=lambda kv: (-kv[1], kv[0])):
+            print(f"  {n:>4}  {path}")
+
+    # A bad base must still be exit 2 for the gate. In report mode it only makes
+    # the change split unavailable; the current-tree inventory above is valid.
+    try:
+        base_scan = scan(args.base)
+    except RuntimeError as exc:
+        if args.report:
+            print(f"Change from {args.base} unavailable: {exc}", file=sys.stderr)
+            return 0
+        print(exc, file=sys.stderr)
+        return 2
+
+    base = base_scan.counts()
+
+    if args.report:
+        report_summary = _change_summary(args.base, base_scan, head_scan)
+        print(
+            f"Change from {args.base}: {report_summary.added} added, "
+            f"{report_summary.annotated} annotated, "
+            f"{report_summary.removed} removed, "
+            f"{report_summary.moved} {_move_label(report_summary.moved)} "
+            f"({report_summary.net:+d} net)."
+        )
+        return 0
 
     if not head and not base:
         # A pathspec that matches nothing exits 1 with an empty stderr, exactly
@@ -1007,9 +1238,6 @@ def main() -> int:
             "this gate should be deleted along with the last of the old names."
         )
         return 1
-
-    _report_new_exemptions(base_scan.exempt(), head_scan.exempt(), args.base)
-    _report_removed_exemptions(base_scan.exempt_by_file, head_scan.exempt_by_file)
 
     head_by_file, base_by_file = head_scan.by_file, base_scan.by_file
     budget = _mint_budget(head_scan.total, base_scan.total)
@@ -1039,6 +1267,8 @@ def main() -> int:
         if minted:
             grown[path] = (before, n, minted)
 
+    _report_new_exemptions(base_scan.exempt(), head_scan.exempt(), args.base)
+    _report_removed_exemptions(base_scan.exempt_by_file, head_scan.exempt_by_file)
     _report_excused_moves(excused, base_by_file, head_by_file)
 
     if generated_changelogs:
@@ -1050,13 +1280,36 @@ def main() -> int:
             print(f"  {path}")
 
     if not grown:
-        removed = sum(max(0, c - head.get(p, 0)) for p, c in base.items())
-        net = sum(head.values()) - sum(base.values())
-        print(
-            f"No new lines. {removed} removed by this change ({net:+d} net)."
-            if removed
-            else "No new lines."
+        gate_summary = _change_summary(
+            args.base,
+            base_scan,
+            head_scan,
+            max_commits=_GATE_REPLAY_LIMIT,
         )
+        if gate_summary is None:
+            print(
+                "No new lines fail the gate. Change split omitted: the range exceeds the "
+                f"{_GATE_REPLAY_LIMIT}-commit gate replay limit; run --report "
+                "for the exact split."
+            )
+            return 0
+        if gate_summary.added:
+            print(
+                f"No new lines fail the gate. {gate_summary.added} added, "
+                f"{gate_summary.annotated} annotated, "
+                f"{gate_summary.removed} removed, "
+                f"{gate_summary.moved} {_move_label(gate_summary.moved)} "
+                f"({gate_summary.net:+d} net)."
+            )
+        elif gate_summary.annotated or gate_summary.removed or gate_summary.moved:
+            print(
+                f"No new lines. {gate_summary.annotated} annotated, "
+                f"{gate_summary.removed} removed, {gate_summary.moved} "
+                f"{_move_label(gate_summary.moved)} "
+                f"({gate_summary.net:+d} net)."
+            )
+        else:
+            print("No new lines.")
         return 0
 
     print(f"This change adds the legacy name in {len(grown)} file(s).\n")

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -520,8 +520,68 @@ def test_removing_a_line_passes_and_reports_progress(repo: Path) -> None:
     result = _run(repo)
 
     assert result.returncode == 0
-    assert "1 removed" in result.stdout
-    assert "-1 net" in result.stdout
+    assert (
+        "No new lines. 0 annotated, 1 removed, 0 excused moves (-1 net)."
+        in result.stdout
+    )
+
+
+def test_annotating_a_line_is_not_reported_as_removing_it(repo: Path) -> None:
+    """A marker changes the ratchet count, but the underlying line remains."""
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: published URL\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0
+    assert (
+        "No new lines. 1 annotated, 0 removed, 0 excused moves (-1 net)."
+        in result.stdout
+    )
+
+
+def test_an_unrelated_marked_line_does_not_disguise_a_removal(repo: Path) -> None:
+    (repo / "existing.py").write_text(f"{LEGACY}\n")
+    _git(repo, "add", "existing.py")
+    _git(repo, "commit", "-qm", "use a short legacy line")
+    _stage(
+        repo,
+        "existing.py",
+        f'NEW = "{LEGACY}-cli"  # legacy-name-ok: permanent command alias\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0
+    assert (
+        "No new lines. 0 annotated, 1 removed, 0 excused moves (-1 net)."
+        in result.stdout
+    )
+
+
+def test_removing_an_old_exemption_does_not_hide_an_annotation(repo: Path) -> None:
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"\n'
+        f'ALIAS = "{LEGACY}-cli"  # legacy-name-ok: old alias\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add an exempt alias")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: published URL\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0
+    assert (
+        "No new lines. 1 annotated, 0 removed, 0 excused moves (-1 net)."
+        in result.stdout
+    )
 
 
 def test_an_addition_is_not_masked_by_a_deletion_elsewhere(repo: Path) -> None:
@@ -736,6 +796,27 @@ def test_an_excused_move_is_always_named(repo: Path) -> None:
     assert "treated as moved rather than added" in result.stdout
     assert "somewhere-unrelated.py" in result.stdout
     assert "was in: existing.py" in result.stdout
+    assert (
+        "No new lines. 0 annotated, 0 removed, 1 excused move (+0 net)."
+        in result.stdout
+    )
+
+
+def test_a_line_moved_while_being_annotated_is_not_removed(repo: Path) -> None:
+    _stage(repo, "existing.py", "")
+    _stage(
+        repo,
+        "moved.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: published URL\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0
+    assert (
+        "No new lines. 1 annotated, 0 removed, 0 excused moves (-1 net)."
+        in result.stdout
+    )
 
 
 def test_a_file_that_kept_its_copy_is_not_named_as_the_source(repo: Path) -> None:
@@ -1250,6 +1331,312 @@ def test_report_mode_never_fails(repo: Path) -> None:
 
     assert result.returncode == 0
     assert "2 lines across 2 files" in result.stdout
+    assert (
+        "Change from HEAD: 1 added, 0 annotated, 0 removed, "
+        "0 excused moves (+1 net)." in result.stdout
+    )
+
+
+def test_report_mode_keeps_counts_when_the_base_is_unresolvable(repo: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "no-such-ref", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "1 lines across 1 files" in result.stdout
+    assert "Change from no-such-ref unavailable" in result.stderr
+
+
+def test_report_mode_separates_annotation_from_removal(repo: Path) -> None:
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: published URL\n',
+    )
+
+    result = _run(repo, "--report")
+
+    assert result.returncode == 0
+    assert "0 lines across 0 files" in result.stdout
+    assert (
+        "Change from HEAD: 0 added, 1 annotated, 0 removed, "
+        "0 excused moves (-1 net)." in result.stdout
+    )
+
+
+def test_summary_replays_annotation_before_later_exempt_churn(repo: Path) -> None:
+    """A later deletion cannot rewrite an earlier annotation as a removal."""
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: published URL\n',
+    )
+    _git(repo, "commit", "-qm", "annotate the URL")
+    _stage(repo, "existing.py", 'URL = "https://caura.ai"\n')
+    _stage(
+        repo,
+        "new.py",
+        f'ALIAS = "{LEGACY}-cli"  # legacy-name-ok: permanent command alias\n',
+    )
+    _git(repo, "commit", "-qm", "replace the URL and add an alias")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~2", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert (
+        "Change from HEAD~2: 0 added, 1 annotated, 0 removed, "
+        "0 excused moves (-1 net)." in result.stdout
+    )
+
+
+def test_summary_replays_transient_addition_and_removal(repo: Path) -> None:
+    """Endpoint equality must not erase gross churn inside the range."""
+    _stage(repo, "new.py", f'KEY = "{LEGACY}"\n')
+    _git(repo, "commit", "-qm", "add a transient legacy line")
+    _stage(repo, "new.py", "")
+    _git(repo, "commit", "-qm", "remove the transient legacy line")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~2", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert (
+        "Change from HEAD~2: 1 added, 0 annotated, 1 removed, "
+        "0 excused moves (+0 net)." in result.stdout
+    )
+
+
+def test_summary_does_not_call_a_removed_then_readded_line_annotated(
+    repo: Path,
+) -> None:
+    _stage(repo, "existing.py", 'URL = "https://caura.ai"\n')
+    _git(repo, "commit", "-qm", "remove the legacy URL")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: published URL\n',
+    )
+    _git(repo, "commit", "-qm", "restore the URL as a floor mention")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~2", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert (
+        "Change from HEAD~2: 0 added, 0 annotated, 1 removed, "
+        "0 excused moves (-1 net)." in result.stdout
+    )
+
+
+def test_summary_replays_a_pure_rename_before_removal(repo: Path) -> None:
+    _git(repo, "mv", "existing.py", "moved.py")
+    _git(repo, "commit", "-qm", "move the legacy URL")
+    _stage(repo, "moved.py", 'URL = "https://caura.ai"\n')
+    _git(repo, "commit", "-qm", "remove the legacy URL")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~2", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert (
+        "Change from HEAD~2: 0 added, 0 annotated, 1 removed, "
+        "1 excused move (-1 net)." in result.stdout
+    )
+
+
+def test_summary_replays_a_file_becoming_binary_then_text(repo: Path) -> None:
+    original = f'URL = "https://{LEGACY}.net"\n'.encode()
+    (repo / "existing.py").write_bytes(original + b"\0binary payload\n")
+    _git(repo, "add", "existing.py")
+    _git(repo, "commit", "-qm", "make the legacy file binary")
+    (repo / "existing.py").write_bytes(original)
+    _git(repo, "add", "existing.py")
+    _git(repo, "commit", "-qm", "make the legacy file text again")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~2", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert (
+        "Change from HEAD~2: 1 added, 0 annotated, 1 removed, "
+        "0 excused moves (+0 net)." in result.stdout
+    )
+
+
+@pytest.mark.parametrize(
+    ("empty_commits", "expected_greps"),
+    [(False, 6), (True, 2)],
+)
+def test_multi_commit_summary_avoids_full_tree_replay(
+    repo: Path, empty_commits: bool, expected_greps: int
+) -> None:
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: published URL\n',
+    )
+    _git(repo, "commit", "-qm", "annotate the URL")
+    for i in range(4):
+        if empty_commits:
+            _git(repo, "commit", "--allow-empty", "-qm", f"empty {i}")
+        else:
+            _stage(repo, "clean.py", f"VALUE = {i}\n")
+            _git(repo, "commit", "-qm", f"unrelated edit {i}")
+    trace = repo / "git-trace.log"
+    env = {k: v for k, v in os.environ.items() if k != "GITHUB_HEAD_REF"}
+    env["GIT_TRACE"] = str(trace)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~5", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    grep_calls = [
+        line for line in trace.read_text().splitlines() if " git grep " in line
+    ]
+    assert result.returncode == 0
+    assert (
+        "Change from HEAD~5: 0 added, 1 annotated, 0 removed, "
+        "0 excused moves (-1 net)." in result.stdout
+    )
+    assert len(grep_calls) == expected_greps
+    assert sum(line.endswith(" -- :/") for line in grep_calls) == 2
+
+
+def test_single_commit_summary_replays_a_dirty_worktree(repo: Path) -> None:
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: published URL\n',
+    )
+    _git(repo, "commit", "-qm", "annotate the URL")
+    _stage(repo, "existing.py", 'URL = "https://caura.ai"\n')
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~1", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert (
+        "Change from HEAD~1: 0 added, 1 annotated, 0 removed, "
+        "0 excused moves (-1 net)." in result.stdout
+    )
+
+
+def test_gate_caps_replay_but_report_remains_exact(repo: Path) -> None:
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: published URL\n',
+    )
+    _git(repo, "commit", "-qm", "annotate the URL")
+    _stage(repo, "existing.py", 'URL = "https://caura.ai"\n')
+    _git(repo, "commit", "-qm", "remove the annotated URL")
+    for i in range(62):
+        _git(repo, "commit", "--allow-empty", "-qm", f"empty {i}")
+
+    at_limit = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~64"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    _git(repo, "commit", "--allow-empty", "-qm", "empty 62")
+    gate = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~65"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    report = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~65", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert at_limit.returncode == 0
+    assert (
+        "No new lines. 1 annotated, 0 removed, 0 excused moves (-1 net)."
+        in at_limit.stdout
+    )
+    assert gate.returncode == 0
+    assert "No new lines fail the gate. Change split omitted" in gate.stdout
+    assert "range exceeds the 64-commit gate replay limit" in gate.stdout
+    assert " net)." not in gate.stdout
+    assert report.returncode == 0
+    assert (
+        "Change from HEAD~65: 0 added, 1 annotated, 0 removed, "
+        "0 excused moves (-1 net)." in report.stdout
+    )
+
+
+def test_a_marker_swap_stays_visible_as_exemption_churn(repo: Path) -> None:
+    """A kind change is neither annotation nor removal from the floor tally."""
+    old = f'ALIAS = "{LEGACY}"  # legacy-name-ok: permanent alias\n'
+    (repo / "alias.py").write_text(old)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add marked alias")
+    _stage(
+        repo,
+        "alias.py",
+        f'ALIAS = "{LEGACY}"  # legacy-name-floor: published name\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0
+    assert "1 exempt line(s) written by this change" in result.stdout
+    assert "1 exempt line(s) removed by this change" in result.stdout
+    assert result.stdout.rstrip().endswith("No new lines.")
+    assert " annotated," not in result.stdout
+
+    report = _run(repo, "--report")
+    assert (
+        "Change from HEAD: 0 added, 0 annotated, 0 removed, "
+        "0 excused moves (+0 net)." in report.stdout
+    )
 
 
 # ── removed exemptions: reported, never fatal ────────────────────────────────
@@ -1445,6 +1832,19 @@ def test_a_changelog_passes_on_a_release_please_branch(repo: Path) -> None:
     assert result.returncode == 0, result.stdout
     assert "1 generated CHANGELOG file(s) exempt on this" in result.stdout
     assert "CHANGELOG.md" in result.stdout
+
+
+def test_a_release_changelog_addition_is_not_hidden_from_the_net(repo: Path) -> None:
+    _stage(repo, "existing.py", 'URL = "https://caura.ai"\n')
+    _stage(repo, "CHANGELOG.md", f"* fix: retire the {LEGACY} gateway (#123)\n")
+
+    result = _run(repo, env=_RELEASE_ENV)
+
+    assert result.returncode == 0
+    assert (
+        "No new lines fail the gate. 1 added, 0 annotated, 1 removed, "
+        "0 excused moves (+0 net)." in result.stdout
+    )
 
 
 def test_the_same_changelog_fails_off_the_bot_branch(repo: Path) -> None:


### PR DESCRIPTION
## Summary

- report added annotations separately from genuinely removed legacy-name lines
- preserve marker exemption semantics and the existing gate decision path
- add the same split to --report, including added lines and excused moves so the net reconciles

The passing summary uses explicit gross quantities: added, annotated, removed, and excused moves, followed by the existing net change. This keeps real work distinct from marker-only edits while making every count reconcilable. Detailed exemption churn remains visible and marker-kind swaps remain zero change.

## Regression

Measured from non-shallow commit 00abbf305a3c38317cd3fae117158e0955938bb7 to 1304e3ee0a06608e12f98c40530d6b7b3e1880e7:

    No new lines. 26 annotated, 0 removed, 0 excused moves (-26 net).

The new assertions were run against the old script first and failed before the implementation.

## Verification

- 86 ratchet tests passed
- Ruff check passed at CI scopes
- Ruff format --check passed at CI scopes
- mypy passed for scripts/
- Python byte-compilation passed
- legacy-name ratchet passed against origin/main
- do-not-touch sentinel: all 39 protected strings survive
- one DCO-signed commit