### PR TITLE
test: make the wall-clock benchmarks opt-in

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,7 +11,28 @@ asyncio_default_fixture_loop_scope = session
 asyncio_default_test_loop_scope = session
 testpaths = tests
 pythonpath = core-api/src core-storage-api/src core-worker/src .
+# Benchmarks are opt-in. All 16 ``benchmark``-marked tests assert a fixed
+# wall-clock budget around pure CPU work — 13 assertions across 5 files, the
+# tightest 10μs (``test_visibility.py``) and 5μs/call
+# (``test_p5_p6_benchmarks.py``). Elapsed time on a shared machine is not a
+# property of the code: this suite runs ~5,700 tests in ~2 minutes with heavy
+# concurrent database work, so those budgets measure contention. Concretely,
+# ``test_cluster_1000_pairs`` failed 2 of 6 full-suite runs while measuring
+# 3,794μs against its 50,000μs budget in isolation — a 13x margin. Nothing was
+# slow; the machine was busy.
+#
+# Deselected rather than loosened: a budget chosen to survive a saturated runner
+# catches only a catastrophic regression and is still flaky at the tail. These
+# numbers are meaningful on a quiet machine, which is where to take them:
+#
+#     uv run pytest tests/ -m benchmark -s
+#
+# A ``-m`` on the command line replaces this one, so that works as written.
+# Correctness of the code they exercise stays in the ordinary suite — e.g.
+# ``_build_clusters`` has ``test_p5_crystallizer.py::TestBuildClusters``.
+addopts = -m "not benchmark"
+
 markers =
     unit: pure algorithmic tests (no DB required)
     integration: tests requiring PostgreSQL + pgvector
-    benchmark: latency measurement tests
+    benchmark: latency measurement tests — opt-in, see addopts above

--- a/tests/test_benchmark_scoring.py
+++ b/tests/test_benchmark_scoring.py
@@ -4,7 +4,11 @@ Measures the Python-side computation overhead of the old vs new formulas.
 These are pure-math benchmarks (no DB) — they measure the scoring logic only,
 not the SQL query execution time (which is dominated by pgvector ANN search).
 
