### PR TITLE
docs(plugin): correct pre-A1 matcher history

### DIFF
--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -434,7 +434,7 @@ describe("writeEducationFiles", () => {
 
   // ── Fenced-block migration (A1) ──
   //
-  // Pre-A1 idempotency was substring-based (`includes("Caura")` /
+  // Pre-A1 idempotency was substring-based (`includes("MemClaw")` / // legacy-name-floor: historical matcher behavior
   // `includes("## Memory V2")`), so once a workspace had any MemClaw // legacy-name-floor: historical matcher behavior
   // content, plugin upgrades never refreshed it. Below: every behaviour
   // the new versioned-fence implementation must guarantee.


### PR DESCRIPTION
## What

Correct the pre-A1 idempotency history in `plugin/src/educate.test.ts`: the old
presence-based check used `includes("MemClaw")`, not `includes("Caura")`.

The exact defect was traced from the 2026-08-28 OSS legacy review finding. Its sibling
comment in `plugin/src/educate.ts` records the matcher correctly. The restored historical
literal carries a same-line `legacy-name-floor` marker, so the ratchet reports the new
mention without treating immutable history as a new declaration.

## Why the gate missed it

The rename made the comment wrong while removing the legacy token, so a detector that
searches only for that token structurally could not surface it. A cheap follow-up audit
would inspect old-to-new substitutions in comment lines from rename commits, prioritising
temporal language such as `pre-`, `before`, `previously`, `legacy`, and `used to`. That
generalisation is noted here but intentionally not implemented in this PR.

## Gates

- `python3 scripts/legacy_name_ratchet.py --base origin/main` reports one new floor
  mention and then `No new lines.`
- `python3 scripts/do_not_touch_sentinel.py`
- `ruff check` and `ruff format --check` separately at every scope in `ci.yml`
- `npm run build`
- focused `educate.test.ts` suite: 77 passed
- the full plugin suite was attempted locally; 419 tests passed before seven unrelated
  tests hit the workspace sandbox's write denial under `~/.openclaw`. CI supplies the
  normal isolated home and remains the full-suite signal.
- all four `uv.lock` hashes and `plugin/package-lock.json` unchanged

Comment-only correction; runtime behavior is unchanged.
