### PR TITLE
fix(storage): scope dedup review decisions to tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -791,12 +791,12 @@ class CoreStorageClient:
             **{k: v for k, v in params.items() if v is not None},
         )
 
-    async def decide_dedup_review(self, review_id, status: str, *, decided_by: str | None = None) -> dict:
+    async def decide_dedup_review(self, review_id, status: str, *, tenant_id: str) -> dict:
         """Record a terminal decision (confirmed_duplicate /
         override_not_duplicate / dismissed) on a review row."""
         return await self._post(  # type: ignore[return-value]
             f"/memories/dedup-reviews/{review_id}/decision",
-            {"status": status, "decided_by": decided_by},
+            {"status": status, "tenant_id": tenant_id},
             read=False,
         )
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1116,12 +1116,28 @@ async def list_dedup_reviews(
 @router.post("/dedup-reviews/{review_id}/decision")
 async def decide_dedup_review(review_id: UUID, request: Request) -> dict:
     body: dict = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="request body must be a JSON object")
+    tenant_id = body.get("tenant_id")
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_id' is required and must be a non-empty string",
+        )
     status = body.get("status")
-    decided_by = body.get("decided_by")
     if not isinstance(status, str):
         raise HTTPException(status_code=400, detail="status (string) required")
+    if "decided_by" in body:
+        raise HTTPException(
+            status_code=422,
+            detail="'decided_by' cannot be supplied at the storage boundary",
+        )
     try:
