### PR TITLE
fix(fleet): scope command deletion to tenant

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/fleet.py
+++ b/core-storage-api/src/core_storage_api/routers/fleet.py
@@ -114,7 +114,10 @@ async def delete_node(
         raise HTTPException(status_code=404, detail="Node not found")
     fleet_id = getattr(node, "fleet_id", None)
     if fleet_id:
-        await _svc.fleet_delete_commands_for_nodes(node_ids=[node_id])
+        await _svc.fleet_delete_commands_for_nodes(
+            tenant_id=tenant_id,
+            node_ids=[node_id],
+        )
     return {"ok": True}
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -9220,12 +9220,20 @@ class PostgresService:
     async def fleet_delete_commands_for_nodes(
         self,
         *,
+        tenant_id: str,
         node_ids: list[UUID],
     ) -> None:
         if not node_ids:
             return
         async with get_session() as session:
-            await session.execute(_table(FleetCommand).delete().where(FleetCommand.node_id.in_(node_ids)))
+            await session.execute(
+                _table(FleetCommand)
+                .delete()
+                .where(
+                    FleetCommand.tenant_id == tenant_id,
+                    FleetCommand.node_id.in_(node_ids),
+                )
+            )
 
     # ══════════════════════════════════════════════════════════════════════
     #  AUDIT

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -155,13 +155,6 @@
       "category": "id-addressed-read"
     },
     {
-      "id": "method:fleet_delete_commands_for_nodes",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1090."
-    },
-    {
       "id": "method:fleet_get_command_by_id",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",

--- a/core-storage-api/tests/test_fleet_command_delete_tenant_scope.py
+++ b/core-storage-api/tests/test_fleet_command_delete_tenant_scope.py
@@ -1,0 +1,82 @@
+"""``fleet_delete_commands_for_nodes`` must bind deletes to a tenant.
+
+The route already resolves a node within the caller's tenant before invoking
+the method. This is defence-in-depth for the service method: a future caller
+must not be able to delete another tenant's commands with a known node UUID.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from core_storage_api.services.postgres_service import PostgresService
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _new_tenant_id() -> str:
+    """Return a unique tenant id that matches the end-of-run sweep prefix."""
+    return f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+
+async def _node_and_command(client: AsyncClient, tenant_id: str) -> tuple[str, str, str]:
+    node_name = f"delete-node-{uuid.uuid4().hex[:8]}"
+    node = await client.post(
+        f"{PREFIX}/fleet/nodes",
+        json={
+            "tenant_id": tenant_id,
+            "fleet_id": "fleet-a",
+            "node_name": node_name,
+        },
+    )
+    assert node.status_code == 200, node.text
+
+    command = await client.post(
+        f"{PREFIX}/fleet/commands",
+        json={
+            "tenant_id": tenant_id,
+            "node_id": node.json()["id"],
+            "command": "deploy",
+            "status": "queued",
+        },
+    )
+    assert command.status_code == 200, command.text
+    return node.json()["id"], node_name, command.json()["id"]
+
+
+async def _command_ids(client: AsyncClient, tenant_id: str) -> set[str]:
+    response = await client.get(f"{PREFIX}/fleet/commands", params={"tenant_id": tenant_id})
+    assert response.status_code == 200, response.text
+    return {row["id"] for row in response.json()}
+
+
+class TestFleetCommandDeleteTenantScope:
+    async def test_service_deletes_only_the_callers_commands(self, client: AsyncClient) -> None:
+        caller = _new_tenant_id()
+        other = _new_tenant_id()
+        caller_node, _, caller_command = await _node_and_command(client, caller)
+        other_node, _, other_command = await _node_and_command(client, other)
+
+        await PostgresService().fleet_delete_commands_for_nodes(
+            tenant_id=caller,
+            node_ids=[uuid.UUID(caller_node), uuid.UUID(other_node)],
+        )
+
+        assert caller_command not in await _command_ids(client, caller)
+        assert other_command in await _command_ids(client, other)
+
+    async def test_route_passes_the_tenant_to_the_delete(self, client: AsyncClient) -> None:
+        tenant = _new_tenant_id()
+        _, node_name, command_id = await _node_and_command(client, tenant)
+
+        response = await client.delete(
+            f"{PREFIX}/fleet/nodes/{node_name}",
+            params={"tenant_id": tenant},
+        )
+
+        assert response.status_code == 200, response.text
+        assert command_id not in await _command_ids(client, tenant)


### PR DESCRIPTION
## Summary

- require `tenant_id` when deleting fleet commands by node id
- bind that tenant directly in the hard-delete predicate
- pass the route's already-resolved tenant into the service method
- add mixed-tenant service coverage and route-plumbing coverage
- remove the resolved `method:fleet_delete_commands_for_nodes` allowlist entry

## Security posture

This is defence-in-depth, not a live cross-tenant hole through the current route. Its one current caller already resolves the node within the caller's tenant before invoking the delete. The change moves that guarantee into the hard-delete query so a future service caller cannot delete another tenant's commands with known node UUIDs.

This path performs a fixed `DELETE`; it has no caller-controlled update field set or identity-column repoint shape.

Against current `main`, the tenant-scope allowlist shrinks from 111 to 110 and `id-addressed-write` shrinks from 17 to 16. All 35 annotated `opaque-body-write` entries are preserved. The four #1124 entity-link entries remain out of scope.

## Fails without the fix

With only `FleetCommand.tenant_id == tenant_id` removed from the delete predicate, the mixed-tenant regression fails because the foreign command is deleted:

```text
FAILED core-storage-api/tests/test_fleet_command_delete_tenant_scope.py::TestFleetCommandDeleteTenantScope::test_service_deletes_only_the_callers_commands
E       AssertionError: assert '44bccbd4-cc7e-4954-b65a-f1d4bf0c9c4e' in set()
1 failed in 0.57s
```

## Verification

- focused regression: `2 passed`
- full core-storage-api suite: `242 passed`
- full root suite: `5694 passed, 4 skipped, 16 deselected, 1 xfailed`
- Ruff check and format check: passed
- core-storage-api mypy: `Success: no issues found in 85 source files`
- tenant-scope gate: `272 bound to a tenant, 110 allowlisted`; `id-addressed-write` 17 → 16

Closes #1090
