### PR TITLE
chore(storage): delete the unreachable entity_get_entity_links_for_memories

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -5980,19 +5980,6 @@ class PostgresService:
             result = await session.execute(stmt)
             return list(result.all())  # type: ignore[arg-type]
 
-    async def entity_get_entity_links_for_memories(
-        self,
-        memory_ids: list[UUID],
-    ) -> list[MemoryEntityLink]:
-        """Return all MemoryEntityLink rows for the given memory IDs."""
-        if not memory_ids:
-            return []
-        async with get_session() as session:
-            result = await session.execute(
-                select(MemoryEntityLink).where(MemoryEntityLink.memory_id.in_(memory_ids))
-            )
-            return list(result.scalars().all())
-
     async def entity_get_memory_ids_by_entity_ids(
         self,
         entity_ids: list[UUID],

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -93,13 +93,6 @@
       "category": "id-addressed-read"
     },
     {
-      "id": "method:entity_get_entity_links_for_memories",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read",
-      "note": "Join table has no tenant column; rows are tenant-scoped only via the ids."
-    },
-    {
       "id": "method:entity_get_memory_ids_by_entity_ids",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",


### PR DESCRIPTION
First of three clearing the five `id-addressed-read` allowlist entries that share the note *"Join table has no tenant column; rows are tenant-scoped only via the ids"* — the read siblings of #1085 / #1124, whose write halves landed in #1148, #1152 and #1156.

### Does this method need to exist?

Asked first, because the precedent on this exact table is #1091, closed 30 August: `entity_delete_entity_links` was **deleted, not scoped**, once a search found no caller.

This one is the same case. A repo-wide search across every file type finds exactly two references to `entity_get_entity_links_for_memories`:

```
core-storage-api/src/core_storage_api/services/postgres_service.py:5975:    async def entity_get_entity_links_for_memories(
core-storage-api/tenant_scope_allowlist.json:96:      "id": "method:entity_get_entity_links_for_memories",
```

Its own definition, and the allowlist entry recording that it is unscoped. No route, no service, no client wrapper, no test, no script, no doc.

It is also a near-duplicate of the live `memory_get_entity_links_for_memories`: the same query — `select(MemoryEntityLink).where(MemoryEntityLink.memory_id.in_(memory_ids))` — differing only in return shape (a flat list of ORM rows rather than a dict keyed by memory id). The memory-side one is what `POST /memories/entity-links` actually calls, and it is scoped in the next PR of this set.

So this is an unscoped read of the tenantless join table sitting in the class waiting for someone to wire it up — which is worse than a used one, because it will be adopted by whoever needs "the existing helper". That is the argument #1091 accepted. If a flat-list variant is wanted later it should be written with a tenant parameter from the start.

### Why there is no test

There is nothing to test: no caller to regress and no behaviour to pin. A test asserting the method is absent would only restate the diff. What guards this is the tenant-scope gate — the entry is gone from the allowlist, and the gate's stale-entry check (`tenant_scope_gate.py:1060-1063`) fails if the method comes back unscoped without one.

Both suites were run to confirm nothing depended on it: `core-storage-api/tests/` 267 passed, root `tests/` 5734 passed, 4 skipped, 1 xfailed.

### Allowlist

96 → 95 entries; `id-addressed-read` 22 → 21. Regenerated with `python3 scripts/tenant_scope_gate.py --write` in this commit, as the gate requires. (96, not 98, because #1146 removed two entries after this branch was cut — rebased onto it and regenerated. This PR's own contribution is one entry.) The method count in the gate's summary drops 191 → 190, which is the deletion.

### The remaining four, for context

They are live and get the predicate rather than deletion. Split into two follow-up PRs so the delete-vs-scope decision on one of them is reviewable on its own:

| method | route | status |
|---|---|---|
| `memory_get_entity_links_for_memories` | `POST /memories/entity-links` | live — 3 core-api callers |
| `entity_get_memory_ids_by_entity_ids` | `POST /entities/memory-ids-by-entity-ids` | live — 3 core-api callers |
| `entity_count_memories_per_entity` | `POST /entities/count-memories` | live — 2 core-api callers, and **the client already sends `tenant_id` in the body while the route reads only `entity_ids`** |
| `entity_find_entity_link` | `GET /entities/links/find` | **no production caller** — the two core-api mentions are comments describing the flow `entity_bulk_upsert_links` replaced. Delete-vs-scope gets its own PR |

### Verification

- `core-storage-api/tests/`: 267 passed.
- Root `tests/`: 5734 passed, 4 skipped, 1 xfailed.
- `ruff check` / `ruff format --check` at CI's scopes: clean.
- `mypy` core-storage-api, 85 files: no issues.
- Tenant-scope gate against `origin/main`: green, "Allowlist shrank by 1". Legacy-name ratchet: no new lines.

Run against a dedicated local pgvector instance provisioned CI's way (`alembic upgrade head` on the root database, a separate database for the storage suite). **Not checked:** anything requiring CI's own environment — the Actions matrix, the coverage floors step, the enterprise re-vendor path.
