### PR TITLE
chore(storage): delete the never-called fleet_get_command_by_id

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -9290,14 +9290,6 @@ class PostgresService:
 
     # -- Commands --
 
-    async def fleet_get_command_by_id(
-        self,
-        *,
-        command_id: UUID,
-    ) -> FleetCommand | None:
-        async with get_session() as session:
-            return await session.get(FleetCommand, command_id)
-
     async def fleet_get_pending_commands(
         self,
         *,

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -99,12 +99,6 @@
       "category": "id-addressed-read"
     },
     {
-      "id": "method:fleet_get_command_by_id",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read"
-    },
-    {
       "id": "method:fleet_get_node_by_id",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",


### PR DESCRIPTION
`method:fleet_get_command_by_id`, one of the twelve `id-addressed-read` entries left in `core-storage-api/tenant_scope_allowlist.json`.

## The prior question first

Precedent #1091 set on this surface, and followed by #1161, #1163 and #1168: ask whether the method should exist before asking what predicate it needs. This one has **no caller anywhere**.

- A repo-wide search for `fleet_get_command_by_id` across all file types returns the allowlist entry and the definition itself. No route, no storage-client wrapper, no test, not even a mock spy.
- No route reaches it. The only parameterised command route is `PATCH /fleet/commands/{command_id}/status` — scoped in #1082, and it calls `fleet_update_command_status`. There is no `GET /fleet/commands/{command_id}`.
- Nothing dispatches to service methods by name (no `getattr(_svc, …)` in either package), so a name-only search is conclusive here.

So it is deleted rather than scoped.

## What this is, precisely

**Not reachable from the wire.** The other members of this backlog are live paths where knowing a UUID is enough to read another tenant's row today. This was an unexposed helper with the same shape — a hazard, not a disclosure. It is on the list because the gate reads signatures rather than reachability, which is the right default, but nobody should read this PR as closing an open hole.

Scoping it instead would have left a tenant-checked helper with no caller, the outcome #1091 rejected: an unused helper is the one someone later adopts without noticing where its tenant comes from. That is not theoretical on this table — `fleet_get_pending_commands` carries a comment about exactly this trap (a `node_id`-only predicate "looks tenant-safe and is not"), and `create_command` exists to stop a command being filed against another tenant's node.

## Out-of-repo consumers — checked, not assumed

No hit for `fleet_get_command_by_id` or `get_command_by_id` in caura-enterprise, caura-ops, caura-daemon, caura-onprem, caura-onprem-installer, gateway, caura-test-automation or caura-github. It is an internal service method rather than an HTTP surface, so only a repo that vendored `postgres_service.py` could reach it, and none does. `core-api/openapi.broker.json` is the one frozen contract in play and is untouched.

## No new test

Same as #1161, #1163 and #1168: no caller to regress, no behaviour to pin. A test asserting the method is absent would pin an absence rather than anything anyone depends on. The guard is the tenant-scope gate, whose stale-entry check fails if the entry returns without a scope.

## Numbers

| | before | after |
|---|---|---|
| allowlist total | 84 | **83** |
| `id-addressed-read` | 12 | **11** |
| service methods | 188 | **187** |
| routes | 189 | 189 |

Regenerated with `scripts/tenant_scope_gate.py --write` in the same commit, after rebasing onto #1168 and #1169. All 40 hand-written notes survived and every entry kept its category. The gate classifies the change as `removed — gone (1)`, not a recategorisation.

## Verification

- `core-storage-api/tests/` — 283 passed
- root-suite fleet + gate tests (`test_ph3_storage_documents_fleet.py`, `test_fleet_heartbeat_auto_upgrade.py`, `test_tenant_scope_gate.py`) — 189 passed
- `ruff check` and `ruff format --check` clean at CI's scopes; mypy clean on core-storage-api (85 files)
- `legacy_name_ratchet.py --base origin/main` — no new lines; `do_not_touch_sentinel.py` — all 46 protected strings survive
- Re-ran both suites after the rebase, against `origin/main` at `b8978969`

## Scope note

First of a set clearing the remaining `id-addressed-read` backlog. #1167 covers the report pair; the fleet auto-upgrade reads, `fleet_get_node_by_id` and the three `entities/{entity_id}` reads follow as separate PRs.