-Run with: pytest tests/test_benchmark_scoring.py -v -s --tb=short
+These carry ``@pytest.mark.benchmark``, which the root ``pytest.ini``
+deselects by default — a wall-clock budget cannot gate a 5,700-test suite on a
+shared machine. ``-m benchmark`` is required to select them, so:
+
+Run with: pytest tests/test_benchmark_scoring.py -m benchmark -v -s --tb=short
 """
 
 import statistics


### PR DESCRIPTION
No existing issue — I checked (#858 is a different flake: an interview-scheduler job-claim race). Happy to file one if you'd rather have it tracked.

### The finding is bigger than the reported test

`test_cluster_1000_pairs` failed 2 of 6 full root-suite runs while measuring **3,794μs against its 50,000μs budget in isolation** — a 13× margin. Nothing was slow; the machine was busy. It wraps a pure in-memory union-find in `perf_counter_ns` inside a suite that runs ~5,700 tests in ~2 minutes with heavy concurrent database work, so what it measures is contention.

But it is not one test. **All 16 `benchmark`-marked tests across 5 files assert a fixed wall-clock budget** — 13 assertions in total:

| file | assertion | budget |
|---|---|---|
| `test_visibility.py` | `mean_us < 10` | **10μs** |
| `test_p5_p6_benchmarks.py` | `per_call_us < 5.0` | **5μs/call** |
| `test_p5_p6_benchmarks.py` | `per_pair_us < 5.0` | **5μs/pair** |
| `test_p5_p6_benchmarks.py` | `ratio < 3.0` | typed vs flat |
| `test_p5_p6_benchmarks.py` | `elapsed_us < 5_000` / `< 50_000` | 5ms / 50ms |
| `test_rule_type.py` | `per_call_us < 50.0` | 50μs/call |
| `test_redistribute.py` | `elapsed_us < 10_000` | 10ms |
| `test_visibility.py` | `filter_mean_us < 500` | 500μs |
| `test_benchmark_scoring.py` | `mean_us < 50` ×3, `< 100` | 50μs / 100μs |

Several are far tighter in relative terms than the cluster one — a 10μs and two 5μs budgets against a 13× margin. The reported test is simply the one that tripped first; fixing only it would have left twelve more waiting.

### The fix was already designed, just never wired up

Every one of those classes **already carries `@pytest.mark.benchmark`**, and the root `pytest.ini` **already registers** the marker as *"latency measurement tests"*. Nothing deselected it, so CI has been running all 16 as correctness gates. One line closes it:

```ini
addopts = -m "not benchmark"
```

A `-m` on the command line replaces addopts', so they stay runnable on demand:

```bash
uv run pytest tests/ -m benchmark -s
```

This is option (a) from the brief, chosen because the marker's existence and description are the original author's stated intent — the change is wiring, not a new policy.

### Why not loosen the budgets instead

A number chosen to survive a saturated runner catches only a catastrophic regression, and is still flaky at the tail — you trade a 2-in-6 failure for a 1-in-50 one and keep the false-red. It would also mean picking 13 new numbers by guesswork, each machine-dependent, with nothing to stop the next person re-tightening them. These measurements are meaningful on a quiet machine, which is where the marker now sends them.

### No correctness coverage is lost — checked, not assumed

The benchmarks assert timing **and nothing else**. `test_cluster_1000_pairs` computes `clusters` and only *prints* `len(clusters)`; there is no assertion about the clustering being right.

What actually guards `_build_clusters` is `tests/test_p5_crystallizer.py::TestBuildClusters` — four `@pytest.mark.unit` tests covering a single pair, chain merge, disconnected pairs, and >50 pairs uncapped. Those stay in the default suite. I checked this before considering adding a replacement correctness test, and did not add one: it would have duplicated existing coverage, since union-find correctness does not change between 60 and 1000 pairs.

### One thing this would have silently broken

`tests/test_benchmark_scoring.py`'s docstring documented:

> Run with: `pytest tests/test_benchmark_scoring.py -v -s --tb=short`

With `addopts` in place that command collects **nothing** (`no tests collected (4 deselected)`) — a documented command turned into a silent no-op. The docstring now names `-m benchmark` and says why. It was the only such command in the tree; I grepped.

### Verification

- Default run: **5,718 passed, 4 skipped, 16 deselected, 1 xfailed**.
- Opt-in run: `-m benchmark` selects and **passes all 16** in 7.3s.
- Documented command: `pytest tests/test_benchmark_scoring.py -m benchmark` collects 4.
- **Coverage floors still met per package** — the thing most likely to break from removing 16 tests, so it was measured the way CI measures it (`coverage report --rcfile=<pkg>/pyproject.toml`): core-api **85%**, core-storage-api **67%**, floor 50 each, both exit 0.
- Legacy-name ratchet: no new lines. `core-storage-api/tests/` unaffected (its own `pytest.ini`, no marker).

**One honest gap.** In one of the coverage runs, `tests/test_unknown_field_rejection.py::test_memory_update_rejects_unknown_field` failed. That is the known flake #1137 (fix in flight as #1140) — a `409 DUPLICATE_MEMORY` / `semantic_similarity` collision from `get_test_auth()` defaulting every caller to tenant `"default"` against a cosine-similarity dedup gate. It passes in isolation (21/21) and did not recur on the two subsequent full runs, **so I could not capture its traceback to confirm that mechanism first-hand** — I am relying on the filed description, not my own evidence. Worth flagging that deselecting 16 tests changes suite composition and could shift the timing of an order-dependent flake either way; it cannot create one, and this flake and its cause predate this change.

**Not checked:** anything requiring CI's own environment — the Actions matrix and the runner's own timing characteristics. Run against a dedicated local pgvector instance provisioned CI's way.
