### PR TITLE
fix(storage): scope recall increments to tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1270,13 +1270,17 @@ class CoreStorageClient:
     # datetimes, so callers stringify UUIDs + ISO-format datetimes first.
     # =====================================================================
 
-    async def increment_recall(self, memory_ids: list[str]) -> int:
+    async def increment_recall(self, memory_ids: list[str], *, tenant_id: str) -> int:
         """Bump ``recall_count`` + ``last_recalled_at`` for memories by id.
 
         ``memory_ids`` must already be stringified (the storage endpoint
-        re-parses each as a UUID). Returns the rows-updated count.
+        re-parses each as a UUID). ``tenant_id`` binds the update to the
+        caller's tenant. Returns the rows-updated count.
         """
-        result = await self._post("/memories/increment-recall", {"memory_ids": memory_ids})
+        result = await self._post(
+            "/memories/increment-recall",
+            {"tenant_id": tenant_id, "memory_ids": memory_ids},
+        )
         return result.get("updated", 0)  # type: ignore[union-attr]
 
     async def log_recall(self, event: dict, candidates: list[dict]) -> str:

--- a/core-api/src/core_api/pipeline/steps/search/track_recalls.py
+++ b/core-api/src/core_api/pipeline/steps/search/track_recalls.py
@@ -18,20 +18,17 @@ from core_api.tasks import track_task
 logger = logging.getLogger(__name__)
 
 
-async def _track_recalls_background(memory_ids: list[UUID]) -> None:
+async def _track_recalls_background(memory_ids: list[UUID], *, tenant_id: str) -> None:
     """Background task: bump recall stats via the storage client.
 
     ``memory_ids`` are stringified for the JSON payload (``_post`` does not
     auto-encode UUIDs); the storage endpoint re-parses each as a UUID.
-
-    This intentionally calls ``increment_recall`` directly rather than the
-    ``ServiceHooks.on_recall`` extension hook: the hook's only registration is
-    ``memory_repo.increment_recall`` (app.py), i.e. exactly this recall-count
-    bump, which now lives behind storage. The hook itself stays for its other
-    consumers (memory_service/entity_service) until they migrate (PR3).
     """
     try:
-        await get_storage_client().increment_recall([str(m) for m in memory_ids])
+        await get_storage_client().increment_recall(
+            [str(m) for m in memory_ids],
+            tenant_id=tenant_id,
+        )
     except Exception:
         logger.warning("Background recall tracking failed", exc_info=True)
 
@@ -64,5 +61,10 @@ class TrackRecalls:
             return None
         memory_ids = [row.Memory.id for row in ctx.data["filtered_rows"]]
         if memory_ids:
-            track_task(_track_recalls_background(memory_ids))
+            track_task(
+                _track_recalls_background(
+                    memory_ids,
+                    tenant_id=ctx.data["tenant_id"],
+                )
+            )
         return None

