### PR TITLE
fix(contradiction): decouple the judge's provider from entity extraction (C2, A32)

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -124,6 +124,14 @@ class Settings(BaseSettings):
     # None (the default) sends no parameter at all — REQUIRED for
     # non-reasoning models, which reject the parameter outright.
     contradiction_reasoning_effort: str | None = None
+    # C2 — the contradiction judge historically read the ENTITY-EXTRACTION
+    # provider/model config, so an operator who moved entity extraction to a
+    # cheaper or different model silently moved the contradiction judge with
+    # it, and could not tune the two independently. These override the
+    # entity-extraction values for contradiction judging only; empty keeps
+    # the historical behaviour exactly.
+    contradiction_provider: str = ""
+    contradiction_model: str = ""
     # Default for the ``search.entity_retrieval`` org setting: query-time entity
     # lookup + graph search. A tenant override wins; this is the fleet-wide
     # fallback so an operator can disable entity/graph reads on a whole box

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -622,6 +622,15 @@ async def _detect(
             # ``updates`` is empty. Keyed by ``memory_id`` — see
             # ``_merge_status_update`` for the dedupe rationale.
             updates: dict[str, dict] = {}
+            # A32 (verified 2026-08-31, no code change): the bare ``if
+            # verdict`` below is safe. ``_judge_contradiction`` forces the
+            # verdict to False on every low-confidence branch, so an
+            # LLM-derived True always carries ``_CONF_CLEAN`` — pinned
+            # exhaustively in ``tests/test_a32_forward_confidence_gate.py``.
+            # The one producer of a low-confidence True is the DELIBERATE fake
+            # provider (``_pairwise_fake_fn`` -> ``_CONF_FALLBACK``), which an
+            # operator opts into for dev/CI; gating that away would break the
+            # stand-in without making anything safer.
             for candidate, (verdict, _confidence, _raw) in zip(candidates, judged):
                 # CAURA-132 diag — Path A semantic per-candidate verdict.
                 logger.debug(
@@ -1097,6 +1106,28 @@ _CONF_GATE1 = 0.60
 _CONF_FALLBACK = 0.50
 
 
+def _judge_provider(tenant_config) -> str:
+    """Provider for CONTRADICTION judging.
+
+    C2 — this used to read the entity-extraction provider directly, so the
+    two were welded together: moving entity extraction to a cheaper model
+    silently moved the contradiction judge with it. ``contradiction_provider``
+    overrides it when set; empty preserves the historical behaviour exactly.
+    """
+    if settings.contradiction_provider:
+        return settings.contradiction_provider
+    return tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
+
+
+def _judge_model_attr() -> str:
+    """Model attribute name handed to ``call_with_fallback`` for judging.
+
+    Same split as ``_judge_provider``: an explicit ``contradiction_model``
+    wins, otherwise the entity-extraction model is used as before.
+    """
+    return "contradiction_model" if settings.contradiction_model else "entity_extraction_model"
+
+
 def _judge_contradiction(raw) -> tuple[bool, float]:
     """A4 #12 — wrap ``_parse_contradiction_response`` with a confidence
     score derived from the model's own coherence.
@@ -1168,9 +1199,7 @@ async def _llm_contradiction_check(
     3. Abstain — or, when the operator ASKED for the fake provider, the
        negation-word heuristic. See :func:`common.llm.retry.deliberate_fake_provider`.
     """
-    provider_name = (
-        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
-    )
+    provider_name = _judge_provider(tenant_config)
 
     prompt = CONTRADICTION_PROMPT.format(new_content=new_content[:500], old_content=old_content[:500])
 
@@ -1184,7 +1213,7 @@ async def _llm_contradiction_check(
         fake_fn=_pairwise_fake_fn(provider_name, new_content, old_content),
         tenant_config=tenant_config,
         service_label="contradiction",
-        model_attr="entity_extraction_model",
+        model_attr=_judge_model_attr(),
         timeout=10.0,
     )
 
@@ -1317,9 +1346,7 @@ async def _llm_contradiction_check_batch(
     a contradiction. The caller runs each raw through ``_judge_contradiction``,
     so the safety gates are identical to the per-candidate path. E4: the reply
     is sparse — see ``_expand_sparse_batch``."""
-    provider_name = (
-        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
-    )
+    provider_name = _judge_provider(tenant_config)
     candidates_block = "\n".join(f"[{i}] {c.get('content', '')[:500]}" for i, c in enumerate(candidates))
     prompt = BATCH_CONTRADICTION_PROMPT.format(
         new_content=new_content[:500], candidates_block=candidates_block
@@ -1335,7 +1362,7 @@ async def _llm_contradiction_check_batch(
         fake_fn=_batch_fake_fn(provider_name, new_content, candidates),
         tenant_config=tenant_config,
         service_label="contradiction_batch",
-        model_attr="entity_extraction_model",
+        model_attr=_judge_model_attr(),
         timeout=15.0,
     )
 
@@ -1746,9 +1773,7 @@ async def _llm_entity_aware_contradiction_check(
     non-empty before invoking — see ``_attempt_path_c_retraction`` for
     the guard.
     """
-    provider_name = (
-        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
-    )
+    provider_name = _judge_provider(tenant_config)
 
     prompt = ENTITY_AWARE_CONTRADICTION_PROMPT.format(
         new_content=new_content[:500],
@@ -1767,7 +1792,7 @@ async def _llm_entity_aware_contradiction_check(
         fake_fn=_pairwise_fake_fn(provider_name, new_content, old_content),
         tenant_config=tenant_config,
         service_label="contradiction-entity-aware",
-        model_attr="entity_extraction_model",
+        model_attr=_judge_model_attr(),
         timeout=10.0,
     )
 
@@ -1866,9 +1891,7 @@ async def _llm_entity_aware_contradiction_check_batch(
     through ``_judge_contradiction`` so the safety gates are identical to the
     per-candidate entity-aware path.
     """
-    provider_name = (
-        tenant_config.entity_extraction_provider if tenant_config else settings.entity_extraction_provider
-    )
+    provider_name = _judge_provider(tenant_config)
     candidates_block = "\n".join(
         f"[{i}] {c.get('content', '')[:500]}\n    RESOLVED ENTITIES: "
         f"{_format_entity_context(c.get('entities', []))}"
@@ -1890,7 +1913,7 @@ async def _llm_entity_aware_contradiction_check_batch(
         fake_fn=_batch_fake_fn(provider_name, new_content, candidates),
         tenant_config=tenant_config,
         service_label="contradiction-entity-aware_batch",
-        model_attr="entity_extraction_model",
+        model_attr=_judge_model_attr(),
         timeout=15.0,
     )
 

--- a/tests/test_a32_forward_confidence_gate.py
+++ b/tests/test_a32_forward_confidence_gate.py
@@ -1,0 +1,65 @@
+"""A32 — forward Path-A detection must not act on a weak judgment.
+
+The row was filed because the forward path marks the older row
+``conflicted`` on a bare ``if verdict:`` and discards the confidence, while
+the retraction path carries a 0.90 gate. Verified before changing anything:
+the premise does NOT hold in current code — ``_judge_contradiction`` forces
+the verdict to False on every low-confidence branch, so a True verdict
+always carries ``_CONF_CLEAN``.
+
+A confidence gate was implemented and then REVERTED: it changed behaviour
+only for the deliberate fake provider (whose True verdicts carry
+``_CONF_FALLBACK``), breaking the dev/CI stand-in without making anything
+safer. What remains is the invariant, pinned here so a future change to the
+rubric — which WOULD make the bare check unsafe — fails loudly.
+"""
+
+import pytest
+from core_api.services.contradiction_detector import (
+    _CONF_CLEAN,
+    _CONF_FALLBACK,
+    NON_CONFLICT_REASONS,
+    RETRACTION_CONFIDENCE_THRESHOLD,
+    _judge_contradiction,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_retraction_threshold_is_the_clean_confidence():
+    assert RETRACTION_CONFIDENCE_THRESHOLD == _CONF_CLEAN
+
+
+def test_a_true_verdict_is_never_low_confidence():
+    """The invariant the forward gate relies on, probed exhaustively over the
+    judge's whole input space."""
+    seen = set()
+    for contradicts in (True, False):
+        for same_subject in (True, False):
+            for ncr in (None, "not_a_listed_reason", next(iter(NON_CONFLICT_REASONS))):
+                raw = {"contradicts": contradicts, "same_subject": same_subject}
+                if ncr:
+                    raw["non_conflict_reason"] = ncr
+                verdict, confidence = _judge_contradiction(raw)
+                if verdict:
+                    seen.add(confidence)
+    assert seen == {_CONF_CLEAN}, f"a True verdict carried {seen}"
+
+
+def test_malformed_response_is_false_and_low_confidence():
+    for raw in (None, {}, "nonsense", []):
+        verdict, confidence = _judge_contradiction(raw)
+        assert verdict is False and confidence == _CONF_FALLBACK
+
+
+def test_the_only_low_confidence_true_is_the_deliberate_fake_provider():
+    """Why the forward path needs no confidence gate: the sole producer of a
+    low-confidence True verdict is the fake heuristic an operator opts into,
+    not a weak LLM judgment."""
+    from pathlib import Path
+
+    import core_api.services.contradiction_detector as cd
+
+    src = Path(cd.__file__).read_text()
+    assert "_CONF_FALLBACK)" in src  # the fake fn's confidence
+    assert "A32 (verified 2026-08-31, no code change)" in src

--- a/tests/test_c2_contradiction_provider_split.py
+++ b/tests/test_c2_contradiction_provider_split.py
@@ -1,0 +1,52 @@
+"""C2 — the contradiction judge must be configurable apart from entity extraction.
+
+Moving entity extraction to a cheaper model used to move the contradiction
+judge with it, silently, because the judge read the entity-extraction
+provider/model config directly.
+"""
+
+import pytest
+from core_api.config import settings
+from core_api.services.contradiction_detector import _judge_model_attr, _judge_provider
+
+pytestmark = pytest.mark.unit
+
+
+class _Cfg:
+    entity_extraction_provider = "tenant-entity-provider"
+
+
+def test_defaults_preserve_historical_behaviour(monkeypatch):
+    monkeypatch.setattr(settings, "contradiction_provider", "")
+    monkeypatch.setattr(settings, "contradiction_model", "")
+    assert _judge_provider(_Cfg()) == "tenant-entity-provider"
+    assert _judge_model_attr() == "entity_extraction_model"
+
+
+def test_explicit_override_wins(monkeypatch):
+    monkeypatch.setattr(settings, "contradiction_provider", "judge-provider")
+    monkeypatch.setattr(settings, "contradiction_model", "judge-model")
+    assert _judge_provider(_Cfg()) == "judge-provider"
+    assert _judge_model_attr() == "contradiction_model"
+
+
+def test_falls_back_to_global_when_no_tenant_config(monkeypatch):
+    monkeypatch.setattr(settings, "contradiction_provider", "")
+    monkeypatch.setattr(
+        settings, "entity_extraction_provider", "global-entity-provider"
+    )
+    assert _judge_provider(None) == "global-entity-provider"
+
+
+def test_every_judge_call_site_uses_the_helper():
+    from pathlib import Path
+
+    import core_api.services.contradiction_detector as cd
+
+    src = Path(cd.__file__).read_text()
+    # the entity-provider read survives in exactly ONE place — the helper
+    # itself, which is the fallback. Any second occurrence is a call site
+    # that bypassed the split.
+    assert src.count("tenant_config.entity_extraction_provider if tenant_config") == 1
+    assert src.count("_judge_provider(tenant_config)") >= 4
+    assert 'model_attr="entity_extraction_model"' not in src

--- a/tests/test_p1_contradiction.py
+++ b/tests/test_p1_contradiction.py
@@ -568,6 +568,12 @@ class TestContradictionIntegration:
             "core_api.services.contradiction_detector.settings"
         ) as mock_settings:
             mock_settings.entity_extraction_provider = "fake"
+            # C2 — the judge now consults ``contradiction_provider`` first.
+            # This patch replaces the whole settings object, so every field the
+            # judge reads must be declared: an undeclared attribute comes back
+            # as a truthy MagicMock and would be used as a provider name.
+            mock_settings.contradiction_provider = ""
+            mock_settings.contradiction_model = ""
             contradictions = await detect_contradictions(new, emb)
 
         # The fake heuristic should detect negation + overlap
@@ -588,6 +594,12 @@ class TestContradictionIntegration:
             "core_api.services.contradiction_detector.settings"
         ) as mock_settings:
             mock_settings.entity_extraction_provider = "fake"
+            # C2 — the judge now consults ``contradiction_provider`` first.
+            # This patch replaces the whole settings object, so every field the
+            # judge reads must be declared: an undeclared attribute comes back
+            # as a truthy MagicMock and would be used as a provider name.
+            mock_settings.contradiction_provider = ""
+            mock_settings.contradiction_model = ""
             contradictions = await detect_contradictions(new, emb)
 
         assert len(contradictions) == 0


### PR DESCRIPTION
## Summary

Two rows from the consolidated list, one subsystem.

### C2 — decouple the judge's provider from entity extraction

The contradiction judge read the **entity-extraction** provider and model config directly, at four call sites. An operator who moved entity extraction to a cheaper model silently moved the contradiction judge with it, and had no way to tune the two independently.

`CONTRADICTION_PROVIDER` / `CONTRADICTION_MODEL` now override for judging only. Empty — the default — resolves exactly as before, so this is a **no-op until an operator sets one**. All four sites route through one helper, and a test asserts the entity-provider read survives in exactly one place (the helper's own fallback), so a future call site can't quietly bypass the split.

### A32 — verified, deliberately no code change

The row says forward Path-A detection acts on weak verdicts because it discards confidence, while the retraction path has a 0.90 gate. **That premise does not hold in current code.** `_judge_contradiction` forces the verdict to `False` on every low-confidence branch (gate 1, gate 2, malformed), so an LLM-derived `True` always carries `_CONF_CLEAN` — probed exhaustively over the judge's whole input space in the new test.

I implemented the confidence gate anyway, and the test suite caught that it **changed behaviour for exactly one producer**: the *deliberate* fake provider, whose `True` verdicts carry `_CONF_FALLBACK`. Gating those away breaks the dev/CI stand-in and makes nothing safer, so the gate was reverted.

What ships instead is the invariant itself — pinned by test, plus a comment at the bare `if verdict:` explaining why it's safe. If someone later changes the confidence rubric so a weak `True` becomes possible, the test fails loudly rather than the system silently marking rows `conflicted` on a weak judgment.

## Note for reviewers

The wholesale `settings` patches in `test_p1_contradiction.py` now declare the two new fields. An undeclared attribute on a `MagicMock` reads back **truthy**, so it would have been used as a provider name — that's how this surfaced.

## Testing

8 new unit tests; full suite **5718 passed**; ruff + mypy clean.

**Wet test** on the live stack with `ENTITY_EXTRACTION_PROVIDER=openai` and `CONTRADICTION_PROVIDER=fake` — the deployed image resolves the judge to `fake` while extraction stays on `openai`:

```
env CONTRADICTION_PROVIDER = 'fake'
env ENTITY_EXTRACTION_PROVIDER = 'openai'
judge provider resolves to -> fake
judge model attr resolves to -> entity_extraction_model
```

(The end-to-end judge path couldn't be exercised in this environment — the shared OpenAI backend was erroring and fake embeddings produce no semantic neighbours — so the split is proven at the resolution point in the deployed image rather than through a live contradiction.)

Refs: canonical C2, A32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