-        review = await _svc.dedup_review_decide(review_id, status, decided_by=decided_by)
+        review = await _svc.dedup_review_decide(
+            review_id,
+            tenant_id=tenant_id,
+            status=status,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     if review is None:

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1708,23 +1708,38 @@ class PostgresService:
             return list(result.scalars().all())
 
     async def dedup_review_decide(
-        self, review_id: UUID, status: str, decided_by: str | None = None
+        self,
+        review_id: UUID,
+        *,
+        tenant_id: str,
+        status: str,
     ) -> DedupReview | None:
         """Transition a review from ``pending`` to one of the terminal
         statuses (``confirmed_duplicate`` / ``override_not_duplicate``
         / ``dismissed``). Returns the updated row, or None if the row
-        doesn't exist. Raises ``ValueError`` for unknown statuses."""
+        does not belong to ``tenant_id``. Raises ``ValueError`` for unknown
+        statuses.
+
+        This storage seam has no end-user identity to derive a reviewer from,
+        so decisions remain explicitly unattributed instead of persisting a
+        caller-supplied identity claim.
+        """
         from common.models.dedup_review import DEDUP_REVIEW_STATUSES
 
         if status not in DEDUP_REVIEW_STATUSES or status == "pending":
             raise ValueError(f"invalid terminal status: {status!r}")
 
         async with get_session() as session:
-            row = await session.get(DedupReview, review_id)
+            row = await session.scalar(
+                select(DedupReview).where(
+                    DedupReview.id == review_id,
+                    DedupReview.tenant_id == tenant_id,
+                )
+            )
             if row is None:
                 return None
             row.status = status
-            row.decided_by = decided_by
+            row.decided_by = None
             row.decided_at = datetime.now(UTC)
             await session.flush()
             return row

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -52,13 +52,6 @@
       "category": "cross-tenant-by-design"
     },
     {
-      "id": "method:dedup_review_decide",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1087."
-    },
-    {
       "id": "method:dedup_review_enqueue",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -613,13 +606,6 @@
       "evidence": "no binding tenant read from the request",
       "category": "opaque-body-write",
       "note": "Verified: body tenant_id is assigned directly to the DedupReview row by dedup_review_enqueue."
-    },
-    {
-      "id": "route:POST /api/v1/storage/memories/dedup-reviews/{review_id}/decision",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1087."
     },
     {
       "id": "route:POST /api/v1/storage/memories/entity-links",

--- a/core-storage-api/tests/test_dedup_review_decision_tenant_scope.py
+++ b/core-storage-api/tests/test_dedup_review_decision_tenant_scope.py
@@ -1,0 +1,86 @@
+"""Tenant binding for dedup-review decisions."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _enqueue_review(client: AsyncClient, tenant_id: str) -> dict:
+    response = await client.post(
+        f"{PREFIX}/memories/dedup-reviews",
+        json={
+            "tenant_id": tenant_id,
+            "fleet_id": None,
+            "agent_id": "review-agent",
+            "new_memory_id": None,
+            "candidate_memory_id": str(uuid.uuid4()),
+            "new_content": "new review content",
+            "candidate_content": "candidate review content",
+            "similarity": 0.93,
+            "judge_verdict": True,
+            "judge_confidence": 0.8,
+            "decision_band": "judge_band_reject",
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+async def _pending_review_ids(client: AsyncClient, tenant_id: str) -> set[str]:
+    response = await client.get(
+        f"{PREFIX}/memories/dedup-reviews",
+        params={"tenant_id": tenant_id},
+    )
+    assert response.status_code == 200, response.text
+    return {row["id"] for row in response.json()}
+
+
+async def test_wrong_tenant_cannot_decide_review(client: AsyncClient) -> None:
+    victim = f"test-tenant-dedup-victim-{uuid.uuid4().hex[:8]}"
+    attacker = f"test-tenant-dedup-attacker-{uuid.uuid4().hex[:8]}"
+    review = await _enqueue_review(client, victim)
+
+    response = await client.post(
+        f"{PREFIX}/memories/dedup-reviews/{review['id']}/decision",
+        json={"tenant_id": attacker, "status": "dismissed"},
+    )
+
+    assert response.status_code == 404, response.text
+    assert review["id"] in await _pending_review_ids(client, victim)
+
+
+async def test_omitted_tenant_cannot_decide_review(client: AsyncClient) -> None:
+    tenant_id = f"test-tenant-dedup-omitted-{uuid.uuid4().hex[:8]}"
+    review = await _enqueue_review(client, tenant_id)
+
+    response = await client.post(
+        f"{PREFIX}/memories/dedup-reviews/{review['id']}/decision",
+        json={"status": "dismissed"},
+    )
+
+    assert response.status_code == 422, response.text
+    assert review["id"] in await _pending_review_ids(client, tenant_id)
+
+
+async def test_caller_supplied_reviewer_is_rejected(client: AsyncClient) -> None:
+    tenant_id = f"test-tenant-dedup-actor-{uuid.uuid4().hex[:8]}"
+    review = await _enqueue_review(client, tenant_id)
+
+    response = await client.post(
+        f"{PREFIX}/memories/dedup-reviews/{review['id']}/decision",
+        json={
+            "tenant_id": tenant_id,
+            "status": "dismissed",
+            "decided_by": "someone-else",
+        },
+    )
+
+    assert response.status_code == 422, response.text
+    assert review["id"] in await _pending_review_ids(client, tenant_id)

--- a/tests/test_a1_18_dedup_review_queue.py
+++ b/tests/test_a1_18_dedup_review_queue.py
@@ -93,7 +93,7 @@ async def test_list_returns_pending_only_by_default(sc):
         }
     )
     # Mark one as decided.
-    await sc.decide_dedup_review(decided["id"], "dismissed", decided_by="reviewer-1")
+    await sc.decide_dedup_review(decided["id"], "dismissed", tenant_id=tenant)
 
     rows = await sc.list_dedup_reviews({"tenant_id": tenant})
     ids = {r["id"] for r in rows}
@@ -102,9 +102,9 @@ async def test_list_returns_pending_only_by_default(sc):
 
 
 @pytest.mark.integration
-async def test_decide_sets_status_and_decided_fields(sc):
+async def test_decide_sets_status_and_timestamp(sc):
     """``decide_dedup_review`` transitions ``pending`` → one of the
-    terminal statuses and records who decided and when."""
+    terminal statuses and records when it was decided."""
     tenant = f"test-tenant-a1-18-decide-{uuid4().hex[:8]}"
     cand_id = str(uuid4())
     review = await sc.enqueue_dedup_review(
@@ -123,10 +123,10 @@ async def test_decide_sets_status_and_decided_fields(sc):
         }
     )
     updated = await sc.decide_dedup_review(
-        review["id"], "override_not_duplicate", decided_by="reviewer-7"
+        review["id"], "override_not_duplicate", tenant_id=tenant
     )
     assert updated["status"] == "override_not_duplicate"
-    assert updated["decided_by"] == "reviewer-7"
+    assert updated["decided_by"] is None
     assert updated["decided_at"] is not None
 
 
@@ -154,7 +154,7 @@ async def test_decide_rejects_unknown_status(sc):
         }
     )
     with pytest.raises(httpx.HTTPStatusError) as ei:
-        await sc.decide_dedup_review(review["id"], "rofl", decided_by="r")
+        await sc.decide_dedup_review(review["id"], "rofl", tenant_id=tenant)
     assert ei.value.response.status_code == 400
 
 


### PR DESCRIPTION
## Summary

- Require a non-empty `tenant_id` throughout the dedup-review decision call chain and fetch the review by both primary key and tenant.
- Return the same 404 for foreign and missing reviews, so a caller cannot decide another tenant's review by UUID.
- Reject caller-supplied `decided_by`. The storage seam has no end-user identity to derive a reviewer from, so decisions remain explicitly unattributed instead of persisting an unvalidated identity claim.
- Remove the fixed method and route from the tenant-scope allowlist while preserving every hand-written opaque-body-write annotation.

There is no current production caller of this endpoint in the repository; the existing integration callers now pass their binding tenant. This change puts the guarantee in the route and query for direct and future callers.

## Related Issue

Closes #1087.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

The wrong-tenant regression was run with only the new `DedupReview.tenant_id == tenant_id` predicate removed. It failed as intended and showed that the foreign review had been changed to `dismissed`:

```text
>       assert response.status_code == 404, response.text
E       assert 200 == 404
```

With the predicate restored:

- Final focused storage regression: 3 passed
- Existing dedup-review queue tests plus #1153's focused guard tests: 18 passed
- Full core-storage-api suite: 267 passed
- Full root suite: 5,700 passed, 4 skipped, 16 deselected, 1 xfailed
- Full core-operations suite: 50 passed; full core-worker suite: 80 passed
- Ruff check and format check: all CI Python scopes pass
- Mypy: core-api, core-storage-api, core-operations, core-worker, common, and scripts all pass
- Package builds: core-api and core-storage-api pass
- Coverage floors: core-api 85%, core-storage-api 66%; combined root coverage 80%
- `scripts/tenant_scope_gate.py`: passes with 98 allowlisted entries

The full suites ran after rebasing onto #1148, #1151, and #1152. #1153 landed during the final check, touched only `memory_service.py` and its guard test, and rebased without overlap; the final focused storage regression, existing dedup-review tests, and #1153 guard tests were then rerun on the exact pushed commit.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes (or explained why none are needed)
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally
- [x] I have updated relevant documentation (no documentation changes are needed for this internal storage boundary)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (not user-facing; release-please derives this fix from the conventional commit)

## Additional Notes

- Allowlist total: 100 before, 98 after. `id-addressed-write`: 6 before, 4 after.
- All 35 `opaque-body-write` entries and all 35 hand-written notes survived regeneration.
- The decision UPDATE writes only the fixed fields `status`, `decided_by`, and `decided_at`; neither `id` nor `tenant_id` is caller-writable.
