### PR TITLE
feat(gate): check that a tenant predicate cannot be rewritten by its own request

### DIFF
--- a/scripts/tenant_scope_gate.py
+++ b/scripts/tenant_scope_gate.py
@@ -16,7 +16,7 @@ failure. It is a row belonging to somebody else.
 This makes the invariant checkable. It does NOT attempt to prove that any
 particular statement is correctly scoped: that is a semantic question, a gate
 that guesses at semantics produces false positives, and a security gate with
-false positives gets switched off. What it checks instead are three things that
+false positives gets switched off. What it checks instead are four things that
 are exactly decidable:
 
 1. **Completeness.** Every route and every public service method is enumerated
@@ -25,6 +25,19 @@ are exactly decidable:
    appear in the allowlist with a reason someone wrote and a reviewer read.
 3. **Direction.** The allowlist may shrink. It may not grow. A new unscoped
    path fails the build (``--base``).
+4. **Immutability of what the predicate filters on.** A statement bound to
+   ``WHERE tenant_id = :tenant`` is only as good as the caller's inability to
+   rewrite ``tenant_id`` — or the primary key — in the same request. Any method
+   building an ``UPDATE ... SET`` from a caller-controlled dict must filter the
+   keys through a named set, and that set must exclude the model's identity,
+   scope and database-maintained columns.
+
+Checks 1–3 were the whole gate for its first month, and three primary-key
+rewrites got through them: #1081, #1118 and #1121. Two of the three were
+correctly tenant-bound, so nothing in 1–3 had any objection to make — the
+statement satisfied its predicate and then moved the row out from under it.
+Check 4 is that gap, and it is why "bound to a tenant" is reported separately
+from "cannot be unbound by the same request".
 
 The semantics stay a human claim, as they must, but the claim is forced into the
 diff where review can see it, and the population it has to cover can only get
@@ -68,6 +81,7 @@ import json
 import re
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -142,6 +156,54 @@ FAIL_CLOSED_GUARDS = frozenset({"_require", "_require_dict", "_require_number"})
 # that must keep the scope out of a column update reads it that way, and it is
 # no less a read of the request for removing the key afterwards.
 DICT_READS = frozenset({"get", "pop"})
+
+# --- Identity-column writability: the write-side half of the same invariant ---
+#
+# A tenant predicate is worth exactly as much as the immutability of the column
+# it filters on. Three methods proved that in a week, and two of the three were
+# ALREADY passing the binding-scope checks above:
+#
+#   entity_update      (#1081/#1119)  ``if hasattr(entity, key): setattr(...)``
+#   memory_update      (#1118/#1122)  ``if hasattr(Memory, key)`` in a comprehension
+#   fleet_upsert_node  (#1121/#1129)  ``if k not in ("tenant_id", "node_name")``
+#
+# Each built an ``UPDATE ... SET`` from a caller-controlled dict, and each
+# admitted ``id``. The statement became ``SET id = <caller's choice> WHERE
+# id = :id AND tenant_id = :tenant``: predicate satisfied, primary key moved.
+# ``memory_update`` and ``fleet_upsert_node`` were correctly tenant-bound the
+# whole time, so nothing above had anything to say — the defect lives one layer
+# below where this gate was looking.
+#
+# ``IDENTITY_WRITE_GUARDS`` pairs each such method with the model it writes and
+# the constant that filters the caller's keys. ``admits`` records the polarity:
+# True for ``key in CONST`` (the constant lists what may be written), False for
+# ``key not in CONST`` (it lists what may not).
+IDENTITY_WRITE_GUARDS: dict[str, tuple[str, str, bool]] = {
+    "entity_update": ("Entity", "_ENTITY_UPDATABLE_FIELDS", True),
+    "memory_update": ("Memory", "_MEMORY_UPDATABLE_FIELDS", True),
+    "fleet_upsert_node": ("FleetNode", "_FLEET_NODE_IMMUTABLE_FIELDS", False),
+}
+
+# Column types a caller may never write because the database maintains them.
+# ``search_vector`` is the live case: its trigger fires ``BEFORE INSERT OR
+# UPDATE OF content, title``, so a patch naming only the vector does not fire it
+# and the caller's value persists — the row leaves keyword recall with no
+# content change to explain it (#1122). Matched on type rather than name, so a
+# second tsvector column is covered the day it is added.
+DERIVED_COLUMN_TYPES = frozenset({"TSVECTOR"})
+
+# What a ``.values(**…)`` chain has to hang off before it can move an existing
+# row. ``pg_insert(...).values(**data)`` is deliberately absent: naming the id of
+# a row you are creating collides rather than overwrites. Enumerated rather than
+# prefix-matched, for the reason ``FAIL_CLOSED_GUARDS`` gives — a set that
+# quietly grows to fit a new name is a set that stops meaning anything.
+UPDATE_STATEMENT_ROOTS = frozenset({"sql_update", "update"})
+
+# The statements that create rather than move a row. Named so that a chain
+# resolving to neither set is treated as an update: an unrecognised builder is
+# an unknown, and this check's stated bias is to report an unknown rather than
+# assume it is the harmless one.
+INSERT_STATEMENT_ROOTS = frozenset({"pg_insert", "insert"})
 
 # How much of a binding a verdict represents, so "weaker than" is a comparison
 # rather than a rule spelled out at each site. REQUIRED binds every call;
@@ -388,6 +450,453 @@ def _widening_grant_findings() -> list[Entry]:
                 )
             )
     return findings
