### PR TITLE
fix(storage): scope the entity-link reads to the caller's tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -980,8 +980,16 @@ class CoreStorageClient:
     async def get_entity_links_for_memories(
         self,
         memory_ids: list[str],
+        tenant_id: str,
     ) -> dict:
-        return await self._post("/memories/entity-links", {"memory_ids": memory_ids}, read=True)  # type: ignore[return-value]
+        # Memories are addressed by bare UUID, so the tenant travels with them.
+        # Storage restricts each link to rows whose memory AND entity are both
+        # in it, so a memory outside the tenant is absent from the result.
+        return await self._post(  # type: ignore[return-value]
+            "/memories/entity-links",
+            {"memory_ids": memory_ids, "tenant_id": tenant_id},
+            read=True,
+        )
 
     async def get_memory_stats(
         self,
@@ -1499,10 +1507,14 @@ class CoreStorageClient:
     async def get_memory_ids_by_entity_ids(
         self,
         entity_ids: list[str],
+        tenant_id: str,
     ) -> list[dict]:
+        # The returned memory ids get fetched next, so an unscoped call handed
+        # this caller other tenants' rows to look up. Storage restricts each
+        # link to rows with both ends in ``tenant_id``.
         result = await self._post(
             "/entities/memory-ids-by-entity-ids",
-            {"entity_ids": entity_ids},
+            {"entity_ids": entity_ids, "tenant_id": tenant_id},
         )
         return result  # type: ignore[return-value]
 

--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -381,6 +381,7 @@ class ClassifyQuery:
         # Returns list of {"memory_id", "entity_id", "role"} dicts.
         raw_links = await sc.get_memory_ids_by_entity_ids(
             [str(eid) for eid in all_entity_ids],
+            tenant_id,
         )
 
         # Sort by hop distance so closest entities are processed first.

--- a/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
+++ b/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
@@ -114,6 +114,7 @@ async def _entity_boost_via_storage(
 
             raw_links = await sc.get_memory_ids_by_entity_ids(
                 [str(eid) for eid in all_entity_ids],
+                tenant_id,
             )
 
             # Sort by hop order (closest entities first).

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1671,7 +1671,7 @@ async def _bounded_gather(coros, limit=_ENTITY_CTX_FANOUT_LIMIT):
     return await asyncio.gather(*(_run(c) for c in coros))
 
 
-async def _fetch_entity_context(sc, memory_id: str) -> list[dict]:
+async def _fetch_entity_context(sc, memory_id: str, tenant_id: str) -> list[dict]:
     """Fetch and denormalise ``MemoryEntityLink`` rows for a single memory.
 
     Two storage round-trips at worst:
@@ -1686,7 +1686,7 @@ async def _fetch_entity_context(sc, memory_id: str) -> list[dict]:
     function never raises on missing data.
     """
     try:
-        links_by_mem = await sc.get_entity_links_for_memories([memory_id])
+        links_by_mem = await sc.get_entity_links_for_memories([memory_id], tenant_id)
     except Exception as e:
         logger.warning(
             "Path C entity-context fetch failed (links) for memory %s: %s",
@@ -1985,7 +1985,10 @@ async def _attempt_path_c_retraction(
     if not retraction_target_id:
         return False
 
-    candidate = await sc.get_memory(str(retraction_target_id), str(new_memory["tenant_id"]))
+    # Bound once: both the candidate lookup and the entity-context fetches below
+    # are by bare id and must be scoped to the row's own tenant.
+    retraction_tenant_id = str(new_memory["tenant_id"])
+    candidate = await sc.get_memory(str(retraction_target_id), retraction_tenant_id)
     if not candidate or candidate.get("deleted_at") is not None:
         return False
     # Only retract rows still in the conflicted state Path A produced.
@@ -2016,8 +2019,8 @@ async def _attempt_path_c_retraction(
     try:
         new_entities, old_entities = await asyncio.wait_for(
             asyncio.gather(
-                _fetch_entity_context(sc, str(new_memory.get("id"))),
-                _fetch_entity_context(sc, str(candidate.get("id"))),
+                _fetch_entity_context(sc, str(new_memory.get("id")), retraction_tenant_id),
+                _fetch_entity_context(sc, str(candidate.get("id")), retraction_tenant_id),
             ),
             timeout=_CONTEXT_FETCH_TIMEOUT_SECONDS,
         )
@@ -2356,8 +2359,8 @@ async def detect_contradictions_by_entities_async(
                 fetched = await asyncio.wait_for(
                     _bounded_gather(
                         [
-                            _fetch_entity_context(sc, str(memory_id)),
-                            *(_fetch_entity_context(sc, str(c.get("id"))) for c in candidates),
+                            _fetch_entity_context(sc, str(memory_id), tenant_id),
+                            *(_fetch_entity_context(sc, str(c.get("id")), tenant_id) for c in candidates),
                         ]
                     ),
                     timeout=_CONTEXT_FETCH_TIMEOUT_SECONDS,

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -3860,7 +3860,7 @@ async def update_memory(
         )
 
     # Load entity links for response
-    links_data = await sc.get_entity_links_for_memories([str(memory_id)])
+    links_data = await sc.get_entity_links_for_memories([str(memory_id)], tenant_id)
     entity_links = [
         EntityLinkOut(entity_id=el.get("entity_id"), role=el.get("role"))
         for el in links_data.get(str(memory_id), [])
@@ -4231,7 +4231,9 @@ async def _entity_boost_pipeline(
         if matched_entity_ids:
             # Collect memories linked to discovered entities via storage client
             all_entity_ids = list(entity_hops.keys())
-            all_links_raw = await sc.get_memory_ids_by_entity_ids([str(eid) for eid in all_entity_ids])
+            all_links_raw = await sc.get_memory_ids_by_entity_ids(
+                [str(eid) for eid in all_entity_ids], tenant_id
+            )
 
             # Process links in hop order (closest entities first)
             all_links = [
@@ -4770,7 +4772,9 @@ async def _search_memories_legacy(
 
     # Fetch entity links for all result memories
     links_data = (
-        await sc.get_entity_links_for_memories([str(mid) for mid in memory_ids]) if memory_ids else {}
+        await sc.get_entity_links_for_memories([str(mid) for mid in memory_ids], tenant_id)
+        if memory_ids
+        else {}
     )
 
     results = []

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -470,16 +470,24 @@ async def find_entity_link(
 @router.post("/memory-ids-by-entity-ids")
 async def get_memory_ids_by_entity_ids(request: Request) -> list[dict]:
     body: dict = await request.json()
+    # This route's payload IS memory ids, and its caller looks them up next, so
+    # unscoped it handed out ids of other tenants' memories to fetch.
+    tenant_id = _require(body, "tenant_id")
     entity_ids = [UUID(eid) for eid in body["entity_ids"]]
-    links = await _svc.entity_get_memory_ids_by_entity_ids(entity_ids)
+    links = await _svc.entity_get_memory_ids_by_entity_ids(entity_ids, tenant_id)
     return [{"memory_id": str(mid), "entity_id": str(eid), "role": role} for mid, eid, role in links]
 
 
 @router.post("/count-memories")
 async def count_memories_per_entity(request: Request) -> dict:
     body: dict = await request.json()
+    # ``core-api``'s client has always sent ``tenant_id`` in this body; the route
+    # read only ``entity_ids`` and dropped it on the floor, so the count spanned
+    # every tenant sharing the entity. Nothing changes on the caller's side —
+    # this reads the field it was already being sent.
+    tenant_id = _require(body, "tenant_id")
     entity_ids = [UUID(eid) for eid in body["entity_ids"]]
-    counts = await _svc.entity_count_memories_per_entity(entity_ids)
+    counts = await _svc.entity_count_memories_per_entity(entity_ids, tenant_id)
     return {str(eid): count for eid, count in counts.items()}
 
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -608,8 +608,14 @@ async def mark_dedup_checked(request: Request) -> dict:
 @router.post("/entity-links")
 async def get_entity_links_for_memories(request: Request) -> dict:
     body: dict = await request.json()
+    # Read side of #1085: the body carried bare memory ids and no tenant, so
+    # knowing a UUID returned that memory's entity graph — and, on rows
+    # predating the write fixes, another tenant's entity ids with it. Memories
+    # outside the tenant are simply absent from the response, which is the same
+    # answer this route already gave for a memory with no links.
+    tenant_id = _require(body, "tenant_id")
     memory_ids = [UUID(mid) for mid in body["memory_ids"]]
-    links = await _svc.memory_get_entity_links_for_memories(memory_ids)
+    links = await _svc.memory_get_entity_links_for_memories(memory_ids, tenant_id)
     # Serialise UUID keys to strings
     return {
         str(k): [{"entity_id": str(el["entity_id"]), "role": el["role"]} for el in v]

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -372,6 +372,45 @@ _ENTITY_UPDATABLE_FIELDS = frozenset({"canonical_name", "entity_type", "attribut
 # word at a time. The true cause is logged, never returned.
 _LINK_REJECTED = "entity link rejected: memory_id or entity_id does not exist, or the link already exists"
 
+
+def _link_within_tenant(tenant_id: str) -> ColumnElement[bool]:
+    """Confine a ``memory_entity_links`` row to ``tenant_id``, via both parents.
+
+    ``memory_entity_links`` has no ``tenant_id``, so a link row carries no
+    predicate of its own — but both parents do (``Memory.tenant_id``,
+    ``Entity.tenant_id``). A row is visible to a tenant exactly when **both**
+    ends belong to it, which is the same invariant the write side enforces
+    (#1085, #1124): a link this tenant could not have created is a link it
+    cannot read.
+
+    Requiring both ends rather than only the one the caller named is what makes
+    this safe on historical data. Rows predating those fixes can still straddle
+    two tenants, and returning one would hand back the other tenant's memory or
+    entity UUID — so the end the caller did *not* name has to be checked too,
+    even though no new such row can be created.
+
+    Correlated ``EXISTS`` rather than a JOIN so this composes into any query
+    over ``MemoryEntityLink`` regardless of its select shape — the four readers
+    variously select the ORM row, three columns, or a ``count()`` aggregate, and
+    a join would change the grouping of the last one. Both subqueries are a
+    primary-key lookup plus an indexed ``tenant_id``.
+
+    Deliberately NOT ``_owned_link_endpoints`` (the write-side helper): that one
+    takes the two id sets up front, which a read does not have — it learns the
+    entity ids *from* the rows it is filtering. Fetching first and filtering in
+    Python would also pull other tenants' rows into the process, which this
+    avoids by keeping the predicate in SQL.
+    """
+    return and_(
+        select(Memory.id)
+        .where(Memory.id == MemoryEntityLink.memory_id, Memory.tenant_id == tenant_id)
+        .exists(),
+        select(Entity.id)
+        .where(Entity.id == MemoryEntityLink.entity_id, Entity.tenant_id == tenant_id)
+        .exists(),
+    )
+
+
 # Columns ``fleet_upsert_node``'s ON CONFLICT DO UPDATE must not rewrite. The
 # insert half of that statement still uses every key the caller sent; this is
 # only the branch that lands on a row that already exists.
@@ -4111,12 +4150,27 @@ class PostgresService:
     async def memory_get_entity_links_for_memories(
         self,
         memory_ids: list[UUID],
+        tenant_id: str,
     ) -> dict[UUID, list[dict]]:
+        """Links for these memories, restricted to ``tenant_id`` on both ends.
+
+        A memory outside the tenant is absent from the result rather than
+        rejected: the caller passes a list, and a per-id error would say which
+        of the ids exist elsewhere. Absent and "has no links" are already the
+        same answer here — the old code omitted link-less memories too — so the
+        result shape discloses nothing new.
+
+        See ``_link_within_tenant`` for why both ends are checked and not just
+        the memory side the caller named.
+        """
         if not memory_ids:
             return {}
         async with get_session() as session:
             result = await session.execute(
-                select(MemoryEntityLink).where(MemoryEntityLink.memory_id.in_(memory_ids))
+                select(MemoryEntityLink).where(
+                    MemoryEntityLink.memory_id.in_(memory_ids),
+                    _link_within_tenant(tenant_id),
+                )
             )
             links_by_memory: dict[UUID, list[dict]] = {}
             for link in result.scalars().all():
@@ -5949,14 +6003,29 @@ class PostgresService:
     async def entity_count_memories_per_entity(
         self,
         entity_ids: list[UUID],
+        tenant_id: str,
     ) -> dict[UUID, int]:
-        """Return {entity_id: count} for the given entity IDs."""
+        """Return {entity_id: count} for the given entity IDs, within ``tenant_id``.
+
+        The count is over links whose memory AND entity are both in the tenant,
+        so it is the number of the caller's own memories referencing the entity
+        — not a tenant-wide popularity figure. Without the memory side, an
+        entity shared by two tenants reported the other tenant's link count,
+        which is a row count for data the caller cannot read.
+
+        ``core-api``'s client has always sent ``tenant_id`` in the body for this
+        endpoint; the route read only ``entity_ids`` and dropped it. This is the
+        parameter it was already being handed.
+        """
         if not entity_ids:
             return {}
         async with get_session() as session:
             result = await session.execute(
                 select(MemoryEntityLink.entity_id, func.count())
-                .where(MemoryEntityLink.entity_id.in_(entity_ids))
+                .where(
+                    MemoryEntityLink.entity_id.in_(entity_ids),
+                    _link_within_tenant(tenant_id),
+                )
                 .group_by(MemoryEntityLink.entity_id)
             )
             return dict(result.all())  # type: ignore[arg-type]
@@ -5983,8 +6052,15 @@ class PostgresService:
     async def entity_get_memory_ids_by_entity_ids(
         self,
         entity_ids: list[UUID],
+        tenant_id: str,
     ) -> list[tuple[UUID, UUID, str]]:
-        """Return (memory_id, entity_id, role) tuples for the given entity IDs."""
+        """Return (memory_id, entity_id, role) tuples within ``tenant_id``.
+
+        This one returns memory ids, so the memory end is not incidental: it is
+        the payload. It feeds the search graph-boost path, which then fetches
+        those memories — unscoped, it handed the caller ids of memories in other
+        tenants to look up. Both ends are checked; see ``_link_within_tenant``.
+        """
         if not entity_ids:
             return []
         async with get_session() as session:
@@ -5992,7 +6068,10 @@ class PostgresService:
                 MemoryEntityLink.memory_id,
                 MemoryEntityLink.entity_id,
                 MemoryEntityLink.role,
-            ).where(MemoryEntityLink.entity_id.in_(entity_ids))
+            ).where(
+                MemoryEntityLink.entity_id.in_(entity_ids),
+                _link_within_tenant(tenant_id),
+            )
             result = await session.execute(stmt)
             return list(result.all())  # type: ignore[arg-type]
 

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -73,13 +73,6 @@
       "note": "Verified: every item carries tenant_id, which scopes updates, inserts, race recovery, and winner lookups."
     },
     {
-      "id": "method:entity_count_memories_per_entity",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read",
-      "note": "Join table has no tenant column; rows are tenant-scoped only via the ids."
-    },
-    {
       "id": "method:entity_find_entity_link",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -91,13 +84,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
       "category": "id-addressed-read"
-    },
-    {
-      "id": "method:entity_get_memory_ids_by_entity_ids",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read",
-      "note": "Join table has no tenant column; rows are tenant-scoped only via the ids."
     },
     {
       "id": "method:fleet_add_command",
@@ -194,13 +180,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
       "category": "cross-tenant-by-design"
-    },
-    {
-      "id": "method:memory_get_entity_links_for_memories",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read",
-      "note": "Join table has no tenant column; rows are tenant-scoped only via the ids."
     },
     {
       "id": "method:memory_list_null_embedding_rows",
@@ -466,18 +445,6 @@
       "note": "Verified: _REQUIRED_BASE requires tenant_id on every item and entity_bulk_upsert scopes every mutation to it."
     },
     {
-      "id": "route:POST /api/v1/storage/entities/count-memories",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-read"
-    },
-    {
-      "id": "route:POST /api/v1/storage/entities/memory-ids-by-entity-ids",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-read"
-    },
-    {
       "id": "route:POST /api/v1/storage/entities/relations",
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
@@ -578,12 +545,6 @@
       "evidence": "no binding tenant read from the request",
       "category": "opaque-body-write",
       "note": "Verified: body tenant_id is assigned directly to the DedupReview row by dedup_review_enqueue."
-    },
-    {
-      "id": "route:POST /api/v1/storage/memories/entity-links",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-read"
     },
     {
       "id": "route:POST /api/v1/storage/reports",

--- a/core-storage-api/tests/test_entity_link_reads_tenant_scope.py
+++ b/core-storage-api/tests/test_entity_link_reads_tenant_scope.py
@@ -1,0 +1,268 @@
+"""The three live reads over ``memory_entity_links`` must be told whose links to return.
+
+Read siblings of #1085 / #1124, whose write halves landed in #1148 and #1152.
+All three took bare UUIDs and read the tenantless join table with no predicate:
+
+* ``POST /memories/entity-links`` — a memory's entity graph, by memory id
+* ``POST /entities/memory-ids-by-entity-ids`` — memory ids, by entity id
+* ``POST /entities/count-memories`` — link counts, by entity id
+
+On a service that authenticates no request (GHSA-wgvw-28pq-jc36), published by
+docker-compose on 0.0.0.0:8002, knowing a UUID was enough to read the graph
+around it. These are disclosure rather than integrity — nothing here lets a
+caller change a row — but the counts and id lists are data about rows the caller
+cannot otherwise read, and the third one hands back memory ids its caller then
+fetches.
+
+**A row is visible to a tenant exactly when BOTH its ends belong to that
+tenant** — the same invariant the write side now enforces, so a link this tenant
+could not have created is a link it cannot read. Requiring both ends is what
+makes it safe on historical data: rows predating #1148 / #1152 can still
+straddle two tenants, and returning one would hand back the other tenant's
+memory or entity UUID.
+
+Both ends therefore get their own case per route. The named end is the obvious
+one; the *other* end is the one a single-direction test would miss, and each
+fails on its own when its half of ``_link_within_tenant`` is reverted.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX, _memory_payload
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _tenant() -> str:
+    """A tenant id unique to one test and visible to the end-of-run sweep.
+
+    The ``test-tenant-`` prefix is not cosmetic: the root suite's
+    ``_setup_schema`` teardown cleans with ``tenant_id LIKE 'test-tenant-%'``
+    (reaching this table through the ``memories`` subquery), so a tenant minted
+    with any other prefix is never reclaimed — which is how #858 left 9,186 rows
+    behind.
+    """
+    return f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+
+async def _memory(client: AsyncClient, tenant_id: str) -> str:
+    fleet_id = f"test-fleet-{uuid.uuid4().hex[:8]}"
+    resp = await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _entity(client: AsyncClient, tenant_id: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/entities",
+        json={
+            "tenant_id": tenant_id,
+            "entity_type": "person",
+            "canonical_name": f"LinkRead-{uuid.uuid4().hex[:8]}",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _force_link(memory_id: str, entity_id: str, role: str = "subject") -> None:
+    """Insert a link row directly, bypassing the scoped write path.
+
+    The whole point of these tests is a link whose two ends are in different
+    tenants, and #1148 / #1152 made that unwriteable through the API — correctly.
+    Historical rows like this exist in databases that predate those fixes, so the
+    row is fabricated in SQL to reproduce the state the reads must not disclose.
+    """
+    from sqlalchemy import text
+
+    from core_storage_api.services.postgres_service import get_session
+
+    async with get_session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO memory_entity_links (memory_id, entity_id, role) "
+                "VALUES (CAST(:mid AS uuid), CAST(:eid AS uuid), :role) "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"mid": memory_id, "eid": entity_id, "role": role},
+        )
+
+
+class TestMemoryEntityLinksRead:
+    """``POST /memories/entity-links``."""
+
+    async def _read(self, client: AsyncClient, memory_id: str, tenant_id: str) -> dict:
+        resp = await client.post(
+            f"{PREFIX}/memories/entity-links",
+            json={"memory_ids": [memory_id], "tenant_id": tenant_id},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+
+    async def test_a_foreign_memory_yields_nothing(self, client: AsyncClient) -> None:
+        """Named end: asking for someone else's memory returns no links."""
+        victim, attacker = _tenant(), _tenant()
+        victim_memory = await _memory(client, victim)
+        victim_entity = await _entity(client, victim)
+        await _force_link(victim_memory, victim_entity)
+
+        body = await self._read(client, victim_memory, attacker)
+
+        assert body.get(victim_memory, []) == [], "another tenant's entity graph was returned"
+
+    async def test_a_foreign_entity_is_not_disclosed(self, client: AsyncClient) -> None:
+        """Other end: the caller's OWN memory, linked to a foreign entity.
+
+        The memory is the attacker's, so the named end passes. Only the entity
+        belongs elsewhere — this is the case the entity half of the predicate
+        exists for, and the one a memory-side-only check would leak.
+        """
+        victim, attacker = _tenant(), _tenant()
+        attacker_memory = await _memory(client, attacker)
+        victim_entity = await _entity(client, victim)
+        await _force_link(attacker_memory, victim_entity)
+
+        body = await self._read(client, attacker_memory, attacker)
+
+        assert body.get(attacker_memory, []) == [], (
+            "a foreign entity's UUID was disclosed through the caller's own memory"
+        )
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        tenant = _tenant()
+        memory_id = await _memory(client, tenant)
+
+        resp = await client.post(f"{PREFIX}/memories/entity-links", json={"memory_ids": [memory_id]})
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+
+    async def test_own_links_are_returned(self, client: AsyncClient) -> None:
+        """The supported call still works."""
+        tenant = _tenant()
+        memory_id = await _memory(client, tenant)
+        first, second = await _entity(client, tenant), await _entity(client, tenant)
+        await _force_link(memory_id, first, "subject")
+        await _force_link(memory_id, second, "object")
+
+        body = await self._read(client, memory_id, tenant)
+
+        assert {link["entity_id"]: link["role"] for link in body[memory_id]} == {
+            first: "subject",
+            second: "object",
+        }
+
+
+class TestMemoryIdsByEntityIdsRead:
+    """``POST /entities/memory-ids-by-entity-ids``."""
+
+    async def _read(self, client: AsyncClient, entity_id: str, tenant_id: str) -> list[dict]:
+        resp = await client.post(
+            f"{PREFIX}/entities/memory-ids-by-entity-ids",
+            json={"entity_ids": [entity_id], "tenant_id": tenant_id},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+
+    async def test_a_foreign_entity_yields_no_memory_ids(self, client: AsyncClient) -> None:
+        """Named end: someone else's entity returns none of its memory ids."""
+        victim, attacker = _tenant(), _tenant()
+        victim_memory = await _memory(client, victim)
+        victim_entity = await _entity(client, victim)
+        await _force_link(victim_memory, victim_entity)
+
+        assert await self._read(client, victim_entity, attacker) == [], (
+            "another tenant's memory ids were returned"
+        )
+
+    async def test_a_foreign_memory_id_is_not_disclosed(self, client: AsyncClient) -> None:
+        """Other end: the caller's OWN entity, linked to a foreign memory.
+
+        This route's payload IS memory ids and its caller fetches them next, so
+        without the memory-side check it hands out ids to look up in a tenant the
+        caller cannot read.
+        """
+        victim, attacker = _tenant(), _tenant()
+        attacker_entity = await _entity(client, attacker)
+        victim_memory = await _memory(client, victim)
+        await _force_link(victim_memory, attacker_entity)
+
+        assert await self._read(client, attacker_entity, attacker) == [], (
+            "a foreign memory id was disclosed through the caller's own entity"
+        )
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            f"{PREFIX}/entities/memory-ids-by-entity-ids",
+            json={"entity_ids": [str(uuid.uuid4())]},
+        )
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+
+    async def test_own_links_are_returned(self, client: AsyncClient) -> None:
+        tenant = _tenant()
+        memory_id = await _memory(client, tenant)
+        entity_id = await _entity(client, tenant)
+        await _force_link(memory_id, entity_id, "subject")
+
+        assert await self._read(client, entity_id, tenant) == [
+            {"memory_id": memory_id, "entity_id": entity_id, "role": "subject"}
+        ]
+
+
+class TestCountMemoriesPerEntityRead:
+    """``POST /entities/count-memories``.
+
+    The client has always sent ``tenant_id`` in this body; the route read only
+    ``entity_ids`` and dropped it, so the count spanned every tenant sharing the
+    entity. Nothing changed on the caller's side.
+    """
+
+    async def _read(self, client: AsyncClient, entity_id: str, tenant_id: str) -> dict:
+        resp = await client.post(
+            f"{PREFIX}/entities/count-memories",
+            json={"entity_ids": [entity_id], "tenant_id": tenant_id},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+
+    async def test_a_foreign_entity_counts_nothing(self, client: AsyncClient) -> None:
+        """Named end: someone else's entity has no count for this caller."""
+        victim, attacker = _tenant(), _tenant()
+        victim_memory = await _memory(client, victim)
+        victim_entity = await _entity(client, victim)
+        await _force_link(victim_memory, victim_entity)
+
+        assert await self._read(client, victim_entity, attacker) == {}, (
+            "another tenant's link count was returned"
+        )
+
+    async def test_foreign_memories_are_not_counted(self, client: AsyncClient) -> None:
+        """Other end: the caller's own entity, plus links from foreign memories.
+
+        Two of the three links belong to another tenant's memories. Only the
+        caller's own may be counted — otherwise the number itself reports on rows
+        the caller cannot read, which is what an entity shared across tenants
+        would leak.
+        """
+        victim, attacker = _tenant(), _tenant()
+        shared_entity = await _entity(client, attacker)
+        await _force_link(await _memory(client, attacker), shared_entity)
+        await _force_link(await _memory(client, victim), shared_entity)
+        await _force_link(await _memory(client, victim), shared_entity)
+
+        assert await self._read(client, shared_entity, attacker) == {shared_entity: 1}, (
+            "the count included memories belonging to another tenant"
+        )
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            f"{PREFIX}/entities/count-memories", json={"entity_ids": [str(uuid.uuid4())]}
+        )
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text

--- a/core-storage-api/tests/test_entity_link_routes_tenant_scope.py
+++ b/core-storage-api/tests/test_entity_link_routes_tenant_scope.py
@@ -77,16 +77,33 @@ async def _entity(client: AsyncClient, tenant_id: str) -> str:
 
 
 async def _links(client: AsyncClient, memory_id: str) -> list[dict]:
-    """Read the links back regardless of tenant, to assert what actually persisted.
+    """Read the raw join table, tenant-blind, to assert what actually persisted.
 
-    Deliberately goes through ``POST /memories/entity-links``, which is still
-    unscoped (allowlisted ``id-addressed-read``) and so answers for any tenant —
-    that is what makes it a usable oracle here. When that route gains a required
-    tenant, this helper needs one too.
+    Reads ``memory_entity_links`` with SQL rather than through
+    ``POST /memories/entity-links``, which it used to use. That route is now
+    tenant-scoped and returns only rows whose memory AND entity are both in the
+    given tenant — precisely the rows these tests are checking for the ABSENCE
+    of. Asking it would answer "no links" for a cross-tenant row that exists,
+    so every assertion below would hold with the bug reintroduced.
+
+    ``client`` is unused but kept in the signature so the call sites read the
+    same and the helper stays swappable; the raw read is the point.
     """
-    resp = await client.post(f"{PREFIX}/memories/entity-links", json={"memory_ids": [memory_id]})
-    assert resp.status_code == 200, resp.text
-    return resp.json().get(memory_id, [])
+    from sqlalchemy import text
+
+    from core_storage_api.services.postgres_service import get_session
+
+    async with get_session() as session:
+        rows = (
+            await session.execute(
+                text(
+                    "SELECT entity_id, role FROM memory_entity_links "
+                    "WHERE memory_id = CAST(:mid AS uuid) ORDER BY entity_id"
+                ),
+                {"mid": memory_id},
+            )
+        ).all()
+    return [{"entity_id": str(entity_id), "role": role} for entity_id, role in rows]
 
 
 class TestSingleLinkRouteTenantScope:

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -1563,7 +1563,7 @@ class TestMemories:
         links_after_first = (
             await client.post(
                 f"{PREFIX}/memories/entity-links",
-                json={"memory_ids": [memory_id]},
+                json={"memory_ids": [memory_id], "tenant_id": tenant_id},
             )
         ).json()[memory_id]
         assert sorted(link["entity_id"] for link in links_after_first) == sorted(entity_ids)
@@ -1597,7 +1597,7 @@ class TestMemories:
         final_links = (
             await client.post(
                 f"{PREFIX}/memories/entity-links",
-                json={"memory_ids": [memory_id]},
+                json={"memory_ids": [memory_id], "tenant_id": tenant_id},
             )
         ).json()[memory_id]
         by_entity = {link["entity_id"]: link["role"] for link in final_links}

--- a/core-storage-api/tests/test_memory_entity_links_tenant_scope.py
+++ b/core-storage-api/tests/test_memory_entity_links_tenant_scope.py
@@ -72,16 +72,33 @@ async def _entity(client: AsyncClient, tenant_id: str) -> str:
 
 
 async def _links(client: AsyncClient, memory_id: str) -> list[dict]:
-    """Read the links back regardless of tenant, to assert what actually persisted.
+    """Read the raw join table, tenant-blind, to assert what actually persisted.
 
-    Deliberately goes through ``POST /memories/entity-links``, which is still
-    unscoped (allowlisted ``id-addressed-read``) and so answers for any tenant —
-    that is what makes it a usable oracle here. When that route gains a required
-    tenant, this helper needs one too.
+    Reads ``memory_entity_links`` with SQL rather than through
+    ``POST /memories/entity-links``, which it used to use. That route is now
+    tenant-scoped and returns only rows whose memory AND entity are both in the
+    given tenant — precisely the rows these tests are checking for the ABSENCE
+    of. Asking it would answer "no links" for a cross-tenant row that exists,
+    so every assertion below would hold with the bug reintroduced.
+
+    ``client`` is unused but kept in the signature so the call sites read the
+    same and the helper stays swappable; the raw read is the point.
     """
-    resp = await client.post(f"{PREFIX}/memories/entity-links", json={"memory_ids": [memory_id]})
-    assert resp.status_code == 200, resp.text
-    return resp.json().get(memory_id, [])
+    from sqlalchemy import text
+
+    from core_storage_api.services.postgres_service import get_session
+
+    async with get_session() as session:
+        rows = (
+            await session.execute(
+                text(
+                    "SELECT entity_id, role FROM memory_entity_links "
+                    "WHERE memory_id = CAST(:mid AS uuid) ORDER BY entity_id"
+                ),
+                {"mid": memory_id},
+            )
+        ).all()
+    return [{"entity_id": str(entity_id), "role": role} for entity_id, role in rows]
 
 
 class TestMemoryEntityLinkTenantScope:

--- a/tests/test_caura_129_entity_aware_retraction_prompt.py
+++ b/tests/test_caura_129_entity_aware_retraction_prompt.py
@@ -25,6 +25,13 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
+# ``_fetch_entity_context`` now takes the binding tenant, because the links read
+# it makes is tenant-scoped on both ends. These are pure-mock unit tests — no
+# database, no rows — so the value is only threaded through to the mock; the
+# ``test-tenant-`` prefix is kept for consistency with the suite's sweep
+# convention rather than out of necessity.
+TENANT = "test-tenant-fetch-entity-context"
+
 
 # ---------------------------------------------------------------------------
 # ENTITY_AWARE_CONTRADICTION_PROMPT template invariants
@@ -443,7 +450,7 @@ async def test_fetch_entity_context_composes_two_round_trips():
 
     sc.get_entity = AsyncMock(side_effect=get_entity)
 
-    out = await _fetch_entity_context(sc, mem_id)
+    out = await _fetch_entity_context(sc, mem_id, TENANT)
     by_name = {e["name"]: e for e in out}
     assert by_name["Project Helios"]["entity_type"] == "project"
     assert by_name["Project Helios"]["role"] == "subject"
@@ -460,7 +467,7 @@ async def test_fetch_entity_context_empty_when_no_links():
     sc.get_entity_links_for_memories = AsyncMock(return_value={mem_id: []})
     sc.get_entity = AsyncMock()
 
-    out = await _fetch_entity_context(sc, mem_id)
+    out = await _fetch_entity_context(sc, mem_id, TENANT)
     assert out == []
     sc.get_entity.assert_not_called()
 
@@ -480,7 +487,7 @@ async def test_fetch_entity_context_falls_back_to_name_if_no_canonical_name():
     sc.get_entity = AsyncMock(
         return_value={"name": "Legacy Entity", "entity_type": "project"}
     )
-    out = await _fetch_entity_context(sc, mem_id)
+    out = await _fetch_entity_context(sc, mem_id, TENANT)
     assert out[0]["name"] == "Legacy Entity"
 
 
@@ -494,7 +501,7 @@ async def test_fetch_entity_context_swallows_links_lookup_error():
     sc.get_entity_links_for_memories = AsyncMock(
         side_effect=RuntimeError("storage down")
     )
-    out = await _fetch_entity_context(sc, str(uuid4()))
+    out = await _fetch_entity_context(sc, str(uuid4()), TENANT)
     assert out == []
 
 
@@ -522,7 +529,7 @@ async def test_fetch_entity_context_swallows_per_entity_error():
         return {"canonical_name": "Fine Entity", "entity_type": "project"}
 
     sc.get_entity = AsyncMock(side_effect=get_entity)
-    out = await _fetch_entity_context(sc, mem_id)
+    out = await _fetch_entity_context(sc, mem_id, TENANT)
     assert len(out) == 1
     assert out[0]["name"] == "Fine Entity"
 

--- a/tests/test_entity_links_are_additive.py
+++ b/tests/test_entity_links_are_additive.py
@@ -27,11 +27,11 @@ from __future__ import annotations
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import select
+from core_storage_api.services.postgres_service import get_read_session
+from sqlalchemy import select, text
 
 from common.embedding import fake_embedding
 from common.models.audit import AuditLog
-from core_storage_api.services.postgres_service import PostgresService, get_read_session
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
@@ -76,8 +76,21 @@ async def _entity(sc, tenant: str, name: str) -> str:
 
 
 async def _links(memory_id: UUID) -> dict[str, str]:
-    by_entity = await PostgresService().memory_get_entity_links_for_memories([memory_id])
-    return {str(link["entity_id"]): link["role"] for link in by_entity.get(memory_id, [])}
+    """Read the raw join table, tenant-blind, to assert what actually persisted.
+
+    SQL rather than ``memory_get_entity_links_for_memories``, which is now
+    tenant-scoped on both ends. Everything here lives in one tenant so a scoped
+    read would agree today, but an oracle that filters by the same predicate the
+    code under test applies is one refactor away from asserting nothing.
+    """
+    async with get_read_session() as session:
+        rows = (
+            await session.execute(
+                text("SELECT entity_id, role FROM memory_entity_links WHERE memory_id = :mid"),
+                {"mid": memory_id},
+            )
+        ).all()
+    return {str(entity_id): role for entity_id, role in rows}
 
 
 async def _patch_links(memory_id: UUID, tenant: str, links: list[dict]) -> None:

--- a/tests/test_tenant_guard_byid_updates.py
+++ b/tests/test_tenant_guard_byid_updates.py
@@ -19,9 +19,10 @@ from uuid import UUID, uuid4
 
 import httpx
 import pytest
+from core_storage_api.services.postgres_service import PostgresService, get_read_session
+from sqlalchemy import text
 
 from common.embedding import fake_embedding
-from core_storage_api.services.postgres_service import PostgresService
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
@@ -180,10 +181,9 @@ async def test_update_memory_surfaces_a_refused_entity_link(sc):
     The memory here belongs to the caller; only the entity is foreign, so this
     is the entity half of the storage predicate seen from core-api.
     """
-    from fastapi import HTTPException
-
     from core_api.schemas import MemoryUpdate
     from core_api.services.memory_service import update_memory
+    from fastapi import HTTPException
 
     owner, stranger = _t(), _t()
     mem_id = UUID(await _seed_memory(sc, owner, embedding=fake_embedding("linkable")))
@@ -206,5 +206,15 @@ async def test_update_memory_surfaces_a_refused_entity_link(sc):
 
     assert exc.value.status_code == 422
     assert "entity_links" in str(exc.value.detail)
-    links = await PostgresService().memory_get_entity_links_for_memories([mem_id])
-    assert links.get(mem_id, []) == [], "the foreign entity was linked anyway"
+    # Raw SQL, not ``memory_get_entity_links_for_memories``: that method is now
+    # tenant-scoped on BOTH ends, so it would hide the very row this asserts is
+    # absent — a link from the owner's memory to the stranger's entity — and the
+    # assertion would hold even if the link had been written.
+    async with get_read_session() as session:
+        leaked = (
+            await session.execute(
+                text("SELECT count(*) FROM memory_entity_links WHERE memory_id = :mid"),
+                {"mid": mem_id},
+            )
+        ).scalar_one()
+    assert leaked == 0, "the foreign entity was linked anyway"


### PR DESCRIPTION
Second of three clearing the five `id-addressed-read` entries that share the note *"Join table has no tenant column; rows are tenant-scoped only via the ids"*. #1161 deleted the unreachable one; this scopes the three live ones.

Read siblings of #1085 / #1124, whose write halves landed in #1148 and #1152.

| route | method | core-api callers |
|---|---|---|
| `POST /memories/entity-links` | `memory_get_entity_links_for_memories` | 3 |
| `POST /entities/memory-ids-by-entity-ids` | `entity_get_memory_ids_by_entity_ids` | 3 |
| `POST /entities/count-memories` | `entity_count_memories_per_entity` | 2 |

All three took bare UUIDs and read the tenantless join table with no predicate. `core-storage-api` authenticates no request (GHSA-wgvw-28pq-jc36) and docker-compose publishes it on `0.0.0.0:8002`, so knowing a UUID was enough to read the graph around it.

**Stated no stronger than it is:** these are disclosure, not integrity — nothing here mutates a row. What leaks is id lists and counts describing rows the caller cannot otherwise read, and in one case memory ids that the caller then fetches. No issue was filed for these five; the wording here is mine, not an issue's.

### Does each need to exist?

Asked first, per #1091's precedent on this table. All three are live, established by searching for the method, the client wrapper and the route path separately: `memory_get_entity_links_for_memories` feeds the update response, Path C entity context and legacy search; `entity_get_memory_ids_by_entity_ids` feeds the search graph-boost path from two pipeline steps and `_entity_boost_pipeline`; `entity_count_memories_per_entity` feeds two entity routes. None is dead, none duplicated. They get the predicate.

### The shape: both ends, not just the named one

**A link row is visible to a tenant exactly when both its ends belong to that tenant** — the same invariant the write side now enforces, so a link this tenant could not have created is a link it cannot read.

Requiring the end the caller did *not* name is what makes this safe on historical data. Rows predating #1148 / #1152 can still straddle two tenants, and returning one hands back the other tenant's memory or entity UUID. Concretely, the case a named-end-only check leaks:

- `POST /memories/entity-links` on **your own** memory, linked to a **foreign** entity → discloses that entity's UUID.
- `POST /entities/memory-ids-by-entity-ids` on **your own** entity, linked to a **foreign** memory → hands you a memory id to fetch.
- `POST /entities/count-memories` on **your own** entity → the count included other tenants' memories, so the number itself reports on unreadable rows.

`_link_within_tenant` holds the predicate as a correlated `EXISTS` pair rather than a join, so it composes into all three queries regardless of select shape — ORM row, three columns, and a `count()` aggregate, where a join would change the grouping. Both subqueries are a primary-key lookup plus an indexed `tenant_id`.

**Deliberately not `_owned_link_endpoints`** (the write-side helper from #1152), which my own note on #1152 suggested reusing. That was wrong for reads and I'd rather say so than follow it: the helper takes both id sets up front, and a read learns the entity ids *from* the rows it is filtering. Fetching first and filtering in Python would also pull other tenants' rows into the process. Keeping the predicate in SQL avoids both.

`count-memories` needed **no caller change**: core-api's client has always sent `tenant_id` in that body, and the route read only `entity_ids` and dropped it. This reads the field it was already being handed.

### The part worth reviewing: four test oracles would have gone vacuous

#1148's and #1152's suites assert what persisted by reading back through `POST /memories/entity-links` or `memory_get_entity_links_for_memories`. Both are now tenant-scoped on both ends — which is **exactly the shape of the row those tests check for the absence of**.

Left alone, `test_foreign_memory_is_not_linked` would have asked a scoped read whether the victim's memory has links, been told "none" because the link's entity is in another tenant, and passed — **with the cross-tenant write bug fully reintroduced**. Four oracles were in that position:

- `core-storage-api/tests/test_memory_entity_links_tenant_scope.py::_links`
- `core-storage-api/tests/test_entity_link_routes_tenant_scope.py::_links`
- `tests/test_entity_links_are_additive.py::_links`
- `tests/test_tenant_guard_byid_updates.py` (inline, in the refused-link assertion)

All four now read `memory_entity_links` in SQL, tenant-blind by construction and immune to future scoping. Each carries a comment saying why it must not go through the API. This is the caveat #1148 and #1152 both flagged in their descriptions coming due, and it is why the oracle change ships in the same PR as the scoping rather than after it.

**Verified rather than asserted:** reverting the *write*-side entity predicate (`_owned_link_endpoints`) makes those two suites fail again — 8 failures including `test_foreign_entity_is_not_linked` on both routes. The rewrite kept their power.

### Failing without the fix

Reverting **only the memory half** of `_link_within_tenant`:

```
FAILED ...TestMemoryIdsByEntityIdsRead::test_a_foreign_memory_id_is_not_disclosed
FAILED ...TestCountMemoriesPerEntityRead::test_foreign_memories_are_not_counted
2 failed, 9 passed in 0.62s
```

Reverting **only the entity half**:

```
FAILED ...TestMemoryEntityLinksRead::test_a_foreign_entity_is_not_disclosed
1 failed, 10 passed in 0.51s
```

Disjoint, and each is the single-foreign-end case for its side.

One honest note on what these two experiments do *not* show: the three named-end tests (`test_a_foreign_memory_yields_nothing`, `test_a_foreign_entity_yields_no_memory_ids`, `test_a_foreign_entity_counts_nothing`) survive **either** single revert, because a wholly-foreign row is caught by whichever half remains. They are not vacuous — reverting **both** halves, i.e. the pre-fix state, fails all six cross-tenant cases:

```
FAILED ...TestMemoryEntityLinksRead::test_a_foreign_memory_yields_nothing
FAILED ...TestMemoryEntityLinksRead::test_a_foreign_entity_is_not_disclosed
FAILED ...TestMemoryIdsByEntityIdsRead::test_a_foreign_entity_yields_no_memory_ids
FAILED ...TestMemoryIdsByEntityIdsRead::test_a_foreign_memory_id_is_not_disclosed
FAILED ...TestCountMemoriesPerEntityRead::test_a_foreign_entity_counts_nothing
FAILED ...TestCountMemoriesPerEntityRead::test_foreign_memories_are_not_counted
6 failed, 5 passed in 0.58s
```

The 5 that pass throughout are the happy-path and 422 cases.

The new tests fabricate cross-tenant rows in SQL (`_force_link`), because #1148 / #1152 correctly made that state unwriteable through the API — and it is the historical state these reads must not disclose.

### Allowlist

95 → 89 entries; `id-addressed-read` 21 → 15. The six entries for these three paths removed, regenerated with `python3 scripts/tenant_scope_gate.py --write` in this commit as the gate's stale-entry check (`tenant_scope_gate.py:1060-1063`) requires. Rebased onto #1161 and #1157 and regenerated; this PR's own contribution is six entries.

### Precedent left for the last one

`entity_find_entity_link` + `GET /entities/links/find` is the only remaining pair. It has **no production caller** — the two core-api mentions are comments describing the flow `entity_bulk_upsert_links` replaced, and `sc.find_entity_link`'s only reference is its own definition. Delete-vs-scope is a route-removal question, so it gets its own PR rather than being decided quietly here.

### Verification

- `core-storage-api/tests/`: 278 passed (11 new).
- Root `tests/`: 5734 passed, 4 skipped, 1 xfailed.
- `ruff check` / `ruff format --check` at CI's exact scopes: clean.
- `mypy` core-api (203 files) and core-storage-api (85 files): no issues.
- Tenant-scope gate against `origin/main`: green, "Allowlist shrank by 6". Legacy-name ratchet: no new lines. Broker OpenAPI baseline: up to date.

Run against a dedicated local pgvector instance provisioned CI's way (`alembic upgrade head` on the root database, a separate database for the storage suite). **Not checked:** anything requiring CI's own environment — the Actions matrix, the coverage floors step, the enterprise re-vendor path.
