### PR TITLE
fix(ratchet): harden passing change summaries

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -1263,7 +1263,13 @@ def main() -> int:
     base = base_scan.counts()
 
     if args.report:
-        report_summary = _change_summary(args.base, base_scan, head_scan)
+        try:
+            report_summary = _change_summary(args.base, base_scan, head_scan)
+        except Exception as exc:  # noqa: BLE001
+            # The inventory above is still valid. Its documented exit-0 contract
+            # must not depend on optional chronology reporting staying healthy.
+            print(f"Change from {args.base} unavailable: {exc}", file=sys.stderr)
+            return 0
         print(
             f"Change from {args.base}: {report_summary.added} added, "
             f"{report_summary.annotated} annotated, "
@@ -1328,12 +1334,21 @@ def main() -> int:
             print(f"  {path}")
 
     if not grown:
-        gate_summary = _change_summary(
-            args.base,
-            base_scan,
-            head_scan,
-            max_commits=_GATE_REPLAY_LIMIT,
-        )
+        try:
+            gate_summary = _change_summary(
+                args.base,
+                base_scan,
+                head_scan,
+                max_commits=_GATE_REPLAY_LIMIT,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # The gate decision is already made; optional reporting cannot turn
+            # this passing input into an infrastructure failure.
+            print(
+                "Gate passes: no new lines currently fail it. "
+                f"Change split unavailable: {exc}"
+            )
+            return 0
         if gate_summary is None:
             print(
                 "No new lines fail the gate. Change split omitted: the range exceeds the "
@@ -1343,7 +1358,8 @@ def main() -> int:
             return 0
         if gate_summary.added:
             print(
-                f"No new lines fail the gate. {gate_summary.added} added, "
+                "Gate passes: no new lines currently fail it. Range history: "
+                f"{gate_summary.added} added, "
                 f"{gate_summary.annotated} annotated, "
                 f"{gate_summary.removed} removed, "
                 f"{gate_summary.moved} {_move_label(gate_summary.moved)} "

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -1408,7 +1408,14 @@ def test_summary_replays_transient_addition_and_removal(repo: Path) -> None:
     _stage(repo, "new.py", "")
     _git(repo, "commit", "-qm", "remove the transient legacy line")
 
-    result = subprocess.run(
+    gate = subprocess.run(
+        [sys.executable, str(SCRIPT), "--base", "HEAD~2"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    report = subprocess.run(
         [sys.executable, str(SCRIPT), "--base", "HEAD~2", "--report"],
         cwd=repo,
         capture_output=True,
@@ -1416,10 +1423,14 @@ def test_summary_replays_transient_addition_and_removal(repo: Path) -> None:
         check=False,
     )
 
-    assert result.returncode == 0
+    assert gate.returncode == report.returncode == 0
+    assert (
+        "Gate passes: no new lines currently fail it. Range history: "
+        "1 added, 0 annotated, 1 removed, 0 excused moves (+0 net)." in gate.stdout
+    )
     assert (
         "Change from HEAD~2: 1 added, 0 annotated, 1 removed, "
-        "0 excused moves (+0 net)." in result.stdout
+        "0 excused moves (+0 net)." in report.stdout
     )
 
 
@@ -1563,6 +1574,55 @@ def test_change_summary_falls_back_when_replay_cannot_spawn_git(
     monkeypatch.setitem(change_summary.__globals__, "_git", cannot_spawn)
 
     assert change_summary("HEAD", base, head) == summary_type(0, 0, 1, 0, -1)
+
+
+def test_report_survives_an_unexpected_change_summary_failure(
+    repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    namespace = runpy.run_path(str(SCRIPT))
+    main = namespace["main"]
+
+    def cannot_summarize(*_args: object, **_kwargs: object) -> None:
+        raise ValueError("broken matcher")
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT), "--base", "HEAD", "--report"])
+    monkeypatch.setitem(main.__globals__, "_change_summary", cannot_summarize)
+
+    assert main() == 0
+    captured = capsys.readouterr()
+    assert "1 lines across 1 files" in captured.out
+    assert "Change from HEAD unavailable: broken matcher" in captured.err
+
+
+def test_passing_gate_survives_an_unexpected_change_summary_failure(
+    repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _stage(repo, "CHANGELOG.md", f"* fix: retire the {LEGACY} gateway (#123)\n")
+    namespace = runpy.run_path(str(SCRIPT))
+    main = namespace["main"]
+
+    def cannot_summarize(*_args: object, **_kwargs: object) -> None:
+        raise ValueError("broken matcher")
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("GITHUB_HEAD_REF", "release-please--branches--main")
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT), "--base", "HEAD"])
+    monkeypatch.setitem(main.__globals__, "_change_summary", cannot_summarize)
+
+    assert main() == 0
+    assert (
+        capsys.readouterr()
+        .out.rstrip()
+        .endswith(
+            "Gate passes: no new lines currently fail it. "
+            "Change split unavailable: broken matcher"
+        )
+    )
 
 
 def test_summary_replays_a_file_becoming_binary_then_text(repo: Path) -> None:
@@ -1938,8 +1998,8 @@ def test_a_release_changelog_addition_is_not_hidden_from_the_net(repo: Path) -> 
 
     assert result.returncode == 0
     assert (
-        "No new lines fail the gate. 1 added, 0 annotated, 1 removed, "
-        "0 excused moves (+0 net)." in result.stdout
+        "Gate passes: no new lines currently fail it. Range history: "
+        "1 added, 0 annotated, 1 removed, 0 excused moves (+0 net)." in result.stdout
     )
 
 


### PR DESCRIPTION
## Summary

- distinguish the current passing gate state from gross churn found in commit history
- exercise the ordinary gate path for a transient add-then-remove, not only report mode
- keep optional change-split failures non-fatal in report mode and after a gate pass
- qualify the fallback wording when a release-please CHANGELOG is exempt

The normal transient-churn message is:

> Gate passes: no new lines currently fail it. Range history: 1 added, 0 annotated, 1 removed, 0 excused moves (+0 net).

If chronology reporting itself raises unexpectedly, report mode retains its current-tree inventory and exit 0, while an already-passing gate remains exit 0 and says the split is unavailable. Gate decisions, existing-input exit codes, and both exemption markers are unchanged.

## Review dispositions

- accepted the wording and missing gate-path coverage finding
- accepted the daemon finding that an unexpected matcher exception could overturn a passing gate
- intentionally declined the report replay cap: report mode is an explicit request for exact archaeology, and endpoint fallback would lose the annotation/removal chronology this package exists to recover

## Validation

- both exception regressions failed against the unguarded code; the release-please wording regression also failed against the unqualified fallback
- uv run pytest tests/test_legacy_name_ratchet.py -q — 100 passed
- uv run ruff check at CI discovery scopes plus both changed files
- uv run ruff format --check run separately; both changed files and CI exact scopes pass
- uv run mypy --config-file scripts/mypy.ini scripts/ — 31 source files clean
- python3 scripts/do_not_touch_sentinel.py — all 46 protected strings survive
- uv run pytest tests/test_do_not_touch_sentinel.py -q — 111 passed
- non-shallow historical worktree at 1304e3ee, base 00abbf3: No new lines. 26 annotated, 0 removed, 0 excused moves (-26 net).

The simplification review found and drove the release-please fallback qualification; all three final passes are clean. actionlint still reports four pre-existing findings in untouched workflows.