### PR TITLE
test(readme): require synchronous title enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker compose up -d --wait                                 # Postgres + pgvecto
 # Write a memory — no API key needed
 curl -X POST http://localhost:8000/api/v1/memories \
   -H "X-API-Key: standalone" -H "Content-Type: application/json" \
-  -d '{"tenant_id": "default", "agent_id": "quickstart", "content": "Our auth service uses JWT with 15-minute expiry."}'
+  -d '{"tenant_id": "default", "agent_id": "quickstart", "write_mode": "strong", "content": "Our auth service uses JWT with 15-minute expiry."}'
 
 # Find it by keyword — no provider key needed
 curl -X POST http://localhost:8000/api/v1/search \
@@ -77,7 +77,7 @@ curl -X POST http://localhost:8000/api/v1/search \
 ```
 <!-- readme-quickstart-ci:end -->
 
-The keyless write response includes `memory_type`, `title`, `status`, and `weight` — plus a `summary` under `metadata` — all derived by a deterministic local heuristic from the single `content` field. With a configured AI provider, those values are model-inferred and `metadata` can also include `tags`.
+The keyless strong-write response includes `memory_type`, `title`, `status`, and `weight` — plus a `summary` under `metadata` — all derived by a deterministic local heuristic from the single `content` field. With a configured AI provider, those values are model-inferred and `metadata` can also include `tags`.
 
 > **Want semantic paraphrases?** The keyless query deliberately reuses words from the memory. After
 > configuring an embedding provider in the next section, try `"authentication token lifetime"`

--- a/scripts/check_readme_quickstart.py
+++ b/scripts/check_readme_quickstart.py
@@ -247,6 +247,11 @@ def assert_round_trip(
     memory_id = write_response.get("id")
     if not isinstance(memory_id, str) or not memory_id:
         raise QuickstartError(f"write response has no memory id: {write_response!r}")
+    title = write_response.get("title")
+    if not isinstance(title, str) or not title.strip():
+        raise QuickstartError(
+            f"write response has no generated title: {write_response!r}"
+        )
 
     items = search_response.get("items")
     if not isinstance(items, list):

--- a/tests/test_readme_quickstart.py
+++ b/tests/test_readme_quickstart.py
@@ -38,6 +38,7 @@ def test_readme_keyless_quickstart_is_the_expected_keyword_round_trip() -> None:
     assert write.payload == {
         "tenant_id": "default",
         "agent_id": "quickstart",
+        "write_mode": "strong",
         "content": "Our auth service uses JWT with 15-minute expiry.",
     }
     assert search.payload == {"tenant_id": "default", "query": "JWT expiry"}
@@ -160,4 +161,15 @@ def test_runtime_override_stays_on_localhost() -> None:
 
 def test_round_trip_requires_search_to_return_the_created_memory() -> None:
     with pytest.raises(QuickstartError, match="did not return"):
-        assert_round_trip({"id": "created-id"}, {"items": [{"id": "other-id"}]})
+        assert_round_trip(
+            {"id": "created-id", "title": "Generated title"},
+            {"items": [{"id": "other-id"}]},
+        )
+
+
+def test_round_trip_requires_the_title_promised_by_the_readme() -> None:
+    with pytest.raises(QuickstartError, match="title"):
+        assert_round_trip(
+            {"id": "created-id", "title": None},
+            {"items": [{"id": "created-id"}]},
+        )


### PR DESCRIPTION
## Summary

- make the documented quickstart write use strong mode so its response contains the title and summary the following prose promises
- make the executable README check reject a missing, null, empty, or whitespace-only title
- pin both the strong-mode payload and the title contract with regression tests

## Why

The default fast write returns title: null with metadata.enrichment_pending: true. The README nevertheless described an immediately generated title. Strong mode is the existing public contract for synchronous enrichment, regardless of whether the configured provider is real or the keyless heuristic fallback.

The freshly pulled published latest image was also checked: the old payload reproduced title: null, while the strong payload returned a title synchronously. The full modified README write-and-search block then passed against a clean published-image stack. The same published image now accepts an omitted agent_id in standalone mode, confirming that the source/image drift from the original audit has been released.

## Validation

- red before fix: the payload regression test failed because write_mode was absent; the title regression test failed because the checker accepted title: null
- uv run pytest tests/test_readme_quickstart.py tests/test_p4_1_llm_fallback.py tests/test_write_mode_dispatch.py -q — 58 passed
- uv run ruff check scripts/check_readme_quickstart.py tests/test_readme_quickstart.py
- uv run ruff format --check scripts/check_readme_quickstart.py tests/test_readme_quickstart.py
- uv run mypy --config-file scripts/mypy.ini scripts/check_readme_quickstart.py
- pre-commit run --files README.md scripts/check_readme_quickstart.py tests/test_readme_quickstart.py
- python3 scripts/legacy_name_ratchet.py --base origin/main — no new lines
- python3 scripts/do_not_touch_sentinel.py — all 46 protected strings survive
- clean published-image run: python3 scripts/check_readme_quickstart.py --base-url http://localhost:18003
- /simplify — no findings

Final follow-up to #1076, #1098, #1100, and #1107.
