### PR TITLE
docs(rebrand): record release-please ratchet scope

### DIFF
--- a/docs/plans/rebrand-sunset-plan.md
+++ b/docs/plans/rebrand-sunset-plan.md
@@ -114,6 +114,16 @@ old-brand string always passes — including when that string was load-bearing.
 **`do_not_touch_sentinel.py`** asserts that specific strings still **exist**. It is the
 only thing standing between a well-meaning sweep and a silently broken dependant.
 
+### The release-please branch exemption is repo-specific
+
+`_release_please_branch()` belongs only in ratchets that can run on a release-please
+branch. Verified 2026-08-30 across the nine-repository estate — eight live repositories
+plus archived `loadtest` — on all three signals: workflow, configuration, and current or
+historical `release-please--*` PR branches. Only `caura` and `caura-enterprise` have any
+of them. The other seven have none, so porting the helper there would be dead code. If
+release automation is added to another repository, recheck all three signals before
+porting the exception.
+
 Neither gate looks at **values**. A setting correctly renamed to `CAURA_*` that still
 *holds* an old-brand value scores as fully migrated forever. Renaming is not migrating.
 


### PR DESCRIPTION
## What

Record `_release_please_branch()` as an intentional repo-specific exception rather than
a missing ratchet port.

## Verification

Measured the complete nine-repository estate on 2026-08-30: eight live repositories plus
archived `loadtest` (read-only). I checked each repository's real default branch for a
release-please workflow and config, fetched current remote branches, searched full local
history for past workflow/config files and `release-please-action`, and searched GitHub's
complete PR history for `head:release-please--`.

| repository | workflow | config | current or historical `release-please--*` PR branch |
| --- | :---: | :---: | :---: |
| `caura` | yes | yes | yes (47 PRs) |
| `caura-enterprise` | yes | yes | yes (31 PRs) |
| `caura-daemon` | no | no | no |
| `caura-test-automation` | no | no | no |
| `caura-onprem` | no | no | no |
| `caura-ops` | no | no | no |
| `caura-onprem-installer` | no | no | no |
| `openclaw-fleet-tester` | no | no | no |
| `loadtest` (archived) | no | no | no |

The helper is live only in the two repositories where release-please can produce a
generated changelog PR. Porting it to the other seven would be dead code. The note also
states the three-signal recheck required if another repository adopts release automation.

## Gates

- `python3 scripts/legacy_name_ratchet.py --base origin/main`
- `python3 scripts/do_not_touch_sentinel.py`
- `ruff check` and `ruff format --check` separately at every scope in `ci.yml`
- all four `uv.lock` hashes unchanged

Documentation only; no gate behavior changes.
