### PR TITLE
fix(memory): say "add" where the entity-link trail said "replaced"

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -1214,6 +1214,7 @@
                 "type": "null"
               }
             ],
+            "description": "Entity links to **add** to this memory. Additive, unlike ``metadata``: links already on the memory are kept even when this list does not name them, and re-sending a pair already present leaves its existing ``role`` unchanged rather than overwriting it. There is no replace mode and no way to remove a link through this endpoint. An ``entity_id`` outside the caller's tenant is rejected with 422.",
             "title": "Entity Links"
           },
           "expires_at": {
@@ -2497,7 +2498,7 @@
         ]
       },
       "patch": {
-        "description": "Update a memory. Only provide fields you want to change.\n\nIf content changes, embedding and entity extraction are re-run automatically.\n\nConcurrency contract (intentional, not a bug):\n\n- Each top-level column is **last-write-wins**. Two concurrent PATCHes that\n  set the same column (e.g. ``title``) will both return 200 and the row\n  will hold whichever update commits second. There is no compare-and-swap\n  and no optimistic-lock token — callers that need that must coordinate\n  externally or use ``If-Match`` semantics layered on top.\n- ``metadata`` defaults to a **JSONB top-level merge** (``||``): keys not\n  present in the patch are preserved, keys present in both patches resolve\n  last-write-wins per key. Pass ``metadata_mode: \"replace\"`` for a full\n  overwrite. Two concurrent PATCHes that each set a distinct metadata key\n  will therefore leave **both keys present** on the row — that is the\n  defined behaviour, not a partial-merge anomaly.",
+        "description": "Update a memory. Only provide fields you want to change.\n\nIf content changes, embedding and entity extraction are re-run automatically.\n\nConcurrency contract (intentional, not a bug):\n\n- Each top-level column is **last-write-wins**. Two concurrent PATCHes that\n  set the same column (e.g. ``title``) will both return 200 and the row\n  will hold whichever update commits second. There is no compare-and-swap\n  and no optimistic-lock token — callers that need that must coordinate\n  externally or use ``If-Match`` semantics layered on top.\n- ``metadata`` defaults to a **JSONB top-level merge** (``||``): keys not\n  present in the patch are preserved, keys present in both patches resolve\n  last-write-wins per key. Pass ``metadata_mode: \"replace\"`` for a full\n  overwrite. Two concurrent PATCHes that each set a distinct metadata key\n  will therefore leave **both keys present** on the row — that is the\n  defined behaviour, not a partial-merge anomaly.\n- ``entity_links`` is **add-only**, and has no replace mode. Links already\n  on the memory survive a PATCH that does not name them, and re-sending a\n  pair already present keeps its existing ``role`` rather than overwriting\n  it (the insert is ``ON CONFLICT DO NOTHING``). So concurrent PATCHes\n  naming different entities leave **both links present**, and there is no\n  request through this endpoint that removes one.",
         "operationId": "update_memory_endpoint_api_v1_memories__memory_id__patch",
         "parameters": [
           {

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1629,6 +1629,12 @@ async def update_memory_endpoint(
       overwrite. Two concurrent PATCHes that each set a distinct metadata key
       will therefore leave **both keys present** on the row — that is the
       defined behaviour, not a partial-merge anomaly.
+    - ``entity_links`` is **add-only**, and has no replace mode. Links already
+      on the memory survive a PATCH that does not name them, and re-sending a
+      pair already present keeps its existing ``role`` rather than overwriting
+      it (the insert is ``ON CONFLICT DO NOTHING``). So concurrent PATCHes
+      naming different entities leave **both links present**, and there is no
+      request through this endpoint that removes one.
     """
     auth.enforce_tenant(tenant_id)
     # C3/C8: server-reserved types (outcome/rule/insight) are authored only by

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -295,7 +295,18 @@ class MemoryUpdate(BaseModel):
     ts_valid_start: datetime | None = None
     ts_valid_end: datetime | None = None
     expires_at: datetime | None = None
-    entity_links: list[EntityLinkIn] | None = None
+    entity_links: list[EntityLinkIn] | None = Field(
+        default=None,
+        description=(
+            "Entity links to **add** to this memory. Additive, unlike "
+            "``metadata``: links already on the memory are kept even when this "
+            "list does not name them, and re-sending a pair already present "
+            "leaves its existing ``role`` unchanged rather than overwriting it. "
+            "There is no replace mode and no way to remove a link through this "
+            "endpoint. An ``entity_id`` outside the caller's tenant is rejected "
+            "with 422."
+        ),
+    )
 
     @model_validator(mode="after")
     def metadata_mode_requires_metadata(self) -> "MemoryUpdate":

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -3745,7 +3745,9 @@ async def update_memory(
         # else (empty dict in merge mode) → storage no-op, no audit
         # entry, no patch field.
 
-    # Entity links: replace if explicitly provided
+    # Entity links: ADD the named links when explicitly provided. Never a
+    # replace — see the ``changes`` entry below for what the storage call does
+    # and does not do. There is no API path that removes a link today.
     if "entity_links" in fields_set and data.entity_links is not None:
         entity_link_dicts = [
             {"entity_id": str(link.entity_id), "role": link.role} for link in data.entity_links
@@ -3768,9 +3770,26 @@ async def update_memory(
                 status_code=422,
                 detail="entity_links names an entity that does not exist in this tenant",
             )
+        # Additive, and the audit record has to say so. ``memory_add_entity_links``
+        # inserts with ``ON CONFLICT (memory_id, entity_id) DO NOTHING`` and has no
+        # delete branch, so links already on the row survive a PATCH that does not
+        # name them, and a re-sent pair keeps its original role. This entry used to
+        # read ``{"old": "replaced", ...}``, which claimed a removal that has never
+        # happened on this path — the trail said the link set was replaced while the
+        # row still held the old links.
+        #
+        # ``mode`` states the semantic explicitly, the way the ``metadata`` entry
+        # above distinguishes merge from replace, rather than leaving an auditor to
+        # infer it from a count.
+        #
+        # No ``old``: ``sc.get_memory`` does not return ``entity_links`` (the field
+        # on the response is populated separately), so the previous link set is not
+        # in hand here, and reporting a count we did not read would be the same
+        # class of error this replaces. ``added`` is what was requested — an upper
+        # bound on rows actually inserted, since a pair already present is a no-op.
         changes["entity_links"] = {
-            "old": "replaced",
-            "new": f"{len(data.entity_links)} links",
+            "added": f"{len(data.entity_links)} links",
+            "mode": "add",
         }
 
     # Apply the patch via storage client

--- a/tests/test_entity_links_are_additive.py
+++ b/tests/test_entity_links_are_additive.py
@@ -1,0 +1,159 @@
+"""``PATCH /memories/{id}`` adds entity links; the audit trail must say so.
+
+The comment on this block read "replace if explicitly provided" and the audit
+record read ``{"old": "replaced", ...}``, but ``memory_add_entity_links`` inserts
+with ``ON CONFLICT (memory_id, entity_id) DO NOTHING`` and has no delete branch.
+So a PATCH naming only entity A on a memory already linked to B left B linked
+while the trail claimed the link set had been replaced — a record that disagreed
+with the row it described.
+
+**Add is the behaviour that was kept, and the wording is what changed.** Nothing
+documented a replace: not the schema field, not the OpenAPI spec, not the route
+docstring (which documents ``metadata``'s merge-vs-replace in detail and was
+silent here), not the integration guide, and no test pinned one. The response
+body has always reported the true, additive link set. Turning it into a real
+replace would mean a shipped endpoint silently starting to DELETE links a caller
+did not name — a destructive change to a public API, which is not something to
+infer from a stale comment.
+
+Both halves are pinned below, because either alone would let the bug back:
+``test_a_patch_does_not_remove_links_it_does_not_name`` fails if someone
+implements the replace, and ``test_the_audit_record_says_add_not_replace`` fails
+if the wording drifts back.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+
+from common.embedding import fake_embedding
+from common.models.audit import AuditLog
+from core_storage_api.services.postgres_service import PostgresService, get_read_session
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _t() -> str:
+    """A tenant id unique to one test AND visible to the end-of-run sweep.
+
+    ``test-tenant-`` is what ``_setup_schema``'s teardown matches
+    (``tenant_id LIKE 'test-tenant-%'``, and it reaches ``memory_entity_links``
+    through the ``memories`` subquery), so any other prefix leaks rows — see
+    ``tests.conftest.new_tenant_id``, which is the same contract.
+    """
+    return f"test-tenant-links-{uuid4().hex[:8]}"
+
+
+async def _memory(sc, tenant: str) -> UUID:
+    content = f"additive links {uuid4().hex[:8]}"
+    row = await sc.create_memory(
+        {
+            "tenant_id": tenant,
+            "agent_id": "test-agent",
+            "content": content,
+            "memory_type": "fact",
+            "weight": 0.5,
+            "status": "active",
+            "visibility": "scope_team",
+            "embedding": fake_embedding(content),
+        }
+    )
+    return UUID(row["id"])
+
+
+async def _entity(sc, tenant: str, name: str) -> str:
+    row = await sc.create_entity(
+        {
+            "tenant_id": tenant,
+            "entity_type": "person",
+            "canonical_name": f"{name}-{uuid4().hex[:6]}",
+        }
+    )
+    return row["id"]
+
+
+async def _links(memory_id: UUID) -> dict[str, str]:
+    by_entity = await PostgresService().memory_get_entity_links_for_memories([memory_id])
+    return {str(link["entity_id"]): link["role"] for link in by_entity.get(memory_id, [])}
+
+
+async def _patch_links(memory_id: UUID, tenant: str, links: list[dict]) -> None:
+    from core_api.schemas import MemoryUpdate
+    from core_api.services.memory_service import update_memory
+
+    await update_memory(memory_id, tenant, MemoryUpdate(entity_links=links))
+
+
+class TestEntityLinksAreAdditive:
+    async def test_a_patch_does_not_remove_links_it_does_not_name(self, sc) -> None:
+        """The behaviour the wording now describes: B survives a PATCH naming only A."""
+        tenant = _t()
+        memory_id = await _memory(sc, tenant)
+        a = await _entity(sc, tenant, "Aaa")
+        b = await _entity(sc, tenant, "Bbb")
+
+        await _patch_links(memory_id, tenant, [{"entity_id": b, "role": "object"}])
+        assert await _links(memory_id) == {b: "object"}
+
+        await _patch_links(memory_id, tenant, [{"entity_id": a, "role": "subject"}])
+
+        assert await _links(memory_id) == {b: "object", a: "subject"}, (
+            "a PATCH naming only A must not remove B — this endpoint has no replace mode"
+        )
+
+    async def test_a_resent_pair_keeps_its_original_role(self, sc) -> None:
+        """``ON CONFLICT DO NOTHING`` preserves the first role, and that is deliberate.
+
+        CAURA-686 chose DO NOTHING so concurrent writes to the same pair do not
+        serialise on ``Lock/transactionid``. A caller cannot re-point a role by
+        re-sending the pair, which is worth pinning: it is the second half of
+        "additive", and the half most likely to be mistaken for a bug.
+        """
+        tenant = _t()
+        memory_id = await _memory(sc, tenant)
+        a = await _entity(sc, tenant, "Aaa")
+
+        await _patch_links(memory_id, tenant, [{"entity_id": a, "role": "subject"}])
+        await _patch_links(memory_id, tenant, [{"entity_id": a, "role": "object"}])
+
+        assert await _links(memory_id) == {a: "subject"}, "the original role must survive a re-send"
+
+    async def test_the_audit_record_says_add_not_replace(self, sc) -> None:
+        """The trail must describe what happened to the row.
+
+        Asserted against the ``audit_log`` table rather than a captured hook call,
+        so what is pinned is the record an operator actually reads.
+        """
+        tenant = _t()
+        memory_id = await _memory(sc, tenant)
+        a = await _entity(sc, tenant, "Aaa")
+        b = await _entity(sc, tenant, "Bbb")
+
+        await _patch_links(memory_id, tenant, [{"entity_id": b, "role": "object"}])
+        await _patch_links(memory_id, tenant, [{"entity_id": a, "role": "subject"}])
+
+        async with get_read_session() as session:
+            rows = (
+                (
+                    await session.execute(
+                        select(AuditLog)
+                        .where(AuditLog.tenant_id == tenant, AuditLog.action == "update")
+                        .order_by(AuditLog.created_at)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert rows, "expected an update audit row for the PATCH"
+        entry = (rows[-1].detail or {}).get("changes", {}).get("entity_links")
+        assert entry is not None, "the PATCH must be recorded in the audit trail"
+
+        assert entry.get("mode") == "add", f"audit must state the additive mode, got {entry!r}"
+        # The specific regression: the row still holds B, so nothing was replaced.
+        assert "replaced" not in str(entry), (
+            f"audit claims a removal that never happens on this path: {entry!r}"
+        )
+        assert b in await _links(memory_id), "guard: B is still linked, so 'replaced' would be false"


### PR DESCRIPTION
Found while tenant-scoping `memory_entity_links` (#1085 / #1124) and deliberately held back from #1148, #1152 and #1153, because it is a behavioural question rather than a bug with one obvious fix. No issue filed — say the word if you want one for tracking.

### The disagreement

```python
# Entity links: replace if explicitly provided
if "entity_links" in fields_set and data.entity_links is not None:
    ...
    changes["entity_links"] = {"old": "replaced", "new": f"{len(data.entity_links)} links"}
```

`memory_add_entity_links` inserts with `ON CONFLICT (memory_id, entity_id) DO NOTHING` and has **no delete branch**. So `PATCH /memories/{id}` with `entity_links=[A]` on a memory already linked to B leaves B linked, while the audit record says the link set was replaced.

Confirmed by running it rather than reading it:

```
before: [{'entity_id': B, 'role': 'object'}]
PATCH entity_links=[{A, 'subject'}]
after : [{'entity_id': B, 'role': 'object'}, {'entity_id': A, 'role': 'subject'}]
B still linked? True
```

### Which one is wrong: the wording

**The behaviour is right and the wording is wrong.** The evidence all points one way:

- **Nothing documents a replace.** Not `MemoryUpdate.entity_links` (no `description`), not the committed OpenAPI spec (`description` absent on every schema carrying the field), not the route docstring — which documents `metadata`'s merge-vs-replace across five lines and was silent on `entity_links` — not `static/docs/integration-guide.md`, which mentions the field only as a write field. The comment dates to `7456e233` "Initial public release v1.0.0" and was never revisited.
- **This codebase documents replace semantics explicitly when it means them.** `metadata_mode` has a pattern-validated body field, a query-param alias, a validator, and multiple paragraphs of docstring. `entity_links` has none of that. If a replace were intended here, this repo would have said so.
- **No test pinned a replace.** Nothing breaks by declaring add.
- **The same field is purely additive on create** — `write_memory_row` loops `create_entity_link` per link — and the storage method is *named* `memory_add_entity_links`.
- **`ON CONFLICT DO NOTHING` is a deliberate design decision, not an oversight.** CAURA-686 chose it so concurrent writes to the same pair don't serialise on `Lock/transactionid`.
- **The response body has always been honest.** `PATCH` re-fetches and returns the true, additive link set, so a caller could already see exactly what happened. Only the audit trail was wrong.

Against that, implementing the replace would mean a **shipped public endpoint silently starting to DELETE links a caller did not name**. That is a destructive change to a v1 contract, and not one to infer from a stale comment. If a replace mode is wanted, it should arrive as an explicit `entity_links_mode` flag mirroring `metadata_mode` — a feature, deliberately not smuggled in here.

### What changed

1. **The audit entry** → `{"added": "N links", "mode": "add"}`.

   `mode` states the semantic the way the `metadata` entry distinguishes merge from replace. `old` is **dropped rather than filled in**: `sc.get_memory` does not return `entity_links` (the field on the response is populated separately — verified, it is absent from that dict), so the previous link set is not in hand at that point, and reporting a count that was never read would be the same class of error this fixes. `added` is what was requested, an upper bound on rows actually inserted since a pair already present is a no-op. Nothing parses `detail["changes"]`, and the `metadata` entry already carries an extra `mode` key, so the shape is not rigid.

2. **The comment**, which now says add and notes there is no removal path.

3. **The contract, where callers actually look** — a `description` on `MemoryUpdate.entity_links` and a bullet in the route docstring beside the `metadata` one. This is the durable half of the fix: the internal comment was wrong precisely because the contract never said anything.

4. **`core-api/openapi.broker.json`** regenerated for those two descriptions (`gen_broker_openapi.py`), since CI's `--check` gate fails on a stale baseline. Both are description-only; I ran the pinned oasdiff image locally against `origin/main`'s baseline: *"No breaking changes to report."*

### Failing without the fix

Reverting **only** the audit entry to `{"old": "replaced", ...}`, leaving behaviour untouched:

```
..F                                                                      [100%]
____ TestEntityLinksAreAdditive.test_the_audit_record_says_add_not_replace _____
tests/test_entity_links_are_additive.py:154: in test_the_audit_record_says_add_not_replace
    assert entry.get("mode") == "add", f"audit must state the additive mode, got {entry!r}"
E   AssertionError: audit must state the additive mode, got {'new': '1 links', 'old': 'replaced'}
E   assert None == 'add'
1 failed, 2 passed in 0.84s
```

The two behaviour tests still pass, because behaviour did not change — which raises the fair question of whether they are load-bearing at all. They are. Implementing the replace as an experiment (delete links not named, `DO UPDATE` the role) fails **all three**:

```
FAILED ...::test_a_patch_does_not_remove_links_it_does_not_name
FAILED ...::test_a_resent_pair_keeps_its_original_role
FAILED ...::test_the_audit_record_says_add_not_replace
3 failed in 0.85s
```

So the wording is pinned in one direction and the behaviour in the other: the trail cannot drift back to "replaced", and the endpoint cannot quietly start deleting. The audit test's last assertion is a guard that B is still linked, so it fails on the premise too rather than only on the wording.

Asserted against the `audit_log` table rather than a captured hook call, so what is pinned is the record an operator actually reads.

### Not fixed here

There is **no way to remove an entity link through the API** — `entity_delete_entity_links` was deleted as dead code in #1091, and there is no replace mode. Now documented as a known limitation in the schema description and the route docstring rather than left for a caller to discover. Adding removal is a feature and needs its own decision about shape (`entity_links_mode: "replace"`, or a dedicated `DELETE` sub-resource).

### Verification

- Root `tests/`: 5720 passed, 4 skipped, 1 xfailed (3 new).
- `core-storage-api/tests/`: 264 passed.
- `ruff check` / `ruff format --check` at CI's exact scopes: clean.
- `mypy` core-api, 203 files: no issues.
- `gen_broker_openapi.py --check`: baseline up to date. oasdiff vs `origin/main`: no breaking changes.
- Tenant-scope gate (98 allowlisted, unchanged by this diff) and legacy-name ratchet: both green.

Run against a dedicated local pgvector instance provisioned the way CI does it — `alembic upgrade head` on the root suite's database, a separate database for the storage suite. Worth noting for anyone reproducing: `alembic.ini` reads the URL from `DATABASE_URL` via `env.py`, **not** from `POSTGRES_HOST`/`POSTGRES_PORT`, so passing only the latter silently migrates whatever is on the default port. **Not checked:** anything requiring CI's own environment — the Actions matrix, the coverage floors step, the enterprise re-vendor path.
