### PR TITLE
fix(storage): bind entity-link creation to the caller's tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1466,19 +1466,26 @@ class CoreStorageClient:
             entity_id=entity_id,
         )
 
-    async def create_entity_link(self, data: dict) -> dict:
-        return await self._post("/entities/links", data)  # type: ignore[return-value]
+    async def create_entity_link(self, tenant_id: str, data: dict) -> dict:
+        # The link is addressed by two bare UUIDs, so the tenant has to travel
+        # with them: storage scopes both ends to it. The explicit arg wins over
+        # any ``tenant_id`` in ``data``.
+        return await self._post("/entities/links", {**data, "tenant_id": tenant_id})  # type: ignore[return-value]
 
-    async def bulk_upsert_entity_links(self, items: list[dict]) -> list[dict]:
+    async def bulk_upsert_entity_links(self, tenant_id: str, items: list[dict]) -> list[dict]:
         """Idempotently create many memory→entity links in one round-trip.
 
         Per-item: ``{"input_idx", "memory_id", "entity_id", "role"}``.
         Response aligned to input with ``{"input_idx", "memory_id",
         "entity_id", "role", "created": bool}``. ``created=False`` means
         the link already existed (its prior role preserved).
+
+        ``tenant_id`` binds every item on both ends. An item naming a memory or
+        entity outside it comes back as ``error="fk_violation"`` — the same
+        answer as an endpoint that does not exist, deliberately.
         """
         return await self._post(  # type: ignore[return-value]
-            "/entities/links/bulk", {"items": items}
+            "/entities/links/bulk", {"tenant_id": tenant_id, "items": items}
         )
 
     async def get_memory_ids_by_entity_ids(

--- a/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
+++ b/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
@@ -125,6 +125,7 @@ class WriteMemoryRow:
         for link in data.entity_links:
             try:
                 await sc.create_entity_link(
+                    data.tenant_id,
                     {
                         "memory_id": memory["id"],
                         # Stringify the UUID for JSON transport — mirrors
@@ -133,7 +134,7 @@ class WriteMemoryRow:
                         # receive, so the persisted value is identical.
                         "entity_id": str(link.entity_id),
                         "role": link.role,
-                    }
+                    },
                 )
             except Exception as exc:
                 # Still degrade in EVERY case — the row is committed, and letting

--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -401,7 +401,7 @@ async def process_entity_extraction(
                 )
                 link_idx += 1
             if link_items:
-                link_result = await sc.bulk_upsert_entity_links(items=link_items)
+                link_result = await sc.bulk_upsert_entity_links(tenant_id, items=link_items)
                 # Surface any FK violations from the per-item path
                 # (storage-side reports ``error="fk_violation"`` for rows
                 # whose memory_id or entity_id no longer exists). Same

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -379,8 +379,16 @@ async def find_relation(
 @router.post("/links")
 async def create_memory_entity_link(request: Request) -> dict:
     body: dict = await request.json()
+    # Tenant guard, same shape as ``PATCH /entities/{entity_id}``: the body
+    # supplied only bare ``memory_id`` / ``entity_id`` / ``role``, so knowing two
+    # UUIDs was enough to create a graph edge across a tenant boundary (#1124).
+    # Removed from the body as well as read, because ``MemoryEntityLink`` has no
+    # ``tenant_id`` column — the join table is tenantless, which is the whole
+    # difficulty — and ``MemoryEntityLink(**data)`` would raise TypeError on it.
+    tenant_id = _require(body, "tenant_id")
+    del body["tenant_id"]
     try:
-        link = await _svc.entity_add_entity_link(body)
+        link = await _svc.entity_add_entity_link(tenant_id, body)
     except ValueError as e:
         # H-05 follow-up: a caller-supplied memory_id/entity_id that does not
         # exist, or a pair already linked, is a client error. It used to escape as
@@ -403,8 +411,13 @@ async def bulk_upsert_memory_entity_links(request: Request) -> list[dict]:
     flow which never overwrites role).
 
     Cap: 500 items per request.
