### PR TITLE
fix(memory): scope the single-row delete to the caller's tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -597,8 +597,15 @@ class CoreStorageClient:
         # patch. The explicit arg wins over any ``tenant_id`` in ``data``.
         return await self._patch(f"/memories/{memory_id}", {**data, "tenant_id": tenant_id})
 
-    async def soft_delete_memory(self, memory_id: str) -> bool:
-        return await self._delete(f"/memories/{memory_id}")
+    async def soft_delete_memory(self, memory_id: str, tenant_id: str) -> bool:
+        """Soft-delete one memory within ``tenant_id``. False when nothing matched.
+
+        ``tenant_id`` is required, not optional: storage scopes the UPDATE by
+        it, and without it the delete keyed on the memory UUID alone and
+        reached other tenants' rows. Positional and non-defaulted so a caller
+        cannot omit it and quietly get the old behaviour back.
+        """
+        return await self._delete(f"/memories/{memory_id}", tenant_id=tenant_id)
 
     async def set_subject_entity_if_null(
         self, memory_id: str, tenant_id: str, subject_entity_id: str

--- a/core-api/src/core_api/services/governance_remediation.py
+++ b/core-api/src/core_api/services/governance_remediation.py
@@ -94,7 +94,7 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutco
                 # audit is the only trace — must survive queue overflow.
                 critical=True,
             )
-            await sc.soft_delete_memory(memory_id)
+            await sc.soft_delete_memory(memory_id, tenant_id)
             logger.info("governance: dropped fast-mode memory %s (pii)", memory_id)
             return RemediationOutcome(dropped=True)
         # mask/flag: the LLM gives no offsets to redact a free-form span, and in
@@ -129,7 +129,7 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutco
                 # Destructive: see the PII-drop branch — audit is the only trace.
                 critical=True,
             )
-            await sc.soft_delete_memory(memory_id)
+            await sc.soft_delete_memory(memory_id, tenant_id)
             logger.info("governance: dropped fast-mode memory %s (non-business)", memory_id)
             return RemediationOutcome(dropped=True)
         if nb_cfg.disposition == "keep_private":

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -3477,7 +3477,7 @@ async def soft_delete_memory(memory_id: UUID, tenant_id: str) -> None:
     if not mem:
         raise HTTPException(status_code=404, detail="Memory not found")
 
-    await sc.soft_delete_memory(str(memory_id))
+    await sc.soft_delete_memory(str(memory_id), tenant_id)
 
     _hooks = get_hooks()
     if _hooks.audit_log:

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1841,6 +1841,26 @@ async def update_memory_entities(memory_id: UUID, request: Request) -> dict:
 
 
 @router.delete("/{memory_id}")
-async def soft_delete_memory(memory_id: UUID) -> dict:
-    await _svc.memory_soft_delete(memory_id)
+async def soft_delete_memory(memory_id: UUID, tenant_id: str) -> dict:
+    """Soft-delete one memory, within ``tenant_id``.
+
+    ``tenant_id`` is a **required** query parameter, matching the ``GET`` twin
+    above. This route read no tenant at all and deleted by primary key, so a
+    caller who knew a UUID could destroy another tenant's memory through a
+    service that authenticates nothing — the write form of
+    GHSA-wgvw-28pq-jc36, which the ``GET`` was fixed for in caura-ai/caura#1075.
+
+    404 covers "no such memory" and "not yours" alike, so this does not become
+    an existence oracle for memory UUIDs.
+
+    Delegates to ``memory_soft_delete_by_ids`` rather than carrying its own
+    single-row variant. That method was already tenant-scoped and is what the
+    bulk delete routes use; keeping a second, unscoped path to the same write
+    is what let this one drift. It also filters ``deleted_at IS NULL``, so
+    deleting an already-deleted memory is a 404 rather than a silent re-stamp
+    that moved the retention clock forward.
+    """
+    deleted = await _svc.memory_soft_delete_by_ids(tenant_id, [memory_id])
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Memory not found")
     return {"ok": True}

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -999,13 +999,6 @@ class PostgresService:
                 out.append({"client_request_id": crid, "id": None, "was_inserted": False})
         return out
 
