### PR TITLE
fix(documents): refuse an upsert that guts a stored document (C34)

### DIFF
--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -4,6 +4,7 @@ import logging
 import re
 from datetime import datetime
 
+import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -94,6 +95,12 @@ class DocWriteRequest(BaseModel):
     collection: str = Field(min_length=1, max_length=200)
     doc_id: str = Field(min_length=1, max_length=500)
     data: dict
+    # C34 — opt out of the server-side catastrophic-shrink guard, which
+    # refuses to replace a substantial document with a near-empty one. A
+    # truncated payload from a failed read looks exactly like an intentional
+    # wipe; that is how the shared task checklist was destroyed on
+    # 2026-08-27. Callers who genuinely mean to gut a document set this.
+    force: bool = False
     # Embed source is no longer caller-chosen. Server reads data["summary"]
     # (and, for collection="skills", falls back to data["description"] for
     # back-compat). See core_api.services.doc_indexing.
@@ -193,6 +200,23 @@ def _dict_to_out(d: dict) -> DocOut:
         created_at=d.get("created_at"),
         updated_at=d.get("updated_at"),
     )
+
+
+def _surface_storage_error(exc: httpx.HTTPStatusError) -> HTTPException:
+    """Carry a storage-api 4xx through with its status and message.
+
+    ``storage_client._post`` raises on non-2xx and the generic upstream
+    handler turns that into a 500, which would hide C34's shrink refusal
+    behind an opaque server error — the caller needs to see WHY the write was
+    refused and that ``force`` exists. Wet-testing caught exactly this: the
+    guard fired storage-side and the client saw a bare 500.
+    """
+    detail: object
+    try:
+        detail = exc.response.json()
+    except ValueError:
+        detail = exc.response.text or str(exc)
+    return HTTPException(status_code=exc.response.status_code, detail=detail)
 
 
 # ── Routes ──
@@ -328,16 +352,21 @@ async def upsert_document(
 
     sc = get_storage_client()
     if embedding is not None:
-        await sc.upsert_document_xmax(
-            {
-                "tenant_id": body.tenant_id,
-                "fleet_id": body.fleet_id,
-                "collection": body.collection,
-                "doc_id": body.doc_id,
-                "data": body.data,
-                "embedding": embedding,
-            }
-        )
+        try:
+            await sc.upsert_document_xmax(
+                {
+                    "tenant_id": body.tenant_id,
+                    "fleet_id": body.fleet_id,
+                    "collection": body.collection,
+                    "doc_id": body.doc_id,
+                    "data": body.data,
+                    # C34 — explicit opt-out of the catastrophic-shrink guard.
+                    "force": body.force,
+                    "embedding": embedding,
+                }
+            )
+        except httpx.HTTPStatusError as exc:
+            raise _surface_storage_error(exc) from exc
         # Storage-api commits in its own session, so no intermediate
         # ``db.commit()`` is needed. Re-fetch from the PRIMARY (read=False):
         # this is a read-after-write, so a replica read under replication lag
@@ -350,15 +379,20 @@ async def upsert_document(
             read=False,
         )
     else:
-        doc = await sc.upsert_document(
-            {
-                "tenant_id": body.tenant_id,
-                "fleet_id": body.fleet_id,
-                "collection": body.collection,
-                "doc_id": body.doc_id,
-                "data": body.data,
-            }
-        )
+        try:
+            doc = await sc.upsert_document(
+                {
+                    "tenant_id": body.tenant_id,
+                    "fleet_id": body.fleet_id,
+                    "collection": body.collection,
+                    "doc_id": body.doc_id,
+                    "data": body.data,
+                    # C34 — explicit opt-out of the catastrophic-shrink guard.
+                    "force": body.force,
+                }
+            )
+        except httpx.HTTPStatusError as exc:
+            raise _surface_storage_error(exc) from exc
     if doc is None:
         raise HTTPException(status_code=500, detail="Document upsert returned no rows")
     # Mint a memory carrying the document body so the BODY becomes reachable by

--- a/core-storage-api/src/core_storage_api/routers/documents.py
+++ b/core-storage-api/src/core_storage_api/routers/documents.py
@@ -21,6 +21,8 @@ async def upsert_document(request: Request) -> dict:
             doc_id=body["doc_id"],
             data=body["data"],
             fleet_id=body.get("fleet_id"),
+            # C34 — explicit opt-out of the catastrophic-shrink guard.
+            force=bool(body.get("force")),
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -43,6 +45,8 @@ async def upsert_document_xmax(request: Request) -> dict:
             doc_id=body["doc_id"],
             data=body["data"],
             fleet_id=body.get("fleet_id"),
+            # C34 — explicit opt-out of the catastrophic-shrink guard.
+            force=bool(body.get("force")),
             embedding=body.get("embedding"),
         )
     except ValueError as exc:

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -7151,9 +7151,7 @@ class PostgresService:
     # guard stays out of the way of genuinely tiny documents.
     _SHRINK_MIN_STORED_BYTES = 2048
 
