### PR TITLE
fix(storage): scope report finalization to the owning tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2798,8 +2798,15 @@ class CoreStorageClient:
         """
         return await self._get(f"/reports/{report_id}", read=read)
 
-    async def update_report(self, report_id: str, data: dict) -> dict | None:
-        return await self._patch(f"/reports/{report_id}", data)
+    async def update_report(self, report_id: str, data: dict, *, tenant_id: str) -> dict | None:
+        """Finalize a report. ``tenant_id`` scopes the UPDATE and is required.
+
+        Keyword-only and outside ``data`` so every caller is checked statically
+        rather than at the 422: a report id alone used to be enough to finalize
+        any tenant's report. It is merged last so a stray ``tenant_id`` left in
+        ``data`` cannot override the one the caller passed deliberately.
+        """
+        return await self._patch(f"/reports/{report_id}", {**data, "tenant_id": tenant_id})
 
     async def find_running_report(
         self,

--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -210,6 +210,7 @@ async def start_crystallization(
                     "completed_at": datetime.now(UTC).isoformat(),
                     "summary": {"error": "could not queue the crystallization run"},
                 },
+                tenant_id=tenant_id,
             )
         except BaseException:
             # Same best-effort rule as the run's own guard: this must not replace
@@ -467,6 +468,7 @@ async def _execute_crystallization(
                 "issues": issues,
                 "crystallization": crystallization,
             },
+            tenant_id=tenant_id,
         )
 
         logger.info(
@@ -492,6 +494,7 @@ async def _execute_crystallization(
                     "completed_at": datetime.now(UTC).isoformat(),
                     "duration_ms": int((time.monotonic() - t0) * 1000),
                 },
+                tenant_id=tenant_id,
             )
         except BaseException:
             # ``BaseException``, matching the outer handler, and for the same

--- a/core-storage-api/src/core_storage_api/routers/reports.py
+++ b/core-storage-api/src/core_storage_api/routers/reports.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
 
+from core_storage_api.routers._validation import _require
 from core_storage_api.schemas import AGENT_DIGEST_FIELDS, REPORT_FIELDS, orm_to_dict
 from core_storage_api.services.postgres_service import PostgresService
 
@@ -137,11 +138,20 @@ async def get_report(report_id: UUID) -> dict:
 
 @router.patch("/{report_id}")
 async def update_report(report_id: UUID, request: Request) -> dict:
+    """Finalize a report. Body: ``{tenant_id, status, completed_at, duration_ms, …}``.
+
+    ``tenant_id`` is the report's owning tenant and scopes the UPDATE. It is
+    required rather than optional: without it this took a bare primary key, so
+    anyone who could reach the port and knew a UUID could finalize another
+    tenant's report and substitute its entire contents.
+    """
     body: dict = await request.json()
+    tenant_id = _require(body, "tenant_id")
     from datetime import datetime
 
-    await _svc.report_update_completed(
+    updated = await _svc.report_update_completed(
         report_id,
+        tenant_id=tenant_id,
         status=body["status"],
         completed_at=datetime.fromisoformat(body["completed_at"])
         if isinstance(body.get("completed_at"), str)
@@ -154,4 +164,6 @@ async def update_report(report_id: UUID, request: Request) -> dict:
         issues=body.get("issues", []),
         crystallization=body.get("crystallization", {}),
     )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Report not found")
     return {"ok": True}

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -10154,6 +10154,7 @@ class PostgresService:
         self,
         report_id: UUID,
         *,
+        tenant_id: str,
         status: str,
         completed_at: datetime,
         duration_ms: int,
@@ -10163,11 +10164,24 @@ class PostgresService:
         usage_data: dict,
         issues: list,
         crystallization: dict,
-    ) -> None:
+    ) -> bool:
+        """Finalize one report. ``False`` when no row matches both id and tenant.
+
+        ``tenant_id`` is part of the predicate, so a report belonging to another
+        tenant is indistinguishable from one that does not exist — the caller
+        turns both into the same 404 rather than confirming the id is real.
+
+        The SET clause is assembled from the keyword arguments above, so no
+        caller-supplied key reaches it and neither ``id`` nor ``tenant_id`` is
+        writable through this path.
+        """
         async with get_session() as session:
-            await session.execute(
+            result = await session.execute(
                 sql_update(CrystallizationReport)
-                .where(CrystallizationReport.id == report_id)
+                .where(
+                    CrystallizationReport.id == report_id,
+                    CrystallizationReport.tenant_id == tenant_id,
+                )
                 .values(
                     status=status,
                     completed_at=completed_at,
@@ -10180,6 +10194,7 @@ class PostgresService:
                     crystallization=crystallization,
                 )
             )
+            return (result.rowcount or 0) > 0  # type: ignore[attr-defined]
 
     async def report_list_by_tenant(
         self,

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -236,13 +236,6 @@
       "category": "id-addressed-read"
     },
     {
-      "id": "method:report_update_completed",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1082."
-    },
-    {
       "id": "method:tenant_usage_increment",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -431,13 +424,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "no-tenant-data"
-    },
-    {
-      "id": "route:PATCH /api/v1/storage/reports/{report_id}",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-write",
-      "note": "Tracked in #1082."
     },
     {
       "id": "route:POST /api/v1/storage/agents",

--- a/core-storage-api/tests/test_report_update_tenant_scope.py
+++ b/core-storage-api/tests/test_report_update_tenant_scope.py
@@ -1,0 +1,185 @@
+"""``PATCH /reports/{report_id}`` must be told which tenant's report it completes.
+
+The write form of GHSA-wgvw-28pq-jc36 on crystallization reports. The route took
+a bare UUID and ``report_update_completed`` matched on the primary key alone, so
+a caller who knew an id could finalize another tenant's report through a service
+that authenticates nothing.
+
+This path writes more than most: ``status``, ``completed_at``, ``duration_ms``
+and six JSONB blobs --- ``summary``, ``hygiene``, ``health``, ``usage_data``,
+``issues``, ``crystallization`` --- every one of them straight from the body. So
+the reachable outcome is substitution rather than disclosure: a victim's report
+could be marked ``completed`` carrying an attacker's scores and issue list, and
+the tenant reading their own dashboard would see exactly that. It is the
+data-integrity half the issue calls out, and it is why this one mattered more
+than its read-side sibling.
+
+Marking a *running* report ``completed`` has a second effect, because
+``report_find_running`` is the short-circuit that serialises crystallization: it
+matches ``status == "running"``, so flipping that column out from under a live
+run releases the lock and lets a concurrent run start.
+
+``tenant_id`` is now required --- 422 when absent, rather than falling back to
+"update by primary key" --- and is part of the UPDATE predicate, so another
+tenant's report is indistinguishable from one that does not exist.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def _report(client: AsyncClient, tenant_id: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/reports",
+        json={"tenant_id": tenant_id, "trigger": "manual"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _read(client: AsyncClient, report_id: str) -> dict:
+    """Read the row back regardless of tenant, to assert what actually persisted.
+
+    Deliberately goes through ``GET /reports/{report_id}``, which is still
+    unscoped (allowlisted ``id-addressed-read``) and so answers for any tenant
+    --- that is what makes it a usable oracle here. When that route gains a
+    required tenant, this helper needs one too.
+    """
+    resp = await client.get(f"{PREFIX}/reports/{report_id}")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _completion(**extra: object) -> dict:
+    """A well-formed completion body, minus whatever the caller overrides."""
+    return {
+        "status": "completed",
+        "completed_at": datetime.now(UTC).isoformat(),
+        "duration_ms": 1234,
+        **extra,
+    }
+
+
+class TestReportUpdateTenantScope:
+    async def test_another_tenants_report_is_not_completed(self, client: AsyncClient) -> None:
+        """The attack, stated as the request an attacker would send."""
+        victim = f"rep-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"rep-attacker-{uuid.uuid4().hex[:8]}"
+        report_id = await _report(client, victim)
+
+        resp = await client.patch(
+            f"{PREFIX}/reports/{report_id}",
+            json=_completion(
+                tenant_id=attacker,
+                summary={"overall_score": 3, "critical": 99},
+                issues=[{"severity": "critical", "message": "OWNED"}],
+                crystallization={"promoted": 0},
+            ),
+        )
+
+        assert resp.status_code == 404, resp.text
+        row = await _read(client, report_id)
+        assert row["status"] == "running", "the victim's report was finalized"
+        assert row["completed_at"] is None
+        assert row["duration_ms"] is None
+        # The substitution half: none of the caller-supplied content landed.
+        assert row["summary"] == {}
+        assert row["issues"] == []
+        assert row["crystallization"] == {}
+        # Naming a tenant you don't own re-points the predicate; it never moves
+        # the row into the tenant you named.
+        assert row["tenant_id"] == victim
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """No tenant used to mean "update by primary key"; it is now a 422.
+
+        Fail-closed matters more here than on the read paths: a caller that
+        simply forgot the field would otherwise get the old unscoped write and
+        no indication anything was wrong.
+        """
+        tenant = f"rep-{uuid.uuid4().hex[:8]}"
+        report_id = await _report(client, tenant)
+
+        resp = await client.patch(f"{PREFIX}/reports/{report_id}", json=_completion())
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+        assert (await _read(client, report_id))["status"] == "running"
+
+    async def test_own_report_is_completed(self, client: AsyncClient) -> None:
+        """The supported call still works, with every blob it is meant to write."""
+        tenant = f"rep-{uuid.uuid4().hex[:8]}"
+        report_id = await _report(client, tenant)
+
+        resp = await client.patch(
+            f"{PREFIX}/reports/{report_id}",
+            json=_completion(
+                tenant_id=tenant,
+                summary={"overall_score": 88},
+                hygiene={"orphans": 2},
+                health={"ok": True},
+                usage_data={"tokens": 41},
+                issues=[{"severity": "warning", "message": "stale"}],
+                crystallization={"promoted": 7},
+            ),
+        )
+
+        assert resp.status_code == 200, resp.text
+        row = await _read(client, report_id)
+        assert row["status"] == "completed"
+        assert row["duration_ms"] == 1234
+        assert row["completed_at"] is not None
+        assert row["summary"] == {"overall_score": 88}
+        assert row["hygiene"] == {"orphans": 2}
+        assert row["health"] == {"ok": True}
+        assert row["usage_data"] == {"tokens": 41}
+        assert row["issues"] == [{"severity": "warning", "message": "stale"}]
+        assert row["crystallization"] == {"promoted": 7}
+        assert row["tenant_id"] == tenant
+
+    async def test_a_foreign_id_is_indistinguishable_from_a_missing_one(self, client: AsyncClient) -> None:
+        """Both 404, so the endpoint is not an existence oracle for report UUIDs."""
+        victim = f"rep-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"rep-attacker-{uuid.uuid4().hex[:8]}"
+        report_id = await _report(client, victim)
+
+        body = _completion(tenant_id=attacker)
+        foreign = await client.patch(f"{PREFIX}/reports/{report_id}", json=body)
+        missing = await client.patch(f"{PREFIX}/reports/{uuid.uuid4()}", json=body)
+
+        assert foreign.status_code == missing.status_code == 404
+        assert foreign.json() == missing.json()
+
+    async def test_the_crystallization_lock_is_not_released_by_another_tenant(
+        self, client: AsyncClient
+    ) -> None:
+        """The availability half, pinned through the query that actually reads it.
+
+        ``report_find_running`` is what ``run_crystallization`` consults to
+        decide a run is already in flight. It matches on ``status``, so a
+        cross-tenant flip to ``completed`` used to release that lock while the
+        real run was still going.
+        """
+        victim = f"rep-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"rep-attacker-{uuid.uuid4().hex[:8]}"
+        report_id = await _report(client, victim)
+
+        running = await client.get(f"{PREFIX}/reports/running", params={"tenant_id": victim})
+        assert running.status_code == 200, running.text
+        assert running.json()["id"] == report_id, "precondition: the lock is held"
+
+        resp = await client.patch(f"{PREFIX}/reports/{report_id}", json=_completion(tenant_id=attacker))
+
+        assert resp.status_code == 404, resp.text
+        still = await client.get(f"{PREFIX}/reports/running", params={"tenant_id": victim})
+        assert still.status_code == 200, "the crystallization lock was released"
+        assert still.json()["id"] == report_id

--- a/tests/test_tenant_scope_gate.py
+++ b/tests/test_tenant_scope_gate.py
@@ -142,8 +142,9 @@ def test_the_id_addressed_backlog_is_split_by_blast_radius() -> None:
     """Reads and writes by bare UUID are not the same finding and are not filed as one.
 
     The flat category let "another tenant's row can be DELETED by UUID" sit in
-    the same count as "another tenant's row can be READ by UUID". The split is
-    the forcing function: the mutating half is what gets fixed first.
+    the same count as "another tenant's row can be READ by UUID". The split was
+    the forcing function: the mutating half got fixed first, and as of #1082 the
+    write half is empty. The read half is still the backlog.
     """
     listed = json.loads(ALLOWLIST.read_text())["exceptions"]
     used = {e["category"] for e in listed}
@@ -151,8 +152,26 @@ def test_the_id_addressed_backlog_is_split_by_blast_radius() -> None:
     assert {"id-addressed-write", "id-addressed-read"} <= set(gate.CATEGORIES)
     assert gate.DESTRUCTIVE_CATEGORIES <= gate.BACKLOG_CATEGORIES
 
-    writes = [e for e in listed if e["category"] == "id-addressed-write"]
-    assert writes, "an empty write backlog means the split silently collapsed"
+    # There is deliberately no assertion that the write list is non-empty. It
+    # used to read ``assert writes, "an empty write backlog means the split
+    # silently collapsed"``, which held while the backlog was being worked
+    # through and became false the moment it was cleared: the census fails on
+    # the success case. Do not restore it — it would go red on green.
+    #
+    # Every route to an empty write list OTHER than the work being done is
+    # already covered, and each by a check that does not expire:
+    #
+    #   the category dropped altogether  -> the CATEGORIES assertion above
+    #   an entry carrying a bogus one    -> test_every_allowlist_entry_claims_
+    #                                       a_known_category, which also names
+    #                                       the offending entry
+    #   an entry relabelled as milder    -> ratchet's relabel guard, pinned by
+    #                                       test_ratchet_fails_when_a_mutating_
+    #                                       path_is_relabelled_as_a_read
+    #   an entry quietly appended        -> the allowlist ratchet
+    #
+    # which leaves deletion as the only way to reach zero, and deletion is what
+    # fixing one looks like.
 
 
 def test_a_multi_line_error_survives_as_one_annotation() -> None:


### PR DESCRIPTION
## Summary

- Require a non-empty `tenant_id` on `PATCH /api/v1/storage/reports/{report_id}` and bind the finalization UPDATE to it, so a report belonging to another tenant is indistinguishable from one that does not exist.
- Thread the owning tenant through `CoreStorageClient.update_report` as a keyword-only argument and the three `crystallizer_service` call sites.
- Remove the fixed method and route from the tenant-scope allowlist.

## Related Issue

Closes #1082.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## What was reachable

The route took a bare UUID and `report_update_completed` matched on the primary key alone. `core-storage-api` authenticates no request (GHSA-wgvw-28pq-jc36) and docker-compose publishes it on `0.0.0.0:8002`, so knowing a report id was enough.

This path writes more than most: `status`, `completed_at`, `duration_ms` and six JSONB blobs — `summary`, `hygiene`, `health`, `usage_data`, `issues`, `crystallization` — every one straight from the body. The outcome is **substitution, not disclosure**: a victim's report marked `completed` carrying an attacker's scores and issue list, which that tenant then reads off their own dashboard as their own crystallization result.

There is a second effect. `report_find_running` is the short-circuit that serialises crystallization, and it matches `status == "running"` — so flipping that column out from under a live run releases the lock and lets a concurrent run start. That is pinned by its own test, through the query that actually reads it rather than by asserting on the column.

## Why `_require` rather than an inline check

The allowlist's `blind-spot` category is for paths that *are* scoped but by an idiom the gate's AST pass cannot read — "an inline `if not isinstance(...): raise` rather than the shared `_require` guard" — and it says to prefer rewriting such a guard to use `_require`. Hand-rolling the check here would have scoped the route while leaving the gate unable to see it, which means an allowlist entry instead of a deletion. Using the shared helper is what makes the route count as bound: 286 bound, up from 284.

## How Has This Been Tested?

All four security assertions fail on the parent commit; the happy-path guard passes either way, which is the point of including it:

```text
FAILED test_another_tenants_report_is_not_completed
FAILED test_omitted_tenant_id_is_rejected
FAILED test_a_foreign_id_is_indistinguishable_from_a_missing_one
FAILED test_the_crystallization_lock_is_not_released_by_another_tenant
4 failed, 1 passed
```

with the cross-tenant case reading:

```text
>       assert resp.status_code == 404, resp.text
E       AssertionError: {"ok":true}
E       assert 200 == 404
```

With the fix:

| check | result |
|---|---|
| `core-storage-api/tests/` | 272 passed |
| root `tests/` | 5717 passed, 4 skipped, 1 xfailed |
| `core-api/tests/` | 52 passed |
| `ruff check` — core-api/src, core-storage-api/src, core-storage-api/tests | all pass |
| `ruff format --check` — same three scopes | all pass |
| `mypy src/` — core-storage-api (85), core-api (203) | both clean |
| `scripts/tenant_scope_gate.py --base origin/main` | exit 0, "Allowlist shrank by 2" |

`tests/test_unknown_field_rejection.py::test_memory_update_rejects_unknown_field` — the test filed in #1137 — failed **once in six** full-suite runs on this tree, and passed in isolation. That matches the rate measured when #1137 was filed (1 of 4 on a clean baseline). I did not manage to capture a traceback for this occurrence, so I am calling it as that flake on the rate and on the fact that this diff touches only the reports path, not on a mechanism confirmed in this run.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally
- [ ] I have updated relevant documentation (no user-facing surface changed; this is an internal storage endpoint)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (not user-facing; release-please derives this fix from the conventional commit)

## Additional Notes

- Allowlist: 98 entries before, 96 after. `id-addressed-write`: 4 before, 2 after — the write half of the backlog is nearly clear.
- The SET clause is assembled from named keyword arguments, so no caller-supplied key reaches it and neither `id` nor `tenant_id` is writable through this path. The defect class of #1081 / #1118 / #1121 does not apply here.
- `tenant_id` is keyword-only on the client and merged into the body **last**, so a stray `tenant_id` left in `data` cannot override the one the caller passed deliberately. Keyword-only also means the existing `update_report` assertions in `tests/test_crystallization_must_not_wedge.py`, which read `await_args_list[0].args[1]`, keep resolving to the data dict.
- All three `crystallizer_service` call sites already had the tenant in scope; none needed new plumbing.
