### PR TITLE
fix(memory): surface an entity link storage refused

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -3750,7 +3750,24 @@ async def update_memory(
         entity_link_dicts = [
             {"entity_id": str(link.entity_id), "role": link.role} for link in data.entity_links
         ]
-        await sc.update_memory_entities(str(memory_id), tenant_id, entity_link_dicts)
+        linked = await sc.update_memory_entities(str(memory_id), tenant_id, entity_link_dicts)
+        if linked is None:
+            # Storage refused: it scopes both ends of every link to the tenant,
+            # and ``_patch`` turns its 404 into ``None``. The memory itself was
+            # already confirmed to be in this tenant above, so what is left is an
+            # ``entity_id`` the caller does not own — raise rather than fall
+            # through, which would record the "replaced" change below and answer
+            # 200 for a write that did not happen.
+            #
+            # Naming the cause is safe here in a way it is not at the storage
+            # layer: this request is authenticated and already scoped to
+            # ``tenant_id``, so "not in your tenant" tells the caller nothing
+            # about rows outside it. Storage keeps its single indistinguishable
+            # answer for the unauthenticated case (GHSA-wgvw-28pq-jc36).
+            raise HTTPException(
+                status_code=422,
+                detail="entity_links names an entity that does not exist in this tenant",
+            )
         changes["entity_links"] = {
             "old": "replaced",
             "new": f"{len(data.entity_links)} links",

--- a/tests/test_tenant_guard_byid_updates.py
+++ b/tests/test_tenant_guard_byid_updates.py
@@ -161,3 +161,50 @@ async def test_mark_dedup_checked_requires_tenant(sc):
     with pytest.raises(httpx.HTTPStatusError) as exc:
         await sc._post("/memories/mark-dedup-checked", {"memory_ids": [mem_id]})
     assert exc.value.response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# memory_add_entity_links (PATCH /memories/{id}/entities)
+# ---------------------------------------------------------------------------
+
+
+async def test_update_memory_surfaces_a_refused_entity_link(sc):
+    """A foreign ``entity_id`` must fail the PATCH, not be silently dropped.
+
+    Storage scopes both ends of every link to the tenant and answers 404, which
+    ``_patch`` turns into ``None``. Without an explicit check on that return,
+    ``update_memory`` fell through and recorded ``entity_links: replaced`` in the
+    audit trail before answering 200 — a success for a write that never
+    happened, which is worse to debug than the cross-tenant link it replaced.
+
+    The memory here belongs to the caller; only the entity is foreign, so this
+    is the entity half of the storage predicate seen from core-api.
+    """
+    from fastapi import HTTPException
+
+    from core_api.schemas import MemoryUpdate
+    from core_api.services.memory_service import update_memory
+
+    owner, stranger = _t(), _t()
+    mem_id = UUID(await _seed_memory(sc, owner, embedding=fake_embedding("linkable")))
+    foreign_entity = (
+        await sc.create_entity(
+            {
+                "tenant_id": stranger,
+                "entity_type": "person",
+                "canonical_name": f"Foreign-{uuid4().hex[:8]}",
+            }
+        )
+    )["id"]
+
+    with pytest.raises(HTTPException) as exc:
+        await update_memory(
+            mem_id,
+            owner,
+            MemoryUpdate(entity_links=[{"entity_id": foreign_entity, "role": "subject"}]),
+        )
+
+    assert exc.value.status_code == 422
+    assert "entity_links" in str(exc.value.detail)
+    links = await PostgresService().memory_get_entity_links_for_memories([mem_id])
+    assert links.get(mem_id, []) == [], "the foreign entity was linked anyway"


### PR DESCRIPTION
Follow-up to [#1148](https://github.com/caura-ai/caura/pull/1148) (#1085), which merged before I caught this. No new issue filed — say the word if you'd like one for tracking.

### The defect

#1148 scoped both ends of every memory→entity link to the caller's tenant, and storage answers `404` when either end is not in it. `StorageClient._patch` maps a 404 to `None` (`storage_client.py:464`), and `update_memory` did not look at the return value:

```python
await sc.update_memory_entities(str(memory_id), tenant_id, entity_link_dicts)
changes["entity_links"] = {"old": "replaced", "new": f"{len(data.entity_links)} links"}
```

So a `PATCH /memories/{id}` carrying an `entity_links` entry for an entity the caller does not own now takes the **success** path: it records `entity_links: replaced` in the audit trail and answers 200, for a write that never happened.

This is worth separating from the hole #1148 closed. That was a wrong write; this is a silent one — and a silent no-op with a matching audit entry is harder to debug than either, because the trail says the links were replaced, the row says they were not, and nothing reports a failure. It is strictly better than the cross-tenant link it replaced, and still not something to leave in.

Reachable only through the entity end. The memory is confirmed to be in `tenant_id` earlier in `update_memory` (`memory_service.py:3506`, 404 if absent), so a foreign `memory_id` never gets this far; a foreign `entity_id` in the request body does.

### The fix

Check the return and raise 422 naming `entity_links`.

Naming the cause is safe at this layer in a way it is not in storage: this request is authenticated and already scoped to `tenant_id`, so "not in this tenant" tells the caller nothing about rows outside it. Storage keeps its single indistinguishable answer for the unauthenticated case (GHSA-wgvw-28pq-jc36) — that asymmetry is deliberate and commented at both ends.

### Failing without the fix

Neutralising just the new guard (`if linked is None:` → `if False:`, leaving the raise unreachable):

```
______________ test_update_memory_surfaces_a_refused_entity_link _______________
tests/test_tenant_guard_byid_updates.py:200: in test_update_memory_surfaces_a_refused_entity_link
    with pytest.raises(HTTPException) as exc:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   Failed: DID NOT RAISE HTTPException
1 failed in 1.14s
```

"DID NOT RAISE" is the silent 200. The test also asserts the row afterwards, so it fails on both halves of the claim — no exception, and no links written.

Placed in `tests/test_tenant_guard_byid_updates.py` because that file already owns "every by-id write core-api routes through storage must be scoped to the row's home tenant" and lists the storage ops covered; this adds `memory_add_entity_links` to that list. Its `_t()` already mints a `test-tenant-`-prefixed id, so the sweep reclaims the rows.

### Not fixed here

`changes["entity_links"] = {"old": "replaced", ...}` still says *replaced* when `memory_add_entity_links` only ever inserts (`ON CONFLICT DO NOTHING`) and never deletes — so `entity_links=[A]` on a memory already linked to B leaves B linked while the audit claims a replace. That is pre-existing, unrelated to tenancy, and a behavioural question (should the endpoint replace, or is the audit wording wrong?) rather than something to decide inside a fix for a silent 200. Flagged rather than folded in.

### Verification

- Root `tests/`: 5717 passed, 4 skipped, 1 xfailed.
- `ruff check` / `ruff format --check` at CI's scopes: clean.
- `mypy` core-api, 203 files: no issues.
- Tenant-scope gate and legacy-name ratchet against `origin/main`: both green, and neither the allowlist (100 entries) nor any storage path changes in this diff.

Run against a dedicated local pgvector instance. **Not checked:** anything requiring CI's own environment — the Actions matrix, the coverage floors step, the enterprise re-vendor path.