+
+
+# ---------------------------------------------------------------------------
+# Identity-column writability
+# ---------------------------------------------------------------------------
+
+
+def _literal_keys(node: ast.expr | None) -> bool:
+    """Whether ``node`` is a collection of constant strings written in the source.
+
+    A loop over ``("fleet_id", "trust_level", …)`` cannot reach a column the
+    author did not type, so it is safe however the caller's dict is shaped —
+    ``agent_add`` is the live example. A loop over ``data.items()`` can reach any
+    key the caller sends, and that is the shape this check looks for.
+    """
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        return all(isinstance(e, ast.Constant) and isinstance(e.value, str) for e in node.elts)
+    if isinstance(node, ast.Dict):
+        return all(isinstance(k, ast.Constant) and isinstance(k.value, str) for k in node.keys)
+    return False
+
+
+def _walk_scope(node: ast.AST) -> Iterator[ast.AST]:
+    """Walk ``node``'s subtree without descending into a nested function scope.
+
+    A closure defined inside a method has its own locals, so an assignment to
+    ``values`` in there says nothing about the ``values`` the method passes to
+    ``.values(**…)``. Walking through it would let an inner name decide whether
+    an outer statement is judged safe — in either direction.
+    """
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        yield child
+        yield from _walk_scope(child)
+
+
+def _enclosing_loops(fn: ast.FunctionDef | ast.AsyncFunctionDef, target: ast.AST) -> list[ast.AST]:
+    """The loops that actually contain ``target``, innermost first.
+
+    Ancestry, not line numbers. Comparing ``node.lineno >= loop.lineno`` counts
+    every loop that merely STARTS earlier, so an unrelated sibling loop over
+    written-out names — ``for flag in ("a", "b")`` — would vouch for a later
+    ``setattr`` over ``data.items()`` and the site would go unreported. That is
+    a false negative in the one direction this check exists to cover.
+
+    The ascent stops at a function boundary, because a loop only vouches for
+    names it actually binds. A nested scope rebinds them::
+
+        for key in ("a", "b"):
+            f = lambda key, value: setattr(row, key, value)
+            f(caller_key, caller_value)
+
+    Lexically the loop encloses that ``setattr``, and the key is spelled
+    ``key`` — but it is the lambda's parameter, filled by the caller. Matching
+    on the name alone let the loop clear a write it has nothing to do with.
+    A ``def`` in that position is caught anyway, since every function is
+    scanned as its own scope; a ``Lambda`` is not a ``FunctionDef`` and never
+    gets that second reading, so the boundary is what covers it.
+    """
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(fn):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+    loops: list[ast.AST] = []
+    current = parents.get(target)
+    while current is not None:
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            break
+        if isinstance(current, (ast.For, ast.AsyncFor)):
+            loops.append(current)
+        current = parents.get(current)
+    return loops
+
+
+def _bound_names(target: ast.expr) -> set[str]:
+    """The names a ``for`` target binds, including through tuple unpacking."""
+    return {n.id for n in ast.walk(target) if isinstance(n, ast.Name)}
+
+
+def _key_is_bound_to_literal_names(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef, call: ast.Call
+) -> bool:
+    """Whether the key handed to ``setattr`` provably comes from written-out names.
+
+    Provenance, not proximity. Asking whether ANY enclosing loop iterates literal
+    names lets an outer loop vouch for an inner one::
+
+        for group in ("core", "extra"):        # literal, and irrelevant
+            for key, value in data[group].items():
+                setattr(row, key, value)       # key comes from HERE
+
+    so the innermost binding is the only one that answers the question. A key
+    that no enclosing loop binds — a bare variable from somewhere else — is not
+    provably safe either, and falls through to being reported.
+    """
+    if len(call.args) < 2:
+        return False
+    key = call.args[1]
+    if isinstance(key, ast.Constant):
+        return True
+    if not isinstance(key, ast.Name):
+        return False
+    for loop in _enclosing_loops(fn, call):
+        target = getattr(loop, "target", None)
+        if target is not None and key.id in _bound_names(target):
+            return _literal_keys(getattr(loop, "iter", None))
+    return False
+
+
+def _local_assignments(fn: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> list[ast.expr]:
+    """Every value assigned to ``name`` in ``fn``'s own scope, in source order."""
+    found: list[ast.expr] = []
+    for node in _walk_scope(fn):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    found.append(node.value)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+            and node.value
+        ):
+            found.append(node.value)
+    return found
+
+
+def _statement_roots(
+    expr: ast.expr,
+    fn: ast.FunctionDef | ast.AsyncFunctionDef | None = None,
+    seen: frozenset[str] = frozenset(),
+) -> set[str]:
+    """Every constructor a ``.values(...)`` chain could hang off.
+
+    A set rather than one answer because a name can be assigned more than once,
+    and ``stmt = sql_update(M)`` followed by ``stmt = stmt.values(**data)``
+    makes the LAST assignment self-referential — resolving only that one answers
+    ``stmt`` and the update disappears. Considering every assignment finds the
+    ``sql_update`` that the chain actually started from.
+    """
+    current: ast.AST = expr
+    while True:
+        if isinstance(current, ast.Call):
+            current = current.func
+        elif isinstance(current, ast.Attribute):
+            current = current.value
+        elif isinstance(current, ast.Name):
+            if fn is None or current.id in seen:
+                return {current.id}
+            origins = _local_assignments(fn, current.id)
+            if not origins:
+                return {current.id}
+            roots: set[str] = set()
+            for origin in origins:
+                roots |= _statement_roots(origin, fn, seen | {current.id})
+            return roots or {current.id}
+        else:
+            return set()
+
+
+def _is_update_statement(
+    expr: ast.expr, fn: ast.FunctionDef | ast.AsyncFunctionDef | None = None
+) -> bool:
+    """Whether a ``.values(...)`` chain hangs off something that moves an existing row.
+
+    An INSERT is exempt for the reason given on ``_caller_keyed_update_sites``.
+    Anything that resolves to neither an insert nor an update builder is treated
+    as an update: it is a shape this pass does not recognise, and reporting an
+    unknown costs one registry line a reviewer can delete, while assuming it is
+    an insert costs a silent miss.
+    """
+    roots = _statement_roots(expr, fn)
+    if roots & UPDATE_STATEMENT_ROOTS:
+        return True
+    return not (roots & INSERT_STATEMENT_ROOTS)
+
+
+def _all_literal_keys(fn: ast.FunctionDef | ast.AsyncFunctionDef, expr: ast.expr | None) -> bool:
+    """Whether ``expr``'s keys are written out in the source on *every* path to it.
+
+    A bare name is resolved through ``_local_assignments``, and all of them have
+    to be literal-keyed for the name to clear. Not a reaching-definitions pass:
+    this deliberately ignores which assignment reaches the call, because the
+    cheap alternative — take the last one — is wrong in the direction that
+    matters::
+
+        values = {k: v for k, v in patch.items()}   # caller-keyed
+        await session.execute(sql_update(M).values(**values))
+        values = {"status": "done"}                 # unrelated, later
+
+    The dict that reaches the UPDATE is the first one. Answering with the last
+    reports "literal" and the site disappears — a silent miss, where the failure
+    mode of being conservative is one registry line a reviewer deletes. Same
+    rule as ``_statement_roots``, for the same reason: any origin can sink the
+    verdict. Nested scopes are excluded — see ``_walk_scope``.
+    """
+    if not isinstance(expr, ast.Name):
+        return _literal_keys(expr)
+    origins = _local_assignments(fn, expr.id)
+    # A name with no local assignment is a parameter or a global: unreadable
+    # here, so it does not clear.
+    return bool(origins) and all(_literal_keys(origin) for origin in origins)
+
+
+def _caller_keyed_update_sites(source: str) -> dict[str, str]:
+    """Methods whose UPDATE keys come from a caller-controlled dict.
+
+    Three shapes, one per defect actually found:
+
+    * ``setattr(row, key, …)`` under a loop that is not over literal names.
+    * ``set_=`` given anything but a dict written out in the source — the
+      ``ON CONFLICT DO UPDATE`` half of an upsert.
+    * ``.values(**X)`` where ``X`` is built by a comprehension, which is how a
+      caller's dict gets filtered into an ``UPDATE ... SET``.
+
+    INSERT is deliberately not a site. ``pg_insert(...).values(**data)`` lets a
+    caller name the id of a row *they are creating*; colliding with an existing
+    key raises rather than overwriting, so no existing row moves. The defect is
+    an existing row's identity changing under it, which only the update paths
+    above can do. That cut is what keeps ``relation_add``, ``agent_add`` and
+    ``agent_activity_digest_upsert`` off this list.
+
+    Heuristic, and biased the way the route classifier is: it would rather name
+    a method that turns out to be safe — one registry line, which a reviewer can
+    read and delete — than miss one that is not, which is invisible.
+    """
+    tree = ast.parse(source)
+    sites: dict[str, str] = {}
+    # Private helpers are scanned too. Skipping them left a hole big enough to
+    # drive the whole defect through: move the ``setattr`` loop into
+    # ``_apply_patch`` and call it from a public method, and neither one is a
+    # site — the public method's own body is clean and the helper is invisible.
+    # A private helper that qualifies is reported under its own name, which is
+    # also where the guard belongs, since that is where the keys are applied.
+    for fn in [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]:
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.Call):
+                continue
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "setattr"
+                and not _key_is_bound_to_literal_names(fn, node)
+            ):
+                sites.setdefault(fn.name, "setattr over caller-supplied keys")
+            for kw in node.keywords:
+                if kw.arg == "set_" and not _all_literal_keys(fn, kw.value):
+                    sites.setdefault(fn.name, "ON CONFLICT set_ from caller-supplied keys")
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "values"
+                and _is_update_statement(node.func.value, fn)
+            ):
+                # Both ways of handing ``values()`` a whole dict. ``.values(**d)``
+                # puts it in ``keywords`` with ``arg=None``; ``.values(d)`` puts
+                # it in ``args``, and that form is if anything the more likely —
+                # it is what you must write when a key is not a valid Python
+                # identifier. Reading only ``keywords`` saw the spread and never
+                # the argument, so the whole defect with two characters removed
+                # went through.
+                #
+                # A NAMED keyword is deliberately not included: ``arg`` being a
+                # real column name is the author typing it out, which is the
+                # opposite of a caller-keyed dict, and is what keeps
+                # ``report_update_completed`` and every other explicit SET off
+                # this list.
+                spread = [kw.value for kw in node.keywords if kw.arg is None]
+                if any(not _all_literal_keys(fn, v) for v in [*node.args, *spread]):
+                    sites.setdefault(fn.name, "UPDATE values(…) from caller-supplied keys")
+    return sites
+
+
+def _names_referenced(source: str) -> dict[str, set[str]]:
+    """Every name each method mentions, so a registration can be checked.
+
+    Without this the registry is a claim about code rather than a reading of it:
+    ``IDENTITY_WRITE_GUARDS`` could name the right constant while the method had
+    gone back to ``hasattr``, and both other halves would still pass — the
+    runtime half validates the constant, not its use.
+
+    Attribute access counts as mentioning the name: ``models.Entity`` is the
+    same registration as ``Entity``. Reading only ``ast.Name`` meant a change to
+    qualified imports would report every guard in the file as stale — a red gate
+    fixed by reverting an import style, which is the wrong lesson. This makes
+    the check weaker in the direction that cannot block a correct tree, which is
+    the right way round for a question as loose as "is this name spoken here".
+    """
+    tree = ast.parse(source)
+    out: dict[str, set[str]] = {}
+    for fn in [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]:
+        out[fn.name] = {n.id for n in ast.walk(fn) if isinstance(n, ast.Name)} | {
+            n.attr for n in ast.walk(fn) if isinstance(n, ast.Attribute)
+        }
+    return out
+
+
+def _service_tree() -> ast.Module:
+    """The parsed source of the one module check 4 reads."""
+    import core_storage_api.services.postgres_service as service
+
+    return ast.parse(Path(inspect.getfile(service)).read_text())
+
+
+def _scan_assumption_findings(cls: type, tree: ast.Module) -> list[str]:
+    """The two things check 4's single-file, bare-name scan takes for granted.
+
+    Checks 1-3 enumerate the class through ``inspect.getmembers`` so a method
+    arriving from a mixin is never silently skipped — see ``_public_methods``.
+    Check 4 parses the text of one module instead, and keys everything by bare
+    function name. Both are true of the tree today and neither is guaranteed,
+    and each would fail SILENTLY: a mixin's ``setattr`` loop would simply not be
+    read, and two same-named functions would have one supply the verdict while
+    the other supplies the names it is checked against, since ``sites`` keeps
+    the first and ``_names_referenced`` the last.
+
+    Reported rather than handled. Walking every module that defines a reachable
+    method, or keying by a qualified name, are both real answers — but the first
+    is speculative machinery for a case that cannot arise yet, and the second
+    would push a class path into ``IDENTITY_WRITE_GUARDS``, which is written by
+    hand and would go stale. Failing here puts the decision in front of whoever
+    creates the situation, with a concrete second module or collision to look at.
+    """
+    errors: list[str] = []
+
+    bases = [base.__name__ for base in cls.__mro__[1:] if base is not object]
+    if bases:
+        errors.append(
+            f"{cls.__name__} now has a base class ({', '.join(bases)}), and check 4 only "
+            f"reads {cls.__name__}'s own module. A caller-keyed UPDATE inherited from one "
+            "would not be scanned, while checks 1-3 would still enumerate it. Scan every "
+            "module that defines a reachable method, or state here why the base cannot "
+            "carry one."
+        )
+
+    seen: dict[str, int] = {}
+    for fn in [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]:
+        seen[fn.name] = seen.get(fn.name, 0) + 1
+    for name, count in sorted(seen.items()):
+        if count > 1:
+            errors.append(
+                f"the scanned module defines {count} functions named {name!r}, and check 4 "
+                "keys sites, references and IDENTITY_WRITE_GUARDS by bare name. One of them "
+                "would decide the verdict and the other would supply the names it is checked "
+                "against. Rename one."
+            )
+    return errors
+
+
+def _protected_columns(model: Any) -> dict[str, str]:
+    """Columns on ``model`` a caller must never write, and why.
+
+    All three reasons are read off the model, so a schema change moves them
+    without anybody remembering to update this file.
+    """
+    protected: dict[str, str] = {}
+    for column in model.__table__.primary_key.columns:
+        protected[column.key] = "primary key"
+    for column in model.__table__.columns:
+        if column.key in BINDING_SCOPE:
+            protected[column.key] = "tenant scope"
+        elif type(column.type).__name__.upper() in DERIVED_COLUMN_TYPES:
+            protected[column.key] = "database-maintained"
+    return protected
+
+
+def _identity_writability_findings() -> list[str]:
+    """No registered write filter admits an identity column, and none is missing.
+
+    Three failure modes, and they are genuinely different. The AST half answers
+    "is there a filter at all", which ``entity_update`` and ``memory_update``
+    failed. The reference check answers "does the method still use the filter it
+    is registered for", without which the registry is a claim nobody reads
+    against the code. The runtime half answers "does the filter actually exclude
+    the identity columns", which ``fleet_upsert_node`` failed while carrying a
+    filter that looked deliberate.
+
+    ``_scan_assumption_findings`` guards the ground all three stand on — that
+    the methods are one class in one file, addressable by bare name.
+    """
+    import core_storage_api.services.postgres_service as service
+
+    from common import models
+
+    errors: list[str] = []
+    source = Path(inspect.getfile(service)).read_text()
+    errors.extend(_scan_assumption_findings(service.PostgresService, ast.parse(source)))
+    sites = _caller_keyed_update_sites(source)
+    referenced = _names_referenced(source)
+
+    for method in sorted(set(sites) - set(IDENTITY_WRITE_GUARDS)):
+        errors.append(
+            f"method:{method} builds an UPDATE from caller-supplied keys ({sites[method]}) "
+            "with no registered identity guard. A tenant predicate does not protect a "
+            "column the same request can rewrite: filter the keys through a frozenset that "
+            "excludes the model's primary key and tenant scope, then register it in "
+            "IDENTITY_WRITE_GUARDS in scripts/tenant_scope_gate.py."
+        )
+
+    for method, (model_name, const_name, admits) in sorted(IDENTITY_WRITE_GUARDS.items()):
+        if method not in sites:
+            errors.append(
+                f"method:{method} is registered in IDENTITY_WRITE_GUARDS but no longer builds "
+                "an UPDATE from caller-supplied keys. Delete the entry — a registration "
+                "matching nothing reads as coverage nobody has."
+            )
+            continue
+        if const_name not in referenced.get(method, set()):
+            errors.append(
+                f"method:{method} is registered as guarded by {const_name} but does not "
+                "mention it. The registration is a claim about code that no longer reads "
+                "that way — point the filter back at the constant, or delete the entry and "
+                "let the unregistered-site check speak."
+            )
+            continue
+        # The model half of the same claim. A constant can be genuinely used and
+        # the entry still name the wrong table, and then the column check below
+        # runs against columns the method never writes: registering
+        # ``memory_update`` against ``Entity`` stops ``Memory.search_vector``
+        # being checked at all, because Entity has no TSVECTOR to find.
+        # By reference, not by reading the model off the statement — the
+        # ``setattr`` shape has no statement to read, and that is the shape the
+        # first of these defects had.
+        if model_name not in referenced.get(method, set()):
+            errors.append(
+                f"method:{method} is registered against {model_name} but does not mention "
+                f"{model_name}. The entry would validate {const_name} against a table this "
+                "method does not write, so the columns actually at risk go unchecked."
+            )
+            continue
+        model = getattr(models, model_name, None)
+        constant = getattr(service, const_name, None)
+        if model is None or constant is None:
+            errors.append(
+                f"method:{method} names {model_name}/{const_name}, which no longer both "
+                "exist. A guard that cannot be resolved is not a guard."
+            )
+            continue
+        columns = {c.key for c in model.__table__.columns}
+        written = set(constant) if admits else columns - set(constant)
+        for column, reason in sorted(_protected_columns(model).items()):
+            if column in written:
+                errors.append(
+                    f"method:{method} may write {model_name}.{column} ({reason}) — "
+                    f"{const_name} admits it. A caller who satisfies the tenant predicate can "
+                    "then move the row out from under it."
+                )
+    return errors
 
 
 # ---------------------------------------------------------------------------