+
+    ``tenant_id`` is required and binds every item, on both ends. One tenant for
+    the request rather than one per item: a per-item tenant would let a single
+    batch span namespaces, which is what #1124 is about.
     """
     body: dict = await request.json()
+    tenant_id = _require(body, "tenant_id")
     items = body.get("items", [])
     if not isinstance(items, list):
         raise HTTPException(status_code=422, detail="'items' must be a list")
@@ -437,7 +450,7 @@ async def bulk_upsert_memory_entity_links(request: Request) -> list[dict]:
                     detail=f"invalid {field} UUID at input_idx {item.get('input_idx')!r}",
                 )
     _validate_input_idxs(items)
-    return await _svc.entity_bulk_upsert_links(items)
+    return await _svc.entity_bulk_upsert_links(tenant_id, items)
 
 
 @router.get("/links/find")

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -364,6 +364,14 @@ _MEMORY_UPDATABLE_FIELDS = _MEMORY_VALID_FIELDS - _MEMORY_IMMUTABLE_FIELDS
 # ``_MEMORY_UPDATABLE_FIELDS`` above follows.
 _ENTITY_UPDATABLE_FIELDS = frozenset({"canonical_name", "entity_type", "attributes", "name_embedding"})
 
+# The one answer ``entity_add_entity_link`` gives for every way a link can be
+# refused: either endpoint absent, either endpoint owned by another tenant, or
+# the pair already linked. A constant rather than the string repeated at each
+# raise, because the whole point is that the causes are indistinguishable on the
+# wire — two copies could drift apart and reintroduce the existence oracle one
+# word at a time. The true cause is logged, never returned.
+_LINK_REJECTED = "entity link rejected: memory_id or entity_id does not exist, or the link already exists"
+
 # Columns ``fleet_upsert_node``'s ON CONFLICT DO UPDATE must not rewrite. The
 # insert half of that statement still uses every key the caller sent; this is
 # only the branch that lands on a row that already exists.
@@ -5947,8 +5955,72 @@ class PostgresService:
             )
             return result.scalar_one_or_none()
 
-    async def entity_add_entity_link(self, data: dict) -> MemoryEntityLink:
+    async def _owned_link_endpoints(
+        self,
+        session: AsyncSession,
+        tenant_id: str,
+        memory_ids: set[UUID],
+        entity_ids: set[UUID],
+    ) -> tuple[set[UUID], set[UUID]]:
+        """Which of these memory / entity ids actually belong to ``tenant_id``.
+
+        ``memory_entity_links`` has no ``tenant_id`` of its own, so a link row
+        cannot carry a predicate — but both parents do (``Memory.tenant_id``,
+        ``Entity.tenant_id``), which is what lets an existence check stand in
+        for one and keeps this a data change rather than a schema change.
+
+        Returns the owned subset of each side rather than a bool, so a caller
+        holding many pairs can test membership per pair without a query each.
+        Callers must treat "not in the returned set" as refusal for **both**
+        ends: the two failures are independent, and checking one leaves the
+        other half of the hole open.
+        """
+        owned_memories = set(
+            (
+                await session.scalars(
+                    select(Memory.id).where(Memory.id.in_(memory_ids), Memory.tenant_id == tenant_id)
+                )
+            ).all()
+        )
+        owned_entities = set(
+            (
+                await session.scalars(
+                    select(Entity.id).where(Entity.id.in_(entity_ids), Entity.tenant_id == tenant_id)
+                )
+            ).all()
+        )
+        return owned_memories, owned_entities
+
+    async def entity_add_entity_link(self, tenant_id: str, data: dict) -> MemoryEntityLink:
+        """Create one memory→entity link, both ends scoped to ``tenant_id``.
+
+        Raises ``ValueError`` — which the router maps to 409 — when either end
+        is absent or belongs to another tenant. Deliberately the same exception,
+        with the same message, that a genuine FK violation already raised: a
+        distinguishable answer would make the route an existence oracle for both
+        id spaces, on a service that authenticates no request
+        (GHSA-wgvw-28pq-jc36).
+        """
         async with get_session() as session:
+            memory_id, entity_id = data["memory_id"], data["entity_id"]
+            if not isinstance(memory_id, UUID):
+                memory_id = UUID(memory_id)
+            if not isinstance(entity_id, UUID):
+                entity_id = UUID(entity_id)
+            owned_memories, owned_entities = await self._owned_link_endpoints(
+                session, tenant_id, {memory_id}, {entity_id}
+            )
+            if memory_id not in owned_memories or entity_id not in owned_entities:
+                logger.info(
+                    "Entity link rejected for memory %s → entity %s: not in tenant %s",
+                    memory_id,
+                    entity_id,
+                    tenant_id,
+                )
+                # Same message as the IntegrityError branch below, so the two
+                # causes are one answer on the wire. The distinct log line above
+                # is what keeps the real cause available to an operator.
+                raise ValueError(_LINK_REJECTED)
             link = MemoryEntityLink(**data)
             session.add(link)
             try:
@@ -5977,12 +6049,10 @@ class PostgresService:
                     data.get("entity_id"),
                     exc.orig,
                 )
-                raise ValueError(
-                    "entity link rejected: memory_id or entity_id does not exist, or the link already exists"
-                ) from exc
+                raise ValueError(_LINK_REJECTED) from exc
             return link
 
-    async def entity_bulk_upsert_links(self, items: list[dict]) -> list[dict]:
+    async def entity_bulk_upsert_links(self, tenant_id: str, items: list[dict]) -> list[dict]:
         """Idempotently create many memory→entity links in one statement.
 
         Each input item: ``{"input_idx", "memory_id", "entity_id", "role"}``.
@@ -5991,6 +6061,13 @@ class PostgresService:
         same composite PK ``(memory_id, entity_id)`` already existed;
         its ``role`` is preserved (mirrors today's ``find_entity_link``
         → ``create_entity_link`` flow which skips on a hit).
