### PR TITLE
test(sentinel): pin legacy Python import contract

### DIFF
--- a/scripts/do_not_touch_sentinel.py
+++ b/scripts/do_not_touch_sentinel.py
@@ -229,6 +229,48 @@ SENTINELS: tuple[Sentinel, ...] = (
     ),
     # -- Published channel names. Renaming these strands installed users. ------
     Sentinel(
+        path="clients/python/src/memclaw_client/__init__.py",  # legacy-name-floor: pinned floor path
+        text="from caura_client import *",
+        kind=LITERAL,
+        breaks="both pip install spellings lose the permanent legacy import surface",
+    ),
+    Sentinel(
+        path="clients/python/src/caura_client/client.py",
+        text="MemClaw = Caura",  # legacy-name-floor: pinned floor assignment
+        kind=LITERAL,
+        breaks="existing legacy imports stop resolving to the canonical client class",
+    ),
+    Sentinel(
+        path="clients/python/src/caura_client/exceptions.py",
+        text="MemClawError = CauraError",  # legacy-name-floor: pinned floor assignment
+        kind=LITERAL,
+        breaks="existing legacy error handlers stop catching canonical client errors",
+    ),
+    Sentinel(
+        path="clients/python/src/caura_client/exceptions.py",
+        text="MemClawAPIError = CauraAPIError",  # legacy-name-floor: pinned floor assignment
+        kind=LITERAL,
+        breaks="existing legacy API-error handlers stop catching canonical API errors",
+    ),
+    Sentinel(
+        path="clients/python/tests/test_legacy_alias.py",
+        text="assert memclaw_client.MemClaw is caura_client.Caura",  # legacy-name-floor: pinned floor assertion
+        kind=LITERAL,
+        breaks="the end-to-end legacy client identity contract can disappear with its test",
+    ),
+    Sentinel(
+        path="clients/python/tests/test_legacy_alias.py",
+        text="assert memclaw_client.MemClawError is caura_client.CauraError",  # legacy-name-floor: pinned floor assertion
+        kind=LITERAL,
+        breaks="the end-to-end legacy error identity contract can disappear with its test",
+    ),
+    Sentinel(
+        path="clients/python/tests/test_legacy_alias.py",
+        text="assert memclaw_client.MemClawAPIError is caura_client.CauraAPIError",  # legacy-name-floor: pinned floor assertion
+        kind=LITERAL,
+        breaks="the end-to-end legacy API-error identity contract can disappear with its test",
+    ),
+    Sentinel(
         path="clients/npm-legacy-client/package.json",
         text="@caura/memclaw-client",  # legacy-name-floor: floor
         kind=LITERAL,


### PR DESCRIPTION
## Summary

- pin the shipped `memclaw_client` module's canonical re-export in the do-not-touch sentinel
- pin all three whole legacy alias assignments
- pin the three end-to-end identity assertions so the export wiring and its tests cannot disappear together

## Guard proof

- pre-change sentinel against a tree missing all seven contracts: exit 0 (`All 39 protected strings survive`)
- this change against that same broken tree: exit 1 with all seven missing contracts named
- legitimate tree: exit 0 (`All 46 protected strings survive`)
- removing the public export wiring makes the legacy-alias suite fail (3 failed, 2 passed); the legitimate case passes (5 passed)

## Verification

- `uv run --frozen pytest tests/test_do_not_touch_sentinel.py -q` — 111 passed
- exact CI Ruff check/format scopes — passed
- changed-file Ruff check and format check — passed
- `python3 scripts/legacy_name_ratchet.py --base origin/main` — seven deliberate floor pins; no new lines
- all four `uv.lock` hashes unchanged
- `/simplify` — clean after two findings were applied