@@ -1319,6 +1828,10 @@ def main() -> int:
 
     errors = check(entries, grants, previous)
     errors.extend(check_category_doc(ALLOWLIST_PATH))
+    # Deliberately not allowlisted. This invariant has no exceptions today, and
+    # one with none does not need a file to hold them: the first would be a
+    # decision worth arguing in review, not a line ``--write`` adds for you.
+    errors.extend(_identity_writability_findings())
     if args.base:
         try:
             errors.extend(ratchet(args.base, ALLOWLIST_PATH, {e.ident: e for e in exceptions(entries)}))

--- a/tests/test_tenant_scope_gate.py
+++ b/tests/test_tenant_scope_gate.py
@@ -23,6 +23,7 @@ import ast
 import json
 import subprocess
 import sys
+import textwrap
 import typing
 from pathlib import Path
 
@@ -1180,3 +1181,694 @@ def _live_entries() -> list[gate.Entry]:
     the caller actually made.
     """
     return gate.enumerate_methods() + gate.enumerate_routes()
+
+
+# ---------------------------------------------------------------------------
+# Identity-column writability — check 4
+# ---------------------------------------------------------------------------
+#
+# The three defects this check exists for were all tenant-bound at the time, so
+# checks 1-3 passed them. What these cases pin is the decision boundary of the
+# AST half: a silent miss here is a method that writes an identity column and
+# nothing objects, which is exactly how #1118 and #1121 reached main.
+
+
+def _sites(source: str) -> dict[str, str]:
+    return gate._caller_keyed_update_sites(textwrap.dedent(source))
+
+
+def test_setattr_over_caller_keys_is_a_site() -> None:
+    """``entity_update``'s shape before #1119."""
+    assert "m" in _sites(
+        """
+        async def m(self, row_id, tenant_id, data):
+            for key, value in data.items():
+                if hasattr(row, key):
+                    setattr(row, key, value)
+        """
+    )
+
+
+def test_a_loop_over_written_out_names_is_not_a_site() -> None:
+    """``agent_add``'s shape: the keys are in the source, so no caller reaches a column.
+
+    This is the case that decides whether the check is usable. Flagging it would
+    put a safe method in the registry, and a registry with entries nobody needed
+    is how a reviewer learns to add lines without reading them.
+    """
+    assert not _sites(
+        """
+        async def m(self, data):
+            for key in ("fleet_id", "trust_level", "display_name"):
+                if key in data:
+                    setattr(row, key, data[key])
+        """
+    )
+
+
+def test_an_unrelated_earlier_loop_does_not_vouch_for_a_later_one() -> None:
+    """Loop containment is ancestry, not line order.
+
+    The first version compared ``setattr.lineno >= loop.lineno``, so any loop
+    STARTING earlier counted — including a sibling that does not contain the
+    call. A harmless ``for flag in ("a", "b")`` above then vouched for an
+    unsafe ``setattr`` over ``data.items()`` below it, and the site went
+    unreported: a false negative in the one direction this check exists for.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, row_id, tenant_id, data):
+            for flag in ("a", "b"):
+                touched = flag
+            for key, value in data.items():
+                setattr(row, key, value)
+        """
+    )
+
+
+def test_a_literal_outer_loop_does_not_vouch_for_a_caller_keyed_inner_one() -> None:
+    """Provenance, not proximity: the innermost binding of the key is what counts.
+
+    Round 1 fixed sibling loops by switching to ancestry. That left the nested
+    case, where the literal loop really is an ancestor and still says nothing
+    about where ``key`` came from::
+
+        for group in ("core", "extra"):        # literal, and irrelevant
+            for key, value in data[group].items():
+                setattr(row, key, value)
+
+    ``any(enclosing loop is literal)`` called that safe.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, tenant_id, data):
+            for group in ("core", "extra"):
+                for key, value in data[group].items():
+                    setattr(row, key, value)
+        """
+    )
+
+
+def test_a_key_no_enclosing_loop_binds_is_not_assumed_safe() -> None:
+    """A key from somewhere else is unproven, and unproven fails toward reporting."""
+    assert "m" in _sites(
+        """
+        async def m(self, data):
+            key = data["column"]
+            setattr(row, key, data["value"])
+        """
+    )
+
+
+def test_an_update_values_comprehension_written_inline_is_a_site() -> None:
+    """The detection cannot depend on the comprehension being given a name first.
+
+    Requiring ``values = {…}`` then ``.values(**values)`` meant inlining the same
+    expression walked straight past the check.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, patch):
+            await session.execute(sql_update(Memory).values(**{k: v for k, v in patch.items()}))
+        """
+    )
+
+
+def test_an_update_values_given_the_dict_positionally_is_a_site() -> None:
+    """``.values(data)`` is the same defect as ``.values(**data)``.
+
+    SQLAlchemy's ``Update.values()`` takes a single dict positionally as well as
+    a ``**`` spread, and the positional form is the one that does not require
+    every key to be a valid Python identifier. Scanning only ``node.keywords``
+    saw the spread and never the argument, so the whole of #1081/#1118/#1121
+    reproduced with two characters removed would have passed the gate.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, patch):
+            await session.execute(sql_update(Memory).values(patch))
+        """
+    )
+
+
+def test_an_update_values_given_a_comprehension_positionally_is_a_site() -> None:
+    """The positional form gets the same provenance reading as the spread."""
+    assert "m" in _sites(
+        """
+        async def m(self, patch):
+            await session.execute(sql_update(Memory).values({k: v for k, v in patch.items()}))
+        """
+    )
+
+
+def test_an_update_values_given_a_literal_dict_positionally_is_not_a_site() -> None:
+    """Written-out keys stay safe whichever way they are passed.
+
+    Without this, "look at the positional argument too" could be satisfied by
+    reporting every ``.values(...)`` call, and the two tests above would pass
+    against a check that names every update in the file.
+    """
+    assert not _sites(
+        """
+        async def m(self, status):
+            await session.execute(sql_update(Memory).values({"status": status}))
+        """
+    )
+
+
+def test_update_values_named_keywords_are_not_a_site() -> None:
+    """``report_update_completed``'s shape: each column named in the source.
+
+    ``.values(status=status, completed_at=completed_at)`` puts real column names
+    in ``kw.arg``, which is the author typing them out — the opposite of a
+    caller-keyed dict. Widening to positional arguments must not sweep this in.
+    """
+    assert not _sites(
+        """
+        async def m(self, status, completed_at):
+            await session.execute(
+                sql_update(Report).where(Report.id == rid).values(
+                    status=status, completed_at=completed_at
+                )
+            )
+        """
+    )
+
+
+def test_an_update_values_built_by_spread_or_dict_call_is_a_site() -> None:
+    """``{**data}`` and ``dict(data)`` carry the caller's keys as surely as a comprehension.
+
+    The ``set_=`` branch already treated "not written out in the source" as
+    unsafe; this branch matched two specific node types instead, so every other
+    way of copying a caller's dict read as safe.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, data):
+            values = {**data}
+            await session.execute(sql_update(Memory).where(x).values(**values))
+        """
+    )
+    assert "m" in _sites(
+        """
+        async def m(self, data):
+            values = dict(data)
+            await session.execute(sql_update(Memory).values(**values))
+        """
+    )
+
+
+def test_an_update_values_written_out_in_the_source_is_not_a_site() -> None:
+    """The conservative default must still let a written-out UPDATE through.
+
+    ``memory_update_status`` and ``lifecycle_audit_finalize`` name their own
+    columns; flagging them would put safe methods in the registry.
+    """
+    assert not _sites(
+        """
+        async def m(self, status):
+            await session.execute(sql_update(Memory).where(x).values(**{"status": status}))
+        """
+    )
+
+
+def test_an_async_for_over_caller_keys_is_a_site() -> None:
+    """``async for`` is a loop too.
+
+    It was invisible to the first version's ``isinstance(p, ast.For)`` test,
+    which happened to report the site anyway — an empty loop list reads as
+    "not literal". Right answer, wrong reason, and the reason is what would
+    have inverted the moment the keys were literal.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, data):
+            async for key, value in data.items():
+                setattr(row, key, value)
+        """
+    )
+
+
+def test_an_async_for_over_written_out_names_is_not_a_site() -> None:
+    """The other half of the same fix: the accident above is now a real read."""
+    assert not _sites(
+        """
+        async def m(self, data):
+            async for key in ("fleet_id", "display_name"):
+                setattr(row, key, data[key])
+        """
+    )
+
+
+def test_a_nested_scope_does_not_decide_the_outer_one() -> None:
+    """``_all_literal_keys`` stops at a nested ``def``.
+
+    A closure assigning its own ``values`` says nothing about the ``values``
+    the method passes to ``.values(**…)``; letting it answer would move a
+    verdict in either direction.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, patch):
+            def helper():
+                values = {"weight": 1}
+                return values
+            values = {k: v for k, v in patch.items()}
+            await session.execute(sql_update(Memory).values(**values))
+        """
+    )
+
+
+def test_a_lambda_does_not_borrow_an_outer_loops_literal_names() -> None:
+    """A function boundary between a ``setattr`` and a loop breaks the loop's vouching.
+
+    ``_enclosing_loops`` matched the key by name against any lexically
+    enclosing loop, so a lambda parameter shadowing a literally-iterated outer
+    name was cleared by a loop it never read::
+
+        for key in ("a", "b"):
+            f = lambda key, value: setattr(row, key, value)
+            f(caller_key, caller_value)
+
+    The ``key`` inside the lambda is the lambda's own parameter, filled from
+    the caller. A ``def`` in that position is reported because every function
+    is scanned as its own scope, but a ``Lambda`` is not a ``FunctionDef`` and
+    so was never visited on its own — leaving the outer pass as the only
+    reader, and it cleared the site.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, data):
+            for key in ("a", "b"):
+                f = lambda key, value: setattr(row, key, value)
+                f(caller_key, caller_value)
+        """
+    )
+
+
+def test_a_nested_def_is_reported_under_its_own_name() -> None:
+    """A nested ``def`` shadowing an outer literal loop name is not cleared.
+
+    The outer pass does clear it — the key matches the outer loop's literal
+    tuple by name — but the helper is also scanned as its own scope, where
+    there is no enclosing loop at all, so the site surfaces under ``helper``.
+    That second reading is what makes the shadowing case reported rather than
+    silent, and it is the reason the ``def`` form needed no fix while the
+    ``lambda`` form above did.
+
+    ``helper`` holds before and after the loop-boundary fix; ``m`` is the half
+    that fix adds, once a function boundary stops the outer loop from vouching.
+    """
+    sites = _sites(
+        """
+        async def m(self, data):
+            for key in ("a", "b", "c"):
+                def helper(key, value):
+                    setattr(row, key, value)
+                helper(caller_key, caller_value)
+        """
+    )
+    assert "helper" in sites
+    assert "m" in sites
+
+
+def test_a_loop_still_vouches_for_a_setattr_in_its_own_scope() -> None:
+    """``agent_add``'s shape: no function boundary in between, so it still clears.
+
+    The guard against fixing the above by simply never clearing anything.
+    """
+    assert not _sites(
+        """
+        async def m(self, data):
+            for key in ("fleet_id", "trust_level"):
+                setattr(row, key, data[key])
+        """
+    )
+
+
+def test_a_later_literal_reassignment_does_not_hide_a_caller_keyed_values() -> None:
+    """The dict that reaches the UPDATE is the one at the call, not the last one written.
+
+    Resolving a name to its final assignment answers "literal" here and the
+    site vanishes, even though the statement two lines above spread a
+    caller-keyed dict into an ``UPDATE ... SET``. Every assignment has to be
+    literal for the name to clear, which is the rule ``_statement_roots``
+    already applies to the statement builder: any origin can sink the verdict.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, patch):
+            values = {k: v for k, v in patch.items()}
+            await session.execute(sql_update(Memory).values(**values))
+            values = {"status": "ok"}
+            log_status(values)
+        """
+    )
+
+
+def test_a_later_literal_reassignment_does_not_hide_a_caller_keyed_conflict_set() -> None:
+    """Same hole on the ``set_=`` half — both call sites resolved the same way."""
+    assert "m" in _sites(
+        """
+        async def m(self, data):
+            update = {k: v for k, v in data.items()}
+            stmt = pg_insert(t).values(**data).on_conflict_do_update(
+                constraint="c",
+                set_=update,
+            )
+            update = {"weight": 1}
+            log_update(update)
+        """
+    )
+
+
+def test_a_name_literal_at_every_assignment_is_still_not_a_site() -> None:
+    """The other side of the rule: requiring ALL assignments must not flag the safe case.
+
+    Without this, "every origin must be literal" could be satisfied by never
+    clearing anything, and the two tests above would pass against a check that
+    reports every name it sees.
+    """
+    assert not _sites(
+        """
+        async def m(self, patch):
+            values = {"status": "running"}
+            await session.execute(sql_update(Memory).values(**values))
+            values = {"status": "done"}
+            await session.execute(sql_update(Memory).values(**values))
+        """
+    )
+
+
+def test_a_conflict_set_built_from_caller_keys_is_a_site() -> None:
+    """``fleet_upsert_node``'s shape before #1129 — a filter, but the wrong one."""
+    assert "m" in _sites(
+        """
+        async def m(self, values):
+            stmt = pg_insert(t).values(**values).on_conflict_do_update(
+                constraint="c",
+                set_={k: v for k, v in values.items() if k not in ("tenant_id",)},
+            )
+        """
+    )
+
+
+def test_a_conflict_set_written_out_in_the_source_is_not_a_site() -> None:
+    """``relation_add``'s shape: the SET names its own columns."""
+    assert not _sites(
+        """
+        async def m(self, data):
+            stmt = pg_insert(t).values(**data).on_conflict_do_update(
+                constraint="c",
+                set_={"weight": excluded.weight, "fleet_id": excluded.fleet_id},
+            )
+        """
+    )
+
+
+def test_an_insert_is_not_a_site() -> None:
+    """A caller naming the id of a row it is creating moves no existing row.
+
+    ``pg_insert(...).values(**data)`` with no DO UPDATE collides rather than
+    overwrites, so the identity of an existing row is never caller-controlled.
+    Counting inserts would flag ``relation_add``, ``agent_add`` and
+    ``agent_activity_digest_upsert`` for a defect none of them has.
+    """
+    assert not _sites(
+        """
+        async def m(self, data):
+            stmt = pg_insert(t).values(**data).on_conflict_do_nothing(index_elements=["a"])
+        """
+    )
+
+
+def test_a_private_helper_is_scanned_too() -> None:
+    """Delegation must not launder the pattern.
+
+    An earlier version skipped ``_``-prefixed functions, so moving the loop one
+    call deep hid it completely: the public method's own body is clean and the
+    helper was never looked at. The helper is reported under its own name, which
+    is also where the filter belongs.
+    """
+    found = _sites(
+        """
+        async def entity_update(self, entity_id, tenant_id, data):
+            return self._apply_patch(row, data)
+
+        def _apply_patch(self, row, data):
+            for key, value in data.items():
+                setattr(row, key, value)
+        """
+    )
+    assert "_apply_patch" in found, found
+
+
+def test_an_update_split_across_an_assignment_is_a_site() -> None:
+    """A statement does not have to be built in one expression."""
+    assert "m" in _sites(
+        """
+        async def m(self, data):
+            stmt = sql_update(Memory).where(cond)
+            await session.execute(stmt.values(**data))
+        """
+    )
+
+
+def test_a_self_referential_statement_assignment_is_a_site() -> None:
+    """``stmt = stmt.values(**data)`` makes the last assignment circular.
+
+    Resolving only the newest assignment answers ``stmt`` and the update
+    vanishes; every assignment of the name is considered so the original
+    ``sql_update`` is still found.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, data):
+            stmt = sql_update(Memory)
+            stmt = stmt.values(**data)
+            await session.execute(stmt)
+        """
+    )
+
+
+def test_an_insert_built_through_a_variable_is_still_exempt() -> None:
+    """The INSERT exclusion has to survive resolving through locals."""
+    assert not _sites(
+        """
+        async def m(self, data):
+            stmt = pg_insert(t)
+            await session.execute(stmt.values(**data))
+        """
+    )
+
+
+def test_an_unrecognised_statement_builder_is_reported() -> None:
+    """Neither insert nor update resolves to "unknown", and unknown is reported.
+
+    The alternative is to assume an unrecognised builder is harmless, which is
+    the direction this check cannot afford to be wrong in.
+    """
+    assert "m" in _sites(
+        """
+        async def m(self, data):
+            await session.execute(some_helper(Memory).values(**data))
+        """
+    )
+
+
+def test_the_registry_covers_exactly_the_methods_that_need_it() -> None:
+    """Every caller-keyed UPDATE on the tree is registered, and none spuriously.
+
+    The trunk-is-green case for check 4. A method drifting into this shape
+    without a registration fails here as well as in CI, and a registration left
+    behind after a method stops writing from caller keys fails too — a stale one
+    reads as coverage that is not there.
+    """
+    source = Path(gate.inspect.getfile(_service())).read_text()
+    assert set(gate._caller_keyed_update_sites(source)) == set(gate.IDENTITY_WRITE_GUARDS)
+
+
+def test_no_registered_guard_admits_an_identity_column() -> None:
+    """The runtime half, against the models as they are now."""
+    assert gate._identity_writability_findings() == []
+
+
+def test_protected_columns_come_from_the_model_not_a_list() -> None:
+    """Primary key, tenant scope and database-maintained columns, all read off the model.
+
+    Named columns would go stale on a rename; these follow the schema.
+    """
+    from common.models import Memory
+
+    protected = gate._protected_columns(Memory)
+    assert protected["id"] == "primary key"
+    assert protected["tenant_id"] == "tenant scope"
+    assert protected["search_vector"] == "database-maintained"
+    assert "content" not in protected
+
+
+def test_a_guard_that_admits_the_primary_key_is_reported() -> None:
+    """The #1121 failure, injected: a filter that looks deliberate and is not.
+
+    Widens the real constant rather than registering a new name, so the method
+    still mentions what it is registered for and the run reaches the runtime
+    half. Pointing the registry at a fresh name instead stops at the reference
+    check, which is a different finding and would not prove this one fires.
+    """
+    from common.models import FleetNode
+
+    service = _service()
+    original = service._FLEET_NODE_IMMUTABLE_FIELDS
+    try:
+        service._FLEET_NODE_IMMUTABLE_FIELDS = frozenset({"tenant_id", "node_name"})  # id dropped
+        findings = gate._identity_writability_findings()
+    finally:
+        service._FLEET_NODE_IMMUTABLE_FIELDS = original
+
+    assert any("FleetNode.id (primary key)" in f for f in findings), findings
+    assert {c.key for c in FleetNode.__table__.primary_key.columns} == {"id"}
+    assert gate._identity_writability_findings() == [], "the constant was not restored"
+
+
+def test_a_registration_naming_a_model_the_method_never_writes_is_reported() -> None:
+    """The constant can be genuinely used and the entry still describe the wrong table.
+
+    ``memory_update`` really does reference ``_MEMORY_UPDATABLE_FIELDS``, so the
+    reference check clears it; naming ``Entity`` as the model then validates
+    that constant against Entity's columns. What is lost is specific:
+    ``Memory.search_vector`` is a TSVECTOR maintained by a trigger, and Entity
+    has no such column, so the derived-column protection stops being checked
+    while everything still reads as registered.
+
+    Checked by reference rather than by reading the model out of the statement:
+    ``entity_update`` has no statement to read — it is a ``select`` plus
+    ``setattr`` — so a statement-target comparison would have to exempt the one
+    shape that started this whole check.
+    """
+    original = gate.IDENTITY_WRITE_GUARDS.copy()
+    try:
+        gate.IDENTITY_WRITE_GUARDS["memory_update"] = (
+            "Entity",  # a real model, wrong one
+            "_MEMORY_UPDATABLE_FIELDS",  # genuinely referenced by memory_update
+            True,
+        )
+        findings = gate._identity_writability_findings()
+    finally:
+        gate.IDENTITY_WRITE_GUARDS.clear()
+        gate.IDENTITY_WRITE_GUARDS.update(original)
+
+    assert any("does not mention Entity" in f for f in findings), findings
+    assert gate._identity_writability_findings() == [], "the registry was not restored"
+
+
+def test_a_registration_the_method_no_longer_uses_is_reported() -> None:
+    """The registry is checked against the code, not trusted as a description of it.
+
+    Without this, ``IDENTITY_WRITE_GUARDS`` could name a correct constant while
+    the method had gone back to ``hasattr``: the runtime half validates the
+    constant, and a constant nobody reads protects nothing.
+    """
+    original = gate.IDENTITY_WRITE_GUARDS.copy()
+    try:
+        gate.IDENTITY_WRITE_GUARDS["entity_update"] = (
+            "Entity",
+            "_MEMORY_UPDATABLE_FIELDS",  # a real constant, wrong method
+            True,
+        )
+        findings = gate._identity_writability_findings()
+    finally:
+        gate.IDENTITY_WRITE_GUARDS.clear()
+        gate.IDENTITY_WRITE_GUARDS.update(original)
+
+    assert any("does not mention it" in f for f in findings), findings
+
+
+def _service():
+    import core_storage_api.services.postgres_service as service
+
+    return service
+
+
+# ---------------------------------------------------------------------------
+# The assumptions check 4's single-file scan rests on
+# ---------------------------------------------------------------------------
+
+
+def test_the_live_service_still_satisfies_the_scan_assumptions() -> None:
+    """The tripwires are silent on the tree as it stands, or they are just noise."""
+    assert gate._scan_assumption_findings(_service().PostgresService, gate._service_tree()) == []
+
+
+def test_a_base_class_on_the_service_is_reported() -> None:
+    """Check 4 reads one file; checks 1-3 enumerate the class.
+
+    ``_public_methods`` goes through ``inspect.getmembers`` precisely so a
+    method arriving from a mixin is not silently skipped. Check 4 parses the
+    text of one module instead, so the same mixin would be invisible to it —
+    the two halves of the gate would disagree about what they cover, and only
+    the quieter one would be wrong.
+
+    Closing that by walking every defining module is speculative work for a
+    case that cannot happen yet: ``PostgresService.__mro__`` is
+    ``(PostgresService, object)``. This fails loudly at the moment someone
+    makes it possible, which is when there is a real second module to point at.
+    """
+
+    class Mixin:
+        pass
+
+    class Derived(Mixin):
+        pass
+
+    findings = gate._scan_assumption_findings(Derived, ast.parse(""))
+
+    assert any("Mixin" in f for f in findings), findings
+
+
+def test_two_scanned_functions_sharing_a_name_are_reported() -> None:
+    """``sites`` and ``_names_referenced`` key by bare name, and disagree on collisions.
+
+    ``sites`` keeps the first (``setdefault``) and ``_names_referenced`` keeps
+    the last, so two same-named functions could have one supply the verdict and
+    the other supply the names it is checked against. A qualified key is not the
+    fix, because ``IDENTITY_WRITE_GUARDS`` is written by hand and a qualified
+    one would have to carry a class path that goes stale. Refusing the collision
+    keeps the registry readable and the ambiguity impossible.
+    """
+    findings = gate._scan_assumption_findings(
+        object,
+        ast.parse(
+            textwrap.dedent(
+                """
+                def apply_patch(self, data): ...
+                class Other:
+                    def apply_patch(self, data): ...
+                """
+            )
+        ),
+    )
+
+    assert any("apply_patch" in f for f in findings), findings
+
+
+def test_a_qualified_reference_counts_as_mentioning_the_name() -> None:
+    """``models.Entity`` is the same registration as ``Entity``.
+
+    The reference checks read ``ast.Name`` only, so switching this file to
+    qualified imports would report every guard as stale — a gate failure fixed
+    by reverting an import style, which is the wrong thing to teach. Attribute
+    access counts too; the check is "is this name spoken here at all", and it
+    is deliberately weak in the direction that does not block a green tree.
+    """
+    referenced = gate._names_referenced(
+        textwrap.dedent(
+            """
+            def m(self, patch):
+                values = {k: v for k, v in patch.items()}
+                return sql_update(models.Entity).values(**values), service._ENTITY_UPDATABLE_FIELDS
+            """
+        )
+    )
+
+    assert "Entity" in referenced["m"]
+    assert "_ENTITY_UPDATABLE_FIELDS" in referenced["m"]


