### PR TITLE
fix(agent): bind search-profile reset to tenant

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/agents.py
+++ b/core-storage-api/src/core_storage_api/routers/agents.py
@@ -85,10 +85,11 @@ async def get_search_profile(agent_id: str, tenant_id: str) -> dict:
 @router.post("/{agent_id}/search-profile/reset")
 async def reset_search_profile(agent_id: str, request: Request) -> dict:
     body: dict = await request.json()
-    agent = await _svc.agent_get_by_id(agent_id, body["tenant_id"])
+    tenant_id = body["tenant_id"]
+    agent = await _svc.agent_get_by_id(agent_id, tenant_id)
     if agent is None:
         raise HTTPException(status_code=404, detail="Agent not found")
-    await _svc.agent_reset_search_profile(agent.id)
+    await _svc.agent_reset_search_profile(agent.id, tenant_id=tenant_id)
     return {"ok": True}
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -7023,11 +7023,18 @@ class PostgresService:
     async def agent_reset_search_profile(
         self,
         agent_id_pk: object,
+        *,
+        tenant_id: str,
     ) -> None:
-        """Clear an agent's search_profile by primary key (Agent.id)."""
+        """Clear one tenant's agent search profile by primary key."""
         async with get_session() as session:
             await session.execute(
-                sql_update(Agent).where(Agent.id == agent_id_pk).values(search_profile=None)
+                sql_update(Agent)
+                .where(
+                    Agent.id == agent_id_pk,
+                    Agent.tenant_id == tenant_id,
+                )
+                .values(search_profile=None)
             )
 
     async def agent_backfill_from_memories(self) -> int:

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -32,13 +32,6 @@
       "category": "cross-tenant-by-design"
     },
     {
-      "id": "method:agent_reset_search_profile",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1089."
-    },
-    {
       "id": "method:agent_update_search_profile",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",

--- a/core-storage-api/tests/test_agent_reset_search_profile_tenant_scope.py
+++ b/core-storage-api/tests/test_agent_reset_search_profile_tenant_scope.py
@@ -1,0 +1,61 @@
+"""``agent_reset_search_profile`` must bind its primary-key update to a tenant.
+
+The HTTP route already looked the agent up within the caller's tenant before
+resetting it.  This is defence-in-depth for the service method itself: the
+query must remain safe when a future caller does not repeat that lookup.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from core_storage_api.services.postgres_service import PostgresService
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def _agent(client: AsyncClient, tenant_id: str, profile: dict) -> tuple[str, str]:
+    logical_id = f"agent-{uuid.uuid4().hex[:8]}"
+    response = await client.post(
+        f"{PREFIX}/agents",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": logical_id,
+            "search_profile": profile,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"], logical_id
+
+
+async def _profile(client: AsyncClient, tenant_id: str, agent_id: str) -> dict | None:
+    response = await client.get(
+        f"{PREFIX}/agents/{agent_id}/search-profile",
+        params={"tenant_id": tenant_id},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["search_profile"]
+
+
+class TestAgentResetSearchProfileTenantScope:
+    async def test_service_does_not_reset_another_tenants_profile(self, client: AsyncClient) -> None:
+        victim = f"reset-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"reset-attacker-{uuid.uuid4().hex[:8]}"
+        profile = {"min_similarity": 0.61}
+        agent_pk, agent_id = await _agent(client, victim, profile)
+
+        await PostgresService().agent_reset_search_profile(agent_pk, tenant_id=attacker)
+
+        assert await _profile(client, victim, agent_id) == profile
+
+    async def test_service_resets_own_tenants_profile(self, client: AsyncClient) -> None:
+        tenant = f"reset-{uuid.uuid4().hex[:8]}"
+        agent_pk, agent_id = await _agent(client, tenant, {"min_similarity": 0.58})
+
+        await PostgresService().agent_reset_search_profile(agent_pk, tenant_id=tenant)
+
+        assert await _profile(client, tenant, agent_id) is None


### PR DESCRIPTION
## Summary

- bind `agent_reset_search_profile` to the caller's tenant in the SQL `WHERE`
- pass the same tenant used by the route's existing scoped lookup into the service method
- add a cross-tenant regression test and a positive same-tenant test
- remove the resolved `method:agent_reset_search_profile` allowlist entry

## Security posture

This is defence-in-depth, not a live cross-tenant hole through the current route. Its one current caller was already safe because it performs a tenant-scoped lookup and returns 404 before calling the reset method. This change moves that guarantee into the update query so the method is safe for its next caller too.

The update has a fixed `SET search_profile = NULL`; it does not build its assignment set from caller-controlled fields, so there is no identity-column repoint path in this method.

The measured tenant-scope allowlist total shrinks from 112 to 111. After #1125 landed, base `main` has 35 `opaque-body-write` entries with notes and four entries recategorized into `id-addressed-write`; this PR preserves those fields and removes only `method:agent_reset_search_profile`.

## Fails without the fix

With only the new `Agent.tenant_id == tenant_id` predicate removed, the regression test fails as follows:

```text
FAILED core-storage-api/tests/test_agent_reset_search_profile_tenant_scope.py::TestAgentResetSearchProfileTenantScope::test_service_does_not_reset_another_tenants_profile
E   AssertionError: assert None == {'min_similarity': 0.61}
1 failed in 0.42s
```

## Verification

- focused regression: `2 passed`
- full core-storage-api integration suite: `236 passed`
- full root suite: `5694 passed, 4 skipped, 16 deselected, 1 xfailed`
- Ruff check and format check: passed
- core-storage-api mypy: `Success: no issues found in 85 source files`
- tenant-scope gate: `271 bound to a tenant, 111 allowlisted`; against the rebased #1125 base, `id-addressed-write` shrinks from 18 to 17 and `opaque-body-write` remains 35

Closes #1089
