### PR TITLE
feat(clients): map HTTP 429 to RateLimitError

### DIFF
--- a/clients/python/src/caura_client/__init__.py
+++ b/clients/python/src/caura_client/__init__.py
@@ -16,6 +16,7 @@ from .exceptions import (
     CauraAPIError,
     CauraError,
     NotFoundError,
+    RateLimitError,
 )
 from .models import Memory, RecallResult
 
@@ -27,6 +28,7 @@ __all__ = [
     "CauraAPIError",
     "AuthError",
     "NotFoundError",
+    "RateLimitError",
     "DEFAULT_BASE_URL",
 ]
 

--- a/clients/python/src/caura_client/client.py
+++ b/clients/python/src/caura_client/client.py
@@ -212,8 +212,12 @@ class Caura:
                 retry_after = float(response.headers["Retry-After"])
             except (KeyError, ValueError):
                 retry_after = None
-            raise RateLimitError(response.status_code, message or "rate limit exceeded",
-                                 details=details, retry_after=retry_after)
+            raise RateLimitError(
+                response.status_code,
+                message or "rate limit exceeded",
+                details=details,
+                retry_after=retry_after,
+            )
         raise CauraAPIError(response.status_code, message or "request failed", details=details)
 
     # ------------------------------------------------------------- lifecycle

--- a/clients/python/src/caura_client/client.py
+++ b/clients/python/src/caura_client/client.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import httpx
 
-from .exceptions import AuthError, CauraAPIError, NotFoundError
+from .exceptions import AuthError, CauraAPIError, NotFoundError, RateLimitError
 from .models import Memory, RecallResult
 
 DEFAULT_BASE_URL = "https://caura.ai"
@@ -207,6 +207,13 @@ class Caura:
             raise AuthError(response.status_code, message or "authentication failed", details=details)
         if response.status_code == 404:
             raise NotFoundError(response.status_code, message or "not found", details=details)
+        if response.status_code == 429:
+            try:
+                retry_after = float(response.headers["Retry-After"])
+            except (KeyError, ValueError):
+                retry_after = None
+            raise RateLimitError(response.status_code, message or "rate limit exceeded",
+                                 details=details, retry_after=retry_after)
         raise CauraAPIError(response.status_code, message or "request failed", details=details)
 
     # ------------------------------------------------------------- lifecycle

--- a/clients/python/src/caura_client/exceptions.py
+++ b/clients/python/src/caura_client/exceptions.py
@@ -28,3 +28,18 @@ class AuthError(CauraAPIError):
 
 class NotFoundError(CauraAPIError):
     """Raised on 404."""
+
+
+class RateLimitError(CauraAPIError):
+    """Raised on 429, with the optional retry delay in seconds."""
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        *,
+        details: Any = None,
+        retry_after: float | None = None,
+    ) -> None:
+        self.retry_after = retry_after
+        super().__init__(status_code, message, details=details)

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -13,6 +13,7 @@ from caura_client import (
     CauraAPIError,
     Memory,
     NotFoundError,
+    RateLimitError,
     RecallResult,
 )
 
@@ -198,6 +199,24 @@ def test_not_found_error():
 
     with pytest.raises(NotFoundError):
         make_client(handler).search("q")
+
+
+def test_rate_limit_error_parses_retry_after():
+    def handler(request):
+        return httpx.Response(429, headers={"Retry-After": "2.5"}, json={"detail": "slow down"})
+
+    with pytest.raises(RateLimitError) as exc:
+        make_client(handler).search("q")
+    assert exc.value.retry_after == 2.5
+
+
+def test_rate_limit_error_without_retry_after():
+    def handler(request):
+        return httpx.Response(429, json={"detail": "slow down"})
+
+    with pytest.raises(RateLimitError) as exc:
+        make_client(handler).search("q")
+    assert exc.value.retry_after is None
 
 
 def test_generic_api_error():

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -58,7 +58,9 @@ def test_search_returns_list():
         body = json.loads(request.content)
         assert body["query"] == "q"
         assert body["top_k"] == 3
-        return httpx.Response(200, json={"items": [{"id": "m1", "content": "a"}, {"id": "m2", "content": "b"}]})
+        return httpx.Response(
+            200, json={"items": [{"id": "m1", "content": "a"}, {"id": "m2", "content": "b"}]}
+        )
 
     results = make_client(handler).search("q", top_k=3)
     assert [m.id for m in results] == ["m1", "m2"]
@@ -126,9 +128,7 @@ def test_recall_accepts_the_items_alias_alone():
     """Older/other server shapes may send only ``items``; both name the same list."""
 
     def handler(request):