+
+        Every item is scoped to ``tenant_id`` on **both** ends. One binding
+        tenant for the request rather than one per item: a per-item tenant would
+        let a single batch span namespaces, which is the property this is here to
+        remove. An item whose memory or entity is not in ``tenant_id`` is
+        reported exactly like one whose endpoint does not exist — see
+        ``error="fk_violation"`` below.
 
         Cap enforced at the router level.
         """
@@ -6011,13 +6088,54 @@ class PostgresService:
         # second slot's result to map overwrite.
         idx_to_result: dict[int, dict[str, Any]] = {}
 
-        for it in items:
-            mid = it["memory_id"]
-            eid = it["entity_id"]
-            if not isinstance(mid, UUID):
-                mid = UUID(mid)
-            if not isinstance(eid, UUID):
-                eid = UUID(eid)
+        # Ownership resolved once for the whole batch, in its own session, then
+        # tested per item below. Two queries rather than two per item — and the
+        # sets are what the per-item test needs anyway, since a batch may name
+        # one memory many times.
+        #
+        # A separate session from the inserts is deliberate and safe: neither
+        # parent's ``tenant_id`` is caller-writable (``_MEMORY_IMMUTABLE_FIELDS``
+        # names it on memories, ``_ENTITY_UPDATABLE_FIELDS`` omits it on
+        # entities), so a row cannot change hands between this read and the
+        # write. Sharing one session instead would undo the per-item isolation
+        # the comment above describes.
+        pair_ids = [
+            (
+                mid if isinstance(mid, UUID) else UUID(mid),
+                eid if isinstance(eid, UUID) else UUID(eid),
+            )
+            for mid, eid in ((it["memory_id"], it["entity_id"]) for it in items)
+        ]
+        async with get_session() as session:
+            owned_memories, owned_entities = await self._owned_link_endpoints(
+                session,
+                tenant_id,
+                {mid for mid, _ in pair_ids},
+                {eid for _, eid in pair_ids},
+            )
+
+        for it, (mid, eid) in zip(items, pair_ids, strict=True):
+            if mid not in owned_memories or eid not in owned_entities:
+                # Same ``error`` value as the FK branch below, because the two
+                # are one answer to the caller: a row outside your tenant is
+                # not distinguishable from a row that is not there, and making
+                # it distinguishable would turn a batch endpoint into a
+                # bulk existence oracle. The log line carries the real cause.
+                logger.warning(
+                    "Entity link bulk-upsert refused: memory_id=%s entity_id=%s not in tenant %s",
+                    mid,
+                    eid,
+                    tenant_id,
+                )
+                idx_to_result[it["input_idx"]] = {
+                    "input_idx": it["input_idx"],
+                    "memory_id": str(mid),
+                    "entity_id": str(eid),
+                    "role": it["role"],
+                    "created": False,
+                    "error": "fk_violation",
+                }
+                continue
             # Annotated because ``literal_column("xmax")`` types as ``Any``, and
             # mypy will not infer a variable whose type is partly ``Any``.
             ins_stmt: ReturningInsert[tuple[UUID, UUID, str, Any]] = (

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -73,25 +73,11 @@
       "note": "Verified: data['tenant_id'] is stored on Entity and scopes the conflict-winner lookup."
     },
     {
-      "id": "method:entity_add_entity_link",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "No tenant is carried; bare memory_id and entity_id values mutate the tenantless join table. Tracked in #1124."
-    },
-    {
       "id": "method:entity_bulk_upsert",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
       "category": "opaque-body-write",
       "note": "Verified: every item carries tenant_id, which scopes updates, inserts, race recovery, and winner lookups."
-    },
-    {
-      "id": "method:entity_bulk_upsert_links",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "No tenant is carried; each item has only memory_id, entity_id, and role for the tenantless join table. Tracked in #1124."
     },
     {
       "id": "method:entity_count_memories_per_entity",
@@ -533,20 +519,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "id-addressed-read"
-    },
-    {
-      "id": "route:POST /api/v1/storage/entities/links",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "No tenant is carried; the body supplies only bare memory/entity ids and role. Tracked in #1124."
-    },
-    {
-      "id": "route:POST /api/v1/storage/entities/links/bulk",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "No tenant is carried; every item supplies only bare memory/entity ids and role. Tracked in #1124."
     },
     {
       "id": "route:POST /api/v1/storage/entities/memory-ids-by-entity-ids",

--- a/core-storage-api/tests/test_entity_link_routes_tenant_scope.py
+++ b/core-storage-api/tests/test_entity_link_routes_tenant_scope.py
@@ -1,0 +1,390 @@
+"""``POST /entities/links`` and ``/links/bulk`` must be told which tenant they link for.
+
+Both handlers accepted only caller-supplied ``memory_id``, ``entity_id`` and
+``role``. Neither read a tenant, and ``memory_entity_links``' foreign keys prove
+only that the two UUIDs exist — not that they belong to the same tenant, nor to
+the caller. On a service that authenticates no request (GHSA-wgvw-28pq-jc36),
+published by docker-compose on 0.0.0.0:8002, that made knowing two UUIDs
+sufficient to create a graph edge across a tenant boundary.
+
+The join table has no ``tenant_id``, so the link row carries no predicate of its
+own; both parents do (``Memory.tenant_id``, ``Entity.tenant_id``), which is what
+makes an existence check on the two ends sufficient and a schema change
+unnecessary.
+
+**Both ends are load-bearing and neither implies the other**, so each has its own
+case on each route: skip the entity check and a caller staples a foreign entity
+onto their own memory, pulling another tenant's graph node into their namespace;
+skip the memory check and they staple their own entity onto a foreign memory.
+Reverting one predicate fails only that direction's tests.
+
+The refusals are deliberately indistinguishable from "that row does not exist" —
+409 with a fixed message on the single route, ``error="fk_violation"`` on the
+bulk route. Distinguishing them would answer as an existence oracle for two id
+spaces, which is what ``test_a_foreign_pair_is_indistinguishable_from_a_ghost``
+pins on each route.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX, _memory_payload
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _tenant() -> str:
+    """A tenant id unique to one test and visible to the end-of-run sweep.
+
+    The ``test-tenant-`` prefix is not cosmetic: the root suite's
+    ``_setup_schema`` teardown cleans with ``tenant_id LIKE 'test-tenant-%'``
+    (and reaches this table through the ``memories`` subquery), so a tenant
+    minted with any other prefix is never reclaimed — which is how #858 left
+    9,186 rows behind. Locally this suite's default ``DATABASE_URL`` points at
+    the same database that sweep runs against, so the prefix is what gets these
+    rows collected; in CI the storage suite is given a database of its own and
+    nothing sweeps either way.
+
+    Local to this module rather than ``tests.conftest.new_tenant_id``, which is
+    the root suite's fixture file and not importable from this one. Same prefix
+    contract, deliberately.
+    """
+    return f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+
+async def _memory(client: AsyncClient, tenant_id: str) -> str:
+    fleet_id = f"test-fleet-{uuid.uuid4().hex[:8]}"
+    resp = await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _entity(client: AsyncClient, tenant_id: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/entities",
+        json={
+            "tenant_id": tenant_id,
+            "entity_type": "person",
+            "canonical_name": f"LinkRoute-{uuid.uuid4().hex[:8]}",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _links(client: AsyncClient, memory_id: str) -> list[dict]:
+    """Read the links back regardless of tenant, to assert what actually persisted.
+
+    Deliberately goes through ``POST /memories/entity-links``, which is still
+    unscoped (allowlisted ``id-addressed-read``) and so answers for any tenant —
+    that is what makes it a usable oracle here. When that route gains a required
+    tenant, this helper needs one too.
+    """
+    resp = await client.post(f"{PREFIX}/memories/entity-links", json={"memory_ids": [memory_id]})
+    assert resp.status_code == 200, resp.text
+    return resp.json().get(memory_id, [])
+
+
+class TestSingleLinkRouteTenantScope:
+    """``POST /entities/links``."""
+
+    async def test_foreign_memory_is_not_linked(self, client: AsyncClient) -> None:
+        """Memory side: the attacker's own entity, hung off someone else's memory."""
+        victim, attacker = _tenant(), _tenant()
+        victim_memory = await _memory(client, victim)
+        attacker_entity = await _entity(client, attacker)
+
+        resp = await client.post(
+            f"{PREFIX}/entities/links",
+            json={
+                "tenant_id": attacker,
+                "memory_id": victim_memory,
+                "entity_id": attacker_entity,
+                "role": "subject",
+            },
+        )
+
+        assert resp.status_code == 409, resp.text
+        assert await _links(client, victim_memory) == [], "an edge was written onto a foreign memory"
+
+    async def test_foreign_entity_is_not_linked(self, client: AsyncClient) -> None:
+        """Entity side: someone else's entity, hung off the attacker's own memory.
+
+        The memory here belongs to the caller, so only the entity end is out of
+        tenant — this is the case the entity half of the predicate exists for.
+        """
+        victim, attacker = _tenant(), _tenant()
+        attacker_memory = await _memory(client, attacker)
+        victim_entity = await _entity(client, victim)
+
+        resp = await client.post(
+            f"{PREFIX}/entities/links",
+            json={
+                "tenant_id": attacker,
+                "memory_id": attacker_memory,
+                "entity_id": victim_entity,
+                "role": "subject",
+            },
+        )
+
+        assert resp.status_code == 409, resp.text
+        assert await _links(client, attacker_memory) == [], (
+            "a foreign entity was pulled into the caller's graph"
+        )
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """No tenant used to mean "link by primary key"; it is now a 422."""
+        tenant = _tenant()
+        memory_id = await _memory(client, tenant)
+        entity_id = await _entity(client, tenant)
+
+        resp = await client.post(
+            f"{PREFIX}/entities/links",
+            json={"memory_id": memory_id, "entity_id": entity_id, "role": "subject"},
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+        assert await _links(client, memory_id) == []
+
+    async def test_own_link_is_created(self, client: AsyncClient) -> None:
+        """The supported call still works, and ``tenant_id`` does not reach the row.
+
+        ``MemoryEntityLink`` has no ``tenant_id`` column — the join table being
+        tenantless is the whole difficulty — so the route must consume the field
+        rather than pass it through to ``MemoryEntityLink(**data)``.
+        """
+        tenant = _tenant()
+        memory_id = await _memory(client, tenant)
+        entity_id = await _entity(client, tenant)
+
+        resp = await client.post(
+            f"{PREFIX}/entities/links",
+            json={
+                "tenant_id": tenant,
+                "memory_id": memory_id,
+                "entity_id": entity_id,
+                "role": "subject",
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert "tenant_id" not in resp.json()
+        assert await _links(client, memory_id) == [{"entity_id": entity_id, "role": "subject"}]
+
+    async def test_a_foreign_pair_is_indistinguishable_from_a_ghost(self, client: AsyncClient) -> None:
+        """A real row you don't own answers exactly like a row that isn't there.
+
+        Checked on each end in turn. If the tenant refusal carried its own status
+        or message, the route would confirm which UUIDs exist in other tenants.
+        """
+        victim, attacker = _tenant(), _tenant()
+        attacker_memory = await _memory(client, attacker)
+        attacker_entity = await _entity(client, attacker)
+
+        async def _post(memory_id: str, entity_id: str) -> tuple[int, str]:
+            resp = await client.post(
+                f"{PREFIX}/entities/links",
+                json={
+                    "tenant_id": attacker,
+                    "memory_id": memory_id,
+                    "entity_id": entity_id,
+                    "role": "subject",
+                },
+            )
+            return resp.status_code, resp.json()["detail"]
+
+        foreign_entity = await _post(attacker_memory, await _entity(client, victim))
+        ghost_entity = await _post(attacker_memory, str(uuid.uuid4()))
+        foreign_memory = await _post(await _memory(client, victim), attacker_entity)
+        ghost_memory = await _post(str(uuid.uuid4()), attacker_entity)
+
+        assert foreign_entity == ghost_entity, "the entity end leaks which ids exist elsewhere"
+        assert foreign_memory == ghost_memory, "the memory end leaks which ids exist elsewhere"
+        # And all four are the same answer, so the caller cannot even tell which
+        # END of the link was refused.
+        assert foreign_entity == foreign_memory
+        assert foreign_entity[0] == 409
+
+
+class TestBulkLinkRouteTenantScope:
+    """``POST /entities/links/bulk``."""
+
+    async def _bulk(
+        self, client: AsyncClient, tenant_id: str | None, items: list[dict]
+    ) -> tuple[int, object]:
+        body: dict = {"items": items}
+        if tenant_id is not None:
+            body["tenant_id"] = tenant_id
+        resp = await client.post(f"{PREFIX}/entities/links/bulk", json=body)
+        return resp.status_code, resp.json()
+
+    async def test_foreign_memory_is_not_linked(self, client: AsyncClient) -> None:
+        """Memory side, per item."""
+        victim, attacker = _tenant(), _tenant()
+        victim_memory = await _memory(client, victim)
+        attacker_entity = await _entity(client, attacker)
+
+        status, body = await self._bulk(
+            client,
+            attacker,
+            [{"input_idx": 0, "memory_id": victim_memory, "entity_id": attacker_entity, "role": "subject"}],
+        )
+
+        assert status == 200, body
+        assert body == [
+            {
+                "input_idx": 0,
+                "memory_id": victim_memory,
+                "entity_id": attacker_entity,
+                "role": "subject",
+                "created": False,
+                "error": "fk_violation",
+            }
+        ]
+        assert await _links(client, victim_memory) == [], "an edge was written onto a foreign memory"
+
+    async def test_foreign_entity_is_not_linked(self, client: AsyncClient) -> None:
+        """Entity side, per item — the memory belongs to the caller."""
+        victim, attacker = _tenant(), _tenant()
+        attacker_memory = await _memory(client, attacker)
+        victim_entity = await _entity(client, victim)
+
+        status, body = await self._bulk(
+            client,
+            attacker,
+            [{"input_idx": 0, "memory_id": attacker_memory, "entity_id": victim_entity, "role": "subject"}],
+        )
+
+        assert status == 200, body
+        assert body[0]["created"] is False  # type: ignore[index]
+        assert body[0]["error"] == "fk_violation"  # type: ignore[index]
+        assert await _links(client, attacker_memory) == [], (
+            "a foreign entity was pulled into the caller's graph"
+        )
+
+    async def test_a_refused_item_does_not_discard_its_valid_siblings(self, client: AsyncClient) -> None:
+        """Per-item isolation survives the tenant check.
+
+        The pre-existing contract is that one bad item does not cost the batch
+        (each insert has its own session). A tenant refusal has to behave the
+        same way, or adding the check would have turned a partial failure into a
+        total one for every caller.
+        """
+        victim, attacker = _tenant(), _tenant()
+        memory_id = await _memory(client, attacker)
+        own_entity = await _entity(client, attacker)
+        victim_entity = await _entity(client, victim)
+
+        status, body = await self._bulk(
+            client,
+            attacker,
+            [
+                {"input_idx": 0, "memory_id": memory_id, "entity_id": own_entity, "role": "subject"},
+                {"input_idx": 1, "memory_id": memory_id, "entity_id": victim_entity, "role": "object"},
+            ],
+        )
+
+        assert status == 200, body
+        assert body[0] == {  # type: ignore[index]
+            "input_idx": 0,
+            "memory_id": memory_id,
+            "entity_id": own_entity,
+            "role": "subject",
+            "created": True,
+        }
+        assert body[1]["error"] == "fk_violation"  # type: ignore[index]
+        assert await _links(client, memory_id) == [{"entity_id": own_entity, "role": "subject"}]
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        tenant = _tenant()
+        memory_id = await _memory(client, tenant)
+        entity_id = await _entity(client, tenant)
+
+        status, body = await self._bulk(
+            client,
+            None,
+            [{"input_idx": 0, "memory_id": memory_id, "entity_id": entity_id, "role": "subject"}],
+        )
+
+        assert status == 422, body
+        assert "tenant_id" in str(body)
+        assert await _links(client, memory_id) == []
+
+    async def test_own_links_are_created(self, client: AsyncClient) -> None:
+        tenant = _tenant()
+        memory_id = await _memory(client, tenant)
+        first, second = await _entity(client, tenant), await _entity(client, tenant)
+
+        status, body = await self._bulk(
+            client,
+            tenant,
+            [
+                {"input_idx": 0, "memory_id": memory_id, "entity_id": first, "role": "subject"},
+                {"input_idx": 1, "memory_id": memory_id, "entity_id": second, "role": "object"},
+            ],
+        )
+
+        assert status == 200, body
+        assert [item["created"] for item in body] == [True, True]  # type: ignore[union-attr]
+        assert {link["entity_id"]: link["role"] for link in await _links(client, memory_id)} == {
+            first: "subject",
+            second: "object",
+        }
+
+    async def test_a_foreign_pair_is_indistinguishable_from_a_ghost(self, client: AsyncClient) -> None:
+        """The batch route must not become a bulk existence oracle.
+
+        This is the sharper version of the single-route case: a caller could
+        submit 500 pairs and read off which of them exist in other tenants, in
+        one request, if the refusals differed.
+        """
+        victim, attacker = _tenant(), _tenant()
+        attacker_memory = await _memory(client, attacker)
+        attacker_entity = await _entity(client, attacker)
+
+        status, body = await self._bulk(
+            client,
+            attacker,
+            [
+                # 0: foreign entity. 1: entity that exists nowhere.
+                {
+                    "input_idx": 0,
+                    "memory_id": attacker_memory,
+                    "entity_id": await _entity(client, victim),
+                    "role": "subject",
+                },
+                {
+                    "input_idx": 1,
+                    "memory_id": attacker_memory,
+                    "entity_id": str(uuid.uuid4()),
+                    "role": "subject",
+                },
+                # 2: foreign memory. 3: memory that exists nowhere.
+                {
+                    "input_idx": 2,
+                    "memory_id": await _memory(client, victim),
+                    "entity_id": attacker_entity,
+                    "role": "subject",
+                },
+                {
+                    "input_idx": 3,
+                    "memory_id": str(uuid.uuid4()),
+                    "entity_id": attacker_entity,
+                    "role": "subject",
+                },
+            ],
+        )
+
+        assert status == 200, body
+        # Every slot reports the same outcome; only the echoed ids differ, and
+        # those are the caller's own input.
+        outcomes = [{k: v for k, v in item.items() if k not in ("memory_id", "entity_id")} for item in body]  # type: ignore[union-attr]
+        assert outcomes == [
+            {"input_idx": idx, "role": "subject", "created": False, "error": "fk_violation"}
+            for idx in range(4)
+        ]

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -1997,6 +1997,7 @@ class TestEntities:
         link_resp = await client.post(
             f"{PREFIX}/entities/links",
             json={
+                "tenant_id": tenant_id,
                 "memory_id": memory_id,
                 "entity_id": entity_id,
                 "role": "subject",
@@ -2041,6 +2042,7 @@ class TestEntities:
         resp = await client.post(
             f"{PREFIX}/entities/links",
             json={
+                "tenant_id": tenant_id,
                 "memory_id": mem["id"],
                 "entity_id": ghost_entity_id,
                 "role": "subject",

--- a/tests/test_a4_11_overlap_includes_conflicted_supersedes.py
+++ b/tests/test_a4_11_overlap_includes_conflicted_supersedes.py
@@ -56,11 +56,12 @@ async def _link_memory_to_entity(
 ) -> None:
     """Wire memory→entity in memory_entity_links so the SQL JOIN finds overlap."""
     await sc.create_entity_link(
+        TENANT_ID,
         {
             "memory_id": memory_id,
             "entity_id": entity_id,
             "role": role,
-        }
+        },
     )
 
 

--- a/tests/test_integration_search.py
+++ b/tests/test_integration_search.py
@@ -117,9 +117,9 @@ async def _insert_entity(tenant_id, name, entity_type="concept", fleet_id=None):
     return entity
 
 
-async def _link_memory_entity(memory_id, entity_id, role="mentioned"):
+async def _link_memory_entity(tenant_id, memory_id, entity_id, role="mentioned"):
     sc = get_storage_client()
-    await sc.create_entity_link({
+    await sc.create_entity_link(tenant_id, {
         "memory_id": str(memory_id),
         "entity_id": str(entity_id),
         "role": role,
@@ -250,7 +250,7 @@ class TestSearchPipelineEndToEnd:
             "kafka cluster status healthy all nodes running",
             weight=0.7,
         )
-        await _link_memory_entity(mem["id"], entity["id"])
+        await _link_memory_entity(tenant_id, mem["id"], entity["id"])
 
         # Create unrelated memory
         await _insert_memory(            tenant_id,
@@ -285,7 +285,7 @@ class TestSearchPipelineEndToEnd:
             last_recalled_at=now - timedelta(hours=2),
             ts_valid_start=now - timedelta(days=1),
         )
-        await _link_memory_entity(mem2["id"], entity["id"])
+        await _link_memory_entity(tenant_id, mem2["id"], entity["id"])
 
         from core_api.services.memory_service import search_memories
 

--- a/tests/test_p3_3_graph_fanout.py
+++ b/tests/test_p3_3_graph_fanout.py
@@ -194,7 +194,7 @@ class TestGraphFanoutIntegration:
         ])
         memory_ids = [row["id"] for row in created]
         assert all(memory_ids), "bulk insert did not return an id for every memory"
-        await sc.bulk_upsert_entity_links([
+        await sc.bulk_upsert_entity_links(tenant_id, [
             {"input_idx": i, "memory_id": mid, "entity_id": entity["id"], "role": "subject"}
             for i, mid in enumerate(memory_ids)
         ])

--- a/tests/test_storage_bulk_endpoints.py
+++ b/tests/test_storage_bulk_endpoints.py
@@ -438,6 +438,7 @@ async def test_bulk_upsert_links_creates_all_new(sc):
     e2 = await _create_entity(sc, tid, "linked-two")
 
     results = await sc.bulk_upsert_entity_links(
+        tid,
         items=[
             {
                 "input_idx": 0,
@@ -469,6 +470,7 @@ async def test_bulk_upsert_links_is_idempotent_on_pk_collision(sc):
     e = await _create_entity(sc, tid, "the-entity")
 
     first = await sc.bulk_upsert_entity_links(
+        tid,
         items=[
             {
                 "input_idx": 0,
@@ -481,6 +483,7 @@ async def test_bulk_upsert_links_is_idempotent_on_pk_collision(sc):
     assert first[0]["created"] is True
 
     second = await sc.bulk_upsert_entity_links(
+        tid,
         items=[
             {
                 "input_idx": 0,
@@ -496,7 +499,7 @@ async def test_bulk_upsert_links_is_idempotent_on_pk_collision(sc):
 
 
 async def test_bulk_upsert_links_empty_input(sc):
-    assert await sc.bulk_upsert_entity_links(items=[]) == []
+    assert await sc.bulk_upsert_entity_links(_t(), items=[]) == []
 
 
 # ============================================================================
@@ -515,6 +518,7 @@ async def test_bulk_upsert_links_fk_violation_isolated_per_item(sc):
     ghost_entity = str(uuid4())  # No matching row → FK violation
 
     results = await sc.bulk_upsert_entity_links(
+        tid,
         items=[
             {
                 "input_idx": 0,
@@ -555,6 +559,7 @@ async def test_bulk_upsert_links_duplicate_input_pair_keeps_both_slots(sc):
     e = await _create_entity(sc, tid, "dup-target")
 
     results = await sc.bulk_upsert_entity_links(
+        tid,
         items=[
             {
                 "input_idx": 0,
@@ -779,6 +784,7 @@ async def test_bulk_upsert_links_input_idx_out_of_range_rejected_422(sc):
 
     with pytest.raises(httpx.HTTPStatusError) as exc:
         await sc.bulk_upsert_entity_links(
+            tid,
             items=[
                 {
                     "input_idx": 7,  # out of range for 1-item batch
@@ -803,6 +809,7 @@ async def test_bulk_upsert_links_input_idx_duplicate_rejected_422(sc):
 
     with pytest.raises(httpx.HTTPStatusError) as exc:
         await sc.bulk_upsert_entity_links(
+            tid,
             items=[
                 {
                     "input_idx": 0,
@@ -940,6 +947,7 @@ async def test_bulk_upsert_links_missing_required_field_returns_422(sc):
 
     with pytest.raises(httpx.HTTPStatusError) as exc:
         await sc.bulk_upsert_entity_links(
+            tid,
             items=[
                 {
                     "input_idx": 0,
@@ -1048,6 +1056,7 @@ async def test_bulk_upsert_links_non_uuid_memory_id_returns_422(sc):
 
     with pytest.raises(httpx.HTTPStatusError) as exc:
         await sc.bulk_upsert_entity_links(
+            tid,
             items=[
                 {
                     "input_idx": 0,
@@ -1069,6 +1078,7 @@ async def test_bulk_upsert_links_non_uuid_entity_id_returns_422(sc):
 
     with pytest.raises(httpx.HTTPStatusError) as exc:
         await sc.bulk_upsert_entity_links(
+            tid,
             items=[
                 {
                     "input_idx": 0,


### PR DESCRIPTION
Closes #1124. Sibling of [#1148](https://github.com/caura-ai/caura/pull/1148) (#1085) — same table, same shape, separate routes and methods.

`POST /api/v1/storage/entities/links` and `POST /api/v1/storage/entities/links/bulk` accepted only caller-supplied `memory_id`, `entity_id` and `role`. Neither read a tenant, and `memory_entity_links`' foreign keys prove only that the two UUIDs exist — not that they belong to the same tenant, or to the caller.

`core-storage-api` authenticates no request (GHSA-wgvw-28pq-jc36) and docker-compose publishes it on `0.0.0.0:8002`, so knowing two UUIDs was enough to create a graph edge across a tenant boundary. As the issue puts it, a live cross-tenant integrity hole through two HTTP routes rather than defence-in-depth.

### No schema change

`memory_entity_links` has no `tenant_id`, which means only that the link row cannot carry a predicate directly. Both parents carry one — `Memory.tenant_id` (`common/models/memory.py:30`) and `Entity.tenant_id` (`common/models/entity.py:18`), both `Text, nullable=False, index=True`. Ordinary rows, ordinary `WHERE`, no DDL.

### Do these methods need to exist?

Asked first, because the precedent on this exact table is #1091, closed 30 August: `entity_delete_entity_links` was **deleted, not scoped**, once a search found no caller at all.

Neither of these is that case. Each has exactly one production caller, found by searching for the method, the client wrapper and the route path separately rather than reading the route — the defect class here is precisely that the tenancy guarantee lived in one caller and never travelled:

| method | route | core-api caller |
|---|---|---|
| `entity_add_entity_link` | `POST /entities/links` | `write_memory_row.py:127`, per-link loop on the write pipeline |
| `entity_bulk_upsert_links` | `POST /entities/links/bulk` | `entity_extraction_worker.py:404` |

**Is the single-link path made redundant by the bulk path?** It is the one plausible deletion candidate here, and the answer is no. The two are not duplicates: the single path returns the link row and maps a conflict to 409, and `write_memory_row` loops per link deliberately so that "a single bad id must not discard the valid links beside it" while recording per-link failures for the H-05 degradation path. Folding it onto the bulk endpoint would change both the 409 contract and that degradation behaviour — a behavioural refactor, not a tenancy fix, and not something to smuggle into an auth-adjacent change. Both keep their check.

Both callers already had a tenant in hand and simply never forwarded it (`write_memory_row`: `data.tenant_id`; `entity_extraction_worker`: `process_entity_extraction(memory_id, tenant_id, ...)`).

### Both ends, separately

Neither check implies the other, and each fails on its own:

- Skip the **entity** check and a caller staples a foreign entity onto their own memory, pulling someone else's graph node into their namespace.
- Skip the **memory** check and they staple their own entity onto a foreign memory.

Each route therefore has its own `test_foreign_memory_is_not_linked` and `test_foreign_entity_is_not_linked`.

### Indistinguishable refusals

A tenant refusal must not be distinguishable from "that row does not exist", or these routes confirm which UUIDs exist in other tenants — and the bulk one does it 500 pairs at a time in a single request.

- Single route: raises the same `ValueError`, with the same message, that a genuine FK violation already raised → the same 409. The message is now a module constant (`_LINK_REJECTED`) so the two raise sites cannot drift apart and reintroduce the distinction one word at a time.
- Bulk route: reports the same per-item `error="fk_violation"`.

The real cause is logged rather than returned, so an operator debugging a batch still has it. Reusing `fk_violation` as the wire label is the deliberate trade: it keeps the existing response contract and leaks nothing, at the cost of a label that is mechanically inaccurate for the tenant case. Flagging it explicitly in case a reviewer prefers a neutral label applied to *both* causes — that would also be leak-free, but it changes the wire contract.

The bulk path keeps its per-item isolation: a refused item is reported in its own slot and its valid siblings still land (`test_a_refused_item_does_not_discard_its_valid_siblings`). Ownership is resolved once per batch — two queries, not two per item — in its own session; neither parent's `tenant_id` is caller-writable (`_MEMORY_IMMUTABLE_FIELDS` names it, `_ENTITY_UPDATABLE_FIELDS` omits it), so a row cannot change hands between that read and the write.

### Failing without the fix

Reverting **only** the memory-side predicate in the shared helper (`Memory.tenant_id == tenant_id` dropped):

```
FAILED ...::TestSingleLinkRouteTenantScope::test_foreign_memory_is_not_linked
FAILED ...::TestSingleLinkRouteTenantScope::test_a_foreign_pair_is_indistinguishable_from_a_ghost
FAILED ...::TestBulkLinkRouteTenantScope::test_foreign_memory_is_not_linked
FAILED ...::TestBulkLinkRouteTenantScope::test_a_foreign_pair_is_indistinguishable_from_a_ghost
4 failed, 7 passed in 0.60s
```

with the bulk slot showing the write that went through:

```
At index 0 diff:
  {'input_idx': 0, ..., 'role': 'subject', 'created': True}
    != {'input_idx': 0, ..., 'role': 'subject', 'created': False, 'error': 'fk_violation'}
```

Every entity-side case still passes. Reverting **only** the entity-side predicate (`Entity.tenant_id == tenant_id` dropped):

```
FAILED ...::TestSingleLinkRouteTenantScope::test_foreign_entity_is_not_linked
FAILED ...::TestSingleLinkRouteTenantScope::test_a_foreign_pair_is_indistinguishable_from_a_ghost
FAILED ...::TestBulkLinkRouteTenantScope::test_foreign_entity_is_not_linked
FAILED ...::TestBulkLinkRouteTenantScope::test_a_refused_item_does_not_discard_its_valid_siblings
FAILED ...::TestBulkLinkRouteTenantScope::test_a_foreign_pair_is_indistinguishable_from_a_ghost
5 failed, 6 passed in 0.60s
```

```
core-storage-api/tests/test_entity_link_routes_tenant_scope.py:134: in test_foreign_entity_is_not_linked
    assert resp.status_code == 409, resp.text
E   AssertionError: {"memory_id":"35ec7a9c-...","entity_id":"1da8aeb2-...","role":"subject"}
E   assert 200 == 409
```

Every memory-side case still passes. The two failure sets are disjoint on the direction-specific tests, which is the point: each half is independently load-bearing.

### Allowlist

106 → 102 entries; `id-addressed-write` 12 → 8. (106, not 108, because #1150 removed two entries after this branch was cut; rebased onto it and regenerated.) All four #1124 entries removed — `method:entity_add_entity_link`, `method:entity_bulk_upsert_links`, `route:POST /api/v1/storage/entities/links`, `route:POST /api/v1/storage/entities/links/bulk` — and regenerated with `python3 scripts/tenant_scope_gate.py --write` in this commit, as the gate's stale-entry check (`tenant_scope_gate.py:1060-1063`) requires. Gate green; hand-written `note` and `category` fields elsewhere are untouched.

Note the issue asked for these to be recategorised from `opaque-body-write` to `id-addressed-write`; that had already happened on `main` before this branch, so there is no relabelling in this diff.

### Precedent for the five `id-addressed-read` siblings

Not fixed here and not mine to fix, but this is the shape they should follow, since eight allowlist entries share the note *"Join table has no tenant column; rows are tenant-scoped only via the ids"*. Same list as [#1148](https://github.com/caura-ai/caura/pull/1148) states, plus what this PR adds:

- **Existence check on both parents, not a schema change.**
- **Scope every end the caller names** — `entity_find_entity_link` names both and should check both.
- **One answer for "absent" and "not yours"**, and put the shared message in a constant so the two paths cannot drift.
- **The check belongs in the service method**, not the route.
- **`_owned_link_endpoints` is the reusable piece.** It takes sets and returns the owned subsets, so a read that resolves many ids can filter without a query each. The reads should use it rather than growing their own variant.
- **Two tests per method, one per end**, each verified to fail with only its own predicate reverted.

Caveat for whoever takes them: `POST /memories/entity-links` is the read oracle in this PR's test helper (`_links`) precisely because it is still unscoped. When it gains a required tenant, that helper needs one too — there is a comment on it saying so.

`memory_add_entity_links` in #1148 carries the same check inline rather than through `_owned_link_endpoints`, because these two PRs branch from `main` independently. Worth folding onto the helper once both land; deliberately not done here to keep the PRs revertable on their own.

### Verification

- `core-storage-api/tests/`: 258 passed (11 new).
- Root `tests/`: 5716 passed, 4 skipped, 1 xfailed.
- `ruff check` and `ruff format --check` at CI's exact scopes: clean.
- `mypy` core-api (203 files) and core-storage-api (85 files): no issues.
- Tenant-scope gate against `origin/main`: green, "Allowlist shrank by 4".
- Legacy-name ratchet against `origin/main`: "No new lines."

Run against a dedicated local pgvector instance. **Not checked:** anything requiring CI's own environment — the GitHub Actions matrix, the coverage floors step, and the enterprise re-vendor path.
