### PR TITLE
fix(storage): scope agent search-profile updates to tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1639,8 +1639,16 @@ class CoreStorageClient:
     async def update_trust_level(self, agent_id: str, data: dict) -> dict | None:
         return await self._patch(f"/agents/{agent_id}/trust-level", data)
 
-    async def update_search_profile(self, agent_id: str, data: dict) -> dict | None:
-        return await self._patch(f"/agents/{agent_id}/search-profile", data)
+    async def update_search_profile(
+        self,
+        agent_id_pk: str,
+        tenant_id: str,
+        search_profile: dict,
+    ) -> dict | None:
+        return await self._patch(
+            f"/agents/{agent_id_pk}/search-profile",
+            {"tenant_id": tenant_id, "search_profile": search_profile},
+        )
 
     async def reset_search_profile(
         self,

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1550,17 +1550,15 @@ async def caura_tune(
         return _with_latency(_error_response("INVALID_ARGUMENTS", f"{e}"), t0)
 
     updates = profile.model_dump(exclude_none=True)
-    # WRITE → home tenant only. ``get_or_create_agent`` is storage-routed and
-    # scopes the lookup/create to ``tenant_id``; the search-profile PATCH then
-    # targets that agent's PK (``agent["id"]``). No cross-tenant widening — a
-    # tune never touches a foreign tenant's agent row.
+    # WRITE → home tenant only. ``get_or_create_agent`` scopes the lookup or
+    # create, and the search-profile PATCH binds that same tenant to the update.
     try:
         agent = await get_or_create_agent(tenant_id, agent_id)
         current = agent.get("search_profile") or {}
         if updates:
             current.update(updates)
             current = validate_search_profile(current)
-            await get_storage_client().update_search_profile(agent["id"], {"search_profile": current})
+            await get_storage_client().update_search_profile(agent["id"], tenant_id, current)
         return _with_latency(json.dumps({"agent_id": agent_id, "search_profile": current}, indent=2), t0)
     except HTTPException as e:
         logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)

--- a/core-api/src/core_api/routes/agents.py
+++ b/core-api/src/core_api/routes/agents.py
@@ -147,7 +147,7 @@ async def patch_agent_tune(
     if updates:
         current.update(updates)
         current = validate_search_profile(current)
-        await sc.update_search_profile(agent["id"], {"tenant_id": tenant_id, "search_profile": current})
+        await sc.update_search_profile(agent["id"], tenant_id, current)
         # Re-fetch to get the updated agent with full fields
         refreshed = await sc.get_agent(agent_id, tenant_id)
         if refreshed:

--- a/core-storage-api/src/core_storage_api/routers/agents.py
+++ b/core-storage-api/src/core_storage_api/routers/agents.py
@@ -70,7 +70,11 @@ async def update_agent_fleet(agent_id: str, request: Request) -> dict:
 async def update_search_profile(agent_id: str, request: Request) -> dict:
     body: dict = await request.json()
     # agent_id here is the PK (Agent.id), not the string agent_id
-    await _svc.agent_update_search_profile(agent_id, body["search_profile"])
+    await _svc.agent_update_search_profile(
+        agent_id,
+        tenant_id=body["tenant_id"],
+        search_profile=body["search_profile"],
+    )
     return {"ok": True}
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -7028,12 +7028,19 @@ class PostgresService:
     async def agent_update_search_profile(
         self,
         agent_id_pk: object,
+        *,
+        tenant_id: str,
         search_profile: dict,
     ) -> None:
-        """Update an agent's search_profile by primary key (Agent.id)."""
+        """Update one tenant's agent search profile by primary key."""
         async with get_session() as session:
             await session.execute(
-                sql_update(Agent).where(Agent.id == agent_id_pk).values(search_profile=search_profile)
+                sql_update(Agent)
+                .where(
+                    Agent.id == agent_id_pk,
+                    Agent.tenant_id == tenant_id,
+                )
+                .values(search_profile=search_profile)
             )
 
     async def agent_reset_search_profile(

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -32,13 +32,6 @@
       "category": "cross-tenant-by-design"
     },
     {
-      "id": "method:agent_update_search_profile",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1084."
-    },
-    {
       "id": "method:audit_add_batch",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -487,13 +480,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "no-tenant-data"
-    },
-    {
-      "id": "route:PATCH /api/v1/storage/agents/{agent_id}/search-profile",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1084."
     },
     {
       "id": "route:PATCH /api/v1/storage/lifecycle-audit/{audit_id}",

--- a/core-storage-api/tests/test_agent_update_search_profile_tenant_scope.py
+++ b/core-storage-api/tests/test_agent_update_search_profile_tenant_scope.py
@@ -1,0 +1,73 @@
+"""Tenant scoping for search-profile updates addressed by agent primary key."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from core_storage_api.services.postgres_service import PostgresService
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _new_tenant_id() -> str:
+    """Return a unique tenant id that matches the end-of-run sweep prefix."""
+    return f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+
+async def _agent(client: AsyncClient, tenant_id: str, profile: dict) -> tuple[str, str]:
+    logical_id = f"profile-agent-{uuid.uuid4().hex[:8]}"
+    response = await client.post(
+        f"{PREFIX}/agents",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": logical_id,
+            "search_profile": profile,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"], logical_id
+
+
+async def _profile(client: AsyncClient, tenant_id: str, agent_id: str) -> dict | None:
+    response = await client.get(
+        f"{PREFIX}/agents/{agent_id}/search-profile",
+        params={"tenant_id": tenant_id},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["search_profile"]
+
+
+class TestAgentUpdateSearchProfileTenantScope:
+    async def test_service_does_not_update_another_tenants_profile(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        victim = _new_tenant_id()
+        attacker = _new_tenant_id()
+        original = {"min_similarity": 0.61}
+        agent_pk, agent_id = await _agent(client, victim, original)
+
+        await PostgresService().agent_update_search_profile(
+            agent_pk,
+            tenant_id=attacker,
+            search_profile={"min_similarity": 0.22},
+        )
+
+        assert await _profile(client, victim, agent_id) == original
+
+    async def test_route_passes_tenant_to_profile_update(self, client: AsyncClient) -> None:
+        tenant = _new_tenant_id()
+        agent_pk, agent_id = await _agent(client, tenant, {"min_similarity": 0.58})
+        updated = {"min_similarity": 0.73}
+
+        response = await client.patch(
+            f"{PREFIX}/agents/{agent_pk}/search-profile",
+            json={"tenant_id": tenant, "search_profile": updated},
+        )
+
+        assert response.status_code == 200, response.text
+        assert await _profile(client, tenant, agent_id) == updated


### PR DESCRIPTION
## Summary

- require the binding `tenant_id` throughout the search-profile update call chain
- bind `Agent.id` and `Agent.tenant_id` together in `agent_update_search_profile`
- keep the update SET fixed to `search_profile`; no caller-controlled keys can repoint the primary key or another identity column
- remove #1084 method and route entries through `tenant_scope_gate.py --write`

The current core API and MCP callers already obtain the agent primary key from a tenant-scoped lookup. This change moves the guarantee into the storage query as well, making the direct storage route and future callers safe without relying on that caller behavior.

## Regression proof

The new negative service test was run with only the tenant predicate removed. It failed as intended:

```text
E   AssertionError: assert {'min_similarity': 0.22} == {'min_similarity': 0.61}
E     Differing items:
E     {'min_similarity': 0.22} != {'min_similarity': 0.61}
```

With the predicate restored, both new tests pass.

## Allowlist

- total: 110 -> 108
- `id-addressed-write`: 16 -> 14
- `opaque-body-write`: 35 -> 35, with all 35 hand-written notes preserved

## Validation

- `core-storage-api/tests/`: 244 passed
- root `tests/` excluding benchmarks: 5694 passed, 4 skipped, 16 deselected, 1 xfailed
- focused core API and MCP tests: 28 passed
- Ruff check and format check
- mypy: core-storage-api 85 files, core-api 203 files
- tenant-scope gate: 108 allowlisted, 14 id-addressed writes

Closes #1084
