### PR TITLE
fix(entity): scope the single-row update to the caller's tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1317,8 +1317,10 @@ class CoreStorageClient:
     async def get_entity(self, entity_id: str) -> dict | None:
         return await self._get(f"/entities/{entity_id}")
 
-    async def update_entity(self, entity_id: str, data: dict) -> dict | None:
-        return await self._patch(f"/entities/{entity_id}", data)
+    async def update_entity(self, entity_id: str, tenant_id: str, data: dict) -> dict | None:
+        # Same contract as ``update_memory`` above, for the same reason.
+        # The explicit arg wins over any ``tenant_id`` in ``data``.
+        return await self._patch(f"/entities/{entity_id}", {**data, "tenant_id": tenant_id})
 
     async def find_exact_entity(
         self,

--- a/core-api/src/core_api/services/entity_service.py
+++ b/core-api/src/core_api/services/entity_service.py
@@ -104,7 +104,7 @@ async def upsert_entity(
         if name_embedding is not None:
             update_data["name_embedding"] = name_embedding
 
-        updated = await sc.update_entity(str(entity_id), update_data)
+        updated = await sc.update_entity(str(entity_id), data.tenant_id, update_data)
         entity = updated or entity
     else:
         # Create new entity. Coerce ``attributes=None`` to ``{}`` so

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -645,7 +645,14 @@ async def get_entity(entity_id: UUID) -> dict:
 @router.patch("/{entity_id}")
 async def update_entity(entity_id: UUID, request: Request) -> dict:
     body: dict = await request.json()
-    entity = await _svc.entity_update(entity_id, body)
+    # Tenant guard, same shape as ``PATCH /memories/{memory_id}``: ``tenant_id``
+    # is the row's home tenant, removed from the body so it scopes the fetch
+    # rather than landing as a patched column (``Entity`` has a ``tenant_id``
+    # column). ``_ENTITY_UPDATABLE_FIELDS`` would drop it anyway; both are kept
+    # because either alone closes the hop and they fail independently.
+    tenant_id = _require(body, "tenant_id")
+    del body["tenant_id"]
+    entity = await _svc.entity_update(entity_id, tenant_id, body)
     if entity is None:
         raise HTTPException(status_code=404, detail="Entity not found")
     return orm_to_dict(entity, ENTITY_FIELDS)

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -327,6 +327,18 @@ _MEMORY_VALID_FIELDS = frozenset(
     {c.key for c in Memory.__table__.columns} | {a.key for a in Memory.__mapper__.column_attrs}
 )
 
+# Columns ``entity_update`` may write. Deliberately a subset, not
+# ``Entity.__table__.columns`` the way ``_MEMORY_VALID_FIELDS`` above is: the
+# previous ``hasattr(entity, key)`` test admitted every mapped column, so a
+# caller who satisfied the route's tenant predicate could still repoint the
+# row's primary key. ``tenant_id`` and ``fleet_id`` are scope rather than
+# content and no caller writes them; ``search_vector`` is trigger-maintained.
+# Keys outside the set are dropped silently rather than rejected: this service
+# validates request shape upstream in core-api, not here. ``memory_update``
+# drops unlisted keys the same way but still tests ``hasattr(Memory, key)``
+# rather than an allowlist, so its primary key is still writable — #1118.
+_ENTITY_UPDATABLE_FIELDS = frozenset({"canonical_name", "entity_type", "attributes", "name_embedding"})
+
 # Columns the admin memory-list endpoint may sort by. Allowlisted so an
 # unexpected ``sort`` value falls back to created_at instead of raising
 # AttributeError (500) at ``getattr(Memory, sort)`` — the endpoint is callable
@@ -5313,7 +5325,7 @@ class PostgresService:
                 # but real window), ``entity_update`` returns None — surface
                 # as "missing" rather than reporting a "merged" that didn't
                 # actually happen.
-                updated = await self.entity_update(existed_before.id, merge_values)
+                updated = await self.entity_update(existed_before.id, item["tenant_id"], merge_values)
                 results[item["input_idx"]] = {
                     "input_idx": item["input_idx"],
                     "entity_id": str(existed_before.id),
@@ -5464,14 +5476,25 @@ class PostgresService:
                 entity = winner
             return entity
 
-    async def entity_update(self, entity_id: UUID, data: dict) -> Entity | None:
-        """Update an existing entity by ID with the given fields."""
+    async def entity_update(self, entity_id: UUID, tenant_id: str, data: dict) -> Entity | None:
+        """Update an existing entity by ID, scoped to its home tenant.
+
+        ``tenant_id`` is in the WHERE for the reason given on
+        ``entity_bulk_upsert``'s update branch. Returning ``None`` for both
+        "no such entity" and "not yours" is what keeps the route from
+        answering as an existence oracle for entity UUIDs.
+
+        Only ``_ENTITY_UPDATABLE_FIELDS`` are applied — see that constant for
+        why the writable set is narrower than "every mapped column".
+        """
         async with get_session() as session:
-            entity = await session.get(Entity, entity_id)
+            entity = await session.scalar(
+                select(Entity).where(Entity.id == entity_id, Entity.tenant_id == tenant_id)
+            )
             if entity is None:
                 return None
             for key, value in data.items():
-                if hasattr(entity, key):
+                if key in _ENTITY_UPDATABLE_FIELDS:
                     setattr(entity, key, value)
             await session.flush()
             return entity

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -133,13 +133,6 @@
       "note": "Join table has no tenant column; rows are tenant-scoped only via the ids."
     },
     {
-      "id": "method:entity_update",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1081."
-    },
-    {
       "id": "method:fleet_add_command",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -496,13 +489,6 @@
       "evidence": "no binding tenant read from the request",
       "category": "id-addressed-write",
       "note": "Tracked in #1084."
-    },
-    {
-      "id": "route:PATCH /api/v1/storage/entities/{entity_id}",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1081."
     },
     {
       "id": "route:PATCH /api/v1/storage/lifecycle-audit/{audit_id}",

--- a/core-storage-api/tests/test_entity_update_tenant_scope.py
+++ b/core-storage-api/tests/test_entity_update_tenant_scope.py
@@ -1,0 +1,151 @@
+"""``PATCH /entities/{entity_id}`` must be told which tenant it writes for.
+
+The write form of GHSA-wgvw-28pq-jc36 on the entity graph. The route took a
+bare UUID and ``entity_update`` fetched by primary key, so a caller who knew an
+id could rewrite another tenant's entity through a service that authenticates
+nothing.
+
+Scoping the fetch alone would not have closed it. The old body loop was
+``if hasattr(entity, key): setattr(entity, key, value)``, which reaches every
+mapped column --- so a caller who satisfied the predicate could still write
+``tenant_id`` and hand the row to another namespace, or repoint ``id``. Two
+things now stop the tenant case, and they fail independently: the route removes
+``tenant_id`` from the body to use it as the predicate, and
+``_ENTITY_UPDATABLE_FIELDS`` would drop it regardless. Because either alone
+suffices, no test here can isolate one of them --- what is pinned below is the
+observable outcome, which needed both to be absent to occur. The primary key is
+the case reachable through the allowlist alone, and
+``test_scope_columns_are_not_caller_writable`` is what pins it.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def _entity(client: AsyncClient, tenant_id: str, name: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/entities",
+        json={
+            "tenant_id": tenant_id,
+            "entity_type": "person",
+            "canonical_name": name,
+            "attributes": {"role": "engineer"},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _read(client: AsyncClient, entity_id: str) -> dict:
+    """Read the row back regardless of tenant, to assert what actually persisted.
+
+    Deliberately goes through ``GET /entities/{entity_id}``, which is still
+    unscoped (allowlisted ``id-addressed-read``) and so answers for any tenant
+    --- that is what makes it a usable oracle here. When that route gains a
+    required tenant, this helper needs one too.
+    """
+    resp = await client.get(f"{PREFIX}/entities/{entity_id}")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+class TestEntityUpdateTenantScope:
+    async def test_another_tenants_entity_is_not_updated(self, client: AsyncClient) -> None:
+        """The attack, stated as the request an attacker would send."""
+        victim = f"ent-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"ent-attacker-{uuid.uuid4().hex[:8]}"
+        name = f"Victim-{uuid.uuid4().hex[:8]}"
+        victim_id = await _entity(client, victim, name)
+
+        resp = await client.patch(
+            f"{PREFIX}/entities/{victim_id}",
+            json={"tenant_id": attacker, "canonical_name": "OWNED", "attributes": {"role": "attacker"}},
+        )
+
+        assert resp.status_code == 404, resp.text
+        row = await _read(client, victim_id)
+        assert row["canonical_name"] == name, "the victim's entity was rewritten"
+        assert row["attributes"] == {"role": "engineer"}
+        # Naming a tenant you don't own re-points the predicate; it never moves
+        # the row into the tenant you named.
+        assert row["tenant_id"] == victim
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """No tenant used to mean "update by primary key"; it is now a 422."""
+        tenant = f"ent-{uuid.uuid4().hex[:8]}"
+        name = f"Mine-{uuid.uuid4().hex[:8]}"
+        entity_id = await _entity(client, tenant, name)
+
+        resp = await client.patch(f"{PREFIX}/entities/{entity_id}", json={"canonical_name": "CHANGED"})
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+        assert (await _read(client, entity_id))["canonical_name"] == name
+
+    async def test_own_entity_is_updated(self, client: AsyncClient) -> None:
+        """The supported call still works."""
+        tenant = f"ent-{uuid.uuid4().hex[:8]}"
+        entity_id = await _entity(client, tenant, f"Mine-{uuid.uuid4().hex[:8]}")
+
+        resp = await client.patch(
+            f"{PREFIX}/entities/{entity_id}",
+            json={"tenant_id": tenant, "canonical_name": "Renamed", "attributes": {"role": "staff"}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["canonical_name"] == "Renamed"
+        row = await _read(client, entity_id)
+        assert row["canonical_name"] == "Renamed"
+        assert row["attributes"] == {"role": "staff"}
+        assert row["tenant_id"] == tenant
+
+    async def test_a_foreign_id_is_indistinguishable_from_a_missing_one(self, client: AsyncClient) -> None:
+        """Both 404, so the endpoint is not an existence oracle for entity UUIDs."""
+        victim = f"ent-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"ent-attacker-{uuid.uuid4().hex[:8]}"
+        victim_id = await _entity(client, victim, f"Victim-{uuid.uuid4().hex[:8]}")
+
+        body = {"tenant_id": attacker, "canonical_name": "OWNED"}
+        foreign = await client.patch(f"{PREFIX}/entities/{victim_id}", json=body)
+        missing = await client.patch(f"{PREFIX}/entities/{uuid.uuid4()}", json=body)
+
+        assert foreign.status_code == missing.status_code == 404
+        assert foreign.json() == missing.json()
+
+    async def test_scope_columns_are_not_caller_writable(self, client: AsyncClient) -> None:
+        """``id`` and ``fleet_id`` are outside ``_ENTITY_UPDATABLE_FIELDS``.
+
+        The primary key was genuinely rewritable through this route: the row
+        moved to the caller's chosen UUID, the old id 404'd, and every
+        ``memory_entity_links`` row still pointing at the old value was
+        stranded. Unlisted keys are dropped rather than rejected, matching
+        ``memory_update`` --- so the request succeeds and the columns hold.
+        """
+        tenant = f"ent-{uuid.uuid4().hex[:8]}"
+        entity_id = await _entity(client, tenant, f"Mine-{uuid.uuid4().hex[:8]}")
+        stolen = str(uuid.uuid4())
+
+        resp = await client.patch(
+            f"{PREFIX}/entities/{entity_id}",
+            json={
+                "tenant_id": tenant,
+                "id": stolen,
+                "fleet_id": "fleet-attacker",
+                "canonical_name": "Renamed",
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["canonical_name"] == "Renamed", "the writable field should still apply"
+        row = await _read(client, entity_id)
+        assert row["id"] == entity_id, "the primary key was repointed"
+        assert row["fleet_id"] is None
+        assert (await client.get(f"{PREFIX}/entities/{stolen}")).status_code == 404

--- a/tests/test_a5a_seed_and_canonical.py
+++ b/tests/test_a5a_seed_and_canonical.py
@@ -191,7 +191,7 @@ async def test_upsert_preserves_canonical_when_longer_alternative_arrives() -> N
         return_value=[{**existing_entity, "similarity": 0.95}]
     )
     sc.update_entity = AsyncMock(
-        side_effect=lambda eid, data: {**existing_entity, **data}
+        side_effect=lambda eid, tenant_id, data: {**existing_entity, **data}
     )
     sc.create_entity = AsyncMock()
 
@@ -202,7 +202,10 @@ async def test_upsert_preserves_canonical_when_longer_alternative_arrives() -> N
         )
 
     sc.update_entity.assert_called_once()
-    _, update_data = sc.update_entity.call_args.args
+    _, update_tenant, update_data = sc.update_entity.call_args.args
+    # The merge is scoped to the caller's tenant (#1081): storage rejects a
+    # by-id PATCH that doesn't name the row's home tenant.
+    assert update_tenant == "t-a5"
     assert update_data["canonical_name"] == "globex", (
         f"First-seen canonical must be preserved; the longer 'globex industries' "
         f"was promoted, producing {update_data['canonical_name']!r}"
@@ -243,7 +246,7 @@ async def test_upsert_preserves_canonical_when_shorter_alternative_arrives() -> 
         return_value=[{**existing_entity, "similarity": 0.95}]
     )
     sc.update_entity = AsyncMock(
-        side_effect=lambda eid, data: {**existing_entity, **data}
+        side_effect=lambda eid, tenant_id, data: {**existing_entity, **data}
     )
     sc.create_entity = AsyncMock()
 
@@ -253,7 +256,8 @@ async def test_upsert_preserves_canonical_when_shorter_alternative_arrives() -> 
             name_embedding=[0.1] * 1536,
         )
 
-    _, update_data = sc.update_entity.call_args.args
+    _, update_tenant, update_data = sc.update_entity.call_args.args
+    assert update_tenant == "t-a5"
     assert update_data["canonical_name"] == "globex industries", (
         "Symmetric case: first-seen 'globex industries' must remain canonical"
     )


### PR DESCRIPTION
Closes #1081.

`PATCH /entities/{entity_id}` took a bare UUID and `entity_update` fetched by primary key, so a caller who knew an id could rewrite another tenant's entity through a service that authenticates nothing (GHSA-wgvw-28pq-jc36). This is the write form of the read hole fixed in #1075.

### The fix

The route takes `tenant_id` in the body and removes it before the rest becomes the patch — the shape `PATCH /memories/{memory_id}` already uses — and `entity_update` carries the predicate into its fetch, matching the one `entity_bulk_upsert`'s update branch already had. A foreign id and a missing one both answer 404, so the endpoint is not an existence oracle for entity UUIDs.

### Scoping the fetch alone would not have closed it

The body loop was `if hasattr(entity, key): setattr(entity, key, value)`, which reaches every mapped column. A predicate is worth exactly as much as the immutability of the column it filters on, and this one filtered on a column the same request could rewrite. Both holes are demonstrated, not inferred — against unmodified `main`:

| request | before |
|---|---|
| `PATCH` another tenant's entity | `200`, victim's row rewritten |
| `PATCH {"tenant_id": victim}` on your own row | `200`, row now in the victim's namespace |
| `PATCH {"id": <chosen>}` | `200`, old id `404`s, row lives at the caller's id |

Writable columns are now `_ENTITY_UPDATABLE_FIELDS`. It is enforced in the service rather than the router because `entity_bulk_upsert` reaches this method without passing through a route; a router-side filter would have left that path on the old behaviour.

### What the tests can and cannot pin

Two independent mechanisms block the tenant case: the route's removal of the key, and the allowlist. I checked this rather than assuming — widening the allowlist to include `tenant_id` leaves the suite green, and so does replacing the removal with a plain read. Either alone closes it, so **no route-level test can isolate one**, and I've said so in the module docstring rather than letting a test's name imply coverage it doesn't have. The primary key is the case reachable through the allowlist alone, and `test_scope_columns_are_not_caller_writable` pins that.

4 of the 5 tests fail on the parent commit. The fifth is the happy-path regression guard, which should pass either way.

### Follow-up filed, not fixed here

`memory_update` has a correct tenant predicate and the same primary-key hole — `PATCH /memories/{memory_id}` with `{"id": <chosen>}` returns 200, the old id 404s, and the row lives at the caller's id. Verified on `main` and filed as #1118 rather than folded in: different route, different issue.

That issue also raises a question worth your call — the gate checks tenant binding only, so neither that hole nor a regression of this one would be caught. Whether scope-column writability belongs in the gate is a design decision, not a fix I should make unilaterally.

### Gate

Both allowlist entries deleted; ratchet holds. `id-addressed-write` 16 → 14, total 114 → 112, bound-to-tenant 268 → 270.

### Verification

Storage suite 228 passed; root suite 5692 passed / 4 skipped / 1 xfailed, zero failures. ruff check + `format --check` clean at all six CI scopes (0.16.5). mypy clean across core-api (203), core-storage-api (85), core-operations (5), core-worker (11), common (99), scripts (31). Rebased onto `e3973266` and re-run there. `uv.lock` unchanged across all four lockfiles.