-    async def memory_soft_delete(self, memory_id: UUID) -> None:
-        async with get_session() as session:
-            memory = await session.get(Memory, memory_id)
-            if memory is not None:
-                memory.deleted_at = datetime.now(UTC)
-                memory.status = "deleted"
-
     async def memory_update(self, memory_id: UUID, tenant_id: str, patch: dict) -> bool:
         """Apply arbitrary field updates to a memory.
 
@@ -1033,8 +1026,8 @@ class PostgresService:
         the row is absent or soft-deleted, which the route turns into
         404. Both UPDATE branches run inside a single
         ``SELECT ... FOR UPDATE`` snapshot so a concurrent
-        ``memory_soft_delete`` can't commit between them and leave the
-        row in a torn state (status updated, metadata not, or vice
+        ``memory_soft_delete_by_ids`` can't commit between them and leave
+        the row in a torn state (status updated, metadata not, or vice
         versa) — the bare per-statement ``deleted_at IS NULL`` guard
         wasn't enough on its own under READ COMMITTED.
         """

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -271,13 +271,6 @@
       "category": "admin-unscoped"
     },
     {
-      "id": "method:memory_soft_delete",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1080."
-    },
-    {
       "id": "method:recall_log_write",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -350,13 +343,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
       "category": "cross-tenant-by-design"
-    },
-    {
-      "id": "route:DELETE /api/v1/storage/memories/{memory_id}",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1080."
     },
     {
       "id": "route:GET /api/v1/storage/_debug/pg_locks",

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -444,7 +444,7 @@ class TestMemories:
         mem = (await client.post(f"{PREFIX}/memories", json=payload)).json()
         memory_id = mem["id"]
 
-        resp = await client.delete(f"{PREFIX}/memories/{memory_id}")
+        resp = await client.delete(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
 
@@ -490,8 +490,9 @@ class TestMemories:
         mem = (await client.post(f"{PREFIX}/memories", json=payload)).json()
         memory_id = mem["id"]
 
-        # 1. Soft-delete the row.
-        await client.delete(f"{PREFIX}/memories/{memory_id}")
+        # 1. Soft-delete the row. ``tenant_id`` is required on this route now
+        # (it deleted by primary key alone before), so pass the fixture tenant.
+        await client.delete(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})
 
         # 2. PATCH it. Both the column-set branch (status) and the
         # metadata-merge branch (metadata_patch) must no-op, and the
@@ -1394,8 +1395,12 @@ class TestMemories:
         assert (await client.get(f"{PREFIX}/memories/distinct-tenants")).json()["count"] >= before_tenants
 
         # Soft-delete both. ``deleted_at`` is set; ``status`` flips to ``"deleted"``.
-        assert (await client.delete(f"{PREFIX}/memories/{m1['id']}")).status_code == 200
-        assert (await client.delete(f"{PREFIX}/memories/{m2['id']}")).status_code == 200
+        assert (
+            await client.delete(f"{PREFIX}/memories/{m1['id']}", params={"tenant_id": tenant_id})
+        ).status_code == 200
+        assert (
+            await client.delete(f"{PREFIX}/memories/{m2['id']}", params={"tenant_id": tenant_id})
+        ).status_code == 200
 
         # Live counters must roll back our two contributions.
         post_total = (await client.get(f"{PREFIX}/memories/count")).json()["count"]

--- a/core-storage-api/tests/test_memory_delete_tenant_scope.py
+++ b/core-storage-api/tests/test_memory_delete_tenant_scope.py
@@ -1,0 +1,110 @@
+"""``DELETE /memories/{memory_id}`` must be told which tenant it deletes for.
+
+The write form of GHSA-wgvw-28pq-jc36. The route took a bare UUID and
+soft-deleted by primary key with no tenant predicate, so a caller who knew an
+id could destroy another tenant's memory through a service that authenticates
+nothing. ``GET /memories/{memory_id}`` was the read form and was fixed in
+caura-ai/caura#1075; this is the same row, addressed the same way, where the
+consequence is destruction rather than disclosure.
+
+The fix routes through ``memory_soft_delete_by_ids``, which was already
+tenant-scoped and already backs the bulk delete routes, rather than scoping a
+second single-row path to the same write. That method also filters
+``deleted_at IS NULL``, which is why a repeat delete now 404s instead of
+re-stamping ``deleted_at`` and moving the retention clock.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def _memory(client: AsyncClient, tenant_id: str, content: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "agent-a",
+            "content": content,
+            "memory_type": "fact",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _is_live(client: AsyncClient, tenant_id: str, memory_id: str) -> bool:
+    resp = await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant_id})
+    return resp.status_code == 200
+
+
+class TestMemoryDeleteTenantScope:
+    async def test_another_tenants_memory_is_not_deleted(self, client: AsyncClient) -> None:
+        """The attack, stated as the request an attacker would send."""
+        victim = f"del-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"del-attacker-{uuid.uuid4().hex[:8]}"
+        victim_id = await _memory(client, victim, "victim's memory")
+
+        resp = await client.delete(f"{PREFIX}/memories/{victim_id}", params={"tenant_id": attacker})
+
+        assert resp.status_code == 404, resp.text
+        assert await _is_live(client, victim, victim_id), "the victim's memory was deleted"
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """No tenant used to mean "delete by primary key"; it is now a 422."""
+        tenant = f"del-{uuid.uuid4().hex[:8]}"
+        memory_id = await _memory(client, tenant, "mine")
+
+        resp = await client.delete(f"{PREFIX}/memories/{memory_id}")
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+        assert await _is_live(client, tenant, memory_id)
+
+    async def test_own_memory_is_deleted(self, client: AsyncClient) -> None:
+        """The supported call still works."""
+        tenant = f"del-{uuid.uuid4().hex[:8]}"
+        memory_id = await _memory(client, tenant, "doomed")
+
+        resp = await client.delete(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant})
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"ok": True}
+        assert not await _is_live(client, tenant, memory_id)
+
+    async def test_a_foreign_id_is_indistinguishable_from_a_missing_one(self, client: AsyncClient) -> None:
+        """Both 404, so the endpoint is not an existence oracle for memory UUIDs."""
+        victim = f"del-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"del-attacker-{uuid.uuid4().hex[:8]}"
+        victim_id = await _memory(client, victim, "victim's memory")
+
+        foreign = await client.delete(f"{PREFIX}/memories/{victim_id}", params={"tenant_id": attacker})
+        missing = await client.delete(f"{PREFIX}/memories/{uuid.uuid4()}", params={"tenant_id": attacker})
+
+        assert foreign.status_code == missing.status_code == 404
+        assert foreign.json() == missing.json()
+
+    async def test_deleting_twice_does_not_move_the_retention_clock(self, client: AsyncClient) -> None:
+        """A repeat delete is a 404, not a silent re-stamp of ``deleted_at``.
+
+        The old single-row path had no ``deleted_at IS NULL`` guard, so a second
+        DELETE rewrote the timestamp and pushed the purge window out. Routing
+        through ``memory_soft_delete_by_ids`` fixes that as a side effect of
+        scoping it, and this pins the behaviour so a future single-row variant
+        cannot quietly reintroduce it.
+        """
+        tenant = f"del-{uuid.uuid4().hex[:8]}"
+        memory_id = await _memory(client, tenant, "doomed")
+
+        first = await client.delete(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant})
+        second = await client.delete(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant})
+
+        assert first.status_code == 200, first.text
+        assert second.status_code == 404, second.text

--- a/tests/test_governance_consumer.py
+++ b/tests/test_governance_consumer.py
@@ -107,7 +107,7 @@ async def test_pii_drop_acks_and_skips_detection(sc, detect, monkeypatch):
 
     await consumer.handle_memory_enriched(_event(mid))
 
-    sc.soft_delete_memory.assert_awaited_once_with(str(mid))
+    sc.soft_delete_memory.assert_awaited_once_with(str(mid), "tenant-gov")
     detect.assert_not_awaited()  # dropped by policy → contradiction detection skipped
 
 

--- a/tests/test_governance_inline_fast_remediation.py
+++ b/tests/test_governance_inline_fast_remediation.py
@@ -215,7 +215,7 @@ async def test_inline_fast_write_drops_a_personal_memory_when_configured():
         storage=sc,
         memory_id=mid,
     )
-    sc.soft_delete_memory.assert_awaited_once_with(str(mid))
+    sc.soft_delete_memory.assert_awaited_once_with(str(mid), TENANT)
 
 
 async def test_inline_fast_write_drops_a_pii_memory_when_configured():
@@ -228,7 +228,7 @@ async def test_inline_fast_write_drops_a_pii_memory_when_configured():
         storage=sc,
         memory_id=mid,
     )
-    sc.soft_delete_memory.assert_awaited_once_with(str(mid))
+    sc.soft_delete_memory.assert_awaited_once_with(str(mid), TENANT)
 
 
 async def test_keep_private_downgrades_visibility_instead_of_dropping():
@@ -302,7 +302,7 @@ async def test_a_stale_read_replica_cannot_defeat_the_verdict():
         storage=sc,
         memory_id=mid,
     )
-    sc.soft_delete_memory.assert_awaited_once_with(str(mid))
+    sc.soft_delete_memory.assert_awaited_once_with(str(mid), TENANT)
 
 
 # ── Wiring: which callers may remediate ───────────────────────────────────────

--- a/tests/test_governance_remediation.py
+++ b/tests/test_governance_remediation.py
@@ -34,8 +34,8 @@ def storage(monkeypatch):
     actions: list[tuple] = []
 
     class _SC:
-        async def soft_delete_memory(self, mid):
-            actions.append(("soft_delete", mid))
+        async def soft_delete_memory(self, mid, tenant_id):
+            actions.append(("soft_delete", mid, tenant_id))
 
         async def update_memory(self, mid, tenant_id, patch):
             actions.append(("update", mid, tenant_id, patch))
@@ -86,7 +86,7 @@ async def test_pii_drop_soft_deletes_and_audits(emitted, storage):
     mem = _mem(metadata={"contains_pii": True, "pii_types": ["health"]})
     outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
     assert outcome.dropped is True
-    assert ("soft_delete", "m1") in storage
+    assert ("soft_delete", "m1", "t1") in storage
     assert any(c["action"] == "pii_drop" for c in emitted)
 
 
@@ -124,7 +124,7 @@ async def test_nonbusiness_drop_soft_deletes(emitted, storage):
     mem = _mem(metadata={"business_relevance": "personal"})
     outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
     assert outcome.dropped is True
-    assert ("soft_delete", "m1") in storage
+    assert ("soft_delete", "m1", "t1") in storage
     assert any(c["action"] == "nonbusiness_drop" for c in emitted)
 
 
@@ -165,7 +165,7 @@ async def test_drop_audits_before_soft_delete(
         order.append(f"audit:{kw['action']}")
 
     class _SC:
-        async def soft_delete_memory(self, _mid):
+        async def soft_delete_memory(self, _mid, _tenant_id):
             order.append("soft_delete")
 
     monkeypatch.setattr(governance_remediation, "emit_governance_audit", _audit)


### PR DESCRIPTION
Closes #1080.

`DELETE /memories/{memory_id}` read no tenant and soft-deleted by primary key:

```python
@router.delete("/{memory_id}")
async def soft_delete_memory(memory_id: UUID) -> dict:
    await _svc.memory_soft_delete(memory_id)
    return {"ok": True}
```

Two lines, no tenant anywhere. `core-storage-api` authenticates nothing (GHSA-wgvw-28pq-jc36), so knowing a UUID was enough to destroy another tenant's memory.

This is the **write form of the same defect** `GET /memories/{memory_id}` had — fixed in caura-ai/caura#1075. Same row, same addressing, destruction instead of disclosure. The route now takes a required `tenant_id` query parameter, matching that GET twin, and 404s for "no such memory" and "not yours" alike so it is not an existence oracle.

### `memory_soft_delete` is deleted, not scoped

`memory_soft_delete_by_ids(tenant_id, ids)` was **already** tenant-scoped and already backs the three bulk-delete routes. Keeping a second, unscoped single-row path to the same write is what let this one drift, and #1075 resolved the read side the same way by deleting `memory_get_by_id`.

Checked equivalence before switching, since the old path mutated an ORM object and the replacement issues a bulk `UPDATE`:

- No ORM event listeners anywhere in `core-storage-api` (`event.listen` / `@listens_for` / `before_update` / `after_update`: none).
- The `memories_search_vector_trigger` fires `BEFORE INSERT OR UPDATE OF content, title` — columns a soft delete does not touch.

### One deliberate behaviour change

`memory_soft_delete_by_ids` filters `deleted_at IS NULL`. The old single-row path did not, so a repeat DELETE **re-stamped `deleted_at` and pushed the retention/purge window forward**. A second delete is now a 404. `test_deleting_twice_does_not_move_the_retention_clock` pins it so a future single-row variant cannot quietly bring it back.

Safe for both callers: `memory_service.soft_delete_memory` already 404s beforehand via its scoped `get_memory`, and `_delete` in the storage client maps 404 to `False` rather than raising, so `governance_remediation` sees a clean no-op.

### Tests

Five new, in `core-storage-api/tests/test_memory_delete_tenant_scope.py`. **Four fail on the parent commit:**

| test | on parent |
|---|---|
| `test_another_tenants_memory_is_not_deleted` | ✅ **fails** — the attack |
| `test_omitted_tenant_id_is_rejected` | ✅ fails |
| `test_a_foreign_id_is_indistinguishable_from_a_missing_one` | ✅ fails |
| `test_deleting_twice_does_not_move_the_retention_clock` | ✅ fails |
| `test_own_memory_is_deleted` | passes — regression guard |

### Existing tests updated, not worked around

The contract changed, so tests written against the old one had to move. Eleven of them, and I checked each rather than blanket-patching:

- **3 in `core-storage-api/tests/test_integration.py`** (4 call sites) — deleted without a tenant. Now pass the fixture tenant.
- **8 governance tests** across `test_governance_remediation.py`, `test_governance_consumer.py`, `test_governance_inline_fast_remediation.py` — fake storage clients needed the new argument, and the `assert_awaited_once_with` calls now **pin the tenant that gets passed**, which is the property this PR is about. `("soft_delete", "m1")` became `("soft_delete", "m1", "t1")`.

### Effect on the gate

```
Allowlist shrank by 2: method:memory_soft_delete, route:DELETE /api/v1/storage/memories/{memory_id}
tenant-scope gate: 191 routes + 191 service methods, 268 bound to a tenant, 114 allowlisted.
```

`id-addressed-write` 18 → 16, total 116 → 114.

### Verification

`core-storage-api`: 10 failed / **213** passed / 7 errors — the same 10 failures as pristine `origin/main`, delta is the new tests. Root suite compared list-against-list with a clean `origin/main` checkout rather than by count, because that suite flakes between 44 and 47: the only difference was `test_semantic_dedup_query_latency`, which passes 3/3 in isolation here and which this diff does not touch (no dedup or query path is modified).

`ruff check` + `ruff format --check` at CI's scopes, clean at 0.16.5. `mypy src/` clean for both packages (85 and 203 files) and `scripts/` (31) — run in a venv with both packages installed editable, so sqlalchemy types are real rather than `Any`. Gate `--base origin/main` exit 0, `--write` no drift. `uv.lock` untouched. Rebased onto `87a68a12` and re-run there.
