### PR TITLE
test: centralize root compatibility fixtures

### DIFF
--- a/tests/_legacy_contracts.py
+++ b/tests/_legacy_contracts.py
@@ -1,0 +1,11 @@
+"""Frozen compatibility identifiers shared by root-level tests."""
+
+FROZEN_PLUGIN_SLUG = "memclaw"  # legacy-name-ok: existing plugin and skill identifier
+FROZEN_TOPIC_PREFIX = "memclaw"  # legacy-name-ok: deployed Pub/Sub wire namespace
+LEGACY_API_KEY_FIELD = "memclaw_api_key"  # legacy-name-ok: Settings compatibility field
+INSIGHTS_AGENT_ID = "memclaw-insighter"  # legacy-name-ok: persisted service-agent identity
+
+
+def frozen_topic(suffix: str) -> str:
+    """Build an independently pinned deployed topic name."""
+    return f"{FROZEN_TOPIC_PREFIX}.{suffix}"

--- a/tests/test_a4_13_path_c_retraction.py
+++ b/tests/test_a4_13_path_c_retraction.py
@@ -262,7 +262,7 @@ async def test_no_retraction_on_gate1_stochastic_signal():
     0.60) is the **stochastic flip case**: model said
     ``contradicts=True`` with ``same_subject=False`` and the parser
     overrode to False. Under the original threshold 0.60 this silently
-    retracted genuine Path A flags on memclaw.net. Now it must NOT
+    retracted genuine Path A flags in production. Now it must NOT
     retract."""
     from core_api.services.contradiction_detector import (
         detect_contradictions_by_entities_async,

--- a/tests/test_api_documents_skills.py
+++ b/tests/test_api_documents_skills.py
@@ -1,10 +1,9 @@
 """Skills-collection invariants on POST /api/v1/documents.
 
-Phase B of the skills-as-documents migration replaced the dedicated
-`memclaw_share_skill` / `memclaw_unshare_skill` MCP tools (and their
-`/skills/*` REST routes) with a single rule on the generic document
-upsert path: when ``collection == "skills"``, the server enforces a
-filesystem-safe slug and indexes a text field automatically.
+Phase B of the skills-as-documents migration replaced the dedicated legacy
+share/unshare MCP tools (and their `/skills/*` REST routes) with a single rule
+on the generic document upsert path: when ``collection == "skills"``, the
+server enforces a filesystem-safe slug and indexes a text field automatically.
 
 As of the `feat/doc-mandate-summary` change the indexed text is taken
 from ``data["summary"]`` (preferred) with a back-compat fallback to

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -5,6 +5,7 @@ import uuid
 import pytest
 
 from tests.conftest import get_test_auth, uid as _uid
+from tests._legacy_contracts import FROZEN_PLUGIN_SLUG
 
 
 # ---------------------------------------------------------------------------
@@ -273,7 +274,7 @@ async def test_heartbeat_persists_reconcile_summary(client):
         "added": ["deploy-runbook"],
         "removed": [],
         "skipped": ["../evil"],
-        "protected": ["memclaw"],
+        "protected": [FROZEN_PLUGIN_SLUG],
     }
     resp = await client.post(
         "/api/v1/fleet/heartbeat",
@@ -313,7 +314,7 @@ async def test_heartbeat_reconcile_latest_snapshot_wins(client):
                     "added": [],
                     "removed": [],
                     "skipped": [],
-                    "protected": ["memclaw"],
+                    "protected": [FROZEN_PLUGIN_SLUG],
                 },
             },
             headers=headers,

--- a/tests/test_api_keystones.py
+++ b/tests/test_api_keystones.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from tests.conftest import get_test_auth, uid as _uid
+from tests._legacy_contracts import FROZEN_PLUGIN_SLUG
 
 pytestmark = pytest.mark.asyncio
 
@@ -83,7 +84,8 @@ async def _set_keystone(client, headers, tenant_id, **overrides):
         "weight": "med",
     }
     payload.update(overrides)
-    resp = await client.post("/api/v1/memclaw/keystones", json=payload, headers=headers)
+    route = f"/api/v1/{FROZEN_PLUGIN_SLUG}/keystones"
+    resp = await client.post(route, json=payload, headers=headers)
     return resp
 
 

