### PR TITLE
fix(fleet): keep the primary key out of the node upsert's conflict path

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -364,6 +364,22 @@ _MEMORY_UPDATABLE_FIELDS = _MEMORY_VALID_FIELDS - _MEMORY_IMMUTABLE_FIELDS
 # ``_MEMORY_UPDATABLE_FIELDS`` above follows.
 _ENTITY_UPDATABLE_FIELDS = frozenset({"canonical_name", "entity_type", "attributes", "name_embedding"})
 
+# Columns ``fleet_upsert_node``'s ON CONFLICT DO UPDATE must not rewrite. The
+# insert half of that statement still uses every key the caller sent; this is
+# only the branch that lands on a row that already exists.
+#
+#   id                    identity — the reported defect (#1121)
+#   tenant_id, node_name  the conflict key itself; rewriting either half would
+#                         move the row out from under the constraint the
+#                         statement just matched on
+#
+# Named rather than the inline ``k not in ("tenant_id", "node_name")`` tuple it
+# replaces, so it reads like its two siblings above and a reviewer can see what
+# the omission was. Column names, not model attribute names: the statement is
+# built against ``_table(FleetNode)``, so ``values`` is keyed by column (which
+# is why ``extra`` arrives as ``metadata``).
+_FLEET_NODE_IMMUTABLE_FIELDS = frozenset({"id", "tenant_id", "node_name"})
+
 # Columns the admin memory-list endpoint may sort by. Allowlisted so an
 # unexpected ``sort`` value falls back to created_at instead of raising
 # AttributeError (500) at ``getattr(Memory, sort)`` — the endpoint is callable
@@ -8916,7 +8932,7 @@ class PostgresService:
             stmt = pg_insert(_table(FleetNode)).values(**values)
             stmt = stmt.on_conflict_do_update(  # type: ignore[assignment]
                 constraint="uq_fleet_nodes_tenant_node",
-                set_={k: v for k, v in values.items() if k not in ("tenant_id", "node_name")},
+                set_={k: v for k, v in values.items() if k not in _FLEET_NODE_IMMUTABLE_FIELDS},
             ).returning(FleetNode.__table__.c.id)
             result = await session.execute(stmt)
             await session.flush()

