### PR TITLE
test: centralize service compatibility fixtures

### DIFF
--- a/core-api/tests/test_report_corpus.py
+++ b/core-api/tests/test_report_corpus.py
@@ -9,6 +9,8 @@ from core_api.services.report_corpus import (
     resolve_parent,
 )
 
+HEALTH_PROBE_TITLE_PREFIX = "memclaw-smoke-"  # legacy-name-ok: deployed health-probe title prefix
+
 
 def test_resolve_parent_explicit_subagent_convention():
     known = frozenset({"quantclaw"})
@@ -66,13 +68,20 @@ def test_is_reserved_agent_predicate():
 
 
 def test_health_check_probe_dropped_as_noise():
-    # __health_check__ writes durable-typed 'fact' rows titled 'memclaw-smoke-*';
-    # both the reserved-agent gate and the title regex must drop them so the probe
-    # never tops the leaderboard.
-    probe = _m(mtype="fact", title="memclaw-smoke-1786983933574 identifier", agent="__health_check__")
+    # The health check writes durable-typed fact rows under its deployed title
+    # prefix. Both the reserved-agent gate and title regex must drop them.
+    probe = _m(
+        mtype="fact",
+        title=f"{HEALTH_PROBE_TITLE_PREFIX}1786983933574 identifier",
+        agent="__health_check__",
+    )
     assert not passes_noise_filter(probe) and not is_cohesive(probe)
-    # the memclaw-smoke title alone drops it even under a non-reserved id
-    smoke_titled = _m(mtype="fact", title="memclaw-smoke-123 identifier", agent="someagent")
+    # The title prefix alone drops it even under a non-reserved id.
+    smoke_titled = _m(
+        mtype="fact",
+        title=f"{HEALTH_PROBE_TITLE_PREFIX}123 identifier",
+        agent="someagent",
+    )
     assert not passes_noise_filter(smoke_titled)
 
 

--- a/core-storage-api/tests/conftest.py
+++ b/core-storage-api/tests/conftest.py
@@ -13,7 +13,7 @@ import uuid
 os.environ.setdefault("TESTING", "1")
 os.environ.setdefault(
     "DATABASE_URL",
-    "postgresql+asyncpg://memclaw:changeme@127.0.0.1:5432/memclaw",
+    "postgresql+asyncpg://memclaw:changeme@127.0.0.1:5432/memclaw",  # legacy-name-ok: local test DB
 )
 os.environ.setdefault("LOG_LEVEL", "WARNING")
 os.environ.setdefault("CORE_STORAGE_SHARED_SECRET", "test-storage-secret")

--- a/core-worker/tests/test_consumer.py
+++ b/core-worker/tests/test_consumer.py
@@ -14,12 +14,14 @@ import core_worker.consumer as consumer
 from common.events.base import Event
 from core_worker.config import Settings
 
+EMBED_REQUESTED_TOPIC = "memclaw.memory.embed-requested"  # legacy-name-ok: deployed Pub/Sub topic
+
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
 def _make_event(payload: dict | None = None) -> Event:
     return Event(
-        event_type="memclaw.memory.embed-requested",
+        event_type=EMBED_REQUESTED_TOPIC,
         tenant_id=(payload or {}).get("tenant_id"),
         payload=payload
         or {
@@ -155,7 +157,7 @@ async def test_validation_error_drops_silently(settings, mock_provider, mock_sto
     consumer.configure(mock_storage_client)
 
     # Missing content + memory_id + tenant_id.
-    event = Event(event_type="memclaw.memory.embed-requested", payload={})
+    event = Event(event_type=EMBED_REQUESTED_TOPIC, payload={})
 
     with caplog.at_level("ERROR"):
         await consumer.handle_embed_request(event)

--- a/core-worker/tests/test_consumer_enrich.py
+++ b/core-worker/tests/test_consumer_enrich.py
@@ -17,6 +17,8 @@ import core_worker.consumer as consumer
 from common.enrichment import EnrichmentResult
 from common.events.base import Event
 
+ENRICH_REQUESTED_TOPIC = "memclaw.memory.enrich-requested"  # legacy-name-ok: deployed Pub/Sub topic
+
 
 def _make_event(payload: dict | None = None) -> Event:
     p = payload or {
@@ -27,7 +29,7 @@ def _make_event(payload: dict | None = None) -> Event:
         "openai_api_key": "sk-tenant",
     }
     return Event(
-        event_type="memclaw.memory.enrich-requested",
+        event_type=ENRICH_REQUESTED_TOPIC,
         tenant_id=p.get("tenant_id"),
         payload=p,
     )
@@ -481,7 +483,7 @@ async def test_validation_error_drops_silently(mock_storage_client, caplog):
     consumer.configure(mock_storage_client)
 
     # Missing required fields.
-    event = Event(event_type="memclaw.memory.enrich-requested", payload={})
+    event = Event(event_type=ENRICH_REQUESTED_TOPIC, payload={})
 
     with caplog.at_level("ERROR"):
         await consumer.handle_enrich_request(event)


### PR DESCRIPTION
## Summary

- centralize the deployed health-probe title prefix and the two frozen Pub/Sub topics in service tests
- annotate the existing local integration-test database DSN in place so environment setup still precedes service imports
- remove every unannotated Package Y legacy-name line from the service-test slice without coupling tests to production constants

## Ratchet accounting

- service-test slice: 9 ratcheted lines across 4 files → 0 unannotated lines
- change split: 0 added, 1 annotated, 8 removed, 0 excused moves (-9 net)
- four compatibility markers remain, one per file, for deployed wire identifiers or the existing local test database identity
- all 46 do-not-touch sentinel strings survive

The remaining intentional Package Y test block is outside this PR: 10 Python legacy-alias contract lines, 9 tool-rename alias lines, 7 immutable-migration quotation lines, 4 root conftest lines reserved while #1140 is open, and 4 recorded JSONL baseline lines. Existing audited plugin markers are untouched.

## Validation

- `core-api/tests/test_report_corpus.py`: 9 passed
- `core-worker/tests/test_consumer.py` + `test_consumer_enrich.py`: 36 passed
- full `core-storage-api/tests`: 267 passed against an isolated PostgreSQL database
- all six exact CI Ruff check/format scope pairs passed
- all six exact CI mypy invocations passed (203, 85, 5, 11, 99, and 31 source files)
- legacy-name ratchet, do-not-touch sentinel, and `git diff --check` passed after the final rebase onto `origin/main`
