### PR TITLE
test(plugin): centralize legacy contract fixtures

### DIFF
--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -15,6 +15,7 @@ import {
   PLUGIN_ID,
 } from "./config.js";
 import { getPluginDir } from "./paths.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
 
 describe("PLUGIN_ID", () => {
   // The id lives in two files that are read by different consumers:
@@ -33,6 +34,11 @@ describe("PLUGIN_ID", () => {
     const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
     assert.equal(
       PLUGIN_ID,
+      FROZEN_PLUGIN_ID,
+      "the plugin id is an existing-install compatibility contract",
+    );
+    assert.equal(
+      FROZEN_PLUGIN_ID,
       manifest.id,
       `config.ts PLUGIN_ID ("${PLUGIN_ID}") and openclaw.plugin.json id ` +
         `("${manifest.id}") must be identical — OpenClaw reads the manifest, ` +
@@ -47,10 +53,10 @@ describe("PLUGIN_ID", () => {
 function happyConfig(): Record<string, unknown> {
   return {
     plugins: {
-      allow: ["memclaw"],
-      entries: { memclaw: { enabled: true } },
+      allow: [FROZEN_PLUGIN_ID],
+      entries: { [FROZEN_PLUGIN_ID]: { enabled: true } },
       load: { paths: [getPluginDir()] },
-      slots: { memory: "memclaw", contextEngine: "memclaw" },
+      slots: { memory: FROZEN_PLUGIN_ID, contextEngine: FROZEN_PLUGIN_ID },
     },
     tools: { alsoAllow: [] },
   };
@@ -96,7 +102,7 @@ describe("isCauraFullyConfigured", () => {
 
   test("false when the plugin is disabled", () => {
     const c = happyConfig();
-    (c as any).plugins.entries.memclaw.enabled = false;
+    (c as any).plugins.entries[FROZEN_PLUGIN_ID].enabled = false;
     assert.equal(isCauraFullyConfigured(c), false);
   });
 
@@ -233,7 +239,7 @@ describe("isCauraAllowed — permissive when allow is missing or empty (CAURA-00
 
   test("true when plugins.allow is non-empty AND includes the plugin id", () => {
     const c: any = {
-      plugins: { allow: ["memclaw", "browser"], entries: {}, load: {}, slots: {} },
+      plugins: { allow: [FROZEN_PLUGIN_ID, "browser"], entries: {}, load: {}, slots: {} },
     };
     assert.equal(isCauraAllowed(c), true);
   });
@@ -357,7 +363,7 @@ describe("autoFixAllowlist — plugins.allow non-creation (CAURA-000)", () => {
       const written = ctx.written as any;
       const allow: string[] = written?.plugins?.allow ?? [];
       assert.ok(
-        allow.includes("memclaw"),
+        allow.includes(FROZEN_PLUGIN_ID),
         `expected the plugin id to be added; got: ${JSON.stringify(allow)}`,
       );
       assert.ok(allow.includes("browser"), "must preserve existing entries");
@@ -370,7 +376,7 @@ describe("autoFixAllowlist — plugins.allow non-creation (CAURA-000)", () => {
   test("does NOT add the plugin id twice when already in a non-empty allowlist", () => {
     const ctx = _autoFixWithConfig({
       plugins: {
-        allow: ["browser", "memclaw", "filesystem"],
+        allow: ["browser", FROZEN_PLUGIN_ID, "filesystem"],
         entries: {},
         load: { paths: [] },
         slots: {},
@@ -381,7 +387,7 @@ describe("autoFixAllowlist — plugins.allow non-creation (CAURA-000)", () => {
       const written = ctx.written as any;
       const allow: string[] = written?.plugins?.allow ?? [];
       assert.equal(
-        allow.filter((p) => p === "memclaw").length,
+        allow.filter((p) => p === FROZEN_PLUGIN_ID).length,
         1,
         `the plugin id must appear exactly once; got: ${JSON.stringify(allow)}`,
       );

--- a/plugin/src/context-engine.test.ts
+++ b/plugin/src/context-engine.test.ts
@@ -19,6 +19,7 @@ import {
   MemClawContextEngine as ContextEngine,  // legacy-name-ok: references the class as currently named
   type ShouldRecallInput,
 } from "./context-engine.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
 
 describe("prepareSubagentSpawn — OpenClaw's rollback contract", () => {
   // OpenClaw's contract is `Promise<SubagentSpawnPreparation | undefined>` with
@@ -149,7 +150,7 @@ describe("shouldRecall — policy=keywords", () => {
 
   test("matches MemClaw / LTM / long term keywords (case-insensitive)", () => { // legacy-name-ok: recall trigger keyword alias
     for (const p of [
-      "any memclaw context here?",
+      `any ${FROZEN_PLUGIN_ID} context here?`,
       "check LTM",
       "any long term notes about this",
       "Long-Term memory needed",
@@ -301,7 +302,7 @@ describe("shouldRecall — policy=auto (the default)", () => {
 
   test("trigger keyword 'memclaw' fires recall on otherwise-skip prompt", () => { // legacy-name-ok: recall trigger keyword alias
     // Rule 3: the old name keeps triggering forever.
-    const r = shouldRecall(input({ prompt: "memclaw?" }));
+    const r = shouldRecall(input({ prompt: `${FROZEN_PLUGIN_ID}?` }));
     assert.equal(r.recall, true);
     assert.equal(r.reason, "explicit-recall-trigger");
   });

--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -13,12 +13,33 @@ import {
 } from "./educate.js";
 import { CAURA_TOOLS } from "./tools.js";
 import { MEMORY_TYPES, STATUSES } from "./tool-definitions.js";
+import {
+  FROZEN_PLUGIN_ID,
+  LEGACY_DISPLAY_NAME,
+} from "./legacy-contracts.test.js";
+
+const BACKUP_SUFFIX = `.${FROZEN_PLUGIN_ID}-bak`;
+
+function fencePattern(section: "tools" | "agents"): RegExp {
+  return new RegExp(`<!-- ${FROZEN_PLUGIN_ID}:${section} v=[a-f0-9]{8} -->`);
+}
+
+function closingFencePattern(section: "tools" | "agents"): RegExp {
+  return new RegExp(`<!-- /${FROZEN_PLUGIN_ID}:${section} -->`);
+}
+
+function staleHeartbeatParagraph(toolCount: number): string {
+  return `You have been connected to ${LEGACY_DISPLAY_NAME} — a shared persistent memory system. ` +
+    `You now have ${toolCount} tools for writing, searching, and managing memories. ` +
+    `Check skills/${FROZEN_PLUGIN_ID}/SKILL.md for full instructions. Key rules: always search before ` +
+    "starting work, always write findings after completing work, always include your agent_id.";
+}
 
 // Resolve the shared SKILL.md that ships with the plugin. Tests run from
 // `plugin/dist/educate.test.js`; the skill lives at
 // `plugin/skills/memclaw/SKILL.md`. // legacy-name-floor: shipped skill path
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const SHARED_SKILL_PATH = join(__dirname, "..", "skills", "memclaw", "SKILL.md");
+const SHARED_SKILL_PATH = join(__dirname, "..", "skills", FROZEN_PLUGIN_ID, "SKILL.md");
 function readSharedSkill(): string {
   return readFileSync(SHARED_SKILL_PATH, "utf-8");
 }
@@ -452,10 +473,10 @@ describe("writeEducationFiles", () => {
 
       const tools = readFile(join(base, "workspace", "TOOLS.md"));
       const agents = readFile(join(base, "workspace", "AGENTS.md"));
-      assert.match(tools, /<!-- memclaw:tools v=[a-f0-9]{8} -->/);
-      assert.match(tools, /<!-- \/memclaw:tools -->/);
-      assert.match(agents, /<!-- memclaw:agents v=[a-f0-9]{8} -->/);
-      assert.match(agents, /<!-- \/memclaw:agents -->/);
+      assert.match(tools, fencePattern("tools"));
+      assert.match(tools, closingFencePattern("tools"));
+      assert.match(agents, fencePattern("agents"));
+      assert.match(agents, closingFencePattern("agents"));
     });
 
     test("re-run on current-version fence is a no-op (toolsUpdated=0, file byte-identical)", () => {
@@ -485,9 +506,9 @@ describe("writeEducationFiles", () => {
       const userAfter =
         "\n\n## Notes\n\nMore user content below the Caura section.\n";
       const staleFenced =
-        "<!-- memclaw:tools v=deadbeef -->\n" +
-        "## MemClaw — Tools Available\n\nObsolete content from a previous version.\n" +
-        "<!-- /memclaw:tools -->\n";
+        `<!-- ${FROZEN_PLUGIN_ID}:tools v=deadbeef -->\n` +
+        `## ${LEGACY_DISPLAY_NAME} — Tools Available\n\nObsolete content from a previous version.\n` +
+        `<!-- /${FROZEN_PLUGIN_ID}:tools -->\n`;
       writeFileSync(
         join(wsDir, "TOOLS.md"),
         userBefore + staleFenced + userAfter,
@@ -502,10 +523,10 @@ describe("writeEducationFiles", () => {
       assert.ok(tools.endsWith(userAfter), "user content below the fence must be preserved verbatim");
       assert.ok(!tools.includes("v=deadbeef"), "stale version tag must be replaced");
       assert.ok(!tools.includes("Obsolete content"), "stale block content must be replaced");
-      assert.match(tools, /<!-- memclaw:tools v=[a-f0-9]{8} -->/);
+      assert.match(tools, fencePattern("tools"));
     });
 
-    test("stale-version fence replace also writes a one-shot .memclaw-bak", () => {
+    test("stale-version fence replace also writes a one-shot backup", () => {
       // Pre-fix the case-2 (stale-version) replace had no backup, so a
       // user who hand-edited inside the fenced block would silently
       // lose those edits on plugin upgrade. Mirror the case-3 behaviour.
@@ -515,16 +536,16 @@ describe("writeEducationFiles", () => {
 
       const userBefore = "# Tools\n\nMy notes.\n\n";
       const handEditedFence =
-        "<!-- memclaw:tools v=deadbeef -->\n" +
-        "## MemClaw — Tools Available\n\n" +
+        `<!-- ${FROZEN_PLUGIN_ID}:tools v=deadbeef -->\n` +
+        `## ${LEGACY_DISPLAY_NAME} — Tools Available\n\n` +
         "OLD CONTENT plus IMPORTANT user note that I added myself.\n" +
-        "<!-- /memclaw:tools -->\n";
+        `<!-- /${FROZEN_PLUGIN_ID}:tools -->\n`;
       const original = userBefore + handEditedFence;
       writeFileSync(join(wsDir, "TOOLS.md"), original, "utf-8");
 
       writeEducationFiles(buildToolsMd(), buildAgentsMd(), undefined, base);
 
-      const bakPath = join(wsDir, "TOOLS.md.memclaw-bak");
+      const bakPath = join(wsDir, `TOOLS.md${BACKUP_SUFFIX}`);
       assert.ok(
         existsSync(bakPath),
         "stale-version replace must write a backup so hand-edits inside the fence are recoverable",
@@ -541,7 +562,7 @@ describe("writeEducationFiles", () => {
     test("legacy v0.98.5 heading variant is detected via prefix match", () => {
       // Wet-test on openclaw-test-ran (CAURA-333) revealed the plugin
       // had emitted an older heading form on 0.98.5:
-      //   "## MemClaw — Long-Term Agent Memory (auto-added by plugin)"
+      //   the historical long-term-memory heading
       // for TOOLS.md, and a different form for AGENTS.md. Pre-fix the
       // legacy splice was exact-match on the 1.x heading text, so 20
       // workspaces ended up with legacy + new fence side-by-side.
@@ -553,7 +574,7 @@ describe("writeEducationFiles", () => {
       const userBefore = "# TOOLS.md - Local Notes\n\nMy notes here.\n";
       const legacy_v0_98 =
         "\n---\n\n" +
-        "## MemClaw — Long-Term Agent Memory (auto-added by plugin)\n\n" +
+        `## ${LEGACY_DISPLAY_NAME} — Long-Term Agent Memory (auto-added by plugin)\n\n` +
         "13 tools:\n" +
         "| `caura_write_bulk` | Store multiple memories at once |\n" +
         "| `caura_search` | Semantic search, returns raw results |\n";
@@ -565,9 +586,9 @@ describe("writeEducationFiles", () => {
       const tools = readFile(join(wsDir, "TOOLS.md"));
       assert.ok(!tools.includes("caura_write_bulk"), "stale 0.98.5 tool name must be replaced");
       assert.ok(!tools.includes("Long-Term Agent Memory"), "stale 0.98.5 heading must be gone");
-      assert.match(tools, /<!-- memclaw:tools v=[a-f0-9]{8} -->/);
+      assert.match(tools, fencePattern("tools"));
       assert.ok(tools.startsWith(userBefore), "user content above legacy block preserved");
-      assert.ok(existsSync(join(wsDir, "TOOLS.md.memclaw-bak")), "v0.98.5 splice must write backup");
+      assert.ok(existsSync(join(wsDir, `TOOLS.md${BACKUP_SUFFIX}`)), "v0.98.5 splice must write backup");
     });
 
     test("legacy v0.98.5 AGENTS.md heading variant is detected via prefix match", () => {
@@ -578,7 +599,7 @@ describe("writeEducationFiles", () => {
       const userBefore = "# AGENTS.md\n\n## Identity\n\nI am Claude.\n";
       const legacy_v0_98 =
         "\n---\n\n" +
-        "## Memory V2 (auto-added by MemClaw plugin — replaces any earlier memory section above)\n\n" +
+        `## Memory V2 (auto-added by ${LEGACY_DISPLAY_NAME} plugin — replaces any earlier memory section above)\n\n` +
         "**Layer 1:** Per-turn write-back — `caura_write` after every meaningful outcome\n" +
         "- Update > Create — prefer `caura_update` over duplicates\n";
       writeFileSync(join(wsDir, "AGENTS.md"), userBefore + legacy_v0_98, "utf-8");
@@ -587,14 +608,14 @@ describe("writeEducationFiles", () => {
 
       assert.equal(result.agentsUpdated, 1);
       const agents = readFile(join(wsDir, "AGENTS.md"));
-      assert.ok(!agents.includes("auto-added by MemClaw plugin"), "stale 0.98.5 heading must be gone");
+      assert.ok(!agents.includes(`auto-added by ${LEGACY_DISPLAY_NAME} plugin`), "stale 0.98.5 heading must be gone");
       assert.ok(!agents.includes("caura_update"), "stale 0.98.5 body must be replaced");
-      assert.match(agents, /<!-- memclaw:agents v=[a-f0-9]{8} -->/);
+      assert.match(agents, fencePattern("agents"));
       assert.ok(agents.startsWith(userBefore), "user content above legacy block preserved");
     });
 
     test("user heading starting with the same prefix but no plugin tool content is left alone", () => {
-      // Defensive: a user happens to write `## MemClaw — my own notes`
+      // Defensive: a user happens to write a similarly prefixed heading
       // with no `memclaw_*` references in the body. The content-shape // legacy-name-floor: historical tool prefix
       // check rejects the splice. We append a fresh fenced block at
       // EOF instead of replacing the user's heading.
@@ -604,7 +625,7 @@ describe("writeEducationFiles", () => {
 
       const userContent =
         "# Tools\n\n" +
-        "## MemClaw — my own notes\n\n" +
+        `## ${LEGACY_DISPLAY_NAME} — my own notes\n\n` +
         "Just my own notes about Claude/MemClaw deployment, no tools listed.\n"; // legacy-name-ok: accepted old-name user prose must not be mistaken for a plugin-owned block
       writeFileSync(join(wsDir, "TOOLS.md"), userContent, "utf-8");
 
@@ -612,9 +633,9 @@ describe("writeEducationFiles", () => {
 
       assert.equal(result.toolsUpdated, 1, "should append fenced block since legacy splice was skipped");
       const tools = readFile(join(wsDir, "TOOLS.md"));
-      assert.ok(tools.includes("## MemClaw — my own notes"), "user heading must be preserved");
+      assert.ok(tools.includes(`## ${LEGACY_DISPLAY_NAME} — my own notes`), "user heading must be preserved");
       assert.ok(tools.includes("Just my own notes"), "user content under that heading must be preserved");
-      assert.match(tools, /<!-- memclaw:tools v=[a-f0-9]{8} -->/, "fresh fence appended");
+      assert.match(tools, fencePattern("tools"), "fresh fence appended");
     });
 
     test("CRLF line endings: legacy heading is still detected and spliced", () => {
@@ -629,7 +650,7 @@ describe("writeEducationFiles", () => {
 
       const userBefore = "# Tools\r\n\r\n";
       const legacy =
-        "---\r\n\r\n## MemClaw — Tools Available\r\n\r\n" +
+        `---\r\n\r\n## ${LEGACY_DISPLAY_NAME} — Tools Available\r\n\r\n` +
         "Obsolete CRLF body with caura_write_bulk reference.\r\n";
       writeFileSync(join(wsDir, "TOOLS.md"), userBefore + legacy, "utf-8");
 
@@ -639,19 +660,19 @@ describe("writeEducationFiles", () => {
       const tools = readFile(join(wsDir, "TOOLS.md"));
       assert.ok(!tools.includes("caura_write_bulk"), "stale CRLF content must be replaced");
       assert.ok(tools.startsWith(userBefore), "user content above legacy block preserved (with original CRLF)");
-      assert.match(tools, /<!-- memclaw:tools v=[a-f0-9]{8} -->/);
+      assert.match(tools, fencePattern("tools"));
     });
 
-    test("legacy pre-fence section is migrated; one-shot .memclaw-bak is written", () => {
+    test("legacy pre-fence section is migrated; one-shot backup is written", () => {
       const base = tmpBase();
       const wsDir = join(base, "workspace");
       mkdirSync(wsDir, { recursive: true });
 
       // A v1.x-shaped TOOLS.md: user content, then the unfenced legacy
-      // MemClaw section (preceded by `---` rule), then more user content.
+      // Legacy plugin section (preceded by `---` rule), then more user content.
       const userBefore = "# Tools notes\n\nMy tools notes.\n";
       const legacy =
-        "\n---\n\n## MemClaw — Tools Available\n\n" +
+        `\n---\n\n## ${LEGACY_DISPLAY_NAME} — Tools Available\n\n` +
         "Obsolete 13-tool listing including caura_write_bulk and caura_search.\n";
       const userAfter = "\n## Other\n\nMy other section.\n";
       const original = userBefore + legacy + userAfter;
@@ -663,13 +684,13 @@ describe("writeEducationFiles", () => {
       const tools = readFile(join(wsDir, "TOOLS.md"));
       assert.ok(!tools.includes("caura_write_bulk"), "legacy stale tool name must be gone");
       assert.ok(!tools.includes("caura_search"), "legacy stale tool name must be gone");
-      assert.match(tools, /<!-- memclaw:tools v=[a-f0-9]{8} -->/);
+      assert.match(tools, fencePattern("tools"));
       assert.ok(tools.startsWith(userBefore), "content above the legacy block must be preserved");
       assert.ok(tools.includes("## Other"), "content below the legacy block must be preserved");
 
       // Backup written exactly once with the pre-splice content.
-      const bakPath = join(wsDir, "TOOLS.md.memclaw-bak");
-      assert.ok(existsSync(bakPath), "expected one-shot .memclaw-bak after legacy splice");
+      const bakPath = join(wsDir, `TOOLS.md${BACKUP_SUFFIX}`);
+      assert.ok(existsSync(bakPath), "expected one-shot backup after legacy splice");
       assert.equal(readFile(bakPath), original);
     });
 
@@ -708,14 +729,14 @@ describe("writeEducationFiles", () => {
       mkdirSync(wsDir, { recursive: true });
 
       const original =
-        // Body must include a `memclaw_` token so the content-shape
+        // Body must include a recognized tool token so the content-shape
         // check in findLegacyRange treats this as our block (and not
         // a coincidental user heading with the same prefix).
-        "user\n\n---\n\n## MemClaw — Tools Available\n\nold body referencing caura_write_bulk.\n";
+        `user\n\n---\n\n## ${LEGACY_DISPLAY_NAME} — Tools Available\n\nold body referencing caura_write_bulk.\n`;
       writeFileSync(join(wsDir, "TOOLS.md"), original, "utf-8");
 
       writeEducationFiles(buildToolsMd(), buildAgentsMd(), undefined, base);
-      const bakPath = join(wsDir, "TOOLS.md.memclaw-bak");
+      const bakPath = join(wsDir, `TOOLS.md${BACKUP_SUFFIX}`);
       const bak1 = readFile(bakPath);
 
       // Hand-edit the live TOOLS.md and re-run — backup must NOT change.
@@ -761,7 +782,7 @@ describe("writeEducationFiles", () => {
       // close markers). The version tag remains unchanged.
       const toolsPath = join(wsDir, "TOOLS.md");
       const canonical = readFile(toolsPath);
-      const closeIdx = canonical.indexOf("<!-- /memclaw:tools -->");
+      const closeIdx = canonical.indexOf(`<!-- /${FROZEN_PLUGIN_ID}:tools -->`);
       assert.ok(closeIdx > 0, "expected close marker in canonical output");
       const handEdit = "\nIMPORTANT user note inside the fence — do not lose me.\n";
       const handEdited =
@@ -777,7 +798,7 @@ describe("writeEducationFiles", () => {
       );
 
       // Backup MUST exist and MUST contain the user's hand-edit.
-      const bakPath = toolsPath + ".memclaw-bak";
+      const bakPath = toolsPath + BACKUP_SUFFIX;
       assert.ok(
         existsSync(bakPath),
         "force=true with matching version MUST still write a backup so hand-edits inside the fence are recoverable",
@@ -796,13 +817,13 @@ describe("writeEducationFiles", () => {
 
     test("unmatched fence opener (user-authored) is treated as no-fence and appended", () => {
       // If a user happens to have something that looks like our opener
-      // (e.g. they hand-added `<!-- memclaw:tools -->` for a comment) but
+      // (e.g. they hand-added a similarly shaped fence comment) but
       // never closed it, we must not eat their content. Treat it as no
       // fence and append at EOF — same as a fresh install.
       const base = tmpBase();
       const wsDir = join(base, "workspace");
       mkdirSync(wsDir, { recursive: true });
-      const userContent = "<!-- memclaw:tools v=garbage -->\nuser note, unclosed\n";
+      const userContent = `<!-- ${FROZEN_PLUGIN_ID}:tools v=garbage -->\nuser note, unclosed\n`;
       writeFileSync(join(wsDir, "TOOLS.md"), userContent, "utf-8");
 
       const result = writeEducationFiles(buildToolsMd(), buildAgentsMd(), undefined, base);
@@ -810,7 +831,7 @@ describe("writeEducationFiles", () => {
       assert.equal(result.toolsUpdated, 1);
       const tools = readFile(join(wsDir, "TOOLS.md"));
       assert.ok(tools.startsWith(userContent), "user's unclosed-opener content must be preserved at the top");
-      assert.match(tools, /<!-- \/memclaw:tools -->\n?$/);
+      assert.match(tools, new RegExp(`<!-- /${FROZEN_PLUGIN_ID}:tools -->\\n?$`));
     });
 
     test("AGENTS.md follows the same fence semantics", () => {
@@ -821,10 +842,10 @@ describe("writeEducationFiles", () => {
       mkdirSync(wsDir, { recursive: true });
 
       const userBefore = "# Agents.md\n\n## Routing\n\nDo this.\n";
-      // Body must include a `memclaw_` token so the content-shape
+      // Body must include a recognized tool token so the content-shape
       // check in findLegacyRange treats this as our block.
       const legacy =
-        "\n---\n\n## Memory V2 — MemClaw Protocol (mandatory)\n\nObsolete agent rules using caura_write.\n";
+        `\n---\n\n## Memory V2 — ${LEGACY_DISPLAY_NAME} Protocol (mandatory)\n\nObsolete agent rules using caura_write.\n`;
       writeFileSync(join(wsDir, "AGENTS.md"), userBefore + legacy, "utf-8");
 
       const result = writeEducationFiles(buildToolsMd(), buildAgentsMd(), undefined, base);
@@ -832,9 +853,9 @@ describe("writeEducationFiles", () => {
       assert.equal(result.agentsUpdated, 1);
       const agents = readFile(join(wsDir, "AGENTS.md"));
       assert.ok(!agents.includes("Obsolete agent rules"), "legacy AGENTS.md content must be replaced");
-      assert.match(agents, /<!-- memclaw:agents v=[a-f0-9]{8} -->/);
+      assert.match(agents, fencePattern("agents"));
       assert.ok(agents.startsWith(userBefore), "user content above the legacy block must be preserved");
-      assert.ok(existsSync(join(wsDir, "AGENTS.md.memclaw-bak")));
+      assert.ok(existsSync(join(wsDir, `AGENTS.md${BACKUP_SUFFIX}`)));
     });
   });
 });
@@ -850,11 +871,7 @@ describe("writeEducationFiles", () => {
 describe("cleanupStaleHeartbeatEducation (unit)", () => {
   test("removes a paragraph appended with leading separator", () => {
     const userContent = "# Heartbeat\n\n## Cron tasks\n- Task 1\n- Task 2";
-    const stale =
-      "\n\n---\n\nYou have been connected to MemClaw — a shared persistent memory system. " +
-      "You now have 9 tools for writing, searching, and managing memories. " +
-      "Check skills/memclaw/SKILL.md for full instructions. Key rules: always search before " +
-      "starting work, always write findings after completing work, always include your agent_id.\n";
+    const stale = `\n\n---\n\n${staleHeartbeatParagraph(9)}\n`;
 
     const result = cleanupStaleHeartbeatEducation(userContent + stale);
 
@@ -868,11 +885,7 @@ describe("cleanupStaleHeartbeatEducation (unit)", () => {
 
   test("removes a paragraph that is the entire file (first-install case)", () => {
     // educateAgents writes only `<prompt>\n` when HEARTBEAT.md was empty.
-    const onlyParagraph =
-      "You have been connected to MemClaw — a shared persistent memory system. " +
-      "You now have 10 tools for writing, searching, and managing memories. " +
-      "Check skills/memclaw/SKILL.md for full instructions. Key rules: always search before " +
-      "starting work, always write findings after completing work, always include your agent_id.\n";
+    const onlyParagraph = `${staleHeartbeatParagraph(10)}\n`;
 
     const result = cleanupStaleHeartbeatEducation(onlyParagraph);
 
@@ -884,11 +897,7 @@ describe("cleanupStaleHeartbeatEducation (unit)", () => {
     // The stale paragraph hard-codes the tool count at write time.
     // Cleanup must work whether the count was 9, 10, 13, etc.
     for (const n of [7, 9, 10, 13, 99]) {
-      const para =
-        "You have been connected to MemClaw — a shared persistent memory system. " +
-        `You now have ${n} tools for writing, searching, and managing memories. ` +
-        "Check skills/memclaw/SKILL.md for full instructions. Key rules: always search before " +
-        "starting work, always write findings after completing work, always include your agent_id.\n";
+      const para = `${staleHeartbeatParagraph(n)}\n`;
       const result = cleanupStaleHeartbeatEducation(para);
       assert.equal(result.cleaned, true, `failed to clean paragraph with N=${n}`);
       assert.equal(result.content, "");
@@ -908,11 +917,10 @@ describe("cleanupStaleHeartbeatEducation (unit)", () => {
     assert.equal(result.content, "");
   });
 
-  test("does NOT match a coincidental mention of MemClaw", () => {
-    // A user-authored note that mentions MemClaw but isn't our exact
+  test("does NOT match a coincidental mention of the legacy brand", () => {
+    // A user-authored note that mentions the legacy brand but isn't our exact
     // paragraph must NOT be touched.
-    const content =
-      "# Heartbeat\n\n- Note: MemClaw is the persistent memory backend.\n";
+    const content = `# Heartbeat\n\n- Note: ${LEGACY_DISPLAY_NAME} is the persistent memory backend.\n`;
     const result = cleanupStaleHeartbeatEducation(content);
     assert.equal(result.cleaned, false);
     assert.equal(result.content, content);
@@ -929,11 +937,7 @@ describe("cleanupStaleHeartbeatEducation (unit)", () => {
       "# HEARTBEAT.md\n\n" +
       "# Keep this file empty (or with only comments) to skip heartbeat API calls.\n\n" +
       "# Add tasks below when you want the agent to check something periodically.";
-    const para = (n: number) =>
-      "You have been connected to MemClaw — a shared persistent memory system. " +
-      `You now have ${n} tools for writing, searching, and managing memories. ` +
-      "Check skills/memclaw/SKILL.md for full instructions. Key rules: always search before " +
-      "starting work, always write findings after completing work, always include your agent_id.";
+    const para = staleHeartbeatParagraph;
     const content =
       userContent +
       "\n\n---\n\n" + para(13) + "\n" +
@@ -954,11 +958,7 @@ describe("cleanupStaleHeartbeatEducation (unit)", () => {
   });
 
   test("strips three accumulated paragraphs (no upper bound on cleanup count)", () => {
-    const para = (n: number) =>
-      "You have been connected to MemClaw — a shared persistent memory system. " +
-      `You now have ${n} tools for writing, searching, and managing memories. ` +
-      "Check skills/memclaw/SKILL.md for full instructions. Key rules: always search before " +
-      "starting work, always write findings after completing work, always include your agent_id.";
+    const para = staleHeartbeatParagraph;
     const content =
       "user note\n\n---\n\n" + para(7) + "\n" +
       "\n---\n\n" + para(13) + "\n" +
@@ -992,11 +992,7 @@ describe("writeEducationFiles → HEARTBEAT.md cleanup (integration)", () => {
 
     const userContent =
       "# Heartbeat tasks\n\n1. Run nightly report\n2. Sync skills\n";
-    const stale =
-      "\n\n---\n\nYou have been connected to MemClaw — a shared persistent memory system. " +
-      "You now have 9 tools for writing, searching, and managing memories. " +
-      "Check skills/memclaw/SKILL.md for full instructions. Key rules: always search before " +
-      "starting work, always write findings after completing work, always include your agent_id.\n";
+    const stale = `\n\n---\n\n${staleHeartbeatParagraph(9)}\n`;
     writeFileSync(join(wsDir, "HEARTBEAT.md"), userContent + stale, "utf-8");
 
     writeEducationFiles(buildToolsMd(), buildAgentsMd(), undefined, base);
@@ -1010,7 +1006,7 @@ describe("writeEducationFiles → HEARTBEAT.md cleanup (integration)", () => {
     const wsDir = join(base, "workspace");
     mkdirSync(wsDir, { recursive: true });
 
-    const userContent = "# My heartbeat\n\nNo MemClaw paragraph here.\n";
+    const userContent = "# My heartbeat\n\nNo stale education paragraph here.\n";
     const hbPath = join(wsDir, "HEARTBEAT.md");
     writeFileSync(hbPath, userContent, "utf-8");
     const mtimeBefore = statSync(hbPath).mtimeMs;
@@ -1050,11 +1046,7 @@ describe("writeEducationFiles → HEARTBEAT.md cleanup (integration)", () => {
     const wsDir = join(base, "workspace");
     mkdirSync(wsDir, { recursive: true });
 
-    const onlyParagraph =
-      "You have been connected to MemClaw — a shared persistent memory system. " +
-      "You now have 9 tools for writing, searching, and managing memories. " +
-      "Check skills/memclaw/SKILL.md for full instructions. Key rules: always search before " +
-      "starting work, always write findings after completing work, always include your agent_id.\n";
+    const onlyParagraph = `${staleHeartbeatParagraph(9)}\n`;
     const hbPath = join(wsDir, "HEARTBEAT.md");
     writeFileSync(hbPath, onlyParagraph, "utf-8");
 
@@ -1102,7 +1094,10 @@ describe("shared plugin-root SKILL.md", () => {
   test("has OpenClaw-required frontmatter keys (name, description)", () => {
     const skill = readSharedSkill();
     assert.ok(skill.startsWith("---\n"), "missing YAML frontmatter delimiter");
-    assert.ok(/\nname:\s*memclaw\b/.test(skill), "missing/wrong name: memclaw");
+    assert.ok(
+      new RegExp(`\\nname:\\s*${FROZEN_PLUGIN_ID}\\b`).test(skill),
+      `missing/wrong name: ${FROZEN_PLUGIN_ID}`,
+    );
     assert.ok(/\ndescription:\s*\S/.test(skill), "missing description");
   });
 
@@ -1117,7 +1112,7 @@ describe("shared plugin-root SKILL.md", () => {
   test("gates on the plugin-enabled config path via requires.config", () => {
     const skill = readSharedSkill();
     assert.ok(
-      skill.includes("plugins.entries.memclaw.enabled"),
+      skill.includes(`plugins.entries.${FROZEN_PLUGIN_ID}.enabled`),
       "shared skill should be gated on plugin-enabled config path",
     );
     // metadata must be a single-line JSON object per OpenClaw's parser
@@ -1263,11 +1258,11 @@ describe("buildToolsMd", () => {
     const tools = buildToolsMd();
     const flat = tools.replace(/\s+/g, " ");
     assert.ok(
-      !flat.includes("skills/memclaw/SKILL.md"),
+      !flat.includes(`skills/${FROZEN_PLUGIN_ID}/SKILL.md`),
       "TOOLS.md must NOT reference the skill by filesystem path",
     );
     assert.ok(
-      /\*\*memclaw\*\* skill/i.test(flat),
+      new RegExp(`\\*\\*${FROZEN_PLUGIN_ID}\\*\\* skill`, "i").test(flat),
       "TOOLS.md must point readers at the bundled skill by name",
     );
   });
@@ -1458,12 +1453,12 @@ describe("buildAgentsMd", () => {
     // source template.
     const flat = agents.replace(/\s+/g, " ");
     assert.ok(
-      !flat.includes("skills/memclaw/SKILL.md"),
+      !flat.includes(`skills/${FROZEN_PLUGIN_ID}/SKILL.md`),
       "AGENTS.md must NOT reference the skill by filesystem path " +
         "(triggers a doomed `search` tool call on cron agents — CAURA-000)",
     );
     assert.ok(
-      /\*\*memclaw\*\* skill/i.test(flat),
+      new RegExp(`\\*\\*${FROZEN_PLUGIN_ID}\\*\\* skill`, "i").test(flat),
       "AGENTS.md must reference the bundled skill by name",
     );
     assert.ok(

--- a/plugin/src/heartbeat.test.ts
+++ b/plugin/src/heartbeat.test.ts
@@ -13,6 +13,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 
 import { __DEPLOY_INTERNALS__ } from "./heartbeat.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
 import { PLUGIN_VERSION } from "./version.js";
 
 describe("deploy cooldown lifecycle", () => {
@@ -24,7 +25,7 @@ describe("deploy cooldown lifecycle", () => {
     // resolves from $HOME by default — point it at a clean tmp dir
     // for each test.
     tmpHome = mkdtempSync(join(tmpdir(), "caura-deploy-test-"));
-    mkdirSync(join(tmpHome, ".openclaw", "plugins", "memclaw"), {
+    mkdirSync(join(tmpHome, ".openclaw", "plugins", FROZEN_PLUGIN_ID), {
       recursive: true,
     });
     prevHome = process.env.HOME;
@@ -99,7 +100,7 @@ describe("deploy post-restart verification", () => {
 
   beforeEach(() => {
     tmpHome = mkdtempSync(join(tmpdir(), "caura-deploy-test-"));
-    mkdirSync(join(tmpHome, ".openclaw", "plugins", "memclaw"), {
+    mkdirSync(join(tmpHome, ".openclaw", "plugins", FROZEN_PLUGIN_ID), {
       recursive: true,
     });
     prevHome = process.env.HOME;

--- a/plugin/src/install-id.test.ts
+++ b/plugin/src/install-id.test.ts
@@ -12,12 +12,13 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 import { getInstallId, _resetInstallIdCacheForTesting } from "./install-id.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
 
 let _origHome: string | undefined;
 let _tmpHome: string | undefined;
 
 function pluginDir(home: string): string {
-  return join(home, ".openclaw", "plugins", "memclaw");
+  return join(home, ".openclaw", "plugins", FROZEN_PLUGIN_ID);
 }
 
 function installFile(home: string): string {

--- a/plugin/src/keystones.test.ts
+++ b/plugin/src/keystones.test.ts
@@ -35,13 +35,14 @@ interface MockCall {
 
 let originalFetch: typeof fetch;
 let calls: MockCall[];
+const KEYSTONES_ROUTE = "/memclaw/keystones"; // legacy-name-ok: live compatibility route
 
 // ``apiCall`` resolves a per-agent key via ``resolveAgentKey`` when an
 // ``agent_id`` is supplied — that's an extra HTTP request alongside the
 // main one. The cache-count assertions need to ignore those, so we
 // filter ``calls`` to just the keystones endpoint when counting.
 function keystoneCalls(): MockCall[] {
-  return calls.filter((c) => c.url.includes("/memclaw/keystones"));
+  return calls.filter((c) => c.url.includes(KEYSTONES_ROUTE));
 }
 
 function installFetch(body: unknown, status = 200): void {
@@ -51,7 +52,7 @@ function installFetch(body: unknown, status = 200): void {
     // resolution) return a benign 404 so the keystones path is the one
     // the test observes.
     const url = String(input);
-    if (!url.includes("/memclaw/keystones")) {
+    if (!url.includes(KEYSTONES_ROUTE)) {
       return new Response("{}", { status: 404 });
     }
     return new Response(JSON.stringify(body), {

--- a/plugin/src/legacy-contracts.test.ts
+++ b/plugin/src/legacy-contracts.test.ts
@@ -1,0 +1,3 @@
+/** Frozen identifiers used to exercise compatibility with existing installs. */
+export const FROZEN_PLUGIN_ID = "memclaw"; // legacy-name-ok: permanent on-disk plugin identifier
+export const LEGACY_DISPLAY_NAME = "MemClaw"; // legacy-name-ok: historical on-disk prose fixture

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -25,6 +25,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, readdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
 
 // Set env BEFORE importing reconcile-skills.js — module reads from
 // process.env at import time via env.ts.
@@ -40,7 +41,7 @@ process.env.HOME = tmpHome;
 
 const { reconcileSkills, PROTECTED_SKILLS, resolveSkillTargets, OWNED_MARKER } = await import("./reconcile-skills.js");
 
-const SKILLS_ROOT = join(tmpHome, ".openclaw", "plugins", "memclaw", "skills");
+const SKILLS_ROOT = join(tmpHome, ".openclaw", "plugins", FROZEN_PLUGIN_ID, "skills");
 
 let originalFetch: typeof fetch;
 type MockCatalogEntry = {
@@ -114,28 +115,28 @@ describe("reconcileSkills", () => {
   });
 
   test("invariant 1: bundled protected skill is never deleted (empty catalog)", async () => {
-    plantOnDisk("memclaw", "# bundled onboarding skill — should survive\n");
+    plantOnDisk(FROZEN_PLUGIN_ID, "# bundled onboarding skill — should survive\n");
     plantOnDisk("foo", "# orphan from a previous unshared skill\n");
     mockCatalog = []; // empty catalog
 
     const summary = await reconcileSkills();
 
-    assert.deepEqual(listSkillDirs(), ["memclaw"]); // foo gone, memclaw stays
+    assert.deepEqual(listSkillDirs(), [FROZEN_PLUGIN_ID]); // foo gone, bundled skill stays
     assert.deepEqual(summary.removed, ["foo"]);
-    assert.deepEqual(summary.protected, ["memclaw"]);
+    assert.deepEqual(summary.protected, [FROZEN_PLUGIN_ID]);
     // No catalog-active skills → nothing installed (the bundled skill
     // is protected, not "installed" from the catalog).
     assert.deepEqual(summary.installed, []);
     // Bundled content must be untouched
-    assert.match(readSkill("memclaw"), /should survive/);
+    assert.match(readSkill(FROZEN_PLUGIN_ID), /should survive/);
   });
 
-  test("PROTECTED_SKILLS is exported and contains memclaw", () => {
-    assert.ok(PROTECTED_SKILLS.has("memclaw"));
+  test("PROTECTED_SKILLS is exported and contains the plugin id", () => {
+    assert.ok(PROTECTED_SKILLS.has(FROZEN_PLUGIN_ID));
   });
 
   test("invariant 2: cold start pulls every catalog skill", async () => {
-    plantOnDisk("memclaw"); // only the bundled skill
+    plantOnDisk(FROZEN_PLUGIN_ID); // only the bundled skill
     mockCatalog = [
       { doc_id: "git-rebase-safety", data: { name: "git-rebase-safety", description: "rebase steps",   content: "# rebase safely\n" } },
       { doc_id: "deploy-runbook",    data: { name: "deploy-runbook",    description: "deploy steps",   content: "# deploy steps\n" } },
@@ -145,7 +146,7 @@ describe("reconcileSkills", () => {
     const summary = await reconcileSkills();
 
     assert.deepEqual(listSkillDirs(), [
-      "deploy-runbook", "git-rebase-safety", "incident-triage", "memclaw",
+      "deploy-runbook", "git-rebase-safety", "incident-triage", FROZEN_PLUGIN_ID,
     ]);
     assert.deepEqual(summary.added.sort(), ["deploy-runbook", "git-rebase-safety", "incident-triage"]);
     assert.deepEqual(summary.removed, []);
@@ -160,7 +161,7 @@ describe("reconcileSkills", () => {
   });
 
   test("invariant 3: convergence — adds B, removes C, in one tick", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     // Plant skill-a with the EXACT content the reconciler would write,
     // so the no-op-on-match path stays quiet for it.
     plantOnDisk("skill-a", withSynthFrontmatter("skill-a", "alpha", "# A from catalog\n"));
@@ -172,13 +173,13 @@ describe("reconcileSkills", () => {
 
     const summary = await reconcileSkills();
 
-    assert.deepEqual(listSkillDirs(), ["memclaw", "skill-a", "skill-b"]);
+    assert.deepEqual(listSkillDirs(), [FROZEN_PLUGIN_ID, "skill-a", "skill-b"]);
     assert.deepEqual(summary.added, ["skill-b"]);
     assert.deepEqual(summary.removed, ["skill-c"]);
   });
 
   test("invariant 4: re-running with no changes is a no-op", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     mockCatalog = [
       { doc_id: "skill-a", data: { name: "skill-a", description: "alpha", content: "# A\n" } },
     ];
@@ -198,7 +199,7 @@ describe("reconcileSkills", () => {
   });
 
   test("invariant 5: unsafe slug from catalog is skipped, never lands on disk", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     mockCatalog = [
       { doc_id: "../etc/passwd", data: { name: "x", description: "exploit",     content: "exploit\n" } },
       { doc_id: "Capitalized",   data: { name: "x", description: "uppercase",   content: "rejected\n" } },
@@ -207,7 +208,7 @@ describe("reconcileSkills", () => {
 
     const summary = await reconcileSkills();
 
-    assert.deepEqual(listSkillDirs(), ["memclaw", "valid-slug"]);
+    assert.deepEqual(listSkillDirs(), [FROZEN_PLUGIN_ID, "valid-slug"]);
     assert.deepEqual(summary.added, ["valid-slug"]);
     assert.equal(summary.skipped.length, 2);
     // No traversal artefact created
@@ -215,7 +216,7 @@ describe("reconcileSkills", () => {
   });
 
   test("catalog returns missing content/description → row skipped, others applied", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     mockCatalog = [
       { doc_id: "no-content",     data: { name: "x", description: "ok" } as MockCatalogEntry["data"] },
       { doc_id: "no-description", data: { name: "x",                       content: "# body\n" } as MockCatalogEntry["data"] },
@@ -224,13 +225,13 @@ describe("reconcileSkills", () => {
 
     const summary = await reconcileSkills();
 
-    assert.deepEqual(listSkillDirs(), ["good", "memclaw"]);
+    assert.deepEqual(listSkillDirs(), ["good", FROZEN_PLUGIN_ID]);
     assert.deepEqual(summary.added, ["good"]);
     assert.equal(summary.skipped.length, 2);
   });
 
   test("frontmatter synthesis: plain markdown gets name+description prepended for OpenClaw discovery", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     mockCatalog = [
       {
         doc_id: "git-rebase-safety",
@@ -255,7 +256,7 @@ describe("reconcileSkills", () => {
   });
 
   test("frontmatter passthrough: skill content that already starts with --- is left untouched", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     const authorContent =
       "---\nname: my-skill\ndescription: hand-authored\nuser-invocable: true\n---\n\n# Body\n";
     mockCatalog = [
@@ -276,7 +277,7 @@ describe("reconcileSkills", () => {
   });
 
   test("catalog query failure → fail open: existing skills preserved", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     plantOnDisk("skill-a", "# from previous tick\n");
     // Replace fetch with a thrower
     globalThis.fetch = (async () => {
@@ -286,14 +287,14 @@ describe("reconcileSkills", () => {
     const summary = await reconcileSkills();
 
     // Disk untouched
-    assert.deepEqual(listSkillDirs(), ["memclaw", "skill-a"]);
+    assert.deepEqual(listSkillDirs(), [FROZEN_PLUGIN_ID, "skill-a"]);
     assert.equal(summary.catalogCount, 0);
     assert.deepEqual(summary.added, []);
     assert.deepEqual(summary.removed, []);
   });
 
   test("content drift on disk → reconciler overwrites with catalog version", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     plantOnDisk("skill-a", "# stale local edits\n");
     mockCatalog = [
       { doc_id: "skill-a", data: { name: "skill-a", description: "alpha", content: "# canonical from catalog\n" } },
@@ -306,7 +307,7 @@ describe("reconcileSkills", () => {
 
   test("de-activation: a skill withheld by the server (active→rejected/quarantined) is removed from disk next tick", async () => {
     // Tick 1: skill is active → server returns it → lands on disk.
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     mockCatalog = [
       { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "deploy steps", content: "# deploy\n" } },
     ];
@@ -324,28 +325,28 @@ describe("reconcileSkills", () => {
     // The heartbeat now reports an empty installed set — the operator
     // sees the skill is no longer live on this node.
     assert.deepEqual(second.installed, []);
-    assert.deepEqual(listSkillDirs(), ["memclaw"]); // gone; bundled survives
+    assert.deepEqual(listSkillDirs(), [FROZEN_PLUGIN_ID]); // gone; bundled survives
   });
 
   test("server fail-closed (503) → reconciler fails safe: disk preserved, nothing pushed", async () => {
     // The install surface raises 503 during a settings outage (fail
     // closed). apiCall throws on non-2xx, so the reconciler catches it
     // and leaves disk untouched — no non-active skill can be pushed.
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     plantOnDisk("skill-a", "# from a healthy prior tick\n");
     globalThis.fetch = (async () =>
       new Response("skill lifecycle gate unavailable", { status: 503 })) as typeof fetch;
 
     const summary = await reconcileSkills();
 
-    assert.deepEqual(listSkillDirs(), ["memclaw", "skill-a"]); // untouched
+    assert.deepEqual(listSkillDirs(), [FROZEN_PLUGIN_ID, "skill-a"]); // untouched
     assert.equal(summary.catalogCount, 0);
     assert.deepEqual(summary.added, []);
     assert.deepEqual(summary.removed, []);
   });
 
   test("installed reflects CONFIRMED disk, not desired intent: a failed write is excluded", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     // Plant a FILE where the reconciler wants a directory, so
     // mkdirSync(skills/bad-skill) throws and its write fails — without
     // mocking fs. ``good-skill`` writes cleanly.
@@ -499,7 +500,7 @@ describe("reconcileSkills — configured targets", () => {
   };
 
   test("additive: writes a catalog skill into the dir, stamps the ownership marker", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     useAdditive();
     mockCatalog = [
       { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# deploy\n" } },
@@ -513,7 +514,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("additive: a foreign (unowned) skill not in the catalog is NEVER removed", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     plantForeign("client-skill");
     useAdditive();
     mockCatalog = []; // empty catalog — owned dir would prune, additive must not touch foreign
@@ -526,7 +527,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("additive: collision — catalog slug occupied by a foreign skill is skipped, not clobbered", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     plantForeign("deploy-runbook", "# CLIENT version — keep me\n");
     useAdditive();
     mockCatalog = [
@@ -545,7 +546,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("additive: a plugin-owned skill dropped from the catalog IS removed", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     plantOwned("old-skill"); // previously written by this plugin (has marker)
     plantForeign("client-skill"); // foreign neighbour — must survive
     useAdditive();
@@ -559,7 +560,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("additive: an owned skill still in the catalog is updated in place", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     plantOwned("deploy-runbook", "# stale owned\n");
     useAdditive();
     mockCatalog = [
@@ -574,7 +575,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("additive: a skill whose marker was deleted is treated as foreign (collision, not clobbered)", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     plantOwned("deploy-runbook", "# was owned, marker now gone\n");
     rmSync(ext("deploy-runbook", OWNED_MARKER), { force: true }); // marker wiped → no longer recognisable as ours
     useAdditive();
@@ -593,7 +594,8 @@ describe("reconcileSkills — configured targets", () => {
   test("additive: a FOREIGN dir whose name matches a protected slug is ignored, not reported protected", async () => {
     // No protected skill in the default owned dir (resetSkillsDir cleared it), so any
     // protected slug in summary.protected could only come from the additive dir.
-    plantForeign("memclaw", "# client's own thing named memclaw\n"); // foreign, no marker
+    const foreignContent = `# client's own thing named ${FROZEN_PLUGIN_ID}\n`;
+    plantForeign(FROZEN_PLUGIN_ID, foreignContent); // foreign, no marker
     useAdditive();
     mockCatalog = []; // nothing active
 
@@ -601,25 +603,25 @@ describe("reconcileSkills — configured targets", () => {
 
     // Ownership gates first: the foreign dir is left untouched AND is not
     // misreported as a Caura-protected skill.
-    assert.equal(readFileSync(ext("memclaw", "SKILL.md"), "utf-8"), "# client's own thing named memclaw\n");
-    assert.ok(!summary.removed.includes("memclaw"), "foreign protected-name dir not removed");
-    assert.ok(!summary.protected.includes("memclaw"), "foreign dir not reported as protected");
+    assert.equal(readFileSync(ext(FROZEN_PLUGIN_ID, "SKILL.md"), "utf-8"), foreignContent);
+    assert.ok(!summary.removed.includes(FROZEN_PLUGIN_ID), "foreign protected-name dir not removed");
+    assert.ok(!summary.protected.includes(FROZEN_PLUGIN_ID), "foreign dir not reported as protected");
   });
 
   test("additive: an OWNED dir matching a protected slug survives (reported protected)", async () => {
-    plantOwned("memclaw", "# memclaw we wrote\n"); // owned (marker present)
+    plantOwned(FROZEN_PLUGIN_ID, "# content we wrote\n"); // owned (marker present)
     useAdditive();
     mockCatalog = []; // not in catalog
 
     const summary = await reconcileSkills();
 
-    assert.ok(existsSync(ext("memclaw", "SKILL.md")), "owned protected dir survives");
-    assert.ok(!summary.removed.includes("memclaw"), "owned protected dir not removed");
-    assert.ok(summary.protected.includes("memclaw"), "owned protected dir reported in protected");
+    assert.ok(existsSync(ext(FROZEN_PLUGIN_ID, "SKILL.md")), "owned protected dir survives");
+    assert.ok(!summary.removed.includes(FROZEN_PLUGIN_ID), "owned protected dir not removed");
+    assert.ok(summary.protected.includes(FROZEN_PLUGIN_ID), "owned protected dir reported in protected");
   });
 
   test("an extra owned target is reconciled alongside the default", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     process.env.CAURA_SKILL_TARGETS = JSON.stringify([{ dir: EXTRA_OWNED, mode: "owned" }]);
     mockCatalog = [
       { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# deploy\n" } },
@@ -633,7 +635,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("per-target: default single target yields one entry mirroring the aggregate", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     mockCatalog = [
       { doc_id: "deploy-runbook", data: { name: "deploy-runbook", description: "d", content: "# deploy\n" } },
     ];
@@ -650,7 +652,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("per-target: owned + additive each report their own slice; aggregate dedups", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     plantForeign("deploy-runbook", "# CLIENT version — keep\n"); // collides in the additive dir
     useAdditive();
     mockCatalog = [
@@ -682,7 +684,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("register: an additive target with register:true is added to skills.load.extraDirs", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     writeOpenClawJson({ tools: {} }); // vanilla config, no skills block yet
     process.env.CAURA_SKILL_TARGETS = JSON.stringify([
       { dir: EXTERNAL, mode: "additive", register: true },
@@ -701,7 +703,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("register: omitted/false leaves openclaw.json untouched", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     writeOpenClawJson({ skills: { load: { extraDirs: ["/pre/existing"] } } });
     useAdditive(); // no register flag
     mockCatalog = [
@@ -715,7 +717,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("register: a write failure is NOT reported as registered", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     // No openclaw.json written → ensureExtraSkillDirs fails closed.
     if (existsSync(OPENCLAW_JSON)) rmSync(OPENCLAW_JSON, { force: true });
     process.env.CAURA_SKILL_TARGETS = JSON.stringify([
@@ -733,7 +735,7 @@ describe("reconcileSkills — configured targets", () => {
   });
 
   test("register: idempotent — re-running does not duplicate the entry", async () => {
-    plantOnDisk("memclaw");
+    plantOnDisk(FROZEN_PLUGIN_ID);
     writeOpenClawJson({ skills: { load: { extraDirs: [EXTERNAL] } } }); // already present
     process.env.CAURA_SKILL_TARGETS = JSON.stringify([
       { dir: EXTERNAL, mode: "additive", register: true },

--- a/plugin/src/runtime-contract.test.ts
+++ b/plugin/src/runtime-contract.test.ts
@@ -29,12 +29,18 @@
 import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import cauraPlugin from "./index.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
 import {
   _resetReachabilityForTests,
   getReachability,
   markReachable,
   markUnreachable,
 } from "./health.js";
+
+const FLUSH_PATH_RE = new RegExp(`^${FROZEN_PLUGIN_ID}/flush-\\d{4}-\\d{2}-\\d{2}\\.md$`);
+const FLUSH_YEAR_PATH_RE = new RegExp(
+  `^${FROZEN_PLUGIN_ID}/flush-(\\d{4})-\\d{2}-\\d{2}\\.md$`,
+);
 
 type RegisteredRuntime = {
   getMemorySearchManager: (p: Record<string, unknown>) => Promise<{
@@ -72,10 +78,10 @@ function loadRuntime(): RegisteredRuntime {
 describe("memory-runtime contract (OpenClaw MemoryPluginRuntime)", () => {
   beforeEach(() => _resetReachabilityForTests());
 
-  test("resolveMemoryBackendConfig returns { backend: 'memclaw' }", () => {
+  test("resolveMemoryBackendConfig returns the registered plugin id", () => {
     const rt = loadRuntime();
     const cfg = rt.resolveMemoryBackendConfig({}) as Record<string, unknown>;
-    assert.equal(cfg.backend, "memclaw");
+    assert.equal(cfg.backend, FROZEN_PLUGIN_ID);
   });
 
   test("getMemorySearchManager returns {manager:null, error} when unreachable — NOT silently a stub", async () => {
@@ -162,7 +168,7 @@ describe("memory-runtime contract (OpenClaw MemoryPluginRuntime)", () => {
     const s = manager.status();
     assert.equal(s.status, "unreachable");
     assert.ok(s.fallback, "status() must include a fallback block when unreachable");
-    assert.equal(s.fallback.from, "memclaw-api");
+    assert.equal(s.fallback.from, `${FROZEN_PLUGIN_ID}-api`);
     assert.match(s.fallback.reason, /backend restart/);
   });
 
@@ -304,7 +310,7 @@ describe("MemoryFlushPlan contract (OpenClaw agent-runner.runtime)", () => {
     assert.equal(rp.startsWith("/"), false);
     assert.equal(rp.startsWith("../"), false);
     assert.equal(rp.includes("/../"), false);
-    assert.match(rp, /^memclaw\//);
+    assert.ok(rp.startsWith(`${FROZEN_PLUGIN_ID}/`));
   });
 
   test("relativePath embeds the provided nowMs date stamp deterministically", () => {
@@ -344,7 +350,7 @@ describe("MemoryFlushPlan resolver — input-hardening (regression: review 2026-
     assert.equal(typeof (plan as Record<string, unknown>).relativePath, "string");
     assert.match(
       (plan as Record<string, unknown>).relativePath as string,
-      /^memclaw\/flush-\d{4}-\d{2}-\d{2}\.md$/,
+      FLUSH_PATH_RE,
     );
   });
 
@@ -353,7 +359,7 @@ describe("MemoryFlushPlan resolver — input-hardening (regression: review 2026-
     const plan = r({ nowMs: Number.NaN });
     assert.ok(plan);
     const rp = (plan as Record<string, unknown>).relativePath as string;
-    assert.match(rp, /^memclaw\/flush-\d{4}-\d{2}-\d{2}\.md$/, `bad rp=${rp}`);
+    assert.match(rp, FLUSH_PATH_RE, `bad rp=${rp}`);
   });
 
   test("resolver({nowMs: Infinity}) falls back to Date.now()", () => {
@@ -361,7 +367,7 @@ describe("MemoryFlushPlan resolver — input-hardening (regression: review 2026-
     const plan = r({ nowMs: Number.POSITIVE_INFINITY });
     assert.ok(plan);
     const rp = (plan as Record<string, unknown>).relativePath as string;
-    assert.match(rp, /^memclaw\/flush-\d{4}-\d{2}-\d{2}\.md$/);
+    assert.match(rp, FLUSH_PATH_RE);
   });
 
   test("resolver({nowMs: -Infinity}) falls back to Date.now()", () => {
@@ -369,7 +375,7 @@ describe("MemoryFlushPlan resolver — input-hardening (regression: review 2026-
     const plan = r({ nowMs: Number.NEGATIVE_INFINITY });
     assert.ok(plan);
     const rp = (plan as Record<string, unknown>).relativePath as string;
-    assert.match(rp, /^memclaw\/flush-\d{4}-\d{2}-\d{2}\.md$/);
+    assert.match(rp, FLUSH_PATH_RE);
   });
 
   test("resolver({nowMs: 'oops' as any}) ignores non-number and falls back", () => {
@@ -382,7 +388,7 @@ describe("MemoryFlushPlan resolver — input-hardening (regression: review 2026-
     });
     assert.ok(plan);
     const rp = (plan as Record<string, unknown>).relativePath as string;
-    assert.match(rp, /^memclaw\/flush-\d{4}-\d{2}-\d{2}\.md$/);
+    assert.match(rp, FLUSH_PATH_RE);
   });
 });
 
@@ -399,7 +405,7 @@ describe("MemoryFlushPlan resolver — negative-timestamp guard (review 2026-05-
     const plan = r({ nowMs: -1 });
     assert.ok(plan);
     const rp = (plan as Record<string, unknown>).relativePath as string;
-    const yearMatch = rp.match(/^memclaw\/flush-(\d{4})-\d{2}-\d{2}\.md$/);
+    const yearMatch = rp.match(FLUSH_YEAR_PATH_RE);
     assert.ok(yearMatch, `unexpected path shape: ${rp}`);
     const yearInPath = Number.parseInt(yearMatch[1], 10);
     const currentYear = new Date().getUTCFullYear();
@@ -415,7 +421,7 @@ describe("MemoryFlushPlan resolver — negative-timestamp guard (review 2026-05-
     const plan = r({ nowMs: -Date.now() });
     assert.ok(plan);
     const rp = (plan as Record<string, unknown>).relativePath as string;
-    const yearMatch = rp.match(/^memclaw\/flush-(\d{4})-\d{2}-\d{2}\.md$/);
+    const yearMatch = rp.match(FLUSH_YEAR_PATH_RE);
     assert.ok(yearMatch);
     assert.equal(Number.parseInt(yearMatch[1], 10), new Date().getUTCFullYear());
   });
@@ -425,7 +431,7 @@ describe("MemoryFlushPlan resolver — negative-timestamp guard (review 2026-05-
     const plan = r({ nowMs: 0 });
     assert.ok(plan);
     const rp = (plan as Record<string, unknown>).relativePath as string;
-    const yearMatch = rp.match(/^memclaw\/flush-(\d{4})-\d{2}-\d{2}\.md$/);
+    const yearMatch = rp.match(FLUSH_YEAR_PATH_RE);
     assert.ok(yearMatch);
     assert.notEqual(
       Number.parseInt(yearMatch[1], 10),
@@ -438,9 +444,9 @@ describe("MemoryFlushPlan resolver — negative-timestamp guard (review 2026-05-
     const r = _loadFlushPlanResolver();
     const plan = r({ nowMs: Date.UTC(2026, 4, 24, 12, 0, 0) });
     assert.ok(plan);
-    assert.match(
-      (plan as Record<string, unknown>).relativePath as string,
-      /^memclaw\/flush-2026-05-24\.md$/,
+    assert.equal(
+      (plan as Record<string, unknown>).relativePath,
+      `${FROZEN_PLUGIN_ID}/flush-2026-05-24.md`,
     );
   });
 });
@@ -908,9 +914,9 @@ describe("ContextEngine.info compaction-ownership (v2.6.4)", () => {
     );
   });
 
-  test("info.id === 'memclaw' (slot resolver depends on this)", () => {
+  test("info.id matches the registered plugin id (slot resolver depends on this)", () => {
     const engine = new CauraContextEngine({});
-    assert.equal(engine.info.id, "memclaw");
+    assert.equal(engine.info.id, FROZEN_PLUGIN_ID);
   });
 });
 

--- a/plugin/src/tool-definitions.test.ts
+++ b/plugin/src/tool-definitions.test.ts
@@ -15,6 +15,7 @@ import { createToolFromSpec } from "./tool-definitions.js";
 import { TOOL_SPECS, TOOL_SPECS_BY_NAME, getSpec } from "./tool-specs.js";
 import { buildToolsMd } from "./educate.js";
 import { cauraPromptSectionText } from "./prompt-section.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
 
 describe("tool-specs loader", () => {
   test("loads a non-empty ordered spec list from tools.json", () => {
@@ -230,7 +231,7 @@ describe("drift checks across tool surface artefacts", () => {
       import.meta.dirname,
       "..",
       "skills",
-      "memclaw",
+      FROZEN_PLUGIN_ID,
       "SKILL.md",
     );
     const skill = readFileSync(skillPath, "utf-8");
@@ -250,7 +251,7 @@ describe("drift checks across tool surface artefacts", () => {
       import.meta.dirname,
       "..",
       "skills",
-      "memclaw",
+      FROZEN_PLUGIN_ID,
       "SKILL.md",
     );
     const skill = readFileSync(skillPath, "utf-8");
@@ -321,11 +322,11 @@ describe("drift checks across tool surface artefacts", () => {
       // burning ~3 min and failing the turn.
       const flat = tools.replace(/\s+/g, " ");
       assert.ok(
-        !flat.includes("skills/memclaw/SKILL.md"),
+        !flat.includes(`skills/${FROZEN_PLUGIN_ID}/SKILL.md`),
         "must NOT reference the skill by filesystem path (CAURA-000)",
       );
       assert.ok(
-        /\*\*memclaw\*\* skill/i.test(flat),
+        new RegExp(`\\*\\*${FROZEN_PLUGIN_ID}\\*\\* skill`, "i").test(flat),
         "must reference the **memclaw** skill by name", // legacy-name-floor: OpenClaw skill slug
       );
       assert.ok(


### PR DESCRIPTION
## Summary

- centralize repeated existing-install identifiers and historical display prose in frozen test-only fixtures
- reword incidental old-name prose while preserving every assertion about shipped paths, config keys, fences, backups, routes, and recall aliases
- keep all previously audited marker-bearing lines unchanged, including the 26 retained plugin markers called out by Package Y

## Ratchet

- plugin tests before: **150 ratcheted lines across 9 files**
- plugin tests after: **0 ratcheted lines**
- delta: **150 removals, 0 unexempted additions**
- whole repository: **574 → 424 ratcheted lines**
- markers introduced: **3 `legacy-name-ok` lines**, concentrated into two frozen test constants and one live compatibility-route constant

The three markers are contracts rather than prose: the permanent on-disk plugin id, historical display text written to customer files, and the live compatibility keystones route. The existing audited plugin floor/compat markers were left byte-for-byte unchanged.

## Package Y exclusions

- `clients/python/tests/test_legacy_alias.py` — all 10 lines prove the legacy Python import/classes remain aliases; untouched
- `tests/test_tool_rename_aliases.py` — all 9 lines prove legacy tool aliases remain callable; untouched
- `scripts/wet_test_baselines/caura-125-baseline.jsonl` — recorded benchmark measurement; untouched
- `scripts/wet_test_baselines/caura-125-postfix.jsonl` — recorded benchmark measurement; untouched
- `tests/test_migration_012_safety_gate.py` — reserved for line-by-line migration-quote verification in the root-tests slice; untouched here
- the 26 retained plugin markers from the 31 August audit — shipped paths, config keys, on-disk formats, and matchers; untouched
- `tests/conftest.py` — deferred to the root-tests slice while OSS #1140 remains open

## Verification

- affected plugin suites: **306/306 passed** after rebasing onto `origin/main`
- full plugin suite: **426/426 passed** in the isolated local test environment before the final rebase; CI will rerun it on this head
- `npm run build`
- `npm run check:version` (2.19.6)
- legacy-name ratchet: **0 new, 0 annotated, 150 removed**
- do-not-touch sentinel: **all 46 protected strings survive**
- Ruff check and Ruff format check: all CI scopes passed, run separately with discovery-based config
- mypy: core-api, core-storage-api, core-operations, core-worker, common, and scripts all passed
- `git diff --check`

No production code or assertions were removed.
