### PR TITLE
fix(storage): scope lifecycle audit finalization to org

### DIFF
--- a/common/events/lifecycle_handlers.py
+++ b/common/events/lifecycle_handlers.py
@@ -57,6 +57,7 @@ class ArchiveStorageAdapter(Protocol):
         self,
         audit_id: int,
         *,
+        org_id: str,
         status: str,
         stats: dict | None = None,
         error_message: str | None = None,
@@ -116,6 +117,7 @@ class PipelineStorageAdapter(Protocol):
         self,
         audit_id: int,
         *,
+        org_id: str,
         status: str,
         stats: dict | None = None,
         error_message: str | None = None,
@@ -218,6 +220,7 @@ async def _run_action(
             try:
                 await adapter.update_lifecycle_audit_row(
                     audit_id,
+                    org_id=org_id,
                     status="success",
                     stats={"skipped": True, "reason": "recent_success"},
                 )
@@ -243,7 +246,11 @@ async def _run_action(
     # still runs — dropping would silently skip an op the operator
     # asked for.
     try:
-        await adapter.update_lifecycle_audit_row(audit_id, status="in_progress")
+        await adapter.update_lifecycle_audit_row(
+            audit_id,
+            org_id=org_id,
+            status="in_progress",
+        )
     except Exception:
         logger.warning(
             "lifecycle audit in_progress update failed; continuing",
@@ -269,6 +276,7 @@ async def _run_action(
         try:
             await adapter.update_lifecycle_audit_row(
                 audit_id,
+                org_id=org_id,
                 status="failure",
                 stats={"terminal": True} if permanent else None,
                 error_message=str(exc)[:500],
@@ -308,6 +316,7 @@ async def _run_action(
 
     await adapter.update_lifecycle_audit_row(
         audit_id,
+        org_id=org_id,
         status="success",
         stats={stats_key: count},
     )

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2638,12 +2638,13 @@ class CoreStorageClient:
         self,
         audit_id: int,
         *,
+        org_id: str,
         status: str,
         stats: dict | None = None,
         error_message: str | None = None,
     ) -> None:
         """Flip the row to ``in_progress``, ``success``, or ``failure``."""
-        body: dict[str, Any] = {"status": status}
+        body: dict[str, Any] = {"org_id": org_id, "status": status}
         if stats is not None:
             body["stats"] = stats
         if error_message is not None:

--- a/core-api/src/core_api/routes/org_deletion.py
+++ b/core-api/src/core_api/routes/org_deletion.py
@@ -91,13 +91,13 @@ async def purge_org_data(
     purged: dict[str, dict[str, int]] = {}
     failed: dict[str, str] = {}
 
-    async def _finalize(audit_id: int | None, **kwargs: Any) -> None:
+    async def _finalize(audit_id: int | None, *, org_id: str, **kwargs: Any) -> None:
         # The purge is the source of truth: a transient audit-write failure
         # must never mask a completed purge or abort the rest of the batch.
         if audit_id is None:
             return
         try:
-            await storage.update_lifecycle_audit_row(audit_id, **kwargs)
+            await storage.update_lifecycle_audit_row(audit_id, org_id=org_id, **kwargs)
         except Exception:
             logger.warning("failed to update lifecycle_audit row %s", audit_id, exc_info=True)
 
@@ -115,11 +115,21 @@ async def purge_org_data(
         except Exception as exc:
             logger.exception("purge_tenant_data failed for tenant %s", tenant_id)
             failed[tenant_id] = str(exc)
-            await _finalize(audit_id, status="failure", error_message=str(exc))
+            await _finalize(
+                audit_id,
+                org_id=tenant_id,
+                status="failure",
+                error_message=str(exc),
+            )
             continue
 
         purged[tenant_id] = counts
-        await _finalize(audit_id, status="success", stats={"deleted": counts})
+        await _finalize(
+            audit_id,
+            org_id=tenant_id,
+            status="success",
+            stats={"deleted": counts},
+        )
 
     logger.info(
         "purge_org_data: %d purged, %d failed (triggered_by=%s)",

--- a/core-api/src/core_api/services/lifecycle_audit.py
+++ b/core-api/src/core_api/services/lifecycle_audit.py
@@ -328,12 +328,17 @@ class _CoreApiLifecycleAdapter:
         self,
         audit_id: int,
         *,
+        org_id: str,
         status: str,
         stats: dict | None = None,
         error_message: str | None = None,
     ) -> None:
         await self._storage.update_lifecycle_audit_row(
-            audit_id, status=status, stats=stats, error_message=error_message
+            audit_id,
+            org_id=org_id,
+            status=status,
+            stats=stats,
+            error_message=error_message,
         )
 
 

--- a/core-storage-api/src/core_storage_api/routers/lifecycle_audit.py
+++ b/core-storage-api/src/core_storage_api/routers/lifecycle_audit.py
@@ -105,13 +105,18 @@ async def get_lifecycle_audit(audit_id: int, org_id: str) -> dict:
 @router.patch("/{audit_id}")
 async def update_lifecycle_audit(audit_id: int, request: Request) -> dict:
     """Update status (+ optional stats / error_message). Body:
-    ``{status, stats?, error_message?}``. ``finished_at`` is stamped
+    ``{org_id, status, stats?, error_message?}``. ``finished_at`` is stamped
     server-side when ``status`` is terminal (``success``/``failure``).
     """
     try:
         body: dict = await request.json()
     except Exception as exc:
         raise HTTPException(status_code=422, detail="request body must be valid JSON") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="request body must be a JSON object")
+    org_id = body.get("org_id")
+    if not isinstance(org_id, str) or not org_id:
+        raise HTTPException(status_code=422, detail="'org_id' must be a non-empty string")
     status = body.get("status")
     if status not in _VALID_STATUSES:
         raise HTTPException(
@@ -120,6 +125,7 @@ async def update_lifecycle_audit(audit_id: int, request: Request) -> dict:
         )
     result = await _svc.lifecycle_audit_finalize(
         audit_id,
+        org_id=org_id,
         status=status,
         stats=body.get("stats"),
         error_message=body.get("error_message"),

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -9654,6 +9654,7 @@ class PostgresService:
         self,
         audit_id: int,
         *,
+        org_id: str,
         status: str,
         stats: dict | None = None,
         error_message: str | None = None,
@@ -9666,12 +9667,17 @@ class PostgresService:
           (the sticky-success gate skipped the UPDATE). A no-op, NOT
           an error — typically a Pub/Sub redelivery of an already-
           acked successful message.
-        * ``False`` — row not found at all (pruned, or a buggy
-          publisher invented an id).
+        * ``False`` — no row matches both ``audit_id`` and ``org_id``
+          (pruned, belongs to another org, or a buggy publisher
+          invented an id).
 
         ``finished_at`` is only stamped on terminal status values so the
         ``in_progress`` transition leaves the row addressable for a
         later success/failure update.
+
+        ``org_id`` is part of both the UPDATE and the no-op existence
+        check, so an id from another org is indistinguishable from a
+        missing row and cannot be finalized by id alone.
         """
         values: dict = {"status": status}
         if status in ("success", "failure"):
@@ -9704,7 +9710,10 @@ class PostgresService:
             # ``failure`` is NOT gated.
             stmt = (
                 sql_update(LifecycleAudit)
-                .where(LifecycleAudit.id == audit_id)
+                .where(
+                    LifecycleAudit.id == audit_id,
+                    LifecycleAudit.org_id == org_id,
+                )
                 .where(LifecycleAudit.status != "success")
                 .values(**values)
             )
@@ -9716,7 +9725,12 @@ class PostgresService:
             # instead of a misleading 404 that would surface as a
             # spurious "audit row not found" warning on every Pub/Sub
             # redelivery of an acked-but-late-acked successful message.
-            exists = await session.scalar(select(LifecycleAudit.id).where(LifecycleAudit.id == audit_id))
+            exists = await session.scalar(
+                select(LifecycleAudit.id).where(
+                    LifecycleAudit.id == audit_id,
+                    LifecycleAudit.org_id == org_id,
+                )
+            )
             return None if exists else False
 
     async def lifecycle_audit_has_recent_success(

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -173,13 +173,6 @@
       "note": "Verified: values['tenant_id'] is stored and participates in the tenant-and-node conflict constraint."
     },
     {
-      "id": "method:lifecycle_audit_finalize",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1083."
-    },
-    {
       "id": "method:memory_add",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -480,13 +473,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "no-tenant-data"
-    },
-    {
-      "id": "route:PATCH /api/v1/storage/lifecycle-audit/{audit_id}",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1083."
     },
     {
       "id": "route:PATCH /api/v1/storage/memories/{memory_id}/entities",

--- a/core-storage-api/tests/test_lifecycle_audit_finalize_tenant_scope.py
+++ b/core-storage-api/tests/test_lifecycle_audit_finalize_tenant_scope.py
@@ -1,0 +1,102 @@
+"""Org scoping for lifecycle-audit status updates."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete
+
+from common.models import LifecycleAudit
+from core_storage_api.services.postgres_service import get_session
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+PREFIX = "/api/v1/storage/lifecycle-audit"
+
+
+def _new_org_id() -> str:
+    """Return a unique org id that matches the end-of-run sweep prefix."""
+    return f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+async def lifecycle_marker() -> str:
+    marker = f"tenant-scope:{uuid.uuid4().hex}"
+    yield marker
+    async with get_session() as session:
+        await session.execute(delete(LifecycleAudit).where(LifecycleAudit.triggered_by == marker))
+
+
+async def _audit(client: AsyncClient, org_id: str, marker: str) -> int:
+    response = await client.post(
+        PREFIX,
+        json={
+            "org_id": org_id,
+            "action": "archive-expired",
+            "triggered_by": marker,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["audit_id"]
+
+
+async def _row(client: AsyncClient, audit_id: int, org_id: str) -> dict:
+    response = await client.get(f"{PREFIX}/{audit_id}", params={"org_id": org_id})
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+class TestLifecycleAuditFinalizeTenantScope:
+    async def test_route_does_not_finalize_another_orgs_audit(
+        self,
+        client: AsyncClient,
+        lifecycle_marker: str,
+    ) -> None:
+        victim = _new_org_id()
+        attacker = _new_org_id()
+        audit_id = await _audit(client, victim, lifecycle_marker)
+
+        response = await client.patch(
+            f"{PREFIX}/{audit_id}",
+            json={"org_id": attacker, "status": "success", "stats": {"archived": 9}},
+        )
+
+        assert response.status_code == 404, response.text
+        row = await _row(client, audit_id, victim)
+        assert row["status"] == "pending"
+        assert row["stats"] is None
+
+    async def test_route_requires_org_id(self, client: AsyncClient) -> None:
+        response = await client.patch(f"{PREFIX}/1", json={"status": "success"})
+
+        assert response.status_code == 422, response.text
+        assert response.json()["detail"] == "'org_id' must be a non-empty string"
+
+    async def test_route_passes_org_to_finalize_and_preserves_sticky_success(
+        self,
+        client: AsyncClient,
+        lifecycle_marker: str,
+    ) -> None:
+        org_id = _new_org_id()
+        audit_id = await _audit(client, org_id, lifecycle_marker)
+
+        response = await client.patch(
+            f"{PREFIX}/{audit_id}",
+            json={"org_id": org_id, "status": "success", "stats": {"archived": 3}},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json() == {"ok": True, "noop": False}
+
+        redelivery = await client.patch(
+            f"{PREFIX}/{audit_id}",
+            json={"org_id": org_id, "status": "failure", "error_message": "late"},
+        )
+        assert redelivery.status_code == 200, redelivery.text
+        assert redelivery.json() == {"ok": True, "noop": True}
+
+        row = await _row(client, audit_id, org_id)
+        assert row["status"] == "success"
+        assert row["stats"] == {"archived": 3}
+        assert row["error_message"] is None

--- a/core-storage-api/tests/test_lifecycle_audit_observation.py
+++ b/core-storage-api/tests/test_lifecycle_audit_observation.py
@@ -47,7 +47,11 @@ async def test_exact_read_and_uncapped_summary(
     entity_link_id = response.json()["audit_id"]
     failure = await client.patch(
         f"{PREFIX}/{entity_link_id}",
-        json={"status": "failure", "error_message": "synthetic failure"},
+        json={
+            "org_id": "test-tenant-lifecycle-observation",
+            "status": "failure",
+            "error_message": "synthetic failure",
+        },
     )
     assert failure.status_code == 200, failure.text
 
@@ -78,14 +82,22 @@ async def test_exact_read_and_uncapped_summary(
     noise_id = response.json()["audit_id"]
     noise_failure = await client.patch(
         f"{PREFIX}/{noise_id}",
-        json={"status": "failure", "error_message": "filter sentinel"},
+        json={
+            "org_id": "test-tenant-lifecycle-observation",
+            "status": "failure",
+            "error_message": "filter sentinel",
+        },
     )
     assert noise_failure.status_code == 200, noise_failure.text
 
     for audit_id in archive_ids:
         success = await client.patch(
             f"{PREFIX}/{audit_id}",
-            json={"status": "success", "stats": {"archived": 0}},
+            json={
+                "org_id": "test-tenant-lifecycle-observation",
+                "status": "success",
+                "stats": {"archived": 0},
+            },
         )
         assert success.status_code == 200, success.text
 
@@ -139,7 +151,11 @@ async def test_exact_read_and_uncapped_summary(
     other_org_id = response.json()["audit_id"]
     success = await client.patch(
         f"{PREFIX}/{other_org_id}",
-        json={"status": "success", "stats": {"archived": 0}},
+        json={
+            "org_id": "another-lifecycle-observation-tenant",
+            "status": "success",
+            "stats": {"archived": 0},
+        },
     )
     assert success.status_code == 200, success.text
 

--- a/core-worker/src/core_worker/clients/storage_client.py
+++ b/core-worker/src/core_worker/clients/storage_client.py
@@ -457,12 +457,13 @@ async def update_lifecycle_audit_row(
     client: httpx.AsyncClient,
     audit_id: int,
     *,
+    org_id: str,
     status: str,
     stats: dict | None = None,
     error_message: str | None = None,
 ) -> None:
     """PATCH the lifecycle_audit row created by core-api fanout."""
-    body: dict[str, Any] = {"status": status}
+    body: dict[str, Any] = {"org_id": org_id, "status": status}
     if stats is not None:
         body["stats"] = stats
     if error_message is not None:

--- a/core-worker/src/core_worker/consumer.py
+++ b/core-worker/src/core_worker/consumer.py
@@ -724,6 +724,7 @@ async def handle_embed_backfill_request(event: Event) -> None:
         await update_lifecycle_audit_row(
             get_storage_client(),
             request.audit_id,
+            org_id=request.org_id,
             status="failure",
             error_message=message,
         )
@@ -743,6 +744,7 @@ async def handle_embed_backfill_request(event: Event) -> None:
         await update_lifecycle_audit_row(
             get_storage_client(),
             request.audit_id,
+            org_id=request.org_id,
             status="in_progress",
         )
     except Exception:
@@ -777,6 +779,7 @@ async def handle_embed_backfill_request(event: Event) -> None:
             await update_lifecycle_audit_row(
                 get_storage_client(),
                 request.audit_id,
+                org_id=request.org_id,
                 status="failure",
                 error_message=str(exc)[:500],
             )
@@ -793,6 +796,7 @@ async def handle_embed_backfill_request(event: Event) -> None:
     await update_lifecycle_audit_row(
         get_storage_client(),
         request.audit_id,
+        org_id=request.org_id,
         status="success",
         stats={
             "scanned": report.scanned,

--- a/core-worker/src/core_worker/lifecycle.py
+++ b/core-worker/src/core_worker/lifecycle.py
@@ -38,6 +38,7 @@ class _CoreWorkerLifecycleAdapter:
         self,
         audit_id: int,
         *,
+        org_id: str,
         status: str,
         stats: dict | None = None,
         error_message: str | None = None,
@@ -45,6 +46,7 @@ class _CoreWorkerLifecycleAdapter:
         await update_lifecycle_audit_row(
             get_storage_client(),
             audit_id,
+            org_id=org_id,
             status=status,
             stats=stats,
             error_message=error_message,

--- a/tests/test_lifecycle_handlers.py
+++ b/tests/test_lifecycle_handlers.py
@@ -46,6 +46,7 @@ class _FakeAdapter:
         self.raise_on_dedup_check = raise_on_dedup_check
         self.archive_calls: list[tuple[str, str, str | None, int | None]] = []
         self.audit_calls: list[tuple[int, str, dict | None, str | None]] = []
+        self.audit_org_ids: list[str] = []
         self.dedup_calls: list[tuple[str, str, int]] = []
 
     async def archive_expired(self, *, org_id: str, fleet_id: str | None) -> int:
@@ -98,10 +99,12 @@ class _FakeAdapter:
         self,
         audit_id: int,
         *,
+        org_id: str,
         status: str,
         stats: dict | None = None,
         error_message: str | None = None,
     ) -> None:
+        self.audit_org_ids.append(org_id)
         self.audit_calls.append((audit_id, status, stats, error_message))
 
 
@@ -219,6 +222,7 @@ async def test_archive_expired_success_marks_audit_progress_then_success():
     # never-started one.
     statuses = [c[1] for c in adapter.audit_calls]
     assert statuses == ["in_progress", "success"]
+    assert adapter.audit_org_ids == ["tenant-x", "tenant-x"]
     final = adapter.audit_calls[-1]
     assert final[0] == 42
     assert final[2] == {"archived": 11}
@@ -276,6 +280,7 @@ async def test_failure_audit_update_error_does_not_swallow_original():
             self,
             audit_id: int,
             *,
+            org_id: str,
             status: str,
             stats: dict | None = None,
             error_message: str | None = None,
@@ -507,6 +512,7 @@ async def test_permanent_error_still_reraises_when_the_failure_row_could_not_be_
             self,
             audit_id: int,
             *,
+            org_id: str,
             status: str,
             stats: dict | None = None,
             error_message: str | None = None,


### PR DESCRIPTION
## Summary

- Require a non-empty `org_id` on `PATCH /api/v1/storage/lifecycle-audit/{audit_id}` and bind both the status UPDATE and sticky-success existence check to that org.
- Thread the audit row's org through the core API, shared lifecycle handlers, core worker, embed-backfill path, and org-deletion finalizer.
- Remove the fixed method and route from the tenant-scope allowlist while preserving the opaque-body-write annotations.

## Related Issue

Closes #1083.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

The cross-org route regression fails when only the new `LifecycleAudit.org_id == org_id` UPDATE predicate is removed:

```text
>       assert response.status_code == 404, response.text
E       AssertionError: {"ok":true,"noop":false}
E       assert 200 == 404
```

With the fix restored:

- `core-storage-api/tests/test_lifecycle_audit_finalize_tenant_scope.py` plus the existing lifecycle observation tests: 10 passed
- `tests/test_lifecycle_handlers.py`: 17 passed
- Full root suite: 5,694 passed, 4 skipped, 1 xfailed, 16 deselected
- Full core-storage-api suite: 247 passed
- Full core-worker suite: 80 passed; 71.43% coverage
- Ruff check and format check: core-api, core-storage-api, core-worker, and common all pass
- Mypy: core-api (203 files), core-storage-api (85), core-worker (11), and common (99) all pass
- Package builds: core-api, core-storage-api, and core-worker all pass
- `scripts/tenant_scope_gate.py`: passes with 106 allowlisted entries

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes (or explained why none are needed)
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally
- [x] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (not user-facing; release-please derives this fix from the conventional commit)

## Additional Notes

- Allowlist total: 108 before, 106 after. `id-addressed-write`: 14 before, 12 after.
- All 35 `opaque-body-write` entries and all 35 hand-written notes survived regeneration.
- The UPDATE values are assembled from the literal keys `status`, `finished_at`, `stats`, and `error_message`; neither `id` nor `org_id` is caller-writable through the SET clause.
