### PR TITLE
fix(memory): keep identity and scope columns out of the by-id patch

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -327,6 +327,32 @@ _MEMORY_VALID_FIELDS = frozenset(
     {c.key for c in Memory.__table__.columns} | {a.key for a in Memory.__mapper__.column_attrs}
 )
 
+# Columns a caller may never rewrite on an existing memory. All four are
+# legitimately SET on insert, so ``_filter_memory_fields`` keeps using the full
+# set above; it is the by-id patch that must not reach them.
+#
+#   id             identity — the reported defect (#1118)
+#   tenant_id      scope
+#   fleet_id       scope
+#   search_vector  trigger-maintained, and the trigger is
+#                  ``BEFORE INSERT OR UPDATE OF content, title`` (migration
+#                  034), so a patch naming ONLY this column does not fire it:
+#                  the caller's tsvector persists verbatim and the row leaves
+#                  keyword recall with no content change to explain it.
+#
+# Same four classes ``_ENTITY_UPDATABLE_FIELDS`` below excludes by listing what
+# it admits.
+_MEMORY_IMMUTABLE_FIELDS = frozenset({"id", "tenant_id", "fleet_id", "search_vector"})
+
+# Columns ``memory_update`` may write. A subtraction rather than the explicit
+# list the entity set uses, because ``Memory`` has 34 columns and many writers
+# (the public ``MemoryUpdate`` surface, core-worker's re-embed, governance
+# remediation, enrichment, the TESTING-gated time-warp route): an allowlist
+# assembled by inspection would be a guess, and a wrong guess silently drops a
+# production write. Entity's is four columns and two callers, so it can be
+# enumerated exactly. Both arrive at the same guarantee.
+_MEMORY_UPDATABLE_FIELDS = _MEMORY_VALID_FIELDS - _MEMORY_IMMUTABLE_FIELDS
+
 # Columns ``entity_update`` may write. Deliberately a subset, not
 # ``Entity.__table__.columns`` the way ``_MEMORY_VALID_FIELDS`` above is: the
 # previous ``hasattr(entity, key)`` test admitted every mapped column, so a