--- a/core-storage-api/tests/test_fleet_node_upsert_immutable_pk.py
+++ b/core-storage-api/tests/test_fleet_node_upsert_immutable_pk.py
@@ -1,0 +1,151 @@
+"""``POST /fleet/nodes`` must not let the caller choose an existing node's id.
+
+``fleet_upsert_node`` builds its ``ON CONFLICT DO UPDATE`` SET clause from the
+caller's dict with a denylist that named the conflict key but not the primary
+key::
+
+    set_={k: v for k, v in values.items() if k not in ("tenant_id", "node_name")}
+
+The route hands it ``await request.json()`` with no schema and no key filter, so
+``id`` reached the SET and a second POST for the same ``(tenant_id, node_name)``
+rewrote the row's primary key to whatever the caller named.
+
+Two outcomes, both pinned below, because they depend on whether anything
+references the node:
+
+* **No referencing commands** --- the repoint succeeds silently and the node's
+  identity becomes caller-controlled.
+* **A referencing command** --- ``FleetCommand.node_id`` is
+  ``ForeignKey("fleet_nodes.id", ondelete="CASCADE")`` with no ``onupdate``, so
+  ``NO ACTION`` applies and Postgres refuses. The ``ForeignKeyViolationError``
+  escapes as an unhandled ``IntegrityError``, which turns a routine heartbeat
+  upsert into a 500 the moment a command is queued for that node.
+
+Third instance of one class --- a caller-controlled dict becoming an
+``UPDATE ... SET`` with no restriction on identity columns. The others were
+``entity_update`` (#1119) and ``memory_update`` (#1122). Note this is not a
+tenant-scope hole: ``tenant_id`` was already excluded, which is exactly why the
+tenant-scope gate never saw it.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+import core_storage_api.services.postgres_service as ps
+from common.models import FleetNode
+from tests.test_integration import PREFIX
+
+# Deliberately NOT a module-level ``asyncio`` mark: the schema-drift guard at
+# the bottom is a plain sync ``def``, which such a mark would flag.
+
+
+async def _node(client: AsyncClient, tenant_id: str, node_name: str, **extra: object) -> dict:
+    resp = await client.post(
+        f"{PREFIX}/fleet/nodes",
+        json={
+            "tenant_id": tenant_id,
+            "fleet_id": "f1",
+            "node_name": node_name,
+            "hostname": "h1",
+            **extra,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+@pytest.mark.asyncio
+class TestFleetNodeUpsertImmutablePk:
+    async def test_the_primary_key_is_not_caller_writable(self, client: AsyncClient) -> None:
+        """The reported defect: a re-POST silently moved the node to a chosen id."""
+        tenant = f"fp-{uuid.uuid4().hex[:8]}"
+        name = f"node-{uuid.uuid4().hex[:6]}"
+        original = (await _node(client, tenant, name))["id"]
+        chosen = str(uuid.uuid4())
+
+        again = await client.post(
+            f"{PREFIX}/fleet/nodes",
+            json={
+                "tenant_id": tenant,
+                "fleet_id": "f1",
+                "node_name": name,
+                "hostname": "h2",
+                "id": chosen,
+            },
+        )
+
+        assert again.status_code == 200, again.text
+        assert again.json()["id"] == original, "the node was moved to the caller's id"
+        listed = await client.get(f"{PREFIX}/fleet/nodes", params={"tenant_id": tenant})
+        ids = {n["id"] for n in listed.json()}
+        assert original in ids
+        assert chosen not in ids
+
+    async def test_a_referencing_command_does_not_make_the_upsert_a_500(self, client: AsyncClient) -> None:
+        """The availability half: the FK refused, and the error was unhandled.
+
+        Once any command references the node, the old SET clause tried to move a
+        primary key the child row points at. ``NO ACTION`` blocks it and the
+        ``ForeignKeyViolationError`` propagated, so the heartbeat upsert 500'd
+        rather than ignoring a key it should never have honoured.
+        """
+        tenant = f"fp-{uuid.uuid4().hex[:8]}"
+        name = f"node-{uuid.uuid4().hex[:6]}"
+        node_id = (await _node(client, tenant, name))["id"]
+        queued = await client.post(
+            f"{PREFIX}/fleet/commands",
+            json={"tenant_id": tenant, "node_id": node_id, "command": "deploy", "payload": {}},
+        )
+        assert queued.status_code == 200, queued.text
+
+        again = await client.post(
+            f"{PREFIX}/fleet/nodes",
+            json={
+                "tenant_id": tenant,
+                "fleet_id": "f1",
+                "node_name": name,
+                "hostname": "h3",
+                "id": str(uuid.uuid4()),
+            },
+        )
+
+        assert again.status_code == 200, again.text
+        assert again.json()["id"] == node_id
+
+    async def test_a_normal_upsert_still_updates_the_node(self, client: AsyncClient) -> None:
+        """Regression guard: the conflict path must still apply real columns."""
+        tenant = f"fp-{uuid.uuid4().hex[:8]}"
+        name = f"node-{uuid.uuid4().hex[:6]}"
+        original = (await _node(client, tenant, name))["id"]
+
+        again = await _node(client, tenant, name, hostname="h2", ip="10.0.0.9")
+
+        assert again["id"] == original, "the upsert should match the existing row, not insert"
+        listed = (await client.get(f"{PREFIX}/fleet/nodes", params={"tenant_id": tenant})).json()
+        row = next(n for n in listed if n["id"] == original)
+        assert row["hostname"] == "h2"
+        assert row["ip"] == "10.0.0.9"
+
+
+def test_the_conflict_update_cannot_touch_identity_columns() -> None:
+    """Schema-drift guard, derived from the model rather than echoing the literal.
+
+    Reached through the module object so this file still *collects* against a
+    commit where the constant does not exist yet, which keeps the fails-on-parent
+    check readable as one failing test rather than an uncollectible module.
+    """
+    immutable = ps._FLEET_NODE_IMMUTABLE_FIELDS
+    pk = {c.key for c in FleetNode.__table__.primary_key.columns}
+    assert pk <= immutable, f"primary key {pk - immutable} is rewritable on conflict"
+    # The conflict target itself: rewriting either half would move the row out
+    # from under the constraint the statement just matched on.
+    conflict_key = {"tenant_id", "node_name"}
+    assert conflict_key <= immutable, f"conflict key {conflict_key - immutable} is rewritable"
+    columns = {c.key for c in FleetNode.__table__.columns}
+    assert immutable <= columns, (
+        f"an immutable name that is not a real column protects nothing: stale={sorted(immutable - columns)}"
+    )


### PR DESCRIPTION
Closes #1121.

`fleet_upsert_node` built its `ON CONFLICT DO UPDATE` SET clause from the caller's dict with a denylist that named the conflict key but not the primary key:

```python
set_={k: v for k, v in values.items() if k not in ("tenant_id", "node_name")}
```

The route hands it `await request.json()` with no schema and no key filter, so `id` reached the SET and a second POST for the same `(tenant_id, node_name)` rewrote the row's primary key to whatever the caller named.

### Two outcomes, and I had the harm wrong in the issue

Both verified against unmodified `main`:

| state of the node | before |
|---|---|
| no referencing commands | `200`; the row now answers at the caller's chosen UUID |
| a queued command | `ForeignKeyViolationError` escapes as an unhandled `IntegrityError` → **500** |

I originally wrote on #1121 that queued commands would be "stranded against the old value." That is wrong: `FleetCommand.node_id` is `ForeignKey("fleet_nodes.id", ondelete="CASCADE")` with no `onupdate`, so `NO ACTION` applies and Postgres refuses to orphan them. Nothing is stranded — instead a routine heartbeat upsert becomes a 500 the moment any command is queued for that node. The correction is [recorded on the issue](https://github.com/caura-ai/caura/issues/1121#issuecomment-5472107905) rather than edited into the description, so the original claim and its correction both stay visible. The fix is unchanged and closes both outcomes.

### Third instance of one class

After `entity_update` (#1119) and `memory_update` (#1122): a caller-controlled dict becoming an `UPDATE ... SET` with no restriction on identity columns. The inline tuple is now `_FLEET_NODE_IMMUTABLE_FIELDS`, sitting beside its two siblings so the three read alike and the omission is visible. Column names, not attribute names — the statement is built against `_table(FleetNode)`, which is why `extra` arrives as `metadata`.

**This is not a tenant-scope hole.** `tenant_id` was already excluded, so the tenant-scope gate never had anything to say — which is the same blind spot that hid #1122. Both allowlist entries are `opaque-body-write` and correctly stay: the fix changes column writability, not tenant binding. The allowlist is untouched by this PR.

### Tests

3 of 4 fail on the parent; the fourth is the regression guard proving the conflict path still applies real columns. The `id` exclusion was verified load-bearing by re-admitting it and watching the key move. The drift guard derives from `FleetNode.__table__.primary_key` rather than echoing the literal, and reaches the constant through the module object so the file still *collects* on a commit where it does not exist yet.

### A red run, and what it actually was

`tests/test_unknown_field_rejection.py::test_memory_update_rejects_unknown_field` failed intermittently during this work. It is **not** caused by this change, and this time that is a measurement rather than an inference: I ran four matched baseline runs with the change reverted on the same base, and it failed **1 of 4** there too. The captured traceback gives the mechanism — the test's *setup* POST is rejected `409 DUPLICATE_MEMORY / reason: semantic_similarity` against a memory left by an earlier test in the same run, so it never reaches the PATCH it is testing. Order-dependent accumulation in a shared test database, unrelated to fleet nodes. Worth its own issue if it keeps costing people time; I have not filed one.

### Verification

Storage suite 238 passed; root suite 5694 passed with the flake above as the only intermittent. ruff check + `format --check` clean at all six CI scopes. mypy clean across core-api (203), core-storage-api (85), core-operations (5), core-worker (11), common (99), scripts (31). Gate exit 0, allowlist unchanged. Rebased onto `24aea6c1` and re-run there. `uv.lock` unchanged across all four lockfiles.
