### PR TITLE
fix(ratchet): reconcile moves across commits

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -600,8 +600,13 @@ def _only_inserts(before: str, after: str) -> bool:
     return after[mismatch + inserted :] == before[mismatch:]
 
 
-def _transition_summary(base: Scan, head: Scan) -> _ChangeSummary:
-    """Classify one tree-to-tree transition without affecting the gate."""
+_LineCounts = dict[tuple[str, str], int]
+
+
+def _transition_delta(
+    base: Scan, head: Scan
+) -> tuple[_LineCounts, _LineCounts, _LineCounts]:
+    """Lines that left or entered the ratcheted and exempt populations."""
     lost = {
         (path, text): n
         for path, lines in base.by_file.items()
@@ -617,7 +622,11 @@ def _transition_summary(base: Scan, head: Scan) -> _ChangeSummary:
         for path, lines in head.exempt_by_file.items()
         for text, n in (lines - base.exempt_by_file.get(path, Counter())).items()
     }
+    return lost, gained, gained_exempt
 
+
+def _match_annotations(lost: _LineCounts, gained_exempt: _LineCounts) -> int:
+    """Consume losses that gained a marker in the same transition."""
     annotated = 0
     for (destination, marked), available in sorted(gained_exempt.items()):
         candidates = sorted(
@@ -631,7 +640,11 @@ def _transition_summary(base: Scan, head: Scan) -> _ChangeSummary:
             lost[key] -= matched
             if not available:
                 break
+    return annotated
 
+
+def _match_moves(lost: _LineCounts, gained: _LineCounts) -> int:
+    """Consume byte-identical lines that reappeared in another file."""
     moved = 0
     for (destination, text), available in sorted(gained.items()):
         sources = sorted(
@@ -647,6 +660,25 @@ def _transition_summary(base: Scan, head: Scan) -> _ChangeSummary:
             gained[(destination, text)] -= matched
             if not available:
                 break
+    return moved
+
+
+def _match_readditions(lost: _LineCounts, gained: _LineCounts) -> int:
+    """Consume lines that left and later returned to the same file."""
+    readded = 0
+    for key, available in sorted(gained.items()):
+        matched = min(available, lost.get(key, 0))
+        readded += matched
+        lost[key] = lost.get(key, 0) - matched
+        gained[key] -= matched
+    return readded
+
+
+def _transition_summary(base: Scan, head: Scan) -> _ChangeSummary:
+    """Classify one tree-to-tree transition without affecting the gate."""
+    lost, gained, gained_exempt = _transition_delta(base, head)
+    annotated = _match_annotations(lost, gained_exempt)
+    moved = _match_moves(lost, gained)
 
     return _ChangeSummary(
         added=sum(gained.values()),
@@ -724,26 +756,42 @@ def _change_summary(
         if sum(bool(paths) for _, paths in transitions) + bool(worktree_paths) <= 1:
             return endpoint
 
-        parts: list[_ChangeSummary] = []
+        # Annotation means a marker was added without first removing the line,
+        # so it is paired only inside one transition. A move can be written as
+        # either delete-then-add or copy-then-delete, so residual gains and
+        # losses wait for a counterpart across transitions. Same-path returns
+        # are add/remove churn rather than moves and take precedence.
+        lost_pool: _LineCounts = {}
+        gained_pool: _LineCounts = {}
+        annotated = moved = readded = 0
         current = base
-        for index, (commit, paths) in enumerate(transitions):
-            if index == len(transitions) - 1 and not worktree_paths:
+        replay_steps: list[tuple[str | None, list[str]]] = list(transitions)
+        if worktree_paths:
+            replay_steps.append((None, worktree_paths))
+        for index, (tree, paths) in enumerate(replay_steps):
+            if tree is None or index == len(replay_steps) - 1:
                 following = head
             else:
-                following = _updated_scan(current, commit, paths)
-            parts.append(_transition_summary(current, following))
+                following = _updated_scan(current, tree, paths)
+
+            lost, gained, gained_exempt = _transition_delta(current, following)
+            annotated += _match_annotations(lost, gained_exempt)
+            for key, count in lost.items():
+                lost_pool[key] = lost_pool.get(key, 0) + count
+            for key, count in gained.items():
+                gained_pool[key] = gained_pool.get(key, 0) + count
+            readded += _match_readditions(lost_pool, gained_pool)
+            moved += _match_moves(lost_pool, gained_pool)
             current = following
-        if worktree_paths:
-            parts.append(_transition_summary(current, head))
-    except RuntimeError:
+    except (OSError, RuntimeError):
         return endpoint
 
     return _ChangeSummary(
-        added=sum(part.added for part in parts),
-        annotated=sum(part.annotated for part in parts),
-        removed=sum(part.removed for part in parts),
-        moved=sum(part.moved for part in parts),
-        net=sum(part.net for part in parts),
+        added=readded + sum(gained_pool.values()),
+        annotated=annotated,
+        removed=readded + sum(lost_pool.values()),
+        moved=moved,
+        net=sum(head.counts().values()) - sum(base.counts().values()),
     )
 
 

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -13,8 +13,10 @@ case-insensitive match are all git's behaviour, not ours.
 from __future__ import annotations
 
 import os
+import runpy
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import NamedTuple
 
@@ -1467,6 +1469,100 @@ def test_summary_replays_a_pure_rename_before_removal(repo: Path) -> None:
         "Change from HEAD~2: 0 added, 0 annotated, 1 removed, "
         "1 excused move (-1 net)." in result.stdout
     )
+
+
+@pytest.mark.parametrize(
+    "delete_first", [True, False], ids=["delete-add", "add-delete"]
+)
+def test_summary_pairs_a_move_across_separate_commits(
+    repo: Path, delete_first: bool
+) -> None:
+    if delete_first:
+        _git(repo, "rm", "existing.py")
+        _git(repo, "commit", "-qm", "remove the legacy URL")
+    else:
+        _stage(repo, "moved.py", f'URL = "https://{LEGACY}.net"\n')
+        _git(repo, "commit", "-qm", "copy the URL elsewhere")
+    _stage(repo, "clean.py", "VALUE = 2\n")
+    _git(repo, "commit", "-qm", "unrelated edit")
+    if delete_first:
+        _stage(repo, "moved.py", f'URL = "https://{LEGACY}.net"\n')
+        _git(repo, "commit", "-qm", "restore the URL elsewhere")
+    else:
+        _git(repo, "rm", "existing.py")
+        _git(repo, "commit", "-qm", "remove the original URL")
+
+    gate = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~3"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    report = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~3", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert gate.returncode == report.returncode == 0
+    assert "1 line(s) treated as moved rather than added" in gate.stdout
+    assert (
+        "No new lines. 0 annotated, 0 removed, 1 excused move (+0 net)." in gate.stdout
+    )
+    assert (
+        "Change from HEAD~3: 0 added, 0 annotated, 0 removed, "
+        "1 excused move (+0 net)." in report.stdout
+    )
+
+
+def test_summary_does_not_reuse_a_loss_after_same_path_readdition(
+    repo: Path,
+) -> None:
+    _git(repo, "rm", "existing.py")
+    _git(repo, "commit", "-qm", "remove the legacy URL")
+    _stage(repo, "existing.py", f'URL = "https://{LEGACY}.net"\n')
+    _git(repo, "commit", "-qm", "restore the URL")
+    _stage(repo, "copied.py", f'URL = "https://{LEGACY}.net"\n')
+    _git(repo, "commit", "-qm", "copy the URL elsewhere")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~3", "--report"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert (
+        "Change from HEAD~3: 2 added, 0 annotated, 1 removed, "
+        "0 excused moves (+1 net)." in result.stdout
+    )
+
+
+def test_change_summary_falls_back_when_replay_cannot_spawn_git(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    namespace = runpy.run_path(str(SCRIPT))
+    change_summary = namespace["_change_summary"]
+    scan_type = namespace["Scan"]
+    summary_type = namespace["_ChangeSummary"]
+    base = scan_type(
+        {"existing.py": Counter({"legacy text": 1})},
+        Counter({"legacy text": 1}),
+        {},
+    )
+    head = scan_type({}, Counter(), {})
+
+    def cannot_spawn(_: list[str]) -> str:
+        raise OSError("argument list too long")
+
+    monkeypatch.setitem(change_summary.__globals__, "_git", cannot_spawn)
+
+    assert change_summary("HEAD", base, head) == summary_type(0, 0, 1, 0, -1)
 
 
 def test_summary_replays_a_file_becoming_binary_then_text(repo: Path) -> None:


### PR DESCRIPTION
## Summary

- reconcile byte-identical moves across commit boundaries in either order (delete-then-add or copy-then-delete)
- count a same-path delete/re-add as add/remove churn before considering later cross-path moves
- fall back to the endpoint classification if an optional replay Git command cannot spawn

This changes reporting only. Both exemption markers still exempt identically, and the gate decision path is unchanged.

## Regression coverage

- both cross-commit move orders now report `0 added, 0 removed, 1 excused move`
- a same-path restoration followed by a copy reports `2 added, 1 removed, 0 excused moves`
- an `OSError` during replay returns the endpoint summary instead of escaping
- each new regression failed against the landed Work Package I implementation before the fix

## Validation

- `python3 -m pytest --noconftest tests/test_legacy_name_ratchet.py -q` — 98 passed
- `uv run ruff check scripts/legacy_name_ratchet.py tests/test_legacy_name_ratchet.py`
- `uv run ruff format --check scripts/legacy_name_ratchet.py tests/test_legacy_name_ratchet.py`
- `uv run mypy --config-file scripts/mypy.ini scripts/` — 31 source files clean
- `python3 scripts/do_not_touch_sentinel.py` — all 46 protected strings survive
- `python3 -m pytest --noconftest tests/test_do_not_touch_sentinel.py -q` — 111 passed
- non-shallow historical worktree at `1304e3ee`, base `00abbf3`: `No new lines. 26 annotated, 0 removed, 0 excused moves (-26 net).`

`actionlint` still reports four pre-existing findings in untouched workflows.
