### PR TITLE
docs(readme): show cross-agent fleet recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,37 @@ The keyless write response includes `memory_type`, `title`, `status`, and `weigh
 > configuring an embedding provider in the next section, try `"authentication token lifetime"`
 > instead — matching that phrase to "JWT with 15-minute expiry" exercises semantic recall.
 
+### See the fleet effect
+
+Connect two MCP clients to the same fleet. Agent A records an operational
+lesson with `caura_write`:
+
+```json
+{
+  "agent_id": "deploy-agent",
+  "fleet_id": "platform",
+  "visibility": "scope_team",
+  "content": "Roll back auth-service with: deployctl rollback auth-service --to <version>."
+}
+```
+
+Agent B asks `caura_recall` from that fleet:
+
+```json
+{
+  "agent_id": "incident-agent",
+  "fleet_ids": ["platform"],
+  "query": "How do I roll back auth-service?"
+}
+```
+
+The result identifies `deploy-agent` as the author: one agent learned it, and
+another reused it. `scope_agent` would keep the memory private;
+`scope_team` shares it within the fleet; `scope_org` enables governed
+cross-fleet recall subject to the [trust ladder](docs/integration-without-plugin.md#4-elevate-trust-when-needed).
+For production, give each client its own
+[agent-scoped credential](docs/integration-without-plugin.md#1-mint-an-agent-scoped-credential).
+
 Ready for semantic recall, multi-tenant, a managed host, or an OpenClaw fleet? Pick a path below.
 
 ---


### PR DESCRIPTION
## Summary

- add a concrete two-agent MCP walkthrough directly after the keyless quick start
- show one agent writing a team-visible operational lesson and another agent recalling it from the same fleet
- explain the `scope_agent`, `scope_team`, and `scope_org` governance boundaries and link to credential/trust setup

## Validation

- `pre-commit run --files README.md`
- `python3 scripts/legacy_name_ratchet.py --base origin/main`
- `PYTHONPATH=core-api/src:core-storage-api/src:. uv run pytest tests/test_mcp_write.py tests/test_mcp_recall.py tests/test_tools_registry.py -q` (49 passed)
- `git diff --check`