### PR DESCRIPTION
The gate checks that a statement is **bound** to a tenant. It never checked that the caller cannot **rewrite the column it is bound on**. Three defects went through it in a week on exactly that gap:

| | method | the filter it had |
|---|---|---|
| #1081 / #1119 | `entity_update` | `if hasattr(entity, key): setattr(…)` |
| #1118 / #1122 | `memory_update` | `if hasattr(Memory, key)` in a comprehension |
| #1121 / #1129 | `fleet_upsert_node` | `if k not in ("tenant_id", "node_name")` |

Each built an `UPDATE ... SET` from a caller-controlled dict and admitted `id`, so the statement became `SET id = <caller's choice> WHERE id = :id AND tenant_id = :tenant` — predicate satisfied, primary key moved. **The last two were correctly tenant-bound the whole time**, so checks 1–3 had nothing to object to. The defect lives one layer below where the gate was looking.

### Three parts, three different failures

They are not redundant — each catches a mode the others miss:

1. **AST discovery** names every method building an UPDATE from caller keys and requires it to be registered. This is what `entity_update` and `memory_update` failed: no filter at all.
2. **Reference check** requires the method to actually mention the constant it is registered for, so the registry stays a *reading* of the code rather than a claim about it. Without it, a method could revert to `hasattr` while the registry still named the right constant and both other parts would pass.
3. **Runtime check** resolves each constant and asserts it admits none of the model's primary key, tenant-scope, or database-maintained columns — read off the model, so a schema change moves them without anyone editing this file. This is what `fleet_upsert_node` failed, carrying a filter that looked deliberate.

