### PR TITLE
fix(fleet): scope the command ack to the caller's tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2348,8 +2348,18 @@ class CoreStorageClient:
             node_name=node_name,
         )
 
-    async def ack_commands(self, command_ids: list[str]) -> dict:
-        return await self._post("/fleet/commands/ack", {"command_ids": command_ids})  # type: ignore[return-value]
+    async def ack_commands(self, command_ids: list[str], tenant_id: str) -> dict:
+        """Ack commands for one tenant. ``tenant_id`` is required, not optional.
+
+        Storage scopes the UPDATE by it; without it the ack keyed on command
+        UUIDs alone and reached other tenants' rows. Positional and
+        non-defaulted so a caller cannot omit it and silently get the old
+        behaviour back.
+        """
+        return await self._post(  # type: ignore[return-value]
+            "/fleet/commands/ack",
+            {"command_ids": command_ids, "tenant_id": tenant_id},
+        )
 
     async def fleet_exists(self, tenant_id: str, fleet_id: str) -> bool:
         result = await self._get(

--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -849,7 +849,7 @@ async def heartbeat(
         commands = pending
 
     if commands:
-        await sc.ack_commands([c.get("id") for c in commands])
+        await sc.ack_commands([c.get("id") for c in commands], body.tenant_id)
 
     return {
         "ok": True,

--- a/core-storage-api/src/core_storage_api/routers/fleet.py
+++ b/core-storage-api/src/core_storage_api/routers/fleet.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
 
+from core_storage_api.routers._validation import _require
 from core_storage_api.schemas import FLEET_COMMAND_FIELDS, FLEET_NODE_FIELDS, orm_to_dict
 from core_storage_api.services.postgres_service import UNSCOPED, PostgresService
 
@@ -247,10 +248,28 @@ async def update_command_status(command_id: UUID, request: Request) -> dict:
 
 @router.post("/commands/ack")
 async def ack_commands(request: Request) -> dict:
+    """Mark commands acked. ``tenant_id`` scopes which ones can be touched.
+
+    Keyed on ``command_ids`` alone, this took a bare list of UUIDs and acked
+    every row that matched, whichever tenant owned it — cross-tenant BOLA, the
+    same shape as GHSA-xw4x-jwf5-8m9h in this subsystem and as
+    ``PATCH /commands/{command_id}/status`` above, which was scoped for it.
+
+    Unlike that route there is no ``null`` admin opt-out, because nothing acks
+    across tenants: the only caller is core-api's heartbeat, whose
+    ``tenant_id`` is a required ``str``. ``_require`` rejects a missing or
+    empty one with a 422.
+
+    ``count`` is the number of rows that actually matched rather than the
+    number asked for, so acking a command that is not yours reports 0 instead
+    of a silent success.
+    """
     body: dict = await request.json()
+    tenant_id = _require(body, "tenant_id")
     command_ids = [UUID(cid) if isinstance(cid, str) else cid for cid in body["command_ids"]]
-    await _svc.fleet_ack_commands(
+    matched = await _svc.fleet_ack_commands(
         command_ids=command_ids,
+        tenant_id=tenant_id,
         now=datetime.now(UTC),
     )
-    return {"ok": True, "count": len(command_ids)}
+    return {"ok": True, "count": matched}

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -9043,16 +9043,41 @@ class PostgresService:
         self,
         *,
         command_ids: list[UUID],
+        tenant_id: str,
         now: datetime,
-    ) -> None:
+    ) -> int:
+        """Mark this tenant's commands acked. Returns how many rows matched.
+
+        ``tenant_id`` scopes the UPDATE. Keyed on ``command_ids`` alone, any
+        caller that knew a command UUID could ack another tenant's commands —
+        the same cross-tenant BOLA as GHSA-xw4x-jwf5-8m9h in this subsystem,
+        and as ``fleet_update_command_result`` above, which was scoped for it.
+
+        Required and plainly ``str``, NOT the ``Unscoped`` sentinel the sibling
+        takes. That sentinel exists because core-api genuinely serializes an
+        admin case as ``{"tenant_id": null}`` when completing a command; ack has
+        no such caller. Its one call path is the heartbeat, whose ``tenant_id``
+        is a non-optional ``str`` on ``HeartbeatIn``. An opt-out nobody needs is
+        just an unlocked door.
+
+        The count is what actually matched, not what was asked for, so a caller
+        acking a command that is not its own is told nothing happened rather
+        than getting a silent success. It is not an existence oracle: a UUID
+        belonging to another tenant and a UUID that does not exist both return
+        0, which is the property ``fleet_update_command_result`` documents.
+        """
         if not command_ids:
-            return
+            return 0
         async with get_session() as session:
-            await session.execute(
+            result = await session.execute(
                 sql_update(FleetCommand)
-                .where(FleetCommand.id.in_(command_ids))
+                .where(
+                    FleetCommand.id.in_(command_ids),
+                    FleetCommand.tenant_id == tenant_id,
+                )
                 .values(status="acked", acked_at=now)
             )
+            return result.rowcount or 0  # type: ignore[attr-defined]
 
     async def fleet_update_command_result(
         self,

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -140,13 +140,6 @@
       "note": "Tracked in #1081."
     },
     {
-      "id": "method:fleet_ack_commands",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1086."
-    },
-    {
       "id": "method:fleet_add_command",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -611,13 +604,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "opaque-body-write"
-    },
-    {
-      "id": "route:POST /api/v1/storage/fleet/commands/ack",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1086."
     },
     {
       "id": "route:POST /api/v1/storage/fleet/nodes",

--- a/core-storage-api/tests/test_fleet_ack_tenant_scope.py
+++ b/core-storage-api/tests/test_fleet_ack_tenant_scope.py
@@ -1,0 +1,169 @@
+"""``POST /fleet/commands/ack`` must be told which tenant it scopes to.
+
+The third instance of one shape in this subsystem. GHSA-xw4x-jwf5-8m9h was the
+*create* path trusting a caller-named tenant without checking the node it
+pointed at; ``PATCH /commands/{id}/status`` was the *complete* path, where a
+missing ``tenant_id`` meant no WHERE clause. This is the *ack* path, which took
+a bare list of command UUIDs and acked every row that matched, whichever tenant
+owned it.
+
+Storage authenticates nothing (GHSA-wgvw-28pq-jc36) and trusts the tenant its
+caller names, so "the caller will remember" is not a control.
+
+Unlike the status route there is no ``null`` admin opt-out here: nothing acks
+across tenants. The only caller is core-api's heartbeat, whose ``tenant_id`` is
+a required ``str``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def _node_and_command(client: AsyncClient, tenant_id: str) -> str:
+    """Create a node + a queued command for ``tenant_id``; return the command id."""
+    node = await client.post(
+        f"{PREFIX}/fleet/nodes",
+        json={
+            "tenant_id": tenant_id,
+            "fleet_id": "fleet-a",
+            "node_name": f"node-{uuid.uuid4().hex[:8]}",
+        },
+    )
+    assert node.status_code == 200, node.text
+
+    command = await client.post(
+        f"{PREFIX}/fleet/commands",
+        json={
+            "tenant_id": tenant_id,
+            "node_id": node.json()["id"],
+            "command": "deploy",
+            "status": "queued",
+        },
+    )
+    assert command.status_code == 200, command.text
+    return command.json()["id"]
+
+
+async def _status_of(client: AsyncClient, tenant_id: str, command_id: str) -> str:
+    listed = await client.get(f"{PREFIX}/fleet/commands", params={"tenant_id": tenant_id})
+    assert listed.status_code == 200, listed.text
+    rows = [r for r in listed.json() if r["id"] == command_id]
+    assert rows, f"command {command_id} not visible to {tenant_id}"
+    return rows[0]["status"]
+
+
+class TestFleetAckTenantScope:
+    async def test_another_tenants_command_is_not_acked(self, client: AsyncClient) -> None:
+        """The attack, stated as the request an attacker would send.
+
+        Knowing a command UUID was enough to ack it. The victim's command must
+        be left exactly as it was.
+        """
+        victim = f"ack-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"ack-attacker-{uuid.uuid4().hex[:8]}"
+        victim_command = await _node_and_command(client, victim)
+        before = await _status_of(client, victim, victim_command)
+
+        resp = await client.post(
+            f"{PREFIX}/fleet/commands/ack",
+            json={"command_ids": [victim_command], "tenant_id": attacker},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["count"] == 0, "the attacker's ack matched a row"
+        assert await _status_of(client, victim, victim_command) == before
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """No tenant used to mean "ack whatever matches"; it is now a 422."""
+        tenant = f"ack-{uuid.uuid4().hex[:8]}"
+        command_id = await _node_and_command(client, tenant)
+
+        resp = await client.post(
+            f"{PREFIX}/fleet/commands/ack",
+            json={"command_ids": [command_id]},
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+        assert await _status_of(client, tenant, command_id) == "queued"
+
+    async def test_a_null_tenant_id_is_rejected_too(self, client: AsyncClient) -> None:
+        """No admin opt-out on this route, unlike ``PATCH /commands/{id}/status``.
+
+        That route accepts ``null`` because core-api genuinely completes
+        commands as an admin. Nothing acks across tenants, so an opt-out here
+        would be an unlocked door with no caller behind it.
+        """
+        tenant = f"ack-{uuid.uuid4().hex[:8]}"
+        command_id = await _node_and_command(client, tenant)
+
+        resp = await client.post(
+            f"{PREFIX}/fleet/commands/ack",
+            json={"command_ids": [command_id], "tenant_id": None},
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert await _status_of(client, tenant, command_id) == "queued"
+
+    async def test_own_command_is_acked(self, client: AsyncClient) -> None:
+        """The supported call still works, and reports what it did."""
+        tenant = f"ack-{uuid.uuid4().hex[:8]}"
+        command_id = await _node_and_command(client, tenant)
+
+        resp = await client.post(
+            f"{PREFIX}/fleet/commands/ack",
+            json={"command_ids": [command_id], "tenant_id": tenant},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"ok": True, "count": 1}
+        assert await _status_of(client, tenant, command_id) == "acked"
+
+    async def test_a_mixed_batch_acks_only_the_callers_own(self, client: AsyncClient) -> None:
+        """A batch naming both tenants' commands must move only the caller's.
+
+        The scope has to be part of the statement rather than a check on the
+        request: a partially-foreign batch is the case a route-level "do these
+        all belong to you" guard would reject wholesale, and the SQL predicate
+        handles correctly.
+        """
+        caller = f"ack-caller-{uuid.uuid4().hex[:8]}"
+        other = f"ack-other-{uuid.uuid4().hex[:8]}"
+        mine = await _node_and_command(client, caller)
+        theirs = await _node_and_command(client, other)
+
+        resp = await client.post(
+            f"{PREFIX}/fleet/commands/ack",
+            json={"command_ids": [mine, theirs], "tenant_id": caller},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["count"] == 1
+        assert await _status_of(client, caller, mine) == "acked"
+        assert await _status_of(client, other, theirs) == "queued"
+
+    async def test_a_foreign_id_is_indistinguishable_from_a_missing_one(self, client: AsyncClient) -> None:
+        """Both report 0, so the count is not an existence oracle for command UUIDs."""
+        victim = f"ack-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"ack-attacker-{uuid.uuid4().hex[:8]}"
+        victim_command = await _node_and_command(client, victim)
+
+        foreign = await client.post(
+            f"{PREFIX}/fleet/commands/ack",
+            json={"command_ids": [victim_command], "tenant_id": attacker},
+        )
+        missing = await client.post(
+            f"{PREFIX}/fleet/commands/ack",
+            json={"command_ids": [str(uuid.uuid4())], "tenant_id": attacker},
+        )
+
+        assert foreign.status_code == missing.status_code == 200
+        assert foreign.json() == missing.json()


### PR DESCRIPTION
Closes #1086.

`POST /fleet/commands/ack` took a bare list of command UUIDs and acked every row that matched, whichever tenant owned it:

```python
async def ack_commands(request: Request) -> dict:
    body: dict = await request.json()
    command_ids = [UUID(cid) if isinstance(cid, str) else cid for cid in body["command_ids"]]
    await _svc.fleet_ack_commands(command_ids=command_ids, now=datetime.now(UTC))
```

No tenant is read. Beneath it, `fleet_ack_commands` ran `UPDATE fleet_commands SET status='acked', acked_at=... WHERE id IN (...)` with no tenant predicate. Storage authenticates nothing (GHSA-wgvw-28pq-jc36), so knowing a command UUID was enough to ack another tenant's command out from under its plugin.

### The third instance of one shape

- **GHSA-xw4x-jwf5-8m9h** — the *create* path. Validated the caller-named tenant, never checked `body.node_id` belonged to it. Fixed in `6db0ae57`.
- **`PATCH /commands/{id}/status`** — the *complete* path. `tenant_id` optional on the wire, `None` meaning no `WHERE`. Fixed in caura-ai/caura#1067.
- **This** — the *ack* path.

### The fix

`fleet_commands.tenant_id` is `NOT NULL` (migration `001_initial_schema.py:244`), so the predicate goes straight into the statement. No cross-table node/tenant check was needed, unlike the create path.

**Required and plainly `str`, not the `Unscoped` sentinel its sibling takes.** That sentinel exists because core-api genuinely serializes an admin case as `{"tenant_id": null}` when *completing* a command. Ack has no such caller: its one call path is the heartbeat, whose `tenant_id` is a non-optional `str` on `HeartbeatIn`, and which **already had the tenant in hand** — it fetched the very same commands with it one line earlier:

```python
commands = await sc.get_pending_commands(body.tenant_id, node_name)
...
await sc.ack_commands([c.get("id") for c in commands])   # ← tenant dropped here
```

An opt-out nobody needs is just an unlocked door, so `null` is a 422 here rather than an admin escape. The route uses the shared `_require` guard, which is also why the gate recognises it without a `blind-spot` entry.

`count` now reports rows actually matched rather than rows asked for, so acking a command that is not yours reports 0 instead of succeeding silently. That is not an existence oracle — a foreign UUID and a nonexistent one both return 0.

### Tests

Six, in `core-storage-api/tests/test_fleet_ack_tenant_scope.py`. **Four fail on the parent commit:**

| test | on parent |
|---|---|
| `test_another_tenants_command_is_not_acked` | ✅ **fails** — the attack |
| `test_omitted_tenant_id_is_rejected` | ✅ fails |
| `test_a_null_tenant_id_is_rejected_too` | ✅ fails — no admin opt-out here |
| `test_a_mixed_batch_acks_only_the_callers_own` | ✅ fails |
| `test_own_command_is_acked` | passes — regression guard |
| `test_a_foreign_id_is_indistinguishable_from_a_missing_one` | passes — only meaningful once scoped |

The mixed-batch one is the case that argues for the predicate living in SQL rather than in a route-level "do these all belong to you?" check: a partially-foreign batch should ack the caller's own and leave the rest, which a wholesale rejection would not do.

### Worth flagging

**Nothing tested `ack_commands` at all** — no test in either package referenced it before this PR. The client signature change is guarded by mypy (positional, non-defaulted) rather than by any existing test, which is why the storage-side HTTP contract is what I pinned.

### Effect on the gate

```
Allowlist shrank by 2: method:fleet_ack_commands, route:POST /api/v1/storage/fleet/commands/ack
tenant-scope gate: 189 routes + 190 service methods, 263 bound to a tenant, 116 allowlisted.
```

`id-addressed-write` 20 → 18, total 118 → 116, bound 261 → 263.

### Verification

`core-storage-api`: 10 failed / **200** passed / 7 errors against a 10 / **194** / 7 baseline — delta is exactly the six new tests. Root suite 46 failed / 5605 passed, the same pre-existing 46 as every recent PR. `ruff check` and `ruff format --check` at CI's scopes across `core-api/src`, `core-storage-api/src`, `core-storage-api/tests` — clean at ruff 0.16.5. `mypy src/` clean for both packages (203 and 84 files) and for `scripts/` (31). Gate `--base origin/main` exit 0, `--write` produces no drift. `uv.lock` untouched. Rebased onto `853b0205` and re-run there.
