### PR TITLE
chore(storage): delete the unused find_relation chain

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1459,19 +1459,6 @@ class CoreStorageClient:
             params["tenant_id"] = tenant_id
         return await self._get_list(f"/entities/{entity_id}/relations", **params)
 
-    async def find_relation(
-        self,
-        source_id: str,
-        target_id: str,
-        relation_type: str,
-    ) -> dict | None:
-        return await self._get(
-            "/entities/relations/find",
-            source_id=source_id,
-            target_id=target_id,
-            relation_type=relation_type,
-        )
-
     async def create_relation(self, data: dict) -> dict:
         return await self._post("/entities/relations", data)  # type: ignore[return-value]
 

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -350,27 +350,6 @@ async def create_relation(request: Request) -> dict:
     return orm_to_dict(relation, RELATION_FIELDS)
 
 
-@router.get("/relations/find")
-async def find_relation(
-    source_id: str,
-    target_id: str,
-    relation_type: str,
-) -> dict | None:
-    # Derive tenant_id from source entity (client doesn't pass it).
-    source = await _svc.entity_get_by_id(UUID(source_id))
-    if source is None:
-        raise HTTPException(status_code=404, detail="Source entity not found")
-    relation = await _svc.relation_find(
-        tenant_id=source.tenant_id,
-        from_entity_id=UUID(source_id),
-        relation_type=relation_type,
-        to_entity_id=UUID(target_id),
-    )
-    if relation is None:
-        raise HTTPException(status_code=404, detail="Relation not found")
-    return orm_to_dict(relation, RELATION_FIELDS)
-
-
 # ------------------------------------------------------------------
 # Memory-entity links
 # ------------------------------------------------------------------

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -5718,29 +5718,6 @@ class PostgresService:
     # Relations
     # ------------------------------------------------------------------
 