--- a/tests/test_api_read_scope_params.py
+++ b/tests/test_api_read_scope_params.py
@@ -464,7 +464,7 @@ async def test_stats_without_a_scope_is_unchanged(client):
 # JSON BODY are validated by a Pydantic model and are not silently dropped the
 # same way, so they are classified rather than checked here.
 _QUERY_PARAM_TOOLS = {
-    # caura_keystones dispatches to the /api/v1/memclaw legacy alias, which is
+    # caura_keystones dispatches to the hidden compatibility alias, which is
     # mounted with include_in_schema=False; the canonical path below is the
     # same router and therefore the same signature.
     "caura_keystones": "/api/v1/keystones",

--- a/tests/test_audit_s6_c1_events.py
+++ b/tests/test_audit_s6_c1_events.py
@@ -25,6 +25,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from tests._legacy_contracts import frozen_topic
+
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
 
@@ -162,7 +164,7 @@ async def test_non_dict_lifecycle_payload_is_dropped():
     # simulate a malformed wire payload reaching the handler.
     event = Event.model_construct(
         event_id=uuid.uuid4(),
-        event_type="memclaw.lifecycle.archive-expired-requested",
+        event_type=frozen_topic("lifecycle.archive-expired-requested"),
         payload=["not", "a", "dict"],
     )
     # Must return cleanly (drop) — the kwargs-splat raised TypeError which

--- a/tests/test_blank_text_is_not_embedded.py
+++ b/tests/test_blank_text_is_not_embedded.py
@@ -1,6 +1,6 @@
 """Blank text must never reach an embedding backend.
 
-Regression cover for 2026-08-18 17:00-18:59Z. ``prod-memclaw-tei`` returned
+Regression cover for 2026-08-18 17:00-18:59Z. The production embedder returned
 274 x ``413 Input validation error: `inputs` cannot be empty`` in one week,
 272 of them inside that window, because nothing checked the text before
 sending it. Three separate faults compounded:

--- a/tests/test_caura_000_graph_frontier_cap.py
+++ b/tests/test_caura_000_graph_frontier_cap.py
@@ -4,7 +4,7 @@ Customer-side ground truth (goodclaw / tenant ``etoro0-40f488``, 2026-06-07):
 a search against a dense entity graph generated a single SQL statement
 with **42,146 bind parameters** on the ``relations`` table, exceeding
 asyncpg's safe window and crashing the ``core-storage-api`` request.
-Cascade visible upstream as 7 ``recall failed: MemClaw API 500`` lines
+Cascade visible upstream as 7 recall-API failure lines
 and 3 ``SMOKE TEST ERROR`` events in the gateway log.
 
 Two cap sites pinned here:

--- a/tests/test_cross_tenant_auth.py
+++ b/tests/test_cross_tenant_auth.py
@@ -17,6 +17,7 @@ import pytest
 from core_api.auth import AuthContext, get_auth_context
 from core_api.config import settings
 from core_api.tenant_context import get_readable_tenants
+from tests._legacy_contracts import LEGACY_API_KEY_FIELD
 
 
 @pytest.fixture
@@ -24,7 +25,7 @@ def _disable_standalone(monkeypatch):
     """Match the install-credential test fixture: turn off standalone
     + key-gate paths so Path 4 (X-Tenant-ID header) executes."""
     monkeypatch.setattr(settings, "is_standalone", False)
-    monkeypatch.setattr(settings, "memclaw_api_key", "")
+    monkeypatch.setattr(settings, LEGACY_API_KEY_FIELD, "")
     monkeypatch.setattr(settings, "admin_api_key", "")
     monkeypatch.setattr(settings, "api_key", "")
 

--- a/tests/test_direct_mcp_skill.py
+++ b/tests/test_direct_mcp_skill.py
@@ -1,9 +1,7 @@
 """Invariants for the direct-MCP SKILL.md adapter.
 
-The adapter at ``static/skills/memclaw/SKILL.md`` is served by
-``/api/v1/skill/memclaw`` and installed into ``~/.claude/skills/memclaw/``
-(Claude Code) or ``~/.agents/skills/memclaw/`` (Codex) by the
-``/api/v1/install-skill`` bash installer.
+The static adapter is served by the default skill route and installed into
+the default Claude Code or Codex skill directory by the install-skill script.
 
 It is *intentionally* maintained independently of the OpenClaw plugin's
 SKILL.md. These tests pin the invariants specific to the direct-MCP
@@ -21,8 +19,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests._legacy_contracts import FROZEN_PLUGIN_SLUG
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
-ADAPTER_PATH = REPO_ROOT / "static" / "skills" / "memclaw" / "SKILL.md"
+ADAPTER_PATH = REPO_ROOT / "static" / "skills" / FROZEN_PLUGIN_SLUG / "SKILL.md"
 
 # Every tool the canonical adapter documents (direct-MCP exposes all 12,
 # including keystones_set — which the OpenClaw plugin variant withholds).
@@ -53,10 +53,10 @@ def test_file_exists_at_expected_path() -> None:
 def test_has_minimal_frontmatter() -> None:
     skill = _read_adapter()
     assert skill.startswith("---\n"), "missing YAML frontmatter delimiter"
-    assert "\nname: memclaw\n" in skill, "missing/wrong 'name: memclaw'"
+    assert f"\nname: {FROZEN_PLUGIN_SLUG}\n" in skill, "missing/wrong skill name"
     assert "\ndescription:" in skill, "missing description field"
     assert "\nuser-invocable: false\n" in skill, (
-        "adapter should set user-invocable: false to suppress /memclaw slash command"
+        "adapter should set user-invocable: false to suppress its slash command"
     )
 
 
@@ -64,7 +64,7 @@ def test_has_no_openclaw_config_gate() -> None:
     """The plugin-enabled config gate is OpenClaw-specific; direct-MCP users
     don't have OpenClaw so the gate is meaningless and confusing."""
     skill = _read_adapter()
-    assert "plugins.entries.memclaw.enabled" not in skill, (
+    assert f"plugins.entries.{FROZEN_PLUGIN_SLUG}.enabled" not in skill, (
         "adapter must not carry the OpenClaw plugin-enabled config gate"
     )
     # Frontmatter must not declare an openclaw metadata block. We check the
@@ -137,10 +137,10 @@ def test_footer_references_direct_mcp_install_targets() -> None:
     after install. Without this, a user who finds the file on disk has no
     context for what it is or how to replace it."""
     skill = _read_adapter()
-    assert "~/.claude/skills/memclaw" in skill, (
+    assert f"~/.claude/skills/{FROZEN_PLUGIN_SLUG}" in skill, (
         "footer should mention the Claude Code install path"
     )
-    assert "~/.agents/skills/memclaw" in skill, (
+    assert f"~/.agents/skills/{FROZEN_PLUGIN_SLUG}" in skill, (
         "footer should mention the Codex install path"
     )
 

--- a/tests/test_doc_memory_sync.py
+++ b/tests/test_doc_memory_sync.py
@@ -248,7 +248,7 @@ async def test_falls_back_to_service_identity_only_when_no_caller(patched, missi
 
     (payload,) = patched.create_memory.call_args.args
     assert payload.agent_id == DOC_INDEXER_AGENT_ID
-    # Self-registered on first use, mirroring memclaw-insighter.
+    # Self-registered on first use, mirroring the insights service identity.
     patched.get_or_create_agent.assert_awaited_once()
     args = patched.get_or_create_agent.call_args.args
     assert args[0] == "t1"

--- a/tests/test_embedding_backfill.py
+++ b/tests/test_embedding_backfill.py
@@ -20,6 +20,7 @@ import pytest
 
 from core_worker.backfill import run_embedding_backfill
 from core_worker.clients.storage_client import NullEmbeddingRow
+from tests._legacy_contracts import frozen_topic
 
 
 def _row() -> NullEmbeddingRow:
@@ -456,7 +457,7 @@ def test_embed_backfill_topic_string() -> None:
 
     assert (
         Topics.Lifecycle.EMBED_BACKFILL_REQUESTED
-        == "memclaw.lifecycle.embed-backfill-requested"
+        == frozen_topic("lifecycle.embed-backfill-requested")
     )
 
 

--- a/tests/test_enrichment_inline_timeout.py
+++ b/tests/test_enrichment_inline_timeout.py
@@ -1,9 +1,9 @@
 """CAURA-000 — configurable inline embed+enrich timeout.
 
-The 504 "Memory write timed out (embedding/enrichment)" was firing on
-memclaw.dev under load because the gather in ParallelEmbedEnrich had a
-hardcoded 20s ceiling, which is too tight once embedding moved off the
-hot path (CAURA-594) and enrichment LLM became the sole occupant.
+The 504 "Memory write timed out (embedding/enrichment)" was firing under load
+in the development deployment because the gather in ParallelEmbedEnrich had a
+hardcoded 20s ceiling, which is too tight once embedding moved off the hot path
+(CAURA-594) and enrichment LLM became the sole occupant.
 
 Verifies:
   - ``settings.enrichment_inline_timeout_seconds`` is the value passed

--- a/tests/test_entity_lookup_short_circuit.py
+++ b/tests/test_entity_lookup_short_circuit.py
@@ -8,9 +8,9 @@ route. Every entity-token query KeyError'd at line 214, the broad
 ``except Exception:`` at line 123 swallowed it, and the pipeline fell
 through to keyword/semantic search.
 
-Confirmed in prod logs before fix:
-  staging-memclaw-core-api : 1,327 occurrences / 24h
-  prod-memclaw-core-api    : 206 occurrences / 24h
+Confirmed in service logs before the fix:
+  staging core API: 1,327 occurrences / 24h
+  production core API: 206 occurrences / 24h
 
 This test pins the dict-shape contract. It mocks storage to return the
 shape the real ``expand_graph`` route emits and asserts ``ClassifyQuery``

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -27,6 +27,10 @@ from common.events.pubsub import (
     _claim_broadcast_slot,
     _process_broadcast_slot_id,
 )
+from tests._legacy_contracts import frozen_topic
+
+EMBEDDED_TOPIC = frozen_topic("memory.embedded")
+EMBEDDED_EVENT_BYTES = json.dumps({"event_type": EMBEDDED_TOPIC}).encode()
 
 
 @pytest.fixture
@@ -67,7 +71,9 @@ async def test_publish_encodes_envelope_as_json(bus: PubSubEventBus) -> None:
 
     bus._publisher.publish.assert_called_once()
     topic_path, data = bus._publisher.publish.call_args[0]
-    assert topic_path == "projects/proj/topics/memclaw.memory.embed-requested"
+    assert (
+        topic_path == f"projects/proj/topics/{frozen_topic('memory.embed-requested')}"
+    )
     parsed = json.loads(data.decode())
     assert parsed["event_type"] == Topics.Memory.EMBED_REQUESTED
     assert parsed["tenant_id"] == "t1"
@@ -84,7 +90,7 @@ async def test_topic_prefix_scopes_publish(bus: PubSubEventBus) -> None:
     )
     await bus.publish(Topics.Memory.EMBEDDED, event)
     topic_path, _ = bus._publisher.publish.call_args[0]
-    assert topic_path == "projects/proj/topics/prod--memclaw.memory.embedded"
+    assert topic_path == f"projects/proj/topics/prod--{EMBEDDED_TOPIC}"
 
 
 def test_topic_name_prefix_and_no_op() -> None:
@@ -94,14 +100,12 @@ def test_topic_name_prefix_and_no_op() -> None:
         topic_prefix="prod",
         dual_subscribe=True,
     )
