### PR TITLE
feat: expose lifecycle audit observation for active probes

### DIFF
--- a/common/models/lifecycle_audit.py
+++ b/common/models/lifecycle_audit.py
@@ -24,6 +24,14 @@ from common.models.base import Base
 class LifecycleAudit(Base):
     __tablename__ = "lifecycle_audit"
     __table_args__ = (
+        # Supports cross-org recent-window health summaries. The older
+        # org/action-leading index cannot serve a predicate on started_at
+        # alone, so the smoke endpoint would otherwise scan the full audit
+        # history as this append-only table grows.
+        Index(
+            "idx_lifecycle_audit_started_at",
+            text("started_at DESC"),
+        ),
         Index(
             "idx_lifecycle_audit_org_action_started",
             "org_id",

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2579,6 +2579,44 @@ class CoreStorageClient:
         )
         return result["audit_id"]  # type: ignore[index]
 
+    async def get_lifecycle_audit_row(
+        self,
+        audit_id: int,
+        *,
+        org_id: str,
+    ) -> dict | None:
+        """Read one row from the writer for exact post-publish polling.
+
+        The normal GET path may use a replica. A smoke probe polling a newly
+        created id needs read-after-write behaviour, otherwise replica lag can
+        manufacture a transient 404 unrelated to lifecycle delivery.
+        """
+        return await self._get(
+            f"/lifecycle-audit/{audit_id}",
+            read=False,
+            org_id=org_id,
+        )
+
+    async def get_lifecycle_audit_summary(
+        self,
+        *,
+        since_hours: int,
+        triggered_by: str | None = None,
+    ) -> dict:
+        """Return uncapped recent status counts grouped by action."""
+        params: dict[str, Any] = {"since_hours": since_hours}
+        if triggered_by is not None:
+            params["triggered_by"] = triggered_by
+        result = await self._post(
+            "/lifecycle-audit/summary",
+            {"org_id": None, **params},
+            read=True,
+            idempotent=True,
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError("lifecycle audit summary endpoint returned a non-object")
+        return result
+
     async def update_lifecycle_audit_row(
         self,
         audit_id: int,

--- a/core-api/src/core_api/routes/lifecycle.py
+++ b/core-api/src/core_api/routes/lifecycle.py
@@ -236,6 +236,47 @@ async def fanout_lifecycle_action(
     return {"action": action, "published": published, "failed": failed}
 
 
+@router.get("/admin/lifecycle/audits/summary")
+async def lifecycle_audit_summary(
+    since_hours: int = 30,
+    triggered_by: str | None = None,
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict:
+    """Return recent lifecycle status counts for deployment health checks.
+
+    The response is aggregate-only and uncapped, so a large fanout cannot push
+    an early failure out of view. Admin auth is required because the result
+    spans every organization in the deployment.
+    """
+    auth.enforce_admin()
+    if since_hours < 1 or since_hours > 168:
+        raise HTTPException(
+            status_code=422,
+            detail="'since_hours' must be in [1, 168] (hours)",
+        )
+    return await get_storage_client().get_lifecycle_audit_summary(
+        since_hours=since_hours,
+        triggered_by=triggered_by,
+    )
+
+
+@router.get("/admin/lifecycle/audits/{audit_id}")
+async def get_lifecycle_audit(
+    audit_id: int,
+    org_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict:
+    """Return one audit row for an active canary's exact message."""
+    auth.enforce_admin()
+    row = await get_storage_client().get_lifecycle_audit_row(
+        audit_id,
+        org_id=org_id,
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"lifecycle audit {audit_id} not found")
+    return row
+
+
 @router.get("/admin/lifecycle/embedding-coverage")
 async def embedding_coverage_all_tenants(
     auth: AuthContext = Depends(get_auth_context),

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/041_lifecycle_audit_started_index.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/041_lifecycle_audit_started_index.py
@@ -1,0 +1,53 @@
+"""Index lifecycle audit rows by recency for cross-org summaries.
+
+The lifecycle smoke summary filters the append-only ``lifecycle_audit`` table
+by ``started_at`` before grouping across every organization. The existing
+``(org_id, action, started_at)`` index cannot serve that predicate because its
+leading columns are unconstrained. Build this index online so adding the
+observation endpoint does not block lifecycle writers on an established
+deployment.
+
+Revision ID: 041
+Revises: 040
+Create Date: 2026-08-30
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "041"
+down_revision: str | None = "040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX_NAME = "idx_lifecycle_audit_started_at"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        connection = op.get_context().connection
+        if connection is None:
+            raise RuntimeError("online migration requires a connection")
+        invalid = connection.execute(
+            sa.text(
+                """
+                SELECT 1 FROM pg_index i
+                JOIN pg_class c ON c.oid = i.indexrelid
+                WHERE c.relname = :name
+                  AND NOT i.indisvalid
+                """
+            ),
+            {"name": _INDEX_NAME},
+        ).fetchone()
+        if invalid:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lifecycle_audit_started_at ON lifecycle_audit (started_at DESC)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")

--- a/core-storage-api/src/core_storage_api/routers/lifecycle_audit.py
+++ b/core-storage-api/src/core_storage_api/routers/lifecycle_audit.py
@@ -1,19 +1,16 @@
 """Lifecycle audit endpoints (CAURA-655).
 
-Two routes back the per-fanout audit row referenced in the operations
-architecture: ``POST`` creates a ``pending`` row and returns its id;
-``PATCH`` flips the row to ``in_progress`` (worker on receipt) or
-``success`` / ``failure`` (worker on completion). Lives here, not in
-core-api, to preserve the "no DB outside core-storage-api" rule —
-both core-api and core-worker call these via their existing
-storage_clients.
+The write routes create and advance the per-fanout audit row referenced in the
+operations architecture. Read routes expose one row for exact probe correlation
+and an uncapped aggregate for deployment health checks. Everything lives here,
+not in core-api, to preserve the "no DB outside core-storage-api" rule.
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
 
-from core_storage_api.services.postgres_service import PostgresService
+from core_storage_api.services.postgres_service import UNSCOPED, PostgresService
 
 router = APIRouter(prefix="/lifecycle-audit", tags=["Lifecycle"])
 _svc = PostgresService()
@@ -61,6 +58,48 @@ async def has_recent_success(org_id: str, action: str, since_hours: int) -> dict
         org_id=org_id, action=action, since_hours=since_hours
     )
     return {"has_recent_success": found}
+
+
+@router.post("/summary")
+async def summarize_lifecycle_audits(request: Request) -> dict:
+    """Aggregate lifecycle rows under an explicit tenant-scope choice."""
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail="request body must be valid JSON") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="request body must be a JSON object")
+    if "org_id" not in body:
+        raise HTTPException(
+            status_code=422,
+            detail="'org_id' is required; send null for the admin-wide aggregate",
+        )
+    raw_org_id = body["org_id"]
+    if raw_org_id is not None and not isinstance(raw_org_id, str):
+        raise HTTPException(status_code=422, detail="'org_id' must be a string or null")
+    since_hours = body.get("since_hours", 30)
+    if type(since_hours) is not int or since_hours < 1 or since_hours > 168:
+        raise HTTPException(
+            status_code=422,
+            detail="'since_hours' must be in [1, 168] (hours)",
+        )
+    triggered_by = body.get("triggered_by")
+    if triggered_by is not None and not isinstance(triggered_by, str):
+        raise HTTPException(status_code=422, detail="'triggered_by' must be a string or null")
+    return await _svc.lifecycle_audit_summary(
+        org_id=UNSCOPED if raw_org_id is None else raw_org_id,
+        since_hours=since_hours,
+        triggered_by=triggered_by,
+    )
+
+
+@router.get("/{audit_id}")
+async def get_lifecycle_audit(audit_id: int, org_id: str) -> dict:
+    """Return one audit row so a caller can follow its exact message."""
+    row = await _svc.lifecycle_audit_get(audit_id, org_id=org_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"lifecycle_audit {audit_id} not found")
+    return row
 
 
 @router.patch("/{audit_id}")

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -9427,6 +9427,95 @@ class PostgresService:
             await session.flush()
             return row.id
 
+    async def lifecycle_audit_get(
+        self,
+        audit_id: int,
+        *,
+        org_id: str,
+    ) -> dict[str, Any] | None:
+        """Return one lifecycle audit row for exact probe correlation."""
+        async with get_session() as session:
+            result = await session.execute(
+                select(LifecycleAudit).where(
+                    LifecycleAudit.id == audit_id,
+                    LifecycleAudit.org_id == org_id,
+                )
+            )
+            row = result.scalar_one_or_none()
+            if row is None:
+                return None
+            return {
+                "audit_id": row.id,
+                "org_id": row.org_id,
+                "action": row.action,
+                "triggered_by": row.triggered_by,
+                "started_at": row.started_at,
+                "finished_at": row.finished_at,
+                "status": row.status,
+                "stats": row.stats,
+                "error_message": row.error_message,
+            }
+
+    async def lifecycle_audit_summary(
+        self,
+        *,
+        org_id: str | Unscoped,
+        since_hours: int,
+        triggered_by: str | None = None,
+    ) -> dict[str, Any]:
+        """Aggregate recent lifecycle rows by action and status.
+
+        This is intentionally an aggregate rather than a capped row listing: a
+        large fanout must not push an early failure out of the response and turn
+        a partial outage into a green deployment probe.
+        """
+        stmt = (
+            select(
+                LifecycleAudit.action,
+                LifecycleAudit.status,
+                func.count().label("row_count"),
+                func.max(LifecycleAudit.started_at).label("latest_started_at"),
+                func.max(LifecycleAudit.finished_at).label("latest_finished_at"),
+            )
+            .where(LifecycleAudit.started_at > func.now() - timedelta(hours=since_hours))
+            .group_by(LifecycleAudit.action, LifecycleAudit.status)
+        )
+        if triggered_by is not None:
+            stmt = stmt.where(LifecycleAudit.triggered_by == triggered_by)
+        if not isinstance(org_id, Unscoped):
+            stmt = stmt.where(LifecycleAudit.org_id == org_id)
+
+        async with get_read_session() as session:
+            rows = (await session.execute(stmt)).all()
+
+        actions: dict[str, dict[str, Any]] = {}
+        for action, status, row_count, latest_started_at, latest_finished_at in rows:
+            summary = actions.setdefault(
+                action,
+                {
+                    "total": 0,
+                    "statuses": {},
+                    "latest_started_at": None,
+                    "latest_finished_at": None,
+                },
+            )
+            count = int(row_count)
+            summary["total"] += count
+            summary["statuses"][status] = count
+            if summary["latest_started_at"] is None or latest_started_at > summary["latest_started_at"]:
+                summary["latest_started_at"] = latest_started_at
+            if latest_finished_at is not None and (
+                summary["latest_finished_at"] is None or latest_finished_at > summary["latest_finished_at"]
+            ):
+                summary["latest_finished_at"] = latest_finished_at
+
+        return {
+            "org_id": None if isinstance(org_id, Unscoped) else org_id,
+            "since_hours": since_hours,
+            "triggered_by": triggered_by,
+            "actions": {action: actions[action] for action in sorted(actions)},
+        }
+
     async def lifecycle_audit_finalize(
         self,
         audit_id: int,

--- a/core-storage-api/tests/test_lifecycle_audit_observation.py
+++ b/core-storage-api/tests/test_lifecycle_audit_observation.py
@@ -1,0 +1,192 @@
+"""Integration coverage for lifecycle-audit observation endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete
+
+from common.models import LifecycleAudit
+from core_storage_api.services.postgres_service import get_session
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+PREFIX = "/api/v1/storage/lifecycle-audit"
+
+
+@pytest.fixture
+async def lifecycle_marker() -> str:
+    marker = f"smoke-test:{uuid.uuid4().hex}"
+    yield marker
+    async with get_session() as session:
+        await session.execute(
+            delete(LifecycleAudit).where(LifecycleAudit.triggered_by.in_((marker, f"{marker}:noise")))
+        )
+
+
+async def test_exact_read_and_uncapped_summary(
+    client: AsyncClient,
+    lifecycle_marker: str,
+) -> None:
+    marker = lifecycle_marker
+    archive_ids: list[int] = []
+
+    # Create the failure first, then cross the old diagnostic query's 30-row
+    # cap. A newest-first capped listing would discard this row and go green.
+    response = await client.post(
+        PREFIX,
+        json={
+            "org_id": "test-tenant-lifecycle-observation",
+            "action": "entity-link",
+            "triggered_by": marker,
+        },
+    )
+    assert response.status_code == 200, response.text
+    entity_link_id = response.json()["audit_id"]
+    failure = await client.patch(
+        f"{PREFIX}/{entity_link_id}",
+        json={"status": "failure", "error_message": "synthetic failure"},
+    )
+    assert failure.status_code == 200, failure.text
+
+    for _ in range(31):
+        response = await client.post(
+            PREFIX,
+            json={
+                "org_id": "test-tenant-lifecycle-observation",
+                "action": "archive-expired",
+                "triggered_by": marker,
+            },
+        )
+        assert response.status_code == 200, response.text
+        archive_ids.append(response.json()["audit_id"])
+
+    # Same action inside the time window but under a different trigger. If the
+    # SQL drops the requested filter, this failure changes the expected count
+    # and status map deterministically even on an otherwise empty test DB.
+    response = await client.post(
+        PREFIX,
+        json={
+            "org_id": "test-tenant-lifecycle-observation",
+            "action": "archive-expired",
+            "triggered_by": f"{marker}:noise",
+        },
+    )
+    assert response.status_code == 200, response.text
+    noise_id = response.json()["audit_id"]
+    noise_failure = await client.patch(
+        f"{PREFIX}/{noise_id}",
+        json={"status": "failure", "error_message": "filter sentinel"},
+    )
+    assert noise_failure.status_code == 200, noise_failure.text
+
+    for audit_id in archive_ids:
+        success = await client.patch(
+            f"{PREFIX}/{audit_id}",
+            json={"status": "success", "stats": {"archived": 0}},
+        )
+        assert success.status_code == 200, success.text
+
+    exact = await client.get(
+        f"{PREFIX}/{archive_ids[0]}",
+        params={"org_id": "test-tenant-lifecycle-observation"},
+    )
+    assert exact.status_code == 200, exact.text
+    assert exact.json() == {
+        "audit_id": archive_ids[0],
+        "org_id": "test-tenant-lifecycle-observation",
+        "action": "archive-expired",
+        "triggered_by": marker,
+        "started_at": exact.json()["started_at"],
+        "finished_at": exact.json()["finished_at"],
+        "status": "success",
+        "stats": {"archived": 0},
+        "error_message": None,
+    }
+    assert exact.json()["finished_at"] is not None
+
+    wrong_org = await client.get(
+        f"{PREFIX}/{archive_ids[0]}",
+        params={"org_id": "a-different-tenant"},
+    )
+    assert wrong_org.status_code == 404
+
+    summary = await client.post(
+        f"{PREFIX}/summary",
+        json={"org_id": None, "since_hours": 1, "triggered_by": marker},
+    )
+    assert summary.status_code == 200, summary.text
+    body = summary.json()
+    assert body["org_id"] is None
+    assert body["since_hours"] == 1
+    assert body["triggered_by"] == marker
+    assert body["actions"]["archive-expired"]["total"] == 31
+    assert body["actions"]["archive-expired"]["statuses"] == {"success": 31}
+    assert body["actions"]["entity-link"]["total"] == 1
+    assert body["actions"]["entity-link"]["statuses"] == {"failure": 1}
+
+    response = await client.post(
+        PREFIX,
+        json={
+            "org_id": "another-lifecycle-observation-tenant",
+            "action": "archive-expired",
+            "triggered_by": marker,
+        },
+    )
+    assert response.status_code == 200, response.text
+    other_org_id = response.json()["audit_id"]
+    success = await client.patch(
+        f"{PREFIX}/{other_org_id}",
+        json={"status": "success", "stats": {"archived": 0}},
+    )
+    assert success.status_code == 200, success.text
+
+    scoped = await client.post(
+        f"{PREFIX}/summary",
+        json={
+            "org_id": "test-tenant-lifecycle-observation",
+            "since_hours": 1,
+            "triggered_by": marker,
+        },
+    )
+    assert scoped.status_code == 200, scoped.text
+    scoped_body = scoped.json()
+    assert scoped_body["org_id"] == "test-tenant-lifecycle-observation"
+    assert scoped_body["actions"]["archive-expired"]["total"] == 31
+    assert scoped_body["actions"]["entity-link"]["total"] == 1
+
+
+async def test_exact_read_returns_404_for_unknown_id(client: AsyncClient) -> None:
+    response = await client.get(
+        f"{PREFIX}/9223372036854775807",
+        params={"org_id": "test-tenant-lifecycle-observation"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize("since_hours", [0, 169])
+async def test_summary_rejects_unbounded_window(
+    client: AsyncClient,
+    since_hours: int,
+) -> None:
+    response = await client.post(
+        f"{PREFIX}/summary",
+        json={"org_id": None, "since_hours": since_hours},
+    )
+    assert response.status_code == 422
+
+
+async def test_summary_requires_explicit_scope_choice(client: AsyncClient) -> None:
+    response = await client.post(f"{PREFIX}/summary", json={"since_hours": 1})
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("body", [[], 42])
+async def test_summary_rejects_non_object_body(
+    client: AsyncClient,
+    body: object,
+) -> None:
+    response = await client.post(f"{PREFIX}/summary", json=body)
+    assert response.status_code == 422

--- a/core-storage-api/tests/test_lifecycle_audit_session_routing.py
+++ b/core-storage-api/tests/test_lifecycle_audit_session_routing.py
@@ -1,0 +1,48 @@
+"""Writer-session regression coverage for exact lifecycle audit polling."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+
+import core_storage_api.services.postgres_service as postgres_service
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_exact_audit_read_uses_writer_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class _Result:
+        @staticmethod
+        def scalar_one_or_none() -> None:
+            return None
+
+    class _Session:
+        async def execute(self, _statement: object) -> _Result:
+            return _Result()
+
+    @asynccontextmanager
+    async def _writer_session():
+        calls.append("writer")
+        yield _Session()
+
+    @asynccontextmanager
+    async def _reader_session():
+        calls.append("reader")
+        yield _Session()
+
+    monkeypatch.setattr(postgres_service, "get_session", _writer_session)
+    monkeypatch.setattr(postgres_service, "get_read_session", _reader_session)
+
+    assert (
+        await postgres_service.PostgresService().lifecycle_audit_get(
+            41,
+            org_id="canary",
+        )
+        is None
+    )
+    assert calls == ["writer"]

--- a/tests/test_lifecycle_audit_observation.py
+++ b/tests/test_lifecycle_audit_observation.py
@@ -1,0 +1,100 @@
+"""Admin observation routes used by lifecycle smoke probes."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from core_api.auth import AuthContext
+from core_api.routes import lifecycle
+from fastapi import HTTPException
+
+pytestmark = pytest.mark.asyncio
+
+
+def _admin() -> AuthContext:
+    return AuthContext(tenant_id=None, is_admin=True)
+
+
+async def test_exact_audit_read_is_admin_only() -> None:
+    tenant_auth = AuthContext(tenant_id="tenant-a", is_admin=False)
+
+    with pytest.raises(HTTPException) as exc:
+        await lifecycle.get_lifecycle_audit(41, org_id="canary", auth=tenant_auth)
+
+    assert exc.value.status_code == 403
+
+
+async def test_exact_audit_read_returns_storage_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = {
+        "audit_id": 41,
+        "org_id": "canary",
+        "action": "archive-expired",
+        "status": "success",
+    }
+    storage = AsyncMock()
+    storage.get_lifecycle_audit_row.return_value = row
+    monkeypatch.setattr(lifecycle, "get_storage_client", lambda: storage)
+
+    assert (
+        await lifecycle.get_lifecycle_audit(41, org_id="canary", auth=_admin()) == row
+    )
+    storage.get_lifecycle_audit_row.assert_awaited_once_with(41, org_id="canary")
+
+
+async def test_exact_audit_read_maps_missing_row_to_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = AsyncMock()
+    storage.get_lifecycle_audit_row.return_value = None
+    monkeypatch.setattr(lifecycle, "get_storage_client", lambda: storage)
+
+    with pytest.raises(HTTPException) as exc:
+        await lifecycle.get_lifecycle_audit(404, org_id="canary", auth=_admin())
+
+    assert exc.value.status_code == 404
+
+
+async def test_summary_is_admin_only() -> None:
+    tenant_auth = AuthContext(tenant_id="tenant-a", is_admin=False)
+
+    with pytest.raises(HTTPException) as exc:
+        await lifecycle.lifecycle_audit_summary(auth=tenant_auth)
+
+    assert exc.value.status_code == 403
+
+
+async def test_summary_forwards_bounded_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected = {
+        "since_hours": 30,
+        "triggered_by": "core-operations",
+        "actions": {},
+    }
+    storage = AsyncMock()
+    storage.get_lifecycle_audit_summary.return_value = expected
+    monkeypatch.setattr(lifecycle, "get_storage_client", lambda: storage)
+
+    body = await lifecycle.lifecycle_audit_summary(
+        since_hours=30,
+        triggered_by="core-operations",
+        auth=_admin(),
+    )
+
+    assert body == expected
+    storage.get_lifecycle_audit_summary.assert_awaited_once_with(
+        since_hours=30,
+        triggered_by="core-operations",
+    )
+
+
+@pytest.mark.parametrize("since_hours", [0, 169])
+async def test_summary_rejects_unbounded_window(since_hours: int) -> None:
+    with pytest.raises(HTTPException) as exc:
+        await lifecycle.lifecycle_audit_summary(
+            since_hours=since_hours,
+            auth=_admin(),
+        )
+
+    assert exc.value.status_code == 422

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -731,7 +731,7 @@ class TestMigrationChain:
         """
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"040"}, f"Expected single head '040', got {sorted(heads)}"
+        assert heads == {"041"}, f"Expected single head '041', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -776,6 +776,8 @@ class TestMigrationChain:
         # 040: one LIVE memory per (tenant, fleet, agent, content_hash) — the
         # dedup contract had no schema behind it (OSS #814)
         assert chain.get("040") == "039", "040 must follow 039"
+        # 041: lifecycle_audit.started_at recency index for cross-org summaries
+        assert chain.get("041") == "040", "041 must follow 040"
 
     def test_no_plain_set_not_null_on_large_tables(self):
         """Tightening a column to NOT NULL on a large table must not full-scan

--- a/tests/test_storage_client_routing.py
+++ b/tests/test_storage_client_routing.py
@@ -8,6 +8,7 @@ collapses both back to a single URL — the OSS / pre-split default.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import httpx
@@ -88,6 +89,43 @@ async def test_find_duplicate_hash_stays_on_writer() -> None:
     await client.find_duplicate_hash("t", "abc123")
     assert len(writer.requests) == 1
     assert len(reader.requests) == 0
+
+
+async def test_exact_lifecycle_audit_read_stays_on_writer() -> None:
+    """A just-created canary audit must not transiently 404 on a replica."""
+    client, writer, reader = await _fresh_client(
+        writer_url="http://writer:8002", reader_url="http://reader:8002"
+    )
+
+    await client.get_lifecycle_audit_row(41, org_id="canary")
+
+    assert len(writer.requests) == 1
+    assert len(reader.requests) == 0
+    assert writer.requests[0].url.path.endswith("/lifecycle-audit/41")
+    assert writer.requests[0].url.params["org_id"] == "canary"
+
+
+async def test_lifecycle_audit_summary_uses_reader_with_explicit_unscoped_body() -> (
+    None
+):
+    client, writer, reader = await _fresh_client(
+        writer_url="http://writer:8002", reader_url="http://reader:8002"
+    )
+
+    await client.get_lifecycle_audit_summary(
+        since_hours=30,
+        triggered_by="core-operations",
+    )
+
+    assert len(writer.requests) == 0
+    assert len(reader.requests) == 1
+    assert reader.requests[0].method == "POST"
+    assert reader.requests[0].url.path.endswith("/lifecycle-audit/summary")
+    assert json.loads(reader.requests[0].content) == {
+        "org_id": None,
+        "since_hours": 30,
+        "triggered_by": "core-operations",
+    }
 
 
 async def test_get_idempotency_stays_on_writer() -> None:


### PR DESCRIPTION
## Diagnosis

The lifecycle topic family cut over from `memclaw.lifecycle.*` to `caura.lifecycle.*` on 28 August. The existing smoke probes continued naming only the legacy family and asserted durable subscription state/backlog rather than correlating a current publish with delivery. Dual-bind kept those legacy subscriptions attached even though both staging and production recorded zero legacy lifecycle publishes.

Every green lifecycle smoke since 28 August was worthless, including the ones that gated production promotes: those runs verified a retained legacy bridge, not current product behaviour.

This PR supplies the exact observation surface required for active, message-correlated probes in the coordinated enterprise and test-automation PRs.

## Changes

- add an admin-only exact audit lookup, bound by both audit ID and organization ID and forced to the writer path for read-after-write polling
- add an uncapped, bounded-window audit aggregate for all seven lifecycle actions, with an explicit internal unscoped sentinel rather than an accidental default
- add a concurrent recency index for the append-only lifecycle audit table
- cover authorization, tenant binding, writer/reader routing, missing rows, malformed scope requests, uncapped failures, trigger filtering, and concrete-org filtering

## Validation

- 166 related unit/regression tests
- 7 PostgreSQL-backed observation integration tests
- writer-session routing test
- tenant-scope ratchet against `origin/main`
- Ruff and Alembic head (`041`)

## Coordination

This is the API prerequisite for the matching `caura-enterprise` and `caura-test-automation` probe PRs. It must be deployed before either new probe can pass.