-    async def relation_find(
-        self,
-        tenant_id: str,
-        from_entity_id: UUID,
-        relation_type: str,
-        to_entity_id: UUID,
-        fleet_id: str | None = None,
-    ) -> Relation | None:
-        async with get_session() as session:
-            stmt = select(Relation).where(
-                Relation.tenant_id == tenant_id,
-                Relation.from_entity_id == from_entity_id,
-                Relation.relation_type == relation_type,
-                Relation.to_entity_id == to_entity_id,
-            )
-            if fleet_id:
-                stmt = stmt.where(Relation.fleet_id == fleet_id)
-            else:
-                stmt = stmt.where(Relation.fleet_id.is_(None))
-
-            result = await session.execute(stmt)
-            return result.scalar_one_or_none()
-
     async def relation_add(self, data: dict) -> Relation:
         """Idempotent UPSERT keyed on the natural key
         ``(tenant_id, from_entity_id, relation_type, to_entity_id)``.

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -258,12 +258,6 @@
       "category": "no-tenant-data"
     },
     {
-      "id": "route:GET /api/v1/storage/entities/relations/find",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-read"
-    },
-    {
       "id": "route:GET /api/v1/storage/entities/{entity_id}",
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",


### PR DESCRIPTION
The entity surface's last `id-addressed-read` entry that predates the `memory_entity_links` sweep. `GET /api/v1/storage/entities/relations/find` took two bare entity UUIDs and derived its tenant predicate from the source row it was addressed by:

```python
# Derive tenant_id from source entity (client doesn't pass it).
source = await _svc.entity_get_by_id(UUID(source_id))
relation = await _svc.relation_find(tenant_id=source.tenant_id, ...)
```

A predicate derived from the row being addressed is not a check — it is satisfied by construction for whatever id the caller supplies, so the `tenant_id=` keyword reads like a scope and enforces nothing.

**Stated no stronger than it is.** `core-storage-api` authenticates no request (GHSA-wgvw-28pq-jc36) and docker-compose publishes it on `0.0.0.0:8002`, so two UUIDs were enough to read a relation in another tenant. This is disclosure, not integrity — nothing here mutates a row — and what leaks is the relation's own fields plus confirmation that the pair is linked at all. No issue was filed for this one; the wording is mine, not an issue's. It is defence-in-depth of the same class as the rest of the sweep, not a known-exploited hole.

### Does it need to exist? No — so it is deleted, not scoped

Asked before choosing a predicate, per the precedent [#1091](https://github.com/caura-ai/caura/issues/1091) set on this surface. The chain has no caller anywhere in the repo:

- `sc.find_relation` — a repo-wide search for `find_relation` across **all file types** returns only the route's own definition and the client wrapper's own definition. No call site, and no test — not even a mock spy, which is what [#1163](https://github.com/caura-ai/caura/pull/1163) found for `find_entity_link`.
- `GET /entities/relations/find` — that wrapper was its only client.
- `relation_find` — the route was its only caller.

So it goes, the same disposition [#1161](https://github.com/caura-ai/caura/pull/1161) and [#1163](https://github.com/caura-ai/caura/pull/1163) gave the two unreachable members of the `memory_entity_links` set. Scoping it instead would leave a tenant-checked endpoint with no caller — the outcome #1091 explicitly rejected, because an unused helper is the one someone later adopts without noticing where its tenant comes from.

**`relation_find` goes with it, for a different reason worth separating.** Unlike #1163's `entity_find_entity_link`, it was *correctly tenant-scoped* — it takes `tenant_id` and puts it in the WHERE clause. The defect was the route deriving the argument, not the method ignoring it. It is deleted because the route's removal leaves it with no caller, not because it was unsafe. It is not on the allowlist and never was.

### Out-of-repo consumers: checked, not assumed

#1163 had to leave this open, so I closed it. No hit for `relations/find` or `find_relation` in `caura-enterprise`, `caura-ops`, `caura-daemon`, `caura-onprem`, `gateway`, `caura-test-automation` or `caura-github`. The same sweep also shows no consumer of #1163's `links/find`, which retroactively supports that call.

`docs/self-hosting.md:121` states core-storage-api is reachable only on the Compose network and has no host URL, and only `core-api/openapi.broker.json` is a frozen contract — untouched here, baseline still reports up to date.

### Why there is no new test

Same as #1161 and #1163: no caller to regress and no behaviour to pin. A test asserting the route now 404s would pin the absence of a route rather than anything anyone depends on. The guard is the tenant-scope gate, whose stale-entry check (`tenant_scope_gate.py:1060-1065`) fails if the entry returns without a scope.

Both suites were run to confirm nothing depended on the chain.

### Allowlist

**85 → 84 entries; `id-addressed-read` 13 → 12.** Route count 190 → 189 and method count 189 → 188, which is the deletion. Regenerated with `python3 scripts/tenant_scope_gate.py --write` in this commit, as the gate's stale-entry check requires.

Rebased onto [#1143](https://github.com/caura-ai/caura/pull/1143) and [#1166](https://github.com/caura-ai/caura/pull/1166) and regenerated after they landed mid-flight. Confirmed the hand-written fields survived: **all 40 notes preserved, every `category` unchanged, one entry removed and none added.** #1143's identity-column-writability check has no finding here, as expected — it fires on UPDATEs built from caller-controlled dicts and this PR deletes read paths.

### What this leaves, and what it means for the rest

The entity/links surface now has **two** `id-addressed-read` entries left, both mine and both on the same method:

| entry | disposition |
|---|---|
| `method:entity_get_by_id` | live, 3 callers — gets the predicate |
| `route:GET /api/v1/storage/entities/{entity_id}` | live — gets the predicate |

That follow-up also has to retire the two *noted* routes `GET /{entity_id}/with-memories` and `GET /{entity_id}/relations`, because they share `entity_get_by_id` and their note (*"Scopes to the entity's OWN tenant when omitted — self-authorizing"*) describes the same derive-from-the-addressed-row shape this PR deletes. It will argue that separately rather than quietly.

**The filter-versus-reject choice this sets up for the fleet cluster and the reports pair:** every surviving path on this surface is addressed by exactly *one* id, so filter and reject are observationally identical — both are a 404 — and the partial-match question does not arise. Where it does arise, [#1162](https://github.com/caura-ai/caura/pull/1162) already chose **filter** for bulk id lookups. For single-id reads, 404-on-mismatch is also the better of the two: a 403 would confirm that the id exists in someone else's tenant, which a 404 does not.

### Verification

- `core-storage-api/tests/`: **283 passed**.
- Root `tests/`: **5759 passed, 4 skipped, 1 xfailed**.
- `ruff check` at CI's 6 scopes and `ruff format --check` at its 5, run separately, discovery-based, no `--config`: clean. Vendored-`common` `--isolated` check: 3 files already formatted.
- `mypy` core-api (203 files) and core-storage-api (85 files): no issues.
- Tenant-scope gate vs `origin/main`: green. Legacy-name ratchet: no new lines. Do-not-touch sentinel: all 46 protected strings survive. Broker OpenAPI baseline: up to date (8 operations).

Run against a dedicated local pgvector instance provisioned CI's way — `alembic upgrade head` on the root database, a separate `memclaw_storage` database for the storage suite. **Not checked:** anything needing CI's own environment — the Actions matrix, the coverage-floors step, the enterprise re-vendor path. The sibling-repo search above covers the local clones only; a consumer outside those checkouts would not have been seen.