-    assert (
-        scoped._topic_name("memclaw.memory.embedded") == "prod--memclaw.memory.embedded"
-    )
+    assert scoped._topic_name(EMBEDDED_TOPIC) == f"prod--{EMBEDDED_TOPIC}"
     # Empty/unset prefix ⇒ the raw topic name (byte-identical to today's behaviour).
     noop = PubSubEventBus(
         project_id="proj", subscription_prefix="test", dual_subscribe=True
     )
-    assert noop._topic_name("memclaw.memory.embedded") == "memclaw.memory.embedded"
+    assert noop._topic_name(EMBEDDED_TOPIC) == EMBEDDED_TOPIC
 
 
 async def test_decode_accepts_well_formed_envelope() -> None:
@@ -1170,7 +1174,7 @@ async def test_pull_loop_drops_foreign_env_message_before_dispatch() -> None:
         dual_subscribe=True,
     )
     foreign = _make_received(
-        b'{"event_type": "memclaw.memory.embedded"}',
+        EMBEDDED_EVENT_BYTES,
         "ack-foreign",
         {"source_env": "sandbox"},
     )
@@ -1191,7 +1195,7 @@ async def test_pull_loop_processes_same_env_message() -> None:
         dual_subscribe=True,
     )
     local = _make_received(
-        b'{"event_type": "memclaw.memory.embedded"}',
+        EMBEDDED_EVENT_BYTES,
         "ack-local",
         {"source_env": "production"},
     )
