### PR TITLE
test: isolate unknown-field rejection setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ def get_admin_headers() -> dict:
 
 
 def uid() -> str:
-    """Short unique suffix — for distinct content (409s) and distinct tenant ids."""
+    """Short unique suffix for exact-duplicate-safe content and tenant ids."""
     return uuid.uuid4().hex[:8]
 
 

--- a/tests/test_unknown_field_rejection.py
+++ b/tests/test_unknown_field_rejection.py
@@ -28,7 +28,6 @@ import pytest
 from tests.conftest import get_test_auth, new_tenant_id
 from tests.conftest import uid as _uid
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_unknown_field_rejection.py
+++ b/tests/test_unknown_field_rejection.py
@@ -25,8 +25,9 @@ Three things are pinned here, and the third matters as much as the first two:
 
 import pytest
 
-from tests.conftest import get_test_auth
+from tests.conftest import get_test_auth, new_tenant_id
 from tests.conftest import uid as _uid
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -105,7 +106,9 @@ async def test_memory_create_rejects_plausible_but_undeclared_field(client):
 
 async def test_memory_update_rejects_unknown_field(client):
     """PATCH /memories/{id} — a typo here is a silent 200 no-op."""
-    tenant_id, headers = get_test_auth()
+    # Use a sweep-visible tenant so semantic dedup from unrelated tests cannot
+    # reject this setup write before the PATCH assertion is reached.
+    tenant_id, headers = get_test_auth(new_tenant_id())
     created = await client.post(
         "/api/v1/memories",
         json={


### PR DESCRIPTION
## Summary

Use the repository's sweep-visible per-test tenant for the memory-update unknown-field regression setup, so semantic deduplication from unrelated tests cannot reject the setup POST before the PATCH assertion runs. Also correct the `uid()` helper docstring, which previously implied uniqueness protected against semantic duplicates.

## Related Issue

Closes #1137

## Testing

- `python -m compileall -q tests/conftest.py tests/test_unknown_field_rejection.py` (passed)
- `git diff --check` (passed)
- Targeted pytest, Ruff, and mypy could not be run locally because this Windows environment does not have `uv`, pytest, Ruff, mypy, or Docker installed; CI should provide the repository's Python 3.12/PostgreSQL test environment.

## Checklist

- [x] Focused change with regression-oriented test isolation
- [x] Uses `new_tenant_id()` so test rows remain covered by end-of-run cleanup
- [x] DCO sign-off included