### What is deliberately not a site

`INSERT` is excluded. Naming the id of a row you are *creating* collides rather than overwrites, so no existing row moves — the defect is an existing row's identity changing under it. That cut keeps `relation_add`, `agent_add` and `agent_activity_digest_upsert` off the list. A loop over written-out column names is also not a site, which keeps `agent_add`'s second write off it. Both boundaries are pinned by tests, because flagging safe methods is how a registry fills with lines nobody reads.

The heuristic is biased the way the route classifier already is, and for the reason its docstring gives: it would rather name a method that turns out to be safe — one registry line a reviewer can delete — than miss one that is not, which is invisible.

### No allowlist

The invariant has no exceptions today. One with none does not need a file to hold them, and the first should be argued in review rather than added by `--write`.

### Validation

**Replayed against history.** Run against `postgres_service.py` as it stood before each fix, the check flags exactly the methods still defective at that commit — three, then two, then one. It would have caught all three.

**Sabotage, one per failure mode**, each confirmed to flip the gate red and back:

- widen a constant to admit the primary key → *"may write FleetNode.id (primary key)"*
- point a method back at `hasattr` while leaving its registration → *"registered as guarded by … but does not mention it"*
- add a new unregistered caller-keyed UPDATE → *"builds an UPDATE from caller-supplied keys … no registered identity guard"*
- leave a registration behind after a method stops qualifying → *"registered … but no longer builds an UPDATE"*

11 new tests, all failing on the parent commit, covering those four modes plus the decision boundary of the AST pass.

### It does not fail anything in flight

Zero findings on the tree as committed. That includes #1141, which landed from the tenancy lane while this was being written and introduces no new sites — checked rather than assumed, since a new gate erroring on someone else's open branch is the obvious way for this to go wrong.

### Verification

Gate tests 83 passed (71 existing + 12). Root suite 5705 passed, storage 242. mypy clean across scripts (31), core-api (203), core-storage-api (85), common (99). `ruff check scripts/` leaves only the one pre-existing ISC004 that was there before. Gate exit 0 with `--base origin/main`; allowlist untouched. Rebased onto `f8fc9513`. `uv.lock` unchanged.

No `Closes` line: the three issues this would have prevented are already fixed, and there is no open issue for the check itself.
