### PR TITLE
fix(storage): bind memory-entity links to the caller's tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -966,11 +966,15 @@ class CoreStorageClient:
     async def update_memory_entities(
         self,
         memory_id: str,
+        tenant_id: str,
         entity_links: list[dict],
     ) -> dict | None:
+        # Same contract as ``update_memory`` above, for the same reason: the
+        # memory is addressed by bare UUID, so the tenant has to travel with it.
+        # Storage scopes the memory AND every named entity to it.
         return await self._patch(
             f"/memories/{memory_id}/entities",
-            {"entity_links": entity_links},
+            {"tenant_id": tenant_id, "entity_links": entity_links},
         )
 
     async def get_entity_links_for_memories(

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -3750,7 +3750,7 @@ async def update_memory(
         entity_link_dicts = [
             {"entity_id": str(link.entity_id), "role": link.role} for link in data.entity_links
         ]
-        await sc.update_memory_entities(str(memory_id), entity_link_dicts)
+        await sc.update_memory_entities(str(memory_id), tenant_id, entity_link_dicts)
         changes["entity_links"] = {
             "old": "replaced",
             "new": f"{len(data.entity_links)} links",

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1827,6 +1827,12 @@ async def update_embedding(memory_id: UUID, request: Request) -> dict:
 @router.patch("/{memory_id}/entities")
 async def update_memory_entities(memory_id: UUID, request: Request) -> dict:
     body: dict = await request.json()
+    # Tenant guard, same shape as ``PATCH /memories/{memory_id}/embedding``
+    # above. This route validated the shape of ``entity_links`` carefully and
+    # read no tenant at all, so a caller who knew a memory UUID could hang
+    # entities off another tenant's row — and name another tenant's entities
+    # while doing it. Both endpoints of the link are scoped in the service.
+    tenant_id = _require(body, "tenant_id")
     entity_links = body.get("entity_links", [])
     if not isinstance(entity_links, list):
         raise HTTPException(status_code=422, detail="'entity_links' must be a list")
@@ -1836,7 +1842,13 @@ async def update_memory_entities(memory_id: UUID, request: Request) -> dict:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     if any(not isinstance(lnk["role"], str) or not lnk["role"] for lnk in links):
         raise HTTPException(status_code=422, detail="Each entity link must have a non-empty string 'role'")
-    await _svc.memory_add_entity_links(memory_id, links)
+    linked = await _svc.memory_add_entity_links(memory_id, tenant_id, links)
+    if not linked:
+        # One 404 for a memory that isn't there, a memory that isn't yours, and
+        # an entity that isn't yours. The detail names only the memory because
+        # saying which of the three it was would answer as an existence oracle
+        # for both id spaces — see the service docstring.
+        raise HTTPException(status_code=404, detail=f"Memory {memory_id} not found")
     return {"ok": True}
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -4020,25 +4020,70 @@ class PostgresService:
     async def memory_add_entity_links(
         self,
         memory_id: UUID,
+        tenant_id: str,
         links: list[dict],
-    ) -> None:
+    ) -> bool:
+        """Link entities to one memory, both endpoints scoped to ``tenant_id``.
+
+        Returns ``False`` when the memory is not in ``tenant_id`` or any named
+        entity is not, having written nothing; ``True`` when the links are in.
+
+        ``memory_entity_links`` has no ``tenant_id`` of its own, so the join row
+        cannot carry a predicate — but both parents do (``Memory.tenant_id``,
+        ``Entity.tenant_id``), which is what makes an existence check sufficient
+        and a schema change unnecessary.
+
+        **Both sides are load-bearing and neither implies the other.** Checking
+        only the memory lets a caller staple a foreign entity onto their own
+        memory, pulling another tenant's graph node into their namespace;
+        checking only the entities lets them staple their own entity onto a
+        foreign memory. The two failures are independent, so the checks are too.
+
+        One ``False`` for "no such memory", "not your memory" and "not your
+        entity" alike: distinguishing them would answer as an existence oracle
+        for memory and entity UUIDs, which is the thing a service that
+        authenticates nothing (GHSA-wgvw-28pq-jc36) must not do.
+
+        The check and the insert share a session and neither parent's
+        ``tenant_id`` is caller-writable — ``_ENTITY_UPDATABLE_FIELDS`` omits it
+        on entities (#1081) and ``_MEMORY_IMMUTABLE_FIELDS`` names it on
+        memories (#1118) — so a row cannot change hands between the two.
+
+        Shares ``_owned_link_endpoints`` with the two ``POST /entities/links``
+        paths (#1124), so all three writers to this join table resolve ownership
+        the same way and a fix to one cannot miss the others.
+        """
         # Bulk-insert with ``ON CONFLICT (memory_id, entity_id) DO NOTHING``
         # so two concurrent writes targeting the same ``(memory_id,
         # entity_id)`` pair don't serialise on ``Lock/transactionid``
         # (CAURA-686). Each ``link`` dict carries ``entity_id`` (UUID) and
         # ``role`` (str).
         if not links:
-            return
+            # Nothing is written, so there is nothing to scope. Reported as
+            # success rather than checked-then-succeeded: the answer is the
+            # same for every tenant, so it discloses nothing either way.
+            return True
+        entity_ids = {link["entity_id"] for link in links}
         rows = [
             {"memory_id": memory_id, "entity_id": link["entity_id"], "role": link["role"]} for link in links
         ]
         async with get_session() as session:
+            owned_memories, owned_entities = await self._owned_link_endpoints(
+                session, tenant_id, {memory_id}, entity_ids
+            )
+            # Set difference on the entity side, not a count: a caller who
+            # repeats one owned id enough times would satisfy
+            # ``len(found) == len(requested)`` while a foreign id rode along in
+            # the same request.
+            if memory_id not in owned_memories or entity_ids - owned_entities:
+                return False
             stmt = (
                 pg_insert(MemoryEntityLink)
                 .values(rows)
                 .on_conflict_do_nothing(index_elements=["memory_id", "entity_id"])
             )
             await session.execute(stmt)
+            return True
 
     async def memory_get_entity_links_for_memories(
         self,

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -173,13 +173,6 @@
       "note": "Verified: every item carries tenant_id; the method rejects mixed-tenant batches and scopes conflict recovery to it."
     },
     {
-      "id": "method:memory_add_entity_links",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Join table has no tenant column; rows are tenant-scoped only via the ids. Tracked in #1085."
-    },
-    {
       "id": "method:memory_admin_list",
       "verdict": "OPTIONAL",
       "evidence": "tenant_id is defaulted; omitting it drops the scope",
@@ -459,13 +452,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "no-tenant-data"
-    },
-    {
-      "id": "route:PATCH /api/v1/storage/memories/{memory_id}/entities",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1085."
     },
     {
       "id": "route:PATCH /api/v1/storage/reports/{report_id}",

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -1555,7 +1555,7 @@ class TestMemories:
         first = [{"entity_id": eid, "role": "mentioned"} for eid in entity_ids]
         resp = await client.patch(
             f"{PREFIX}/memories/{memory_id}/entities",
-            json={"entity_links": first},
+            json={"tenant_id": tenant_id, "entity_links": first},
         )
         assert resp.status_code == 200, resp.text
         assert resp.json()["ok"] is True
@@ -1590,7 +1590,7 @@ class TestMemories:
         ]
         resp2 = await client.patch(
             f"{PREFIX}/memories/{memory_id}/entities",
-            json={"entity_links": second},
+            json={"tenant_id": tenant_id, "entity_links": second},
         )
         assert resp2.status_code == 200, resp2.text
 

--- a/core-storage-api/tests/test_memory_entity_links_tenant_scope.py
+++ b/core-storage-api/tests/test_memory_entity_links_tenant_scope.py
@@ -1,0 +1,240 @@
+"""``PATCH /memories/{memory_id}/entities`` must be told which tenant it links for.
+
+The write form of GHSA-wgvw-28pq-jc36 on the memory→entity join table. The route
+validated the shape of ``entity_links`` carefully and read no tenant at all, so
+``memory_add_entity_links`` upserted against a bare ``memory_id`` with bare
+``entity_id`` values.
+
+``memory_entity_links`` has no ``tenant_id``, so the join row carries no
+predicate of its own — but both parents do (``Memory.tenant_id``,
+``Entity.tenant_id``), which is why an existence check on the two ends closes
+this and no schema change is involved.
+
+**The two ends fail independently, so they are tested independently.** With only
+the memory checked, a caller staples a foreign entity onto their own memory and
+pulls another tenant's graph node into their namespace; with only the entities
+checked, they staple their own entity onto a foreign memory. A test that covers
+one direction passes while half the hole stands open — hence
+``test_foreign_memory_is_not_linked`` and ``test_foreign_entity_is_not_linked``
+as separate cases, each of which fails on its own if its half of the predicate
+is reverted.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX, _memory_payload
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _tenant() -> str:
+    """A tenant id unique to one test and visible to the end-of-run sweep.
+
+    The ``test-tenant-`` prefix is not cosmetic: the root suite's
+    ``_setup_schema`` teardown cleans with ``tenant_id LIKE 'test-tenant-%'``
+    (and reaches this table through the ``memories`` subquery), so a tenant
+    minted with any other prefix is never reclaimed — which is how #858 left
+    9,186 rows behind. Locally this suite's default ``DATABASE_URL`` points at
+    the same database that sweep runs against, so the prefix is what gets these
+    rows collected; in CI the storage suite is given a database of its own and
+    nothing sweeps either way.
+
+    Local to this module rather than ``tests.conftest.new_tenant_id``, which is
+    the root suite's fixture file and not importable from this one. Same prefix
+    contract, deliberately.
+    """
+    return f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+
+async def _memory(client: AsyncClient, tenant_id: str) -> str:
+    fleet_id = f"test-fleet-{uuid.uuid4().hex[:8]}"
+    resp = await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _entity(client: AsyncClient, tenant_id: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/entities",
+        json={
+            "tenant_id": tenant_id,
+            "entity_type": "person",
+            "canonical_name": f"LinkScope-{uuid.uuid4().hex[:8]}",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _links(client: AsyncClient, memory_id: str) -> list[dict]:
+    """Read the links back regardless of tenant, to assert what actually persisted.
+
+    Deliberately goes through ``POST /memories/entity-links``, which is still
+    unscoped (allowlisted ``id-addressed-read``) and so answers for any tenant —
+    that is what makes it a usable oracle here. When that route gains a required
+    tenant, this helper needs one too.
+    """
+    resp = await client.post(f"{PREFIX}/memories/entity-links", json={"memory_ids": [memory_id]})
+    assert resp.status_code == 200, resp.text
+    return resp.json().get(memory_id, [])
+
+
+class TestMemoryEntityLinkTenantScope:
+    async def test_foreign_memory_is_not_linked(self, client: AsyncClient) -> None:
+        """Memory side: the attacker's own entity, hung off someone else's memory."""
+        victim, attacker = _tenant(), _tenant()
+        victim_memory = await _memory(client, victim)
+        attacker_entity = await _entity(client, attacker)
+
+        resp = await client.patch(
+            f"{PREFIX}/memories/{victim_memory}/entities",
+            json={
+                "tenant_id": attacker,
+                "entity_links": [{"entity_id": attacker_entity, "role": "subject"}],
+            },
+        )
+
+        assert resp.status_code == 404, resp.text
+        assert await _links(client, victim_memory) == [], (
+            "the attacker's entity was linked to a foreign memory"
+        )
+
+    async def test_foreign_entity_is_not_linked(self, client: AsyncClient) -> None:
+        """Entity side: someone else's entity, hung off the attacker's own memory.
+
+        Nothing here is a foreign *memory* — the row being written belongs to the
+        caller. Only the entity end is out of tenant, so this case is what the
+        entity half of the predicate exists for.
+        """
+        victim, attacker = _tenant(), _tenant()
+        attacker_memory = await _memory(client, attacker)
+        victim_entity = await _entity(client, victim)
+
+        resp = await client.patch(
+            f"{PREFIX}/memories/{attacker_memory}/entities",
+            json={
+                "tenant_id": attacker,
+                "entity_links": [{"entity_id": victim_entity, "role": "subject"}],
+            },
+        )
+
+        assert resp.status_code == 404, resp.text
+        assert await _links(client, attacker_memory) == [], (
+            "a foreign entity was pulled into the caller's graph"
+        )
+
+    async def test_one_foreign_entity_voids_the_whole_request(self, client: AsyncClient) -> None:
+        """A mixed batch writes nothing — not "the legitimate ones, minus the bad".
+
+        Partial application would still land the foreign edge's siblings and
+        report success, leaving the caller unable to tell which of their links
+        exist. All-or-nothing keeps the failure legible.
+        """
+        victim, attacker = _tenant(), _tenant()
+        attacker_memory = await _memory(client, attacker)
+        own_entity = await _entity(client, attacker)
+        victim_entity = await _entity(client, victim)
+
+        resp = await client.patch(
+            f"{PREFIX}/memories/{attacker_memory}/entities",
+            json={
+                "tenant_id": attacker,
+                "entity_links": [
+                    {"entity_id": own_entity, "role": "subject"},
+                    {"entity_id": victim_entity, "role": "object"},
+                ],
+            },
+        )
+
+        assert resp.status_code == 404, resp.text
+        assert await _links(client, attacker_memory) == []
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """No tenant used to mean "link by primary key"; it is now a 422."""
+        tenant = _tenant()
+        memory_id = await _memory(client, tenant)
+        entity_id = await _entity(client, tenant)
+
+        resp = await client.patch(
+            f"{PREFIX}/memories/{memory_id}/entities",
+            json={"entity_links": [{"entity_id": entity_id, "role": "subject"}]},
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+        assert await _links(client, memory_id) == []
+
+    async def test_own_links_are_created(self, client: AsyncClient) -> None:
+        """The supported call still works, for both ends in one tenant."""
+        tenant = _tenant()
+        memory_id = await _memory(client, tenant)
+        first, second = await _entity(client, tenant), await _entity(client, tenant)
+
+        resp = await client.patch(
+            f"{PREFIX}/memories/{memory_id}/entities",
+            json={
+                "tenant_id": tenant,
+                "entity_links": [
+                    {"entity_id": first, "role": "subject"},
+                    {"entity_id": second, "role": "mentioned"},
+                ],
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["ok"] is True
+        assert {link["entity_id"]: link["role"] for link in await _links(client, memory_id)} == {
+            first: "subject",
+            second: "mentioned",
+        }
+
+    async def test_a_foreign_id_is_indistinguishable_from_a_missing_one(self, client: AsyncClient) -> None:
+        """Both ends: naming a real row you don't own answers as "not there".
+
+        Same status and same detail for a UUID that exists elsewhere and one that
+        exists nowhere, on each end in turn — otherwise the route is an existence
+        oracle for two id spaces, on a service that authenticates no request.
+        """
+        victim, attacker = _tenant(), _tenant()
+        attacker_memory = await _memory(client, attacker)
+        attacker_entity = await _entity(client, attacker)
+
+        foreign_memory = await _memory(client, victim)
+        absent_memory = str(uuid.uuid4())
+        memory_answers = [
+            await client.patch(
+                f"{PREFIX}/memories/{mid}/entities",
+                json={
+                    "tenant_id": attacker,
+                    "entity_links": [{"entity_id": attacker_entity, "role": "subject"}],
+                },
+            )
+            for mid in (foreign_memory, absent_memory)
+        ]
+        assert [r.status_code for r in memory_answers] == [404, 404]
+        # Both details name the memory id the caller asked about, and nothing else.
+        assert [r.json()["detail"] for r in memory_answers] == [
+            f"Memory {foreign_memory} not found",
+            f"Memory {absent_memory} not found",
+        ]
+
+        foreign_entity = await _entity(client, victim)
+        absent_entity = str(uuid.uuid4())
+        entity_answers = [
+            await client.patch(
+                f"{PREFIX}/memories/{attacker_memory}/entities",
+                json={"tenant_id": attacker, "entity_links": [{"entity_id": eid, "role": "subject"}]},
+            )
+            for eid in (foreign_entity, absent_entity)
+        ]
+        assert [r.status_code for r in entity_answers] == [404, 404]
+        # The detail names the memory, not the entity that was actually refused,
+        # so the two entity cases are not merely equal to each other — they
+        # disclose nothing about the entity id space at all.
+        detail = f"Memory {attacker_memory} not found"
+        assert [r.json()["detail"] for r in entity_answers] == [detail, detail]


### PR DESCRIPTION
Closes #1085.

`PATCH /api/v1/storage/memories/{memory_id}/entities` validated the shape of `entity_links` carefully — list, `entity_id`, non-empty string `role` — and read no tenant at all. `memory_add_entity_links` then upserted rows against a bare `memory_id` with bare `entity_id` values.

`core-storage-api` authenticates no request (GHSA-wgvw-28pq-jc36) and docker-compose publishes it on `0.0.0.0:8002`, so a bare primary key is not an authorisation check: knowing a UUID is not being entitled to the row behind it.

### No schema change

`memory_entity_links` has no `tenant_id`, which means only that the join row cannot carry a predicate directly. Both parents carry one — `Memory.tenant_id` (`common/models/memory.py:30`) and `Entity.tenant_id` (`common/models/entity.py:18`), both `Text, nullable=False, index=True`. So the fix is an existence check on the two ends: ordinary rows, ordinary `WHERE`, no DDL.

### Does the method need to exist?

Asked first, because the precedent on this exact table is #1091, closed 30 August: `entity_delete_entity_links` was **deleted, not scoped**, once a search found no caller at all.

`memory_add_entity_links` is not that case. It has exactly one caller — `PATCH /memories/{memory_id}/entities` — reached from `sc.update_memory_entities`, called from `memory_service.update_memory` (`core-api/src/core_api/services/memory_service.py:3753`) whenever a `MemoryUpdate` carries `entity_links`. Live, single-purpose, not duplicated by the bulk path. It gets the check.

Established by searching for the method, the client wrapper and the route path separately rather than reading the route — the defect class here is precisely that the tenancy guarantee lived in one caller and never travelled. `update_memory` has `tenant_id` in its signature and never forwarded it.

### Both ends, separately

Neither check implies the other, and each fails on its own:

- Skip the **entity** check and a caller staples a foreign entity onto their own memory, pulling someone else's graph node into their namespace.
- Skip the **memory** check and they staple their own entity onto a foreign memory.

`test_foreign_memory_is_not_linked` and `test_foreign_entity_is_not_linked` are separate cases for that reason. Reverting one predicate fails only its own direction — pasted below.

A mixed batch writes nothing rather than landing the caller's own links beside the refused one, so a partial success cannot leave the caller unable to tell which edges exist. The entity check is a set difference rather than a count, so repeating one owned id cannot pad a foreign one through.

One `404` covers "no such memory", "not your memory" and "not your entity" alike, and its detail names only the memory — distinguishing them would answer as an existence oracle for two id spaces on a service that authenticates nothing.

### Failing without the fix

Reverting **only** the memory-side predicate in `_owned_link_endpoints` (`Memory.tenant_id == tenant_id` dropped from the `WHERE`):

```
F....F                                                                   [100%]
______ TestMemoryEntityLinkTenantScope.test_foreign_memory_is_not_linked _______
core-storage-api/tests/test_memory_entity_links_tenant_scope.py:102: in test_foreign_memory_is_not_linked
    assert resp.status_code == 404, resp.text
E   AssertionError: {"ok":true}
E   assert 200 == 404
E    +  where 200 = <Response [200 OK]>.status_code
_ TestMemoryEntityLinkTenantScope.test_a_foreign_id_is_indistinguishable_from_a_missing_one _
core-storage-api/tests/test_memory_entity_links_tenant_scope.py:219: in ...
    assert [r.status_code for r in memory_answers] == [404, 404]
E   assert [200, 404] == [404, 404]
E     At index 0 diff: 200 != 404
2 failed, 4 passed in 0.48s
```

The entity-side tests still pass. Reverting **only** the entity-side predicate (`Entity.tenant_id == tenant_id` dropped):

```
.FF..F                                                                   [100%]
______ TestMemoryEntityLinkTenantScope.test_foreign_entity_is_not_linked _______
core-storage-api/tests/test_memory_entity_links_tenant_scope.py:126: in test_foreign_entity_is_not_linked
    assert resp.status_code == 404, resp.text
E   AssertionError: {"ok":true}
E   assert 200 == 404
_ TestMemoryEntityLinkTenantScope.test_one_foreign_entity_voids_the_whole_request _
core-storage-api/tests/test_memory_entity_links_tenant_scope.py:154: in ...
    assert resp.status_code == 404, resp.text
E   AssertionError: {"ok":true}
E   assert 200 == 404
_ TestMemoryEntityLinkTenantScope.test_a_foreign_id_is_indistinguishable_from_a_missing_one _
core-storage-api/tests/test_memory_entity_links_tenant_scope.py:235: in ...
    assert [r.status_code for r in entity_answers] == [404, 404]
E   assert [200, 404] == [404, 404]
3 failed, 3 passed in 0.49s
```

The memory-side test still passes. Each half is independently load-bearing, demonstrated in both directions — `{"ok":true}` is the write that went through.

### Allowlist

102 → 100 entries; `id-addressed-write` 8 → 6. Both #1085 entries (`method:memory_add_entity_links`, `route:PATCH /api/v1/storage/memories/{memory_id}/entities`) removed and regenerated with `python3 scripts/tenant_scope_gate.py --write`, as the gate's stale-entry check (`tenant_scope_gate.py:1060-1063`) requires. Gate green; hand-written `note` and `category` fields elsewhere in the file are untouched.

The baseline moved twice while this was open — it was 108 when the branch was cut, then #1150 removed two entries and #1152 removed four. Rebased onto each and regenerated; the *contribution* of this PR is unchanged at two entries.

### Precedent for the five `id-addressed-read` siblings

Not fixed here and not mine to fix, but this is the shape they should follow, since eight allowlist entries share the note *"Join table has no tenant column; rows are tenant-scoped only via the ids"*:

- **Existence check on both parents, not a schema change.** The absent `tenant_id` on the join table is not a blocker; `Memory.tenant_id` and `Entity.tenant_id` are enough.
- **Scope every end the caller names.** For the reads that take `memory_ids`, that is the memory side; for `entity_get_memory_ids_by_entity_ids`, the entity side; `entity_find_entity_link` names both and should check both.
- **One answer for "absent" and "not yours"** — empty/`404`, never a distinguishable status or message, or the route becomes an existence oracle for UUIDs on a service that authenticates nothing.
- **The check belongs in the service method**, not the route, so it cannot drift away from the query.
- **Two tests per method, one per end**, each verified to fail with only its own predicate reverted. A single-direction test passes while half the hole stands open.

- **`_owned_link_endpoints` is the reusable piece.** It takes sets and returns the owned subsets, so a read resolving many ids can filter without a query each. The reads should use it rather than growing their own variant.

One caveat for whoever takes them: `POST /memories/entity-links` is currently the read oracle in this PR's test helper (`_links`) precisely because it is still unscoped. When it gains a required tenant, that helper needs one too — there is a comment on it saying so.

**Since #1152 merged, this PR now shares its ownership check with the two `POST /entities/links` paths** rather than carrying an inline copy — the follow-up that PR flagged, done here instead of left outstanding. All three writers to this join table now resolve ownership through one helper, so the revert proofs below exercise the code path #1124's routes use too.

### Verification

- `core-storage-api/tests/`: 264 passed (6 new).
- Root `tests/`: 5716 passed, 4 skipped, 1 xfailed.
- `ruff check` and `ruff format --check` at CI's exact scopes: clean.
- `mypy` core-api (203 files) and core-storage-api (85 files): no issues.
- Tenant-scope gate against `origin/main`: green, "Allowlist shrank by 2".

Run against a dedicated local pgvector instance. **Not checked:** anything requiring CI's own environment — the GitHub Actions matrix, the coverage floors step, and the enterprise re-vendor path.
