### PR TITLE
chore(storage): delete the unreachable entity_delete_entity_links

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -6012,23 +6012,6 @@ class PostgresService:
 
         return [idx_to_result[it["input_idx"]] for it in items]
 
-    async def entity_delete_entity_links(
-        self,
-        links_data: list[dict],
-    ) -> None:
-        """Delete entity links by (memory_id, entity_id) pairs."""
-        async with get_session() as session:
-            for ld in links_data:
-                link = await session.execute(
-                    select(MemoryEntityLink).where(
-                        MemoryEntityLink.memory_id == ld["memory_id"],
-                        MemoryEntityLink.entity_id == ld["entity_id"],
-                    )
-                )
-                obj = link.scalar_one_or_none()
-                if obj is not None:
-                    await session.delete(obj)
-
     # ------------------------------------------------------------------
     # Crystallizer helpers (entity)
     # ------------------------------------------------------------------

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -106,13 +106,6 @@
       "note": "Join table has no tenant column; rows are tenant-scoped only via the ids."
     },
     {
-      "id": "method:entity_delete_entity_links",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Join table has no tenant column; rows are tenant-scoped only via the ids. Tracked in #1091."
-    },
-    {
       "id": "method:entity_find_entity_link",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",


### PR DESCRIPTION
Closes #1091.

`PostgresService.entity_delete_entity_links` deletes memory-entity links by `(memory_id, entity_id)` pair with no tenant predicate. Nothing calls it.

### The evidence that it is dead

Two references exist in the entire repository — the definition, and its own allowlist row:

```
core-storage-api/src/core_storage_api/services/postgres_service.py:6015    async def entity_delete_entity_links(
core-storage-api/tenant_scope_allowlist.json:109                          "id": "method:entity_delete_entity_links",
```

Not just absent today — absent always. Across the whole history, **zero commits have ever contained a call site**:

```
$ git log --oneline -S "_svc.entity_delete_entity_links" --all | wc -l
0
```

It arrived in `7456e233 Initial public release v1.0.0` and has been unreachable ever since. There is also no dynamic dispatch that a grep would miss: no `getattr` against the service anywhere in `core-storage-api` or `core-api`.

### Why removing it changes no behaviour

Link cleanup is done by the database, not by this method. `memory_entity_link` declares both foreign keys with `ON DELETE CASCADE` (migration `001_initial_schema.py:138-139`):

```python
sa.Column("memory_id", sa.Uuid(), sa.ForeignKey("memories.id",  ondelete="CASCADE"), primary_key=True),
sa.Column("entity_id", sa.Uuid(), sa.ForeignKey("entities.id", ondelete="CASCADE"), primary_key=True),
```

so deleting a memory or an entity already removes its links with no application code involved.

### One thing found on the way, not fixed here

With this gone there is **no application path that removes a link at all**. `memory_add_entity_links` upserts with `ON CONFLICT DO NOTHING`, and `PATCH /memories/{memory_id}/entities` only calls that — so the route can add links to a memory and never unlink one.

That is a real capability gap, and it is probably why this method was written. Adding it back is a separate change and it must take a tenant scope, which this one did not — an unscoped destructive helper sitting unwired is worse than a used one, because it gets adopted by whoever needs "the existing helper".

### Effect on the gate

```
Allowlist shrank by 1: method:entity_delete_entity_links
tenant-scope gate: 189 routes + 190 service methods, 261 bound to a tenant, 118 allowlisted.
```

`id-addressed-write` 21 → 20, total 119 → 118. Cheapest item in that backlog: it pays down a mutating unscoped path at zero behavioural cost.

### No test, deliberately

There is no new behaviour to pin. A test asserting the symbol is absent would fail on the parent commit while being worthless — it adds no safety and would have to be deleted the moment someone adds a properly scoped replacement. The verification is that the suite is unchanged: `core-storage-api` is **10 failed / 194 passed / 7 errors** both with this change and on pristine `origin/main`, byte-identical, so nothing depended on the method.

### Verification

`ruff check` / `ruff format --check` at CI's scopes (clean, ruff 0.16.5 matching the pinned `>=0.16.2`). `mypy src/` clean, 84 files. `mypy --config-file scripts/mypy.ini scripts/` clean, 31 files. Tenant-scope gate `--base origin/main` exit 0. Gate's own suite 72 passed. `uv.lock` untouched. Rebased onto `8b323fcf` and re-run there.