@@ -1212,7 +1216,9 @@ async def test_pull_loop_processes_message_without_source_env_attribute() -> Non
         dual_subscribe=True,
     )
     legacy = _make_received(
-        b'{"event_type": "memclaw.memory.embedded"}', "ack-legacy", {}
+        EMBEDDED_EVENT_BYTES,
+        "ack-legacy",
+        {},
     )
 
     result = await _drive_one_batch(bus, [legacy])

--- a/tests/test_events/test_topics.py
+++ b/tests/test_events/test_topics.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from common.events import Topics
+from tests._legacy_contracts import frozen_topic
 
 
 def test_members_compare_equal_to_their_string_value() -> None:
     assert Topics.Memory.ENRICHED == "memclaw.memory.enriched"  # legacy-name-ok: rule 3 — asserts the enum's current wire value
-    assert Topics.Audit.EVENT_RECORDED == "memclaw.audit.event-recorded"
+    assert Topics.Audit.EVENT_RECORDED == frozen_topic("audit.event-recorded")
 
 
 def test_members_format_as_their_string_value() -> None:
@@ -15,7 +16,7 @@ def test_members_format_as_their_string_value() -> None:
     # Pub/Sub's topic_path uses f-string interpolation; regressing here
     # breaks every publish.
     assert f"{Topics.Memory.ENRICHED}" == "memclaw.memory.enriched"  # legacy-name-ok: rule 3 — asserts the enum's current wire value
-    assert str(Topics.Memory.EMBED_REQUESTED) == "memclaw.memory.embed-requested"
+    assert str(Topics.Memory.EMBED_REQUESTED) == frozen_topic("memory.embed-requested")
 
 
 def test_members_hash_equal_to_their_string_value() -> None:

--- a/tests/test_fleet_heartbeat_auto_upgrade.py
+++ b/tests/test_fleet_heartbeat_auto_upgrade.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from core_api.routes import fleet as fleet_mod
+from tests._legacy_contracts import FROZEN_PLUGIN_SLUG
 
 
 # ---------------------------------------------------------------------------