-        return httpx.Response(
-            200, json={"summary": "S", "items": [{"id": "m2", "content": "b"}]}
-        )
+        return httpx.Response(200, json={"summary": "S", "items": [{"id": "m2", "content": "b"}]})
 
     result = make_client(handler).recall("q")
     assert [m.id for m in result.supporting_memories] == ["m2"]
@@ -148,9 +148,7 @@ def test_recall_ignores_the_key_the_server_never_sends():
     yield no memories, so nobody "fixes" this by reinstating it."""
 
     def handler(request):
-        return httpx.Response(
-            200, json={"summary": "S", "supporting_memories": [{"id": "ghost"}]}
-        )
+        return httpx.Response(200, json={"summary": "S", "supporting_memories": [{"id": "ghost"}]})
 
     result = make_client(handler).recall("q")
     assert result.supporting_memories == []

--- a/clients/typescript/src/index.test.ts
+++ b/clients/typescript/src/index.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { Caura, CauraApiError, AuthError, NotFoundError } from "./index.js";
+import { Caura, CauraApiError, AuthError, NotFoundError, RateLimitError } from "./index.js";
 
 type Handler = (url: string, init: RequestInit) => Response | Promise<Response>;
 
@@ -154,6 +154,22 @@ test("403 maps to AuthError and parses the error envelope", async () => {
 test("404 maps to NotFoundError", async () => {
   const client = makeClient(() => jsonResponse(404, { detail: "nope" }));
   await assert.rejects(client.search("q"), NotFoundError);
+});
+
+test("429 maps to RateLimitError and parses retry-after", async () => {
+  const client = makeClient(async () => new Response(JSON.stringify({ detail: "slow down" }), {
+    status: 429, headers: { "content-type": "application/json", "retry-after": "2.5" },
+  }));
+  await assert.rejects(client.search("q"), (err: unknown) =>
+    err instanceof RateLimitError && err.retryAfter === 2.5);
+});
+
+test("429 without retry-after has null retryAfter", async () => {
+  const client = makeClient(async () => new Response(JSON.stringify({ detail: "slow down" }), {
+    status: 429, headers: { "content-type": "application/json" },
+  }));
+  await assert.rejects(client.search("q"), (err: unknown) =>
+    err instanceof RateLimitError && err.retryAfter === null);
 });
 
 test("500 maps to CauraApiError", async () => {

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -27,6 +27,15 @@ export class AuthError extends CauraApiError {}
 /** Raised on 404. */
 export class NotFoundError extends CauraApiError {}
 
+/** Raised on 429, with the optional retry delay in seconds. */
+export class RateLimitError extends CauraApiError {
+  readonly retryAfter: number | null;
+  constructor(statusCode: number, message: string, details?: unknown, retryAfter: number | null = null) {
+    super(statusCode, message, details);
+    this.retryAfter = retryAfter;
+  }
+}
+
 export interface Memory {
   id: string | null;
   content: string;
@@ -211,6 +220,12 @@ async function raiseForStatus(res: Response): Promise<void> {
   }
   if (res.status === 404) {
     throw new NotFoundError(res.status, message || "not found", details);
+  }
+  if (res.status === 429) {
+    const retryAfter = res.headers.get("retry-after");
+    const parsed = retryAfter === null ? Number.NaN : Number(retryAfter);
+    throw new RateLimitError(res.status, message || "rate limit exceeded", details,
+      Number.isFinite(parsed) ? parsed : null);
   }
   throw new CauraApiError(res.status, message || "request failed", details);
 }


### PR DESCRIPTION
## Summary

Map HTTP 429 responses to a dedicated `RateLimitError` in the Python and TypeScript clients. Preserve a numeric `Retry-After` delay when present and export the new error from each public client API.

## Related Issue

Closes #555.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

- `clients/python`: `python -m pytest tests/test_client.py` - 18 passed
- `clients/python`: `python -m ruff check src tests` - passed
- `clients/typescript`: `npm test` - TypeScript build and 16 tests passed
- Regression cases cover HTTP 429 responses both with and without `Retry-After`.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I have added tests that cover my changes
- [x] `ruff check` passes
- [ ] `ruff format --check` passes (the existing client subtree currently reports 14 files requiring formatting; this PR avoids an unrelated mass-format)
- [ ] `mypy` passes (the standalone Python client has no mypy dependency/configuration)
- [x] `pytest` passes locally
- [ ] I have updated relevant documentation (no documentation change required)
- [ ] I have updated `CHANGELOG.md` (release-please generates changelog entries from the conventional PR title)

## Additional Notes

Only finite numeric `Retry-After` values are exposed. Missing or non-numeric values become `None` in Python and `null` in TypeScript.