-    async def _guard_document_shrink(
-        self, tenant_id: str, collection: str, doc_id: str, data: dict
-    ) -> None:
+    async def _guard_document_shrink(self, tenant_id: str, collection: str, doc_id: str, data: dict) -> None:
         """Refuse an upsert that would replace a substantial document with a
         near-empty one. Raises ``ValueError`` (surfaced as 400) naming both
         sizes and the override, so a caller who MEANT it can retry."""

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -7097,6 +7097,7 @@ class PostgresService:
         data: dict,
         fleet_id: str | None = None,
         system: bool = False,
+        force: bool = False,
     ) -> Document:
         """INSERT ... ON CONFLICT DO UPDATE. Returns the upserted Document.
 
@@ -7105,9 +7106,19 @@ class PostgresService:
         Public ``/documents`` endpoint never sets the flag, so callers
         that accidentally target a system collection get a clear
         ``ValueError`` instead of polluting governance state.
+
+        C34 — the upsert is last-writer-wins over the whole ``data`` blob, so
+        a caller that computes an empty or truncated payload destroys the
+        stored document and gets a 200 for it. That is not hypothetical: on
+        2026-08-27 a failed GET left a client file empty, the follow-up upsert
+        of those 0 bytes replaced a 105KB shared checklist, and recovery meant
+        reconstructing it by hand. ``_guard_document_shrink`` refuses a
+        catastrophic shrink unless the caller passes ``force``.
         """
         if collection.startswith("_") and not system:
             raise ValueError(f"Collection '{collection}' is system-managed; use the dedicated endpoint.")
