### PR TITLE
docs(sunset): correct the Terraform floor and the ratchet's copy count

### DIFF
--- a/docs/plans/rebrand-sunset-plan.md
+++ b/docs/plans/rebrand-sunset-plan.md
@@ -100,12 +100,57 @@ not. Run it to see what is protected and why:
 python3 scripts/do_not_touch_sentinel.py --list
 ```
 
+### Expensive to move is not floor
+
+Environment Terraform is the standing counter-example. About 300 old-brand lines sit in
+the two deployment environment files, every review of this programme so far has called
+them floor, and **none of them is**. Neither file carries a floor marker today, and that
+is correct rather than an oversight.
+
+Of the staging file's 115 lines, **107 are Pub/Sub family names** — and those families
+are not in the same state as each other:
+
+| the line names a family that | lines | why it is not floor |
+| --- | ---: | --- |
+| has **already** flipped | 65 | the rename reached it; the name is behind the work, not beyond it |
+| has **not yet** flipped | 42 | live infrastructure, renamed when its family flips |
+
+A line whose family flipped last week is the opposite of permanent: it is outstanding
+work. Marking it stops it being counted and starts it being **trusted**, which is much
+the more expensive of the two mistakes — a floor marker is a claim that nobody will ever
+need to look again.
+
+So the test is not what a rename would cost. **It is whether a rename will ever happen.**
+Infrastructure is deferred because recreating a live resource is expensive; *deferred*
+and *never* are different words, and only the second one is floor.
+
 ---
 
 ## The two gates, and what each one misses
 
 Both are required checks. Neither is sufficient alone, and the gap between them is
 where the real risk lives.
+
+### The ratchet is eight copies, not one
+
+`scripts/legacy_name_ratchet.py` exists in **eight repositories**, and they are not the
+same file. By length they fall into four variants:
+
+| lines | copies |
+| ---: | --- |
+| 1,417 | three |
+| 1,418 | two |
+| 1,453 | two, including this repo |
+| 1,589 | one — it alone carries the generated-mirror exclusion |
+
+Two things follow. **A change to the gate is an eight-repo port**, not a one-line commit:
+a fix that lands in one copy is invisible in the other seven, and stays invisible,
+because nothing compares them. And **a total that adds counts from different repos is
+only sound if the instruments agree** — a 172-line spread is room for two copies to mean
+different things by the same number.
+
+Before quoting a cross-repo total, check that the copies agree on whatever it depends on.
+Before changing the gate, plan for eight.
 
 **`legacy_name_ratchet.py`** fails a PR when a file's old-brand count goes **up**. It
 stops the rename going backwards. It is *directional*, so a change that **deletes** an


### PR DESCRIPTION
## Summary

Two items the external review series has carried across multiple revisions, both already
settled by work in this programme, and **neither written down anywhere the series could
read**. Its revision 10 asks for one of them for the second time and proposes an action
that should not be taken.

Docs only. No code, no gate change, no behaviour.

## 1 — Environment Terraform is not floor

Every review so far has described roughly **300 old-brand lines** across the two deployment
environment files as floor, and revision 10 proposes marking them: *"300 lines, one PR, no
operational risk."*

**Zero of them are floor**, and neither file carries a floor marker today. Of the staging
file's 115 lines, **107 are Pub/Sub family names**, split by the state of the family they
name:

| the line names a family that | lines | families |
| --- | ---: | --- |
| has **already** flipped | **65** | lifecycle 54, security 7, fleet 4 |
| has **not yet** flipped | 42 | memory 24, org 11, audit 7 |

A line whose family flipped last week is the opposite of permanent — it is outstanding
work. **Marking it stops it being counted and starts it being trusted**, which is the more
expensive mistake: a floor marker is a claim that nobody need ever look again.

The operational risk is not in the PR. It is that the PR makes 300 lines invisible to the
instrument that would otherwise catch them.

## 2 — The ratchet is eight copies, not one

Revision 10 recommends consolidating "the three ratchets" and quotes drift of 159 and 191
lines. `scripts/legacy_name_ratchet.py` is in **eight repositories**, in **four variants**:

| lines | copies |
| ---: | --- |
| 1,417 | `caura-daemon`, `caura-onprem`, `caura-test-automation` |
| 1,418 | `caura-ops`, `caura-onprem-installer` |
| 1,453 | `caura`, `openclaw-fleet-tester` |
| 1,589 | `caura-enterprise` — the only copy with `GENERATED_MIRRORS`, verified absent from the other seven |

So a gate change is an eight-repo port, and a cross-repo total is only sound if the
instruments agree. The diagnosis was right; the scope was under half.

## What is deliberately NOT here

The series also carries `agent_id` as open across five releases, described as a
source-versus-image contradiction. **It is a documented deliberate design** —
`core-api/src/core_api/schemas.py:70-76`: optional at the schema layer, enforced in the
route for tenant-scoped and gateway callers, with the standalone single-tenant path filling
the reserved `"mcp-agent"` identity.

That is an API-design fact, not a rename rule, and this file's closing line asks it to earn
its place by being correct rather than complete. Adding it here would be bloat. Raising it
where the series can see it is the right route, and the code already says it.

## On the marker count

Both sections are written **without the old-brand literal**, so:

```
Change from origin/main: 0 added, 0 annotated, 0 removed, 0 excused moves (+0 net).
```

That was deliberate, and slightly awkward — this file cannot discuss the names it exists to
retire without either spending exemptions or writing around them. It is a small live
example of revision 10's own item 5, which notes this document is now the largest single
alias holder in the repo (3 markers to 39) and proposes excluding it in the rule.

## Verification

- `legacy_name_ratchet.py --report --base origin/main` → **0 added, 0 annotated, 0 removed, +0 net**
- `do_not_touch_sentinel.py` → **all 46 protected strings survive**
- `git diff --check` → clean
- No added old-brand literal: `git diff | grep -c '^+.*[Mm]em[Cc]law'` → **0**
- Markdown table pipe counts consistent; no markdown linter in CI
- DCO sign-off present. Docs-only, so no ruff/mypy scope is touched