@@ -86,10 +87,10 @@ async def test_auto_upgrade_enabled_default_true(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_auto_upgrade_enabled_override_false(monkeypatch):
-    """Tenant override `memclaw.auto_upgrade_enabled = false` → disabled."""
+    """A false override in the existing plugin namespace disables upgrades."""
 
     async def _fake(_tid):
-        return {"memclaw": {"auto_upgrade_enabled": False}}
+        return {FROZEN_PLUGIN_SLUG: {"auto_upgrade_enabled": False}}
 
     monkeypatch.setattr("core_api.routes.fleet.get_raw_settings", _fake)
     assert await fleet_mod._auto_upgrade_enabled_for_tenant("tenant-1") is False
@@ -97,10 +98,10 @@ async def test_auto_upgrade_enabled_override_false(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_auto_upgrade_enabled_override_true(monkeypatch):
-    """Tenant override `memclaw.auto_upgrade_enabled = true` → enabled."""
+    """A true override in the existing plugin namespace enables upgrades."""
 
     async def _fake(_tid):
-        return {"memclaw": {"auto_upgrade_enabled": True}}
+        return {FROZEN_PLUGIN_SLUG: {"auto_upgrade_enabled": True}}
 
     monkeypatch.setattr("core_api.routes.fleet.get_raw_settings", _fake)
     assert await fleet_mod._auto_upgrade_enabled_for_tenant("tenant-1") is True

--- a/tests/test_fleet_heartbeat_oversized_caps.py
+++ b/tests/test_fleet_heartbeat_oversized_caps.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 
 from core_api.routes.fleet import HeartbeatIn
+from tests._legacy_contracts import FROZEN_PLUGIN_SLUG
 
 
 def _oversized(min_bytes: int) -> dict:
@@ -41,7 +42,7 @@ def test_oversized_recall_metrics_is_dropped_not_rejected():
 
 
 def test_normal_reconcile_passes_through_unchanged():
-    small = {"catalogCount": 1, "installed": ["memclaw"], "removed": []}
+    small = {"catalogCount": 1, "installed": [FROZEN_PLUGIN_SLUG], "removed": []}
     hb = HeartbeatIn(tenant_id="t", node_name="n", reconcile=small)
     assert hb.reconcile == small
 

--- a/tests/test_gateway_secret_gate.py
+++ b/tests/test_gateway_secret_gate.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi import HTTPException
 
 from core_api import auth as auth_mod
+from tests._legacy_contracts import LEGACY_API_KEY_FIELD
 
 
 class _Req:
@@ -21,7 +22,7 @@ class _Req:
 async def _ctx(monkeypatch, headers, *, secret):
     monkeypatch.setattr(auth_mod.settings, "gateway_shared_secret", secret)
     monkeypatch.setattr(auth_mod.settings, "is_standalone", False)
-    monkeypatch.setattr(auth_mod.settings, "memclaw_api_key", None)
+    monkeypatch.setattr(auth_mod.settings, LEGACY_API_KEY_FIELD, None)
     monkeypatch.setattr(auth_mod, "get_admin_key", lambda: None)
 
     async def _noop(*a, **k):

--- a/tests/test_install_credential_auth.py
+++ b/tests/test_install_credential_auth.py
@@ -19,6 +19,7 @@ import pytest
 from core_api.auth import AuthContext, get_auth_context
 from core_api.config import settings
 from core_api.schemas import BulkMemoryCreate, BulkMemoryItem
+from tests._legacy_contracts import LEGACY_API_KEY_FIELD
 
 
 @pytest.fixture
@@ -28,7 +29,7 @@ def _disable_standalone(monkeypatch):
     branch under test is gated on ``not settings.is_standalone``, so
     this fixture flips it off for the install-credential tests only."""
     monkeypatch.setattr(settings, "is_standalone", False)
-    monkeypatch.setattr(settings, "memclaw_api_key", "")
+    monkeypatch.setattr(settings, LEGACY_API_KEY_FIELD, "")
     monkeypatch.setattr(settings, "admin_api_key", "")
     monkeypatch.setattr(settings, "api_key", "")
 

--- a/tests/test_install_skill_endpoint.py
+++ b/tests/test_install_skill_endpoint.py
@@ -19,8 +19,13 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from core_api.routes.plugin import router
+from tests._legacy_contracts import FROZEN_PLUGIN_SLUG
 
 pytestmark = pytest.mark.unit
+
+CLAUDE_SKILL_DIR = f"$HOME/.claude/skills/{FROZEN_PLUGIN_SLUG}"
+CODEX_SKILL_DIR = f"$HOME/.agents/skills/{FROZEN_PLUGIN_SLUG}"
+DEFAULT_SKILL_ENDPOINT = f"/api/v1/skill/{FROZEN_PLUGIN_SLUG}"
 
 
 def _client() -> TestClient:
@@ -104,24 +109,24 @@ def test_both_agent_emits_both_install_blocks():
     client = _client()
     resp = client.get("/api/v1/install-skill?agent=both")
     assert resp.status_code == 200
-    assert "$HOME/.claude/skills/memclaw" in resp.text
-    assert "$HOME/.agents/skills/memclaw" in resp.text
+    assert CLAUDE_SKILL_DIR in resp.text
+    assert CODEX_SKILL_DIR in resp.text
 
 
 def test_claude_code_only_skips_codex_block():
     client = _client()
     resp = client.get("/api/v1/install-skill?agent=claude-code")
     assert resp.status_code == 200
-    assert "$HOME/.claude/skills/memclaw" in resp.text
-    assert "$HOME/.agents/skills/memclaw" not in resp.text
+    assert CLAUDE_SKILL_DIR in resp.text
+    assert CODEX_SKILL_DIR not in resp.text
 
 
 def test_codex_only_skips_claude_block():
     client = _client()
     resp = client.get("/api/v1/install-skill?agent=codex")
     assert resp.status_code == 200
-    assert "$HOME/.agents/skills/memclaw" in resp.text
-    assert "$HOME/.claude/skills/memclaw" not in resp.text
+    assert CODEX_SKILL_DIR in resp.text
+    assert CLAUDE_SKILL_DIR not in resp.text
 
 
 # --- skill selector (?skill=) -------------------------------------------------
@@ -136,15 +141,15 @@ def test_default_skill_slug_unchanged():
     assert resp.status_code == 200
     script = resp.text
     assert "=== Caura Skill Installer (direct-MCP) ===" in script
-    assert "$HOME/.claude/skills/memclaw" in script
-    assert "$HOME/.agents/skills/memclaw" in script
-    assert "/api/v1/skill/memclaw" in script
+    assert CLAUDE_SKILL_DIR in script
+    assert CODEX_SKILL_DIR in script
+    assert DEFAULT_SKILL_ENDPOINT in script
     assert "company-brain" not in script
 
 
 def test_skill_company_brain_installs_to_company_brain_dirs():
     """``?skill=company-brain`` swaps the skill name through the paths, the
-    fetch URL, and the title — and never touches the memclaw dirs."""
+    fetch URL, and the title — and never touches the default skill dirs."""
     client = _client()
     resp = client.get("/api/v1/install-skill?agent=both&skill=company-brain")
     assert resp.status_code == 200
@@ -153,7 +158,7 @@ def test_skill_company_brain_installs_to_company_brain_dirs():
     assert "$HOME/.claude/skills/company-brain" in script
     assert "$HOME/.agents/skills/company-brain" in script
     assert "/api/v1/skill/company-brain" in script
-    assert "skills/memclaw" not in script
+    assert f"skills/{FROZEN_PLUGIN_SLUG}" not in script
 
 
 def test_invalid_skill_returns_400():
@@ -177,9 +182,9 @@ def test_skill_param_is_allowlisted_no_path_traversal():
 
 def test_serve_default_skill_still_works():
     client = _client()
-    resp = client.get("/api/v1/skill/memclaw")
+    resp = client.get(DEFAULT_SKILL_ENDPOINT)
     assert resp.status_code == 200
-    assert "name: memclaw" in resp.text
+    assert f"name: {FROZEN_PLUGIN_SLUG}" in resp.text
 
 
 def test_serve_company_brain_skill():

--- a/tests/test_lifecycle_audit.py
+++ b/tests/test_lifecycle_audit.py
@@ -23,6 +23,7 @@ from core_api.services.lifecycle_audit import (
     _CRYSTALLIZE_MIN_ACTIVE_MEMORIES,
     _CoreApiLifecycleAdapter,
 )
+from tests._legacy_contracts import INSIGHTS_AGENT_ID
 
 
 _UNSET = object()  # "count_active was never called" sentinel
@@ -130,9 +131,8 @@ async def test_crystallize_skips_below_active_threshold() -> None:
 
 @pytest.mark.asyncio
 async def test_insights_attributes_and_registers_dedicated_agent() -> None:
-    """The automated insights run writes under the dedicated ``memclaw-insighter``
-    identity — never the anonymous ``mcp-agent`` fallback — and self-registers it
-    as a service agent (trust 3) for the org before persisting."""
+    """The automated run uses its dedicated identity, never the anonymous
+    ``mcp-agent`` fallback, and self-registers at trust 3 before persisting."""
     registered: list[dict] = []
 
     class _InsightsStorage:
@@ -166,13 +166,13 @@ async def test_insights_attributes_and_registers_dedicated_agent() -> None:
     assert produced == 2
     # Attributed to the dedicated identity, tenant-wide (no fleet → scope='all').
     mock_gen.assert_awaited_once()
-    assert mock_gen.await_args.kwargs["agent_id"] == "memclaw-insighter"
+    assert mock_gen.await_args.kwargs["agent_id"] == INSIGHTS_AGENT_ID
     assert mock_gen.await_args.kwargs["scope"] == "all"
     # Self-registered exactly once as a service agent with cross-fleet trust.
     assert len(registered) == 1
     reg = registered[0]
     assert reg["tenant_id"] == "t1"
-    assert reg["agent_id"] == "memclaw-insighter"
+    assert reg["agent_id"] == INSIGHTS_AGENT_ID
     assert reg["belonging_type"] == "service"
     assert reg["trust_level"] == 3
 
@@ -212,7 +212,7 @@ async def test_insights_does_not_reregister_existing_agent() -> None:
 
     assert produced == 1
     # Still attributed to the dedicated identity even though it was pre-existing.
-    assert mock_gen.await_args.kwargs["agent_id"] == "memclaw-insighter"
+    assert mock_gen.await_args.kwargs["agent_id"] == INSIGHTS_AGENT_ID
 
 
 @pytest.mark.asyncio
@@ -249,7 +249,7 @@ async def test_insights_registration_failure_does_not_abort_run() -> None:
 
     # Run completed despite the registration failure, still under the dedicated id.
     assert produced == 3
-    assert mock_gen.await_args.kwargs["agent_id"] == "memclaw-insighter"
+    assert mock_gen.await_args.kwargs["agent_id"] == INSIGHTS_AGENT_ID
 
 
 @pytest.mark.asyncio

--- a/tests/test_lifecycle_automation.py
+++ b/tests/test_lifecycle_automation.py
@@ -13,6 +13,7 @@ from core_api.constants import (
     LIFECYCLE_BATCH_SIZE,
     LIFECYCLE_STALE_ARCHIVE_WEIGHT,
 )
+from tests._legacy_contracts import frozen_topic
 
 
 @pytest.mark.unit
@@ -69,27 +70,27 @@ class TestLifecycleTopics:
 
         assert (
             Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED
-            == "memclaw.lifecycle.archive-expired-requested"
+            == frozen_topic("lifecycle.archive-expired-requested")
         )
         assert (
             Topics.Lifecycle.ARCHIVE_STALE_REQUESTED
-            == "memclaw.lifecycle.archive-stale-requested"
+            == frozen_topic("lifecycle.archive-stale-requested")
         )
         assert (
             Topics.Lifecycle.PURGE_SOFT_DELETED_REQUESTED
-            == "memclaw.lifecycle.purge-soft-deleted-requested"
+            == frozen_topic("lifecycle.purge-soft-deleted-requested")
         )
         assert (
             Topics.Lifecycle.CRYSTALLIZE_REQUESTED
-            == "memclaw.lifecycle.crystallize-requested"
+            == frozen_topic("lifecycle.crystallize-requested")
         )
         assert (
             Topics.Lifecycle.ENTITY_LINK_REQUESTED
-            == "memclaw.lifecycle.entity-link-requested"
+            == frozen_topic("lifecycle.entity-link-requested")
         )
         assert (
             Topics.Lifecycle.INSIGHTS_REQUESTED
-            == "memclaw.lifecycle.insights-requested"
+            == frozen_topic("lifecycle.insights-requested")
         )
 
     def test_topic_strenum_format(self):
@@ -100,7 +101,7 @@ class TestLifecycleTopics:
         # the embed/enrich topics rely on for Pub/Sub's ``topic_path``.
         assert (
             f"{Topics.Lifecycle.ARCHIVE_EXPIRED_REQUESTED}"
-            == "memclaw.lifecycle.archive-expired-requested"
+            == frozen_topic("lifecycle.archive-expired-requested")
         )
 
 

--- a/tests/test_org_role_plumb.py
+++ b/tests/test_org_role_plumb.py
@@ -23,6 +23,7 @@ from httpx import ASGITransport, AsyncClient
 
 from core_api import auth as auth_mod
 from core_api.routes import skills_inbox as si
+from tests._legacy_contracts import LEGACY_API_KEY_FIELD
 
 pytestmark = pytest.mark.unit
 
@@ -36,7 +37,7 @@ async def _path4_ctx(monkeypatch, headers):
     """Resolve get_auth_context down Path 4 (gateway header trust)."""
     monkeypatch.setattr(auth_mod.settings, "gateway_shared_secret", None)
     monkeypatch.setattr(auth_mod.settings, "is_standalone", False)
-    monkeypatch.setattr(auth_mod.settings, "memclaw_api_key", None)
+    monkeypatch.setattr(auth_mod.settings, LEGACY_API_KEY_FIELD, None)
     monkeypatch.setattr(auth_mod, "get_admin_key", lambda: None)
 
     async def _noop(*a, **k):
@@ -77,7 +78,7 @@ async def test_api_key_path_ignores_org_role_header(monkeypatch):
     admin-only routes by self-asserting X-Org-Role."""
     monkeypatch.setattr(auth_mod.settings, "gateway_shared_secret", None)
     monkeypatch.setattr(auth_mod.settings, "is_standalone", False)
-    monkeypatch.setattr(auth_mod.settings, "memclaw_api_key", "sekrit")
+    monkeypatch.setattr(auth_mod.settings, LEGACY_API_KEY_FIELD, "sekrit")
     monkeypatch.setattr(auth_mod, "get_admin_key", lambda: None)
 
     async def _noop(*a, **k):
@@ -103,7 +104,7 @@ def inbox_app(monkeypatch):
     down Path 4, with the route's service seams stubbed."""
     monkeypatch.setattr(auth_mod.settings, "gateway_shared_secret", None)
     monkeypatch.setattr(auth_mod.settings, "is_standalone", False)
-    monkeypatch.setattr(auth_mod.settings, "memclaw_api_key", None)
+    monkeypatch.setattr(auth_mod.settings, LEGACY_API_KEY_FIELD, None)
     monkeypatch.setattr(auth_mod, "get_admin_key", lambda: None)
 
     async def _noop(*a, **k):

--- a/tests/test_plugin_source_manifest.py
+++ b/tests/test_plugin_source_manifest.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from core_api.routes import fleet as fleet_mod
 from core_api.routes import plugin as plugin_mod
+from tests._legacy_contracts import FROZEN_PLUGIN_SLUG
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -285,7 +286,7 @@ def test_plugin_manifest_version_matches_package_json():
 
 def test_install_script_claims_both_slots():
     """The install script's inline setup.js MUST set both ``slots.memory``
-    AND ``slots.contextEngine`` to ``"memclaw"``.
+    AND ``slots.contextEngine`` to the existing plugin identifier.
 
     Pre-fix the script only set ``slots.memory``. OpenClaw resolves the
     active ContextEngine from ``plugins.slots.contextEngine`` (see
@@ -301,12 +302,11 @@ def test_install_script_claims_both_slots():
     script so we can't regress to the half-claimed state.
     """
     src = Path(plugin_mod.__file__).read_text(encoding="utf-8")
-    assert "config.plugins.slots.memory = 'memclaw'" in src, (
-        "Install script must claim plugins.slots.memory for memclaw."
+    assert f"config.plugins.slots.memory = '{FROZEN_PLUGIN_SLUG}'" in src, (
+        "Install script must claim plugins.slots.memory for the existing plugin."
     )
-    assert "config.plugins.slots.contextEngine = 'memclaw'" in src, (
-        "Install script must ALSO claim plugins.slots.contextEngine for memclaw — "
+    assert f"config.plugins.slots.contextEngine = '{FROZEN_PLUGIN_SLUG}'" in src, (
+        "Install script must ALSO claim plugins.slots.contextEngine — "
         "without it, OpenClaw falls back to the legacy context engine and our "
         "assemble() never runs, silently disabling keystone injection."
     )
-

--- a/tests/test_production_startup_guards.py
+++ b/tests/test_production_startup_guards.py
@@ -17,9 +17,10 @@ from types import SimpleNamespace
 import pytest
 from core_api.app import _validate_startup_settings
 from pydantic import SecretStr
+from tests._legacy_contracts import LEGACY_API_KEY_FIELD
 
 
-def _prod(**overrides):
+def _prod(*, compat_api_key=None, **overrides):
     """A production settings object that passes every guard, before overrides."""
     base = {
         "environment": "production",
@@ -28,7 +29,7 @@ def _prod(**overrides):
         "jwt_secret": "a-real-secret",
         "admin_api_key": "a-real-admin-key",
         "gateway_shared_secret": "a-real-gateway-secret",
-        "memclaw_api_key": None,
+        LEGACY_API_KEY_FIELD: compat_api_key,
         "core_storage_shared_secret": SecretStr("a-real-storage-secret"),
     }
     base.update(overrides)
@@ -66,8 +67,8 @@ def test_production_requires_a_perimeter():
 def test_empty_strings_count_as_unset():
     """`""` is the shape a missing env var actually takes in a container."""
     with pytest.raises(RuntimeError, match="GATEWAY_SHARED_SECRET"):
-        _validate_startup_settings(  # fmt: skip - preserve the ratcheted legacy-key line
-            _prod(gateway_shared_secret="", memclaw_api_key="")
+        _validate_startup_settings(
+            _prod(gateway_shared_secret="", compat_api_key="")
         )
 
 
@@ -82,14 +83,12 @@ def test_api_key_alone_is_an_acceptable_perimeter():
     for.
     """
     _validate_startup_settings(
-        _prod(gateway_shared_secret=None, memclaw_api_key="a-real-memclaw-key")
+        _prod(gateway_shared_secret=None, compat_api_key="a-real-api-key")
     )
 
 
 def test_gateway_secret_alone_is_an_acceptable_perimeter():
-    _validate_startup_settings(
-        _prod(gateway_shared_secret="a-real-gateway-secret", memclaw_api_key=None)
-    )
+    _validate_startup_settings(_prod(gateway_shared_secret="a-real-gateway-secret"))
 
 
 def test_production_refuses_standalone_mode():

--- a/tests/test_query_embedding_stampede_guard.py
+++ b/tests/test_query_embedding_stampede_guard.py
@@ -1,7 +1,7 @@
 """Concurrency tests for the query-embedding cache stampede guard (P4).
 
-Wet-tested on memclaw.dev before the fix: 5 parallel recalls with a novel
-query produced a 3-second tail spread (5.67s → 8.70s) — each request
+Wet-tested in the development deployment before the fix: 5 parallel recalls
+with a novel query produced a 3-second tail spread (5.67s → 8.70s) — each request
 independently issued its own ``get_query_embedding`` round-trip and
 serialized on the embedding provider's HTTP client pool.
 

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -751,7 +751,7 @@ class TestMigrationChain:
         assert chain.get("028") == "027", "028 must follow 027"
         # 029: agent activity digest (cached per-agent summaries, CAURA-222)
         assert chain.get("029") == "028", "029 must follow 028"
-        # 030: register the memclaw-insighter service agent for existing tenants
+        # 030: register the insights service agent for existing tenants
         assert chain.get("030") == "029", "030 must follow 029"
         # 031: broker-write agent ownership column (owner_install_uuid)
         assert chain.get("031") == "030", "031 must follow 030"

--- a/tests/test_storage_client_retry.py
+++ b/tests/test_storage_client_retry.py
@@ -1,6 +1,6 @@
 """F5 — storage_client retries transient ConnectTimeout / 5xx on idempotent calls.
 
-Closes the silent-extraction symptom on memclaw.dev (root cause:
+Closes the silent-extraction symptom in the development deployment (root cause:
 ``httpx.ConnectTimeout`` when ``core-api`` reaches ``storage-api``
 during ``upsert_entity`` — 31% failure rate over 7 days of staging
 traffic per Cloud Run logs). The outer ``except Exception`` in
@@ -84,7 +84,7 @@ async def _make_client():
 
 
 async def test_get_retries_on_connect_timeout_then_succeeds() -> None:
-    """The exact failure mode observed on memclaw.dev: ConnectTimeout on
+    """The exact failure mode observed in development: ConnectTimeout on
     one attempt, then storage-api responds normally on the retry."""
     client, _write, read = await _make_client()
     read.get = AsyncMock(

--- a/tests/test_suppression_handlers.py
+++ b/tests/test_suppression_handlers.py
@@ -24,6 +24,7 @@ from common.events.suppression_handlers import (
     SuppressionStorageAdapter,
     _handle_suppression_changed,
 )
+from tests._legacy_contracts import frozen_topic
 
 
 class _FakeAdapter(SuppressionStorageAdapter):
@@ -41,7 +42,7 @@ class _FakeAdapter(SuppressionStorageAdapter):
 
 def _event(payload: dict, *, correlation_id: str | None = "corr-abc") -> Event:
     return Event(
-        event_type="memclaw.org.suppression-changed",
+        event_type=frozen_topic("org.suppression-changed"),
         correlation_id=correlation_id,
         payload=payload,
     )
@@ -127,7 +128,7 @@ async def test_empty_tenant_ids_is_noop() -> None:
 async def test_missing_correlation_id_defaults_updated_by() -> None:
     adapter = _FakeAdapter()
     evt = Event(
-        event_type="memclaw.org.suppression-changed",
+        event_type=frozen_topic("org.suppression-changed"),
         payload={"tenant_ids": ["t1"], "action": "suppress"},
     )
     # No correlation_id on the envelope.


### PR DESCRIPTION
## Summary

Centralizes the permanent root-test compatibility spellings in a test-only fixture module and rewords incidental historical/operational prose.

Root `tests/` ratchet: **103 lines across 33 files → 20 lines across 3 files**. This removes **83** ratcheted lines with **0 additions**. The repo-wide report moves **424 → 341** relative to the current `origin/main`.

Four new `legacy-name-ok` lines remain in `tests/_legacy_contracts.py`, one for each exact contract that the tests must keep pinning independently of live renamed values:

- existing plugin/skill slug
- deployed Pub/Sub topic prefix
- compatibility settings field
- persisted insights service-agent ID

No production source is changed.

## Exclusions verified

- `tests/test_tool_rename_aliases.py` — all 9 lines are the compatibility assertions; untouched.
- `tests/test_migration_012_safety_gate.py` — all 7 lines quote the immutable migration's dual-read environment contract; untouched.
- `tests/conftest.py` — 4 lines left untouched while #1140 remains open against that file.
- `clients/python/tests/test_legacy_alias.py` — all 10 alias-contract lines remain untouched.
- `scripts/wet_test_baselines/caura-125-baseline.jsonl` and `caura-125-postfix.jsonl` — recorded measurements remain untouched.
- The 26 previously audited plugin floor markers remain untouched; their movable neighbors were handled in #1151.

## Verification

- `python3 scripts/legacy_name_ratchet.py --base origin/main`: 0 added, 0 annotated, 83 removed
- `python3 scripts/do_not_touch_sentinel.py`: all 46 protected strings survive
- Exact CI-shaped root suite with migrations and coverage: **5701 passed, 4 skipped, 1 xfailed, 16 deselected**
- Post-rebase affected modules: **538 passed**
- Ruff check: all six CI scopes passed
- Ruff format check: all six CI scopes passed separately, discovery-based
- mypy: core-api, core-storage-api, core-operations, core-worker, common, and scripts all passed
- `git diff --check`: passed
- DCO sign-off present; one commit

No reviewer tags were added on open because this is a tests-only PR and should take the announced no-source-files review skip path.