@@ -334,9 +360,8 @@ _MEMORY_VALID_FIELDS = frozenset(
 # row's primary key. ``tenant_id`` and ``fleet_id`` are scope rather than
 # content and no caller writes them; ``search_vector`` is trigger-maintained.
 # Keys outside the set are dropped silently rather than rejected: this service
-# validates request shape upstream in core-api, not here. ``memory_update``
-# drops unlisted keys the same way but still tests ``hasattr(Memory, key)``
-# rather than an allowlist, so its primary key is still writable — #1118.
+# validates request shape upstream in core-api, not here — the same contract
+# ``_MEMORY_UPDATABLE_FIELDS`` above follows.
 _ENTITY_UPDATABLE_FIELDS = frozenset({"canonical_name", "entity_type", "attributes", "name_embedding"})
 
 # Columns the admin memory-list endpoint may sort by. Allowlisted so an
@@ -1044,12 +1069,12 @@ class PostgresService:
         wasn't enough on its own under READ COMMITTED.
         """
         metadata_patch = patch.get("metadata_patch") if isinstance(patch, dict) else None
-        # Map JSON keys to model columns. ``metadata_patch`` is handled
-        # via a separate JSONB-merge statement below; skip it here so it
-        # doesn't accidentally land as a column write.
-        values: dict = {
-            key: val for key, val in patch.items() if key != "metadata_patch" and hasattr(Memory, key)
-        }
+        # Map JSON keys to model columns. ``_MEMORY_UPDATABLE_FIELDS`` rather
+        # than ``hasattr(Memory, key)``, which was true of ``id`` — see the
+        # constant. The synthetic ``metadata_patch`` key needs no explicit
+        # exclusion here: it is not a column, so the set already drops it, and
+        # the JSONB-merge statement below is what consumes it.
+        values: dict = {key: val for key, val in patch.items() if key in _MEMORY_UPDATABLE_FIELDS}
         # Embedding provenance, derived here rather than at every call site.
         # A patch that rewrites ``content`` carries the new ``content_hash``
         # and the re-embedded vector together (see ``update_memory``), so the

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -299,7 +299,7 @@ class TestMemories:
            the cast is a no-op on already-jsonb columns so the test
            still validates the corrected SQL shape.
         2. ``metadata_patch`` is a SYNTHETIC key — the body's other
-           top-level fields hit ``hasattr(Memory, key)`` and become
+           top-level fields pass ``_MEMORY_UPDATABLE_FIELDS`` and become
            ``UPDATE ... SET <col>``. Locks that the worker's PATCH
            shape ``{"embedding": ..., "metadata_patch": {...}}``
            applies BOTH branches in the same transaction.

--- a/core-storage-api/tests/test_memory_update_immutable_columns.py
+++ b/core-storage-api/tests/test_memory_update_immutable_columns.py
@@ -1,0 +1,190 @@
+"""``memory_update`` must not let the caller rewrite the row's identity columns.
+
+``memory_update``'s tenant predicate is correct and has been for a while: every
+statement carries ``Memory.tenant_id == tenant_id``. What it did not have was
+any restriction on *which* columns the patch could set --- ``values`` was built
+with ``hasattr(Memory, key)``, which is true of ``id`` and ``tenant_id``. The
+statement then became ``UPDATE memories SET id = <caller's choice> WHERE
+id = :memory_id AND tenant_id = :tenant_id``: the predicate is satisfied, and
+the row's primary key is rewritten to a value the caller picked. Every
+``memory_entity_links`` row, ``supersedes_id`` reference, and client-held id
+still points at the old value.
+
+A scoped predicate is worth exactly as much as the immutability of the column
+it filters on. This is the same defect that was closed on the entity side in
+caura-ai/caura#1119, found while fixing #1081, and filed from there as #1118.
+``_MEMORY_UPDATABLE_FIELDS`` carries the reasoning for the writable set and for
+why it is derived by subtraction rather than listed like the entity one.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+import core_storage_api.services.postgres_service as ps
+from common.models import Memory
+from core_storage_api.services.postgres_service import PostgresService, get_session
+from tests.test_integration import PREFIX
+
+# Deliberately NOT a module-level ``asyncio`` mark: the schema-drift guard at
+# the bottom is a plain sync ``def``, and a module-level mark would flag it.
+# Same reason ``tests/test_patch_null_non_nullable.py`` keeps its module clean.
+
+
+async def _memory(client: AsyncClient, tenant_id: str, content: str = "canary") -> str:
+    resp = await client.post(
+        f"{PREFIX}/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "immutable-tester",
+            "content": f"{content} {uuid.uuid4()}",
+            "memory_type": "fact",
+            "weight": 0.5,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+@pytest.mark.asyncio
+class TestMemoryUpdateImmutableColumns:
+    async def test_the_primary_key_is_not_caller_writable(self, client: AsyncClient) -> None:
+        """The reported defect, stated as the request that exercised it.
+
+        Before: 200, the old id 404s, and the row answers at ``stolen``.
+        """
+        tenant = f"imm-{uuid.uuid4().hex[:8]}"
+        memory_id = await _memory(client, tenant)
+        stolen = str(uuid.uuid4())
+
+        resp = await client.patch(
+            f"{PREFIX}/memories/{memory_id}",
+            json={"tenant_id": tenant, "id": stolen, "title": "kept"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        still_there = await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant})
+        assert still_there.status_code == 200, "the row was moved off its primary key"
+        assert still_there.json()["id"] == memory_id
+        # The writable field in the same body still applied, so the unlisted key
+        # was dropped rather than the whole patch being rejected.
+        assert still_there.json()["title"] == "kept"
+        moved = await client.get(f"{PREFIX}/memories/{stolen}", params={"tenant_id": tenant})
+        assert moved.status_code == 404
+
+    async def test_the_row_cannot_be_moved_to_another_tenant(self, client: AsyncClient) -> None:
+        """Driven at the service, because the route pops ``tenant_id`` first.
+
+        ``PATCH /memories/{memory_id}`` takes the tenant from the body and
+        removes it before the rest becomes the patch, so over HTTP this key can
+        never reach the column set. ``memory_update`` is a public service method
+        that a future route could call without that pop, which is what this
+        pins --- and what makes the exclusion more than decoration.
+        """
+        svc = PostgresService()
+        owner = f"imm-owner-{uuid.uuid4().hex[:8]}"
+        other = f"imm-other-{uuid.uuid4().hex[:8]}"
+        memory_id = uuid.UUID(await _memory(client, owner))
+
+        applied = await svc.memory_update(memory_id, owner, {"tenant_id": other, "title": "kept"})
+
+        assert applied is True
+        row = await svc.memory_get_by_id_for_tenant(memory_id, owner)
+        assert row is not None, "the row was handed to another tenant"
+        assert row.tenant_id == owner
+        assert row.title == "kept"
+
+    async def test_the_search_vector_is_not_caller_writable(self, client: AsyncClient) -> None:
+        """Writing the vector alone evades the trigger and erases keyword recall.
+
+        ``memories_search_vector_trigger`` is ``BEFORE INSERT OR UPDATE OF
+        content, title``, so a patch naming only ``search_vector`` never fires
+        it and the caller's value is what persists. Before this change that
+        returned 200 and the row silently stopped matching its own content ---
+        no content change, nothing in the row to explain the disappearance.
+        """
+        tenant = f"imm-{uuid.uuid4().hex[:8]}"
+        word = f"zebrafish{uuid.uuid4().hex[:6]}"
+        memory_id = await _memory(client, tenant, content=f"the {word} swims")
+
+        resp = await client.patch(
+            f"{PREFIX}/memories/{memory_id}",
+            json={"tenant_id": tenant, "search_vector": ""},
+        )
+
+        assert resp.status_code == 200, resp.text
+        async with get_session() as session:
+            hit = (
+                await session.execute(
+                    text(
+                        "SELECT count(*) FROM memories "
+                        "WHERE id = :i AND search_vector @@ plainto_tsquery('english', :w)"
+                    ),
+                    {"i": memory_id, "w": word},
+                )
+            ).scalar_one()
+        assert hit == 1, "the row was dropped from keyword recall by a patch that changed no content"
+
+    async def test_the_fleet_scope_is_not_caller_writable(self, client: AsyncClient) -> None:
+        """``fleet_id`` is scope, not content, and no caller patches it."""
+        tenant = f"imm-{uuid.uuid4().hex[:8]}"
+        memory_id = await _memory(client, tenant)
+
+        resp = await client.patch(
+            f"{PREFIX}/memories/{memory_id}",
+            json={"tenant_id": tenant, "fleet_id": "attacker-fleet", "title": "kept"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        row = (await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant})).json()
+        assert row["fleet_id"] != "attacker-fleet", "the memory was moved between fleet scopes"
+        assert row["title"] == "kept"
+
+    async def test_a_normal_patch_still_applies(self, client: AsyncClient) -> None:
+        """Regression guard: narrowing the writable set must not drop real writes."""
+        tenant = f"imm-{uuid.uuid4().hex[:8]}"
+        memory_id = await _memory(client, tenant)
+
+        resp = await client.patch(
+            f"{PREFIX}/memories/{memory_id}",
+            json={
+                "tenant_id": tenant,
+                "title": "retitled",
+                "weight": 0.9,
+                "memory_type": "preference",
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = (await client.get(f"{PREFIX}/memories/{memory_id}", params={"tenant_id": tenant})).json()
+        assert body["title"] == "retitled"
+        assert body["weight"] == 0.9
+        assert body["memory_type"] == "preference"
+
+
+def test_no_identity_column_is_writable() -> None:
+    """Schema-drift guard: a new identity-ish column must not arrive writable.
+
+    Asserts against ``_MEMORY_UPDATABLE_FIELDS`` --- the set ``memory_update``
+    actually reads --- rather than the exclusion list, so it stays honest if the
+    two ever stop lining up. Derived from the model, so widening the primary key
+    or renaming a column fails here rather than in production.
+
+    Reached through the module object: the attribute lookup happens at call
+    time, so this file still *collects* against a commit where the constant does
+    not exist yet, which keeps the fails-on-parent check readable as one failing
+    test rather than an uncollectible module.
+    """
+    updatable = ps._MEMORY_UPDATABLE_FIELDS
+    pk = {c.key for c in Memory.__table__.primary_key.columns}
+    assert pk.isdisjoint(updatable), f"primary key {pk & updatable} is caller-writable"
+    assert updatable.isdisjoint({"tenant_id", "fleet_id"}), "a scope column is caller-writable"
+    assert "search_vector" not in updatable, "the trigger-maintained vector is caller-writable"
+    assert ps._MEMORY_IMMUTABLE_FIELDS <= ps._MEMORY_VALID_FIELDS, (
+        "an immutable name that is not a real column protects nothing: "
+        f"stale={sorted(ps._MEMORY_IMMUTABLE_FIELDS - ps._MEMORY_VALID_FIELDS)}"
+    )

--- a/core-worker/src/core_worker/clients/storage_client.py
+++ b/core-worker/src/core_worker/clients/storage_client.py
@@ -498,7 +498,7 @@ async def update_memory_enrichment(
     pre-validated dict of column→value pairs the consumer wants to write
     (memory_type, weight, title, summary, tags, status, ts_valid_*,
     contains_pii, pii_types, retrieval_hint). The storage-side
-    ``memory_update`` filters by ``hasattr(Memory, key)`` so unknown keys
+    ``memory_update`` filters by ``_MEMORY_UPDATABLE_FIELDS`` so unknown keys
     are silently dropped — caller still validates upstream against
     ``EnrichmentResult`` so a typo surfaces as a Pydantic error, not a
     silent no-op.

--- a/core-worker/src/core_worker/consumer.py
+++ b/core-worker/src/core_worker/consumer.py
@@ -330,7 +330,7 @@ _ENRICHMENT_ALWAYS_WRITE_METADATA: frozenset[str] = frozenset(
 )
 
 # Defence-in-depth: a typo in the tuples above would silently drop in
-# the storage layer's ``hasattr(Memory, key)`` filter, *and* a future
+# the storage layer's ``_MEMORY_UPDATABLE_FIELDS`` filter, *and* a future
 # ``EnrichmentResult`` field that no one wires to a routing tuple
 # would silently fall on the floor. Catch both at module import.
 _unrouted = (


### PR DESCRIPTION
Closes #1118.

`memory_update`'s tenant predicate was already correct — every statement carries `Memory.tenant_id == tenant_id`. What it lacked was any restriction on *which* columns the patch could set: `values` was built with `hasattr(Memory, key)`, which is true of `id`. The statement became `UPDATE memories SET id = <caller's choice> WHERE id = :memory_id AND tenant_id = :tenant_id` — predicate satisfied, primary key rewritten. Same defect closed for entities in #1119.

### Two more columns were reachable the same way

Both were found by checking this fix against the exclusions the entity one already made, and both are demonstrated against unmodified `main`:

| patch | before |
|---|---|
| `{"id": <chosen>}` | `200`; old id `404`s, row answers at the caller's id |
| `{"fleet_id": "attacker-fleet"}` | `200`; memory moved between fleet scopes by a *content* endpoint |
| `{"search_vector": ""}` | `200`; vector wiped, **row stops matching its own content** |

The `search_vector` case is the one I'd flag. The trigger is `BEFORE INSERT OR UPDATE OF content, title` (migration 034), so a patch naming *only* that column never fires it and the caller's value persists verbatim. The row silently leaves keyword recall with no content change to explain it. `test_the_search_vector_is_not_caller_writable` asserts through an actual `plainto_tsquery` match, not just the column value.

### Why this is a subtraction and the entity fix was a list

`Memory` has 34 columns and many writers (public `MemoryUpdate`, core-worker's re-embed, governance remediation, enrichment, the TESTING-gated time-warp route). An allowlist assembled by inspection would be a guess there, and a wrong guess silently drops a production write — the SAFE-01 failure mode. Entity's is four columns and two callers, so it can be enumerated exactly. Both arrive at the same guarantee.

To make "nothing else narrows" a measurement rather than a claim, I instrumented `memory_update` and recorded every patch key both suites issue (5,922 tests): 12 distinct keys, none of them the four now excluded. The insert path keeps the full `_MEMORY_VALID_FIELDS`, where all four are legitimately set.

### Test honesty

Each exclusion was verified **load-bearing** by re-admitting it and watching the row move — the sabotage that a prior round of review showed is the only way to catch a test that pins something other than what it claims. `test_the_row_cannot_be_moved_to_another_tenant` is driven at the service deliberately: the route pops `tenant_id`, so over HTTP that key cannot reach the column set, and a route-level test would have proved nothing. 5 of 6 tests fail on the parent commit; the sixth is the regression guard.

### One flake, disclosed

`tests/test_unknown_field_rejection.py::test_memory_update_rejects_unknown_field` failed on 2 of 6 full root-suite runs here and has since passed 5 consecutive times, including post-rebase. It is not caused by this change, and that is checkable rather than asserted: it patches `{"weightt": 0.9}`, and `hasattr(Memory, "weightt")` and `"weightt" in _MEMORY_UPDATABLE_FIELDS` are **both** `False` — old and new filters produce an identical empty `values` for that input. This change alters the treatment of exactly five keys: `id`, `tenant_id`, `fleet_id`, `search_vector`, `registry`. The test is on the known-flaky list for this local environment.

### Follow-up filed, not fixed here

#1121 — `fleet_upsert_node` is the third instance of this class: `set_={k: v for k, v in values.items() if k not in ("tenant_id", "node_name")}` omits `id`, and the route passes `await request.json()` in unfiltered. Verified: a second POST for the same `(tenant_id, node_name)` repoints the node's primary key, stranding every `FleetCommand.node_id` that referenced it.

That makes three methods and three shapes — explicit allowlist, derived denylist, inline literal tuple. It sharpens the question from #1119: the gate checks tenant binding only, so it saw none of these. A runtime assertion in `scripts/tenant_scope_gate.py` — every writable-column set disjoint from its model's primary key and scope columns — would have caught all three, and the gate already enumerates `_public_methods(PostgresService)` for its widening-grant check. Your call; I haven't touched the gate.

### Verification

Storage 234 passed; root 5694 passed / 4 skipped / 1 xfailed, zero failures; core-worker 80 passed. ruff check + `format --check` clean at all six CI scopes. mypy clean across core-api (203), core-storage-api (85), core-operations (5), core-worker (11), common (99), scripts (31). Gate exit 0, allowlist untouched — `memory_update` was already tenant-bound, which is precisely why this hole was invisible to it. Rebased onto `448bde05` and re-run there. `uv.lock` unchanged across all four lockfiles.