+        if not force:
+            await self._guard_document_shrink(tenant_id, collection, doc_id, data)
         async with get_session() as session:
             stmt = (
                 pg_insert(Document)
@@ -7131,6 +7142,45 @@ class PostgresService:
             result = await session.execute(stmt)
             return result.scalar_one()
 
+    # C34 — a replacement this much smaller than what is stored is treated as
+    # a truncated payload, not an intentional edit. 10% keeps ordinary
+    # rewrites (even aggressive pruning) working while catching the
+    # empty/near-empty case that actually caused data loss.
+    _SHRINK_RATIO = 0.10
+    # Below this the absolute loss is small and the ratio gets noisy, so the
+    # guard stays out of the way of genuinely tiny documents.
+    _SHRINK_MIN_STORED_BYTES = 2048
+
+    async def _guard_document_shrink(
+        self, tenant_id: str, collection: str, doc_id: str, data: dict
+    ) -> None:
+        """Refuse an upsert that would replace a substantial document with a
+        near-empty one. Raises ``ValueError`` (surfaced as 400) naming both
+        sizes and the override, so a caller who MEANT it can retry."""
+        async with get_session() as session:
+            stored = (
+                await session.execute(
+                    select(Document.data).where(
+                        Document.tenant_id == tenant_id,
+                        Document.collection == collection,
+                        Document.doc_id == doc_id,
+                    )
+                )
+            ).scalar_one_or_none()
+        if stored is None:
+            return
+        old_len = len(json.dumps(stored, ensure_ascii=False))
+        if old_len < self._SHRINK_MIN_STORED_BYTES:
+            return
+        new_len = len(json.dumps(data, ensure_ascii=False))
+        if new_len >= old_len * self._SHRINK_RATIO:
+            return
+        raise ValueError(
+            f"refusing to shrink document '{collection}/{doc_id}' from {old_len} to {new_len} bytes "
+            f"({new_len / old_len:.1%} of the stored size). A truncated payload from a failed read "
+            f"looks exactly like this. Retry with force=true if the shrink is intended."
+        )
+
     async def document_upsert_returning_xmax(
         self,
         *,
@@ -7141,6 +7191,7 @@ class PostgresService:
         fleet_id: str | None = None,
         embedding: list[float] | None = None,
         system: bool = False,
+        force: bool = False,
     ) -> tuple:
         """Upsert and return (id, created_at, updated_at, xmax) for MCP callers.
 
@@ -7156,6 +7207,12 @@ class PostgresService:
         """
         if collection.startswith("_") and not system:
             raise ValueError(f"Collection '{collection}' is system-managed; use the dedicated endpoint.")
+        # C34 — same catastrophic-shrink guard as ``document_upsert``. This is
+        # the path INDEXED documents take (the one the 2026-08-27 data loss
+        # actually went through), so guarding only the sibling would have
+        # missed the real incident.
+        if not force:
+            await self._guard_document_shrink(tenant_id, collection, doc_id, data)
         async with get_session() as session:
             stmt = (
                 pg_insert(Document)

--- a/tests/test_c34_document_shrink_guard.py
+++ b/tests/test_c34_document_shrink_guard.py
@@ -1,0 +1,77 @@
+"""C34 — refuse an upsert that replaces a substantial document with a husk.
+
+Real incident (2026-08-27): a failed GET left a client file empty, the
+follow-up upsert of those 0 bytes replaced a 105KB shared checklist and
+returned 200. The document API is last-writer-wins over the whole ``data``
+blob with no history, so recovery meant rebuilding the file by hand.
+
+The guard is server-side and applies to BOTH upsert paths — the plain one and
+the ``xmax`` one that INDEXED documents (the checklist among them) actually
+take.
+"""
+
+import pytest
+from core_storage_api.services.postgres_service import PostgresService
+
+pytestmark = pytest.mark.unit
+
+
+BIG = {"content": "x" * 100_000}
+SMALL = {"content": "y" * 500}
+
+
+def test_ratio_and_floor_constants_are_sane():
+    assert PostgresService._SHRINK_RATIO == 0.10
+    assert PostgresService._SHRINK_MIN_STORED_BYTES == 2048
+
+
+def test_guard_math_rejects_catastrophic_shrink():
+    import json
+
+    old_len = len(json.dumps(BIG, ensure_ascii=False))
+    new_len = len(json.dumps({}, ensure_ascii=False))
+    assert old_len >= PostgresService._SHRINK_MIN_STORED_BYTES
+    assert new_len < old_len * PostgresService._SHRINK_RATIO
+
+
+def test_guard_math_allows_ordinary_rewrite():
+    import json
+
+    old_len = len(json.dumps(BIG, ensure_ascii=False))
+    # halving a document is aggressive but legitimate editing
+    new_len = len(json.dumps({"content": "x" * 50_000}, ensure_ascii=False))
+    assert new_len >= old_len * PostgresService._SHRINK_RATIO
+
+
+def test_guard_ignores_small_stored_documents():
+    import json
+
+    old_len = len(json.dumps(SMALL, ensure_ascii=False))
+    assert old_len < PostgresService._SHRINK_MIN_STORED_BYTES
+
+
+def test_both_upsert_paths_call_the_guard():
+    """The xmax path is the one indexed documents take — guarding only the
+    sibling would have missed the incident that motivated this."""
+    from pathlib import Path
+
+    import core_storage_api.services.postgres_service as ps
+
+    src = Path(ps.__file__).read_text()
+    plain = src.index("async def document_upsert(")
+    xmax = src.index("async def document_upsert_returning_xmax(")
+    assert "_guard_document_shrink" in src[plain:xmax]
+    assert "_guard_document_shrink" in src[xmax : xmax + 4000]
+
+
+def test_force_is_threaded_end_to_end():
+    from pathlib import Path
+
+    import core_api.routes.documents as api_docs
+    import core_storage_api.routers.documents as st_docs
+
+    api = Path(api_docs.__file__).read_text()
+    assert "force: bool = False" in api  # request model accepts it
+    assert api.count('"force": body.force') == 2  # both upsert payloads carry it
+    st = Path(st_docs.__file__).read_text()
+    assert st.count('force=bool(body.get("force"))') == 2  # both storage routes


### PR DESCRIPTION
## Summary

The document upsert is **last-writer-wins over the whole `data` blob with no history**, so a caller that computes an empty or truncated payload destroys the stored document — and gets a `200` for it.

That is not hypothetical. On 2026-08-27 a failed GET left a client file empty, the follow-up upsert of those 0 bytes **replaced a 105KB shared task checklist**, and recovery meant reconstructing the document by hand out of session transcripts; one concurrent edit in that window was lost for good.

## The guard

Server-side, in the storage service: reject an upsert whose payload is under **10%** of the stored document, when the stored document is at least **2KB**. The response is a `400` naming both sizes and the override:

```
refusing to shrink document 'caura_shared_tasks/v4-task-checklist' from 105233 to 15 bytes
(0.0% of the stored size). A truncated payload from a failed read looks exactly like this.
Retry with force=true if the shrink is intended.
```

Ordinary editing is untouched — even halving a document passes. `force: true` on the write body is the deliberate escape hatch.

**Both upsert paths are guarded.** The `xmax` path is the one **indexed** documents take (the checklist among them), so guarding only its sibling would have missed the exact incident that motivated this.

## Bonus fix the wet test caught

Storage's `400` reached the caller as an opaque **500**, hiding both the reason and the remedy. The documents routes now carry a storage 4xx through with its status and message, matching what the keystones routes already do.

## Testing

- 6 unit tests: ratio/floor constants, catastrophic-shrink math, ordinary-rewrite and small-document exemptions, both paths guarded, `force` threaded end to end.
- Full suite **5716 passed**; mypy clean on core-api and core-storage-api; ruff clean.
- **Wet test on the live stack replays the incident**: store 25KB doc → empty upsert **refused 400** → document **intact at 25,050 bytes** → `force=true` wipe allowed → halving edit allowed.

## Follow-up (deliberately not here)

Version history per `(collection, doc_id)` with a `?version=` readback, so recovery is a request rather than an archaeology session. The guard prevents the common cause; history is the safety net for everything else.

Refs: canonical C34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
