### PR TITLE
chore(storage): delete the unused find_entity_link chain

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1475,13 +1475,6 @@ class CoreStorageClient:
     async def create_relation(self, data: dict) -> dict:
         return await self._post("/entities/relations", data)  # type: ignore[return-value]
 
-    async def find_entity_link(self, memory_id: str, entity_id: str) -> dict | None:
-        return await self._get(
-            "/entities/links/find",
-            memory_id=memory_id,
-            entity_id=entity_id,
-        )
-
     async def create_entity_link(self, tenant_id: str, data: dict) -> dict:
         # The link is addressed by two bare UUIDs, so the tenant has to travel
         # with them: storage scopes both ends to it. The explicit arg wins over

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -453,20 +453,6 @@ async def bulk_upsert_memory_entity_links(request: Request) -> list[dict]:
     return await _svc.entity_bulk_upsert_links(tenant_id, items)
 
 
-@router.get("/links/find")
-async def find_entity_link(
-    memory_id: str,
-    entity_id: str,
-) -> dict | None:
-    link = await _svc.entity_find_entity_link(
-        memory_id=UUID(memory_id),
-        entity_id=UUID(entity_id),
-    )
-    if link is None:
-        raise HTTPException(status_code=404, detail="Link not found")
-    return orm_to_dict(link, MEMORY_ENTITY_LINK_FIELDS)
-
-
 @router.post("/memory-ids-by-entity-ids")
 async def get_memory_ids_by_entity_ids(request: Request) -> list[dict]:
     body: dict = await request.json()

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -6075,20 +6075,6 @@ class PostgresService:
             result = await session.execute(stmt)
             return list(result.all())  # type: ignore[arg-type]
 
-    async def entity_find_entity_link(
-        self,
-        memory_id: UUID,
-        entity_id: UUID,
-    ) -> MemoryEntityLink | None:
-        async with get_session() as session:
-            result = await session.execute(
-                select(MemoryEntityLink).where(
-                    MemoryEntityLink.memory_id == memory_id,
-                    MemoryEntityLink.entity_id == entity_id,
-                )
-            )
-            return result.scalar_one_or_none()
-
     async def _owned_link_endpoints(
         self,
         session: AsyncSession,

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -73,13 +73,6 @@
       "note": "Verified: every item carries tenant_id, which scopes updates, inserts, race recovery, and winner lookups."
     },
     {
-      "id": "method:entity_find_entity_link",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read",
-      "note": "Join table has no tenant column; rows are tenant-scoped only via the ids."
-    },
-    {
       "id": "method:entity_get_by_id",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -263,12 +256,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "no-tenant-data"
-    },
-    {
-      "id": "route:GET /api/v1/storage/entities/links/find",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-read"
     },
     {
       "id": "route:GET /api/v1/storage/entities/relations/find",


### PR DESCRIPTION
Last of three clearing the five `id-addressed-read` entries that share the note *"Join table has no tenant column; rows are tenant-scoped only via the ids"*. #1161 deleted the unreachable one, [#1162](https://github.com/caura-ai/caura/pull/1162) scoped the three live ones, and this one turns out to have no production caller either.

### Does it need to exist? No — so it is deleted, not scoped

Asked first, per #1091's precedent on this table. The whole chain is unreachable from core-api:

- `sc.find_entity_link` — a search for `find_entity_link(` across `core-api/src` returns **only the wrapper's own definition**.
- `GET /api/v1/storage/entities/links/find` — that wrapper was its only client.
- `entity_find_entity_link` — the route was its only caller.

The two other mentions in core-api are comments, and both describe the flow this served **in the past tense**:

> `entity_extraction_worker.py:369` — *"matching today's `find_entity_link → skip-if-exists` flow"*
> `schedule_background_tasks.py:72` — *"`find_entity_link` short-circuits link creation"*

`entity_bulk_upsert_links` (#1124) replaced it: its `ON CONFLICT DO NOTHING` does the skip in one statement instead of a find-then-create round trip. The comments describe the semantics it inherited, not a call it makes.

### Why deleting a route is safe here

This is the one judgment call in the set, so the basis is worth stating rather than assuming. `core-storage-api`'s HTTP surface is not a public contract — `docs/self-hosting.md:121`:

> `core-storage-api` is intentionally reachable only by services on the Compose network; it has no host URL.

Its being reachable on `0.0.0.0:8002` is the GHSA, not an interface. Nothing in the repo documents this endpoint, and only `core-api/openapi.broker.json` is a frozen contract — that spec covers core-api's broker operations and is untouched here (`gen_broker_openapi.py --check`: up to date).

Scoping it instead would leave a tenant-checked endpoint with no caller, which is the outcome #1091 explicitly rejected: an unscoped-or-otherwise helper sitting in the class is adopted by whoever needs "the existing helper". If a by-pair lookup is wanted later it should be written with a tenant parameter from the start.

### Left in place deliberately

Four tests assign `sc.find_entity_link` on a `MagicMock` and assert `call_count == 0` — `tests/test_p1_entity_extraction_bulk.py` labels them *"Spies for the legacy per-row paths — must stay at zero call_count"*.

I checked whether these became vacuous and they did not. They are spies on the mock passed **into** the code under test, not assertions about the client's API surface, so they still fail if the extraction worker reaches for a per-row `find_entity_link` again. Removing them would delete a live guard, so they stay.

### Why there is no new test

Same as #1161: nothing to test. No caller to regress, no behaviour to pin, and a test asserting the route 404s would pin the absence of a route rather than any behaviour anyone depends on. The guard is the tenant-scope gate — the entries are gone, and its stale-entry check (`tenant_scope_gate.py:1060-1063`) fails if any of them returns unscoped without one.

Both suites were run to confirm nothing depended on the chain: `core-storage-api/tests/` 272 passed, root `tests/` 5734 passed. The route count in the gate summary drops 191 → 190 and the method count 190 → 189, which is the deletion.

### Allowlist

87 → 85 entries; `id-addressed-read` **15 → 13**. **The five entries sharing that note are now zero.**

Rebased onto #1162 and regenerated, which settled a figure I got wrong twice while this was open: I first wrote 15 → 13 (correct, but only once #1162 landed), then "corrected" it to 21 → 19 against a `main` that still carried #1162's six entries, and #1162 has now merged. 15 → 13 is the final, verified state.

Three of the five were live and got the predicate; two were unreachable and went. With this merged the note is fully retired and the `memory_entity_links` set is closed. The write halves (#1148, #1152, #1156) already emptied `id-addressed-write` for this table — and as of `main` today that whole category is at **0** across every path, not just this one.

### Verification

- `core-storage-api/tests/`: 272 passed.
- Root `tests/`: 5734 passed, 4 skipped, 1 xfailed.
- `ruff check` / `ruff format --check` at CI's exact scopes: clean.
- `mypy` core-api (203 files) and core-storage-api (85 files): no issues.
- Tenant-scope gate against `origin/main`: green, "Allowlist shrank by 2". Legacy-name ratchet: no new lines. Broker OpenAPI baseline: up to date.

Run against a dedicated local pgvector instance provisioned CI's way (`alembic upgrade head` on the root database, a separate database for the storage suite). **Not checked:** anything requiring CI's own environment — the Actions matrix, the coverage floors step, the enterprise re-vendor path. In particular I could not check the enterprise repo for a consumer of this route; the self-hosting doc's "no host URL" statement is the basis for treating it as internal, and a maintainer who knows of an out-of-repo caller should say so.