--- a/core-api/src/core_api/services/entity_service.py
+++ b/core-api/src/core_api/services/entity_service.py
@@ -296,7 +296,10 @@ async def get_entity(entity_id: UUID, tenant_id: str, caller_agent_id: str | Non
     memory_ids = [mem.get("id") for mem in linked_memories_raw if mem.get("id")]
     if memory_ids:
         try:
-            await get_storage_client().increment_recall([str(m) for m in memory_ids])
+            await get_storage_client().increment_recall(
+                [str(m) for m in memory_ids],
+                tenant_id=tenant_id,
+            )
         except Exception:
             pass  # Non-critical
 

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -4796,7 +4796,10 @@ async def _search_memories_legacy(
     # Increment recall_count and update last_recalled_at for returned memories
     if memory_ids:
         try:
-            await get_storage_client().increment_recall([str(m) for m in memory_ids])
+            await get_storage_client().increment_recall(
+                [str(m) for m in memory_ids],
+                tenant_id=tenant_id,
+            )
         except Exception:
             logger.debug("Recall tracking failed (non-critical)", exc_info=True)
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1525,14 +1525,21 @@ async def redistribute(request: Request) -> dict:
 async def increment_recall(request: Request) -> dict:
     """Bump ``recall_count`` + ``last_recalled_at`` for many memories by id.
 
-    Exposes the existing ``PostgresService.memory_increment_recall`` (a by-id
-    UPDATE; no tenant scope — matches its prior in-process semantics from
-    core-api's ``track_recalls`` hook). Body: ``{"memory_ids": [str,...]}`` →
-    ``{"updated": int}``. Fail-closed 422 if ``memory_ids`` is missing/not a
-    list; a malformed UUID 422s (mirrors the evolve/entities validation
-    pattern) rather than 500ing inside the service.
+    ``tenant_id`` binds the by-id UPDATE to the caller's tenant. Body:
+    ``{"tenant_id": str, "memory_ids": [str,...]}`` → ``{"updated": int}``.
+    Fail-closed 422 if either field is missing or invalid; a malformed UUID
+    422s (mirrors the evolve/entities validation pattern) rather than 500ing
+    inside the service.
     """
     body: dict = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="request body must be a JSON object")
+    tenant_id = body.get("tenant_id")
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise HTTPException(
+            status_code=422,
+            detail="'tenant_id' is required and must be a non-empty string",
+        )
     raw_ids = body.get("memory_ids")
     if not isinstance(raw_ids, list):
         raise HTTPException(status_code=422, detail="'memory_ids' must be a list")
@@ -1542,7 +1549,7 @@ async def increment_recall(request: Request) -> dict:
         memory_ids = [UUID(str(mid)) for mid in raw_ids]
     except (ValueError, AttributeError) as exc:
         raise HTTPException(status_code=422, detail=f"invalid UUID in memory_ids: {exc}") from exc
-    updated = await _svc.memory_increment_recall(memory_ids)
+    updated = await _svc.memory_increment_recall(memory_ids, tenant_id=tenant_id)
     return {"updated": updated}
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -3798,14 +3798,22 @@ class PostgresService:
     # G) Recall tracking
     # ------------------------------------------------------------------
 
-    async def memory_increment_recall(self, memory_ids: list[UUID]) -> int:
-        """Bump recall_count/last_recalled_at by id; returns rows actually updated."""
+    async def memory_increment_recall(
+        self,
+        memory_ids: list[UUID],
+        *,
+        tenant_id: str,
+    ) -> int:
+        """Bump recall stats for ids owned by ``tenant_id``; return rows updated."""
         if not memory_ids:
             return 0
         async with get_session() as session:
             result = await session.execute(
                 sql_update(Memory)
-                .where(Memory.id.in_(memory_ids))
+                .where(
+                    Memory.id.in_(memory_ids),
+                    Memory.tenant_id == tenant_id,
+                )
                 .values(
                     recall_count=Memory.recall_count + 1,
                     last_recalled_at=func.now(),

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -210,13 +210,6 @@
       "note": "Join table has no tenant column; rows are tenant-scoped only via the ids."
     },
     {
-      "id": "method:memory_increment_recall",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1088."
-    },
-    {
       "id": "method:memory_list_null_embedding_rows",
       "verdict": "OPTIONAL",
       "evidence": "tenant_id is defaulted; omitting it drops the scope",
@@ -612,13 +605,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "id-addressed-read"
-    },
-    {
-      "id": "route:POST /api/v1/storage/memories/increment-recall",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1088."
     },
     {
       "id": "route:POST /api/v1/storage/reports",

--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -337,16 +337,28 @@ async def test_track_recalls_fire_and_forget():
 
     mock_db = AsyncMock()
     ctx = PipelineContext(
-                # caller_agent_id present → genuine agent recall, so recall_count
-                # is bumped (agentless recalls are skipped; see track_recalls).
-                data={"filtered_rows": rows, "caller_agent_id": "test-agent"},
+        # caller_agent_id present → genuine agent recall, so recall_count
+        # is bumped (agentless recalls are skipped; see track_recalls).
+        data={
+            "filtered_rows": rows,
+            "caller_agent_id": "test-agent",
+            "tenant_id": "test-tenant-track-recalls",
+        },
     )
 
-    with patch("core_api.pipeline.steps.search.track_recalls.track_task") as mock_track:
+    with (
+        patch("core_api.pipeline.steps.search.track_recalls.track_task") as mock_track,
+        patch(
+            "core_api.pipeline.steps.search.track_recalls._track_recalls_background"
+        ) as mock_background,
+    ):
         step = TrackRecalls()
         await step.execute(ctx)
 
-        # track_task should have been called with a coroutine
+        mock_background.assert_called_once_with(
+            [mem1.id, mem2.id],
+            tenant_id="test-tenant-track-recalls",
+        )
         mock_track.assert_called_once()
         # Close the coroutine to avoid RuntimeWarning
         coro = mock_track.call_args[0][0]
@@ -373,9 +385,12 @@ async def test_track_recalls_background_routes_to_storage():
         "core_api.pipeline.steps.search.track_recalls.get_storage_client",
         return_value=sc,
     ):
-        await _track_recalls_background(ids)
+        await _track_recalls_background(ids, tenant_id="test-tenant-track-recalls")
 
-    sc.increment_recall.assert_awaited_once_with([str(ids[0]), str(ids[1])])
+    sc.increment_recall.assert_awaited_once_with(
+        [str(ids[0]), str(ids[1])],
+        tenant_id="test-tenant-track-recalls",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_d12_search_diagnostics.py
+++ b/tests/test_d12_search_diagnostics.py
@@ -179,6 +179,7 @@ async def test_track_recalls_still_counts_normal(monkeypatch):
             "caller_agent_id": "brandclaw",
             "diagnostic": False,
             "filtered_rows": [SimpleNamespace(Memory=SimpleNamespace(id=uuid4()))],
+            "tenant_id": "test-tenant-track-recalls-diagnostic",
         }
     )
     await tr.TrackRecalls().execute(ctx)

--- a/tests/test_fix2_cleanup_storage.py
+++ b/tests/test_fix2_cleanup_storage.py
@@ -34,6 +34,7 @@ from sqlalchemy import text
 from common.models import Memory
 from common.models.recall_log import RecallCandidate, RecallEvent  # noqa: F401 — registers tables
 from core_storage_api.services.postgres_service import get_session
+from tests.conftest import new_tenant_id
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
@@ -41,7 +42,7 @@ _PREFIX = "/api/v1/storage"
 
 
 def _t() -> str:
-    return f"test-tenant-fix2-cleanup-{uuid4().hex[:8]}"
+    return new_tenant_id()
 
 
 # ---------------------------------------------------------------------------
@@ -150,7 +151,7 @@ async def test_increment_recall_bumps_count(storage_http):
 
     resp = await storage_http.post(
         f"{_PREFIX}/memories/increment-recall",
-        json={"memory_ids": [m1, m2]},
+        json={"tenant_id": tenant, "memory_ids": [m1, m2]},
     )
     assert resp.status_code == 200
     assert resp.json() == {"updated": 2}
@@ -168,30 +169,72 @@ async def test_increment_recall_stale_id_not_counted(storage_http):
     m1 = await _seed_memory(tenant_id=tenant)
     resp = await storage_http.post(
         f"{_PREFIX}/memories/increment-recall",
-        json={"memory_ids": [m1, str(uuid4())]},
+        json={"tenant_id": tenant, "memory_ids": [m1, str(uuid4())]},
     )
     assert resp.status_code == 200
     assert resp.json() == {"updated": 1}
 
 
 async def test_increment_recall_empty_list_noop(storage_http):
+    tenant = _t()
     resp = await storage_http.post(
         f"{_PREFIX}/memories/increment-recall",
-        json={"memory_ids": []},
+        json={"tenant_id": tenant, "memory_ids": []},
     )
     assert resp.status_code == 200
     assert resp.json() == {"updated": 0}
 
 
 async def test_increment_recall_missing_field_422(storage_http):
-    resp = await storage_http.post(f"{_PREFIX}/memories/increment-recall", json={})
+    resp = await storage_http.post(
+        f"{_PREFIX}/memories/increment-recall",
+        json={"tenant_id": _t()},
+    )
     assert resp.status_code == 422
+
+
+async def test_increment_recall_missing_tenant_422s_without_updating(storage_http):
+    victim = await _seed_memory(tenant_id=new_tenant_id())
+
+    resp = await storage_http.post(
+        f"{_PREFIX}/memories/increment-recall",
+        json={"memory_ids": [victim]},
+    )
+
+    assert resp.status_code == 422
+    assert await _recall_count(victim) == 0
+
+
+async def test_increment_recall_only_updates_callers_tenant(storage_http):
+    caller_tenant = new_tenant_id()
+    owned = await _seed_memory(tenant_id=caller_tenant)
+    foreign = await _seed_memory(tenant_id=new_tenant_id())
+
+    resp = await storage_http.post(
+        f"{_PREFIX}/memories/increment-recall",
+        json={"tenant_id": caller_tenant, "memory_ids": [owned, foreign]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"updated": 1}
+    assert await _recall_count(owned) == 1
+    assert await _last_recalled_at(owned) is not None
+    assert await _recall_count(foreign) == 0
+    assert await _last_recalled_at(foreign) is None
 
 
 async def test_increment_recall_non_list_422(storage_http):
     resp = await storage_http.post(
         f"{_PREFIX}/memories/increment-recall",
-        json={"memory_ids": "not-a-list"},
+        json={"tenant_id": _t(), "memory_ids": "not-a-list"},
+    )
+    assert resp.status_code == 422
+
+
+async def test_increment_recall_non_object_body_422(storage_http):
+    resp = await storage_http.post(
+        f"{_PREFIX}/memories/increment-recall",
+        json=[],
     )
     assert resp.status_code == 422
 
@@ -199,7 +242,7 @@ async def test_increment_recall_non_list_422(storage_http):
 async def test_increment_recall_invalid_uuid_422(storage_http):
     resp = await storage_http.post(
         f"{_PREFIX}/memories/increment-recall",
-        json={"memory_ids": ["not-a-uuid"]},
+        json={"tenant_id": _t(), "memory_ids": ["not-a-uuid"]},
     )
     assert resp.status_code == 422
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -543,7 +543,7 @@ async def test_report_value_highlights_ranked_by_recall(client):
         )
     # Bump the older memory's lifetime recall so it is the top by recall.
     for _ in range(3):
-        assert await sc.increment_recall([older]) == 1
+        assert await sc.increment_recall([older], tenant_id=tenant_id) == 1
 
     resp = await client.get(
         "/api/v1/reports",
@@ -598,8 +598,8 @@ async def test_report_quality_metrics(client):
     await _seed(client, headers, tenant_id, fleet, a1, "episode", 1)
     # Reuse: d1 twice, f1 once → 2 of 4 durable memories ever reused; 3 total recalls.
     for _ in range(2):
-        assert await sc.increment_recall([d1]) == 1
-    assert await sc.increment_recall([f1]) == 1
+        assert await sc.increment_recall([d1], tenant_id=tenant_id) == 1
+    assert await sc.increment_recall([f1], tenant_id=tenant_id) == 1
 
     resp = await client.get(
         "/api/v1/reports",

--- a/tests/test_track_recalls_agentless.py
+++ b/tests/test_track_recalls_agentless.py
@@ -16,7 +16,11 @@ def _row():
 
 def _ctx(caller_agent_id):
     return PipelineContext(
-        data={"caller_agent_id": caller_agent_id, "filtered_rows": [_row(), _row()]}
+        data={
+            "caller_agent_id": caller_agent_id,
+            "filtered_rows": [_row(), _row()],
+            "tenant_id": "test-tenant-track-recalls-agentless",
+        }
     )
 
 


### PR DESCRIPTION
## Summary

- require a binding `tenant_id` at the recall-increment client, route, and service boundaries
- constrain the UPDATE with `Memory.tenant_id == tenant_id` and propagate the tenant from every production caller
- reject missing or non-object tenant-bearing request bodies with 422
- add mixed-tenant and tenant-forwarding regressions
- regenerate the tenancy allowlist, removing only the #1088 method and route entries

## Risk framing

Current production callers derive memory IDs from tenant-scoped reads, so those paths were already safe. The storage method and direct route still relied on that caller-side guarantee: a direct or future caller could increment recall metadata for another tenant by UUID. This moves the guarantee into the query. Recall metadata feeds ranking; this PR makes no claim of observed exploitation.

## Regression proof

With only `Memory.tenant_id == tenant_id` removed from the UPDATE, the mixed-tenant regression fails:

```text
FAILED tests/test_fix2_cleanup_storage.py::test_increment_recall_only_updates_callers_tenant
E   AssertionError: assert {"updated": 2} == {"updated": 1}
E     {"updated": 2} != {"updated": 1}
```

After restoring the predicate, the same test passes.

## Validation

- affected root files: 79 passed
- full root suite after rebase: 5707 passed, 4 skipped, 16 deselected, 1 xfailed
- core-storage-api: 267 passed
- core-operations: 50 passed, coverage floor met
- core-worker: 80 passed, coverage floor met
- core-api and core-storage-api coverage floors met
- all Ruff check and format scopes passed
- all six mypy scopes passed
- all four Python packages built
- tenant-scope gate passed

Allowlist on current main: 98 total, 4 `id-addressed-write`. This PR: 96 total, 2 `id-addressed-write`. All 35 `opaque-body-write` notes survive regeneration.

Closes #1088