### PR TITLE
fix(storage): scope the fleet read paths to the caller's tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2410,7 +2410,7 @@ class CoreStorageClient:
     async def delete_fleet(self, tenant_id: str, fleet_id: str) -> bool:
         return await self._delete(f"/fleet/{fleet_id}", tenant_id=tenant_id)
 
-    async def fleet_in_flight_deploy(self, *, node_id: UUID, since: datetime) -> bool:
+    async def fleet_in_flight_deploy(self, *, node_id: UUID, tenant_id: str, since: datetime) -> bool:
         result = await self._get(
             "/fleet/commands/in-flight-deploy",
             # primary, not replica: read-after-write deploy-dedup gate — it must see
@@ -2418,15 +2418,19 @@ class CoreStorageClient:
             # duplicate through (the acked-stuck-queue storm this gate prevents).
             read=False,
             node_id=str(node_id),
+            tenant_id=tenant_id,
             since=since.isoformat(),
         )
         return bool((result or {}).get("in_flight"))
 
-    async def fleet_deploy_attempt_count(self, *, node_id: UUID, target_version: str, since: datetime) -> int:
+    async def fleet_deploy_attempt_count(
+        self, *, node_id: UUID, tenant_id: str, target_version: str, since: datetime
+    ) -> int:
         result = await self._get(
             "/fleet/commands/deploy-attempt-count",
             read=False,  # primary: attempt budget must count just-queued deploys (see fleet_in_flight_deploy)
             node_id=str(node_id),
+            tenant_id=tenant_id,
             target_version=target_version,
             since=since.isoformat(),
         )

--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -555,6 +555,7 @@ async def _maybe_queue_auto_upgrade(
     try:
         in_flight = await sc.fleet_in_flight_deploy(
             node_id=UUID(node_id),
+            tenant_id=body.tenant_id,
             since=datetime.now(UTC) - DEPLOY_IN_FLIGHT_WINDOW,
         )
     except Exception:
@@ -585,6 +586,7 @@ async def _maybe_queue_auto_upgrade(
     try:
         recent_attempts = await sc.fleet_deploy_attempt_count(
             node_id=UUID(node_id),
+            tenant_id=body.tenant_id,
             target_version=target_version,
             since=datetime.now(UTC) - AUTO_UPGRADE_ATTEMPT_WINDOW,
         )

--- a/core-storage-api/src/core_storage_api/routers/fleet.py
+++ b/core-storage-api/src/core_storage_api/routers/fleet.py
@@ -97,7 +97,7 @@ async def get_node(
     tenant_id: str,
 ) -> dict:
     node_id = await _svc.fleet_get_node_id(tenant_id=tenant_id, node_name=node_name)
-    node = await _svc.fleet_get_node_by_id(node_id=node_id)
+    node = await _svc.fleet_get_node_by_id(node_id=node_id, tenant_id=tenant_id)
     if node is None:
         raise HTTPException(status_code=404, detail="Node not found")
     return orm_to_dict(node, FLEET_NODE_FIELDS)
@@ -109,7 +109,7 @@ async def delete_node(
     tenant_id: str,
 ) -> dict:
     node_id = await _svc.fleet_get_node_id(tenant_id=tenant_id, node_name=node_name)
-    node = await _svc.fleet_get_node_by_id(node_id=node_id)
+    node = await _svc.fleet_get_node_by_id(node_id=node_id, tenant_id=tenant_id)
     if node is None:
         raise HTTPException(status_code=404, detail="Node not found")
     fleet_id = getattr(node, "fleet_id", None)
@@ -132,19 +132,28 @@ async def create_command(request: Request) -> dict:
     # The node must belong to the tenant the command is being filed under.
     # ``fleet_commands.node_id`` has an FK to ``fleet_nodes.id`` but there is no
     # cross-column tenant constraint, so an insert naming ANOTHER tenant's node
-    # UUID satisfies the FK and lands — and ``fleet_get_pending_commands`` keys
-    # on ``node_id`` alone, so that node collects the row on its next heartbeat.
-    # The caller's tenant gate upstream only ever sees ``tenant_id``, which the
-    # caller is free to set to its own; the node/tenant PAIR is checked nowhere
-    # else, so it has to be checked here.
+    # UUID satisfies the FK and lands. The caller's tenant gate upstream only
+    # ever sees ``tenant_id``, which the caller is free to set to its own, so
+    # the node/tenant PAIR has to be checked here.
+    #
+    # It is the fetch predicate now rather than a comparison afterwards:
+    # ``fleet_get_node_by_id`` takes the tenant and returns None when either
+    # half misses. Same outcome, one fewer thing a later caller can forget.
+    #
+    # ``_require`` rather than ``body.get``: a missing tenant would otherwise
+    # scope to nothing and surface as "Node not found" — fail-closed, but it
+    # says the wrong thing, and it leaves this route's scoping unreadable to the
+    # tenant-scope gate's AST pass, which is the whole of the ``blind-spot``
+    # category. A malformed request is a 422.
+    tenant_id = _require(body, "tenant_id")
     raw_node_id = body.get("node_id")
     node = None
     if raw_node_id is not None:
         try:
-            node = await _svc.fleet_get_node_by_id(node_id=UUID(str(raw_node_id)))
+            node = await _svc.fleet_get_node_by_id(node_id=UUID(str(raw_node_id)), tenant_id=tenant_id)
         except ValueError:
             node = None
-    if node is None or node.tenant_id != body.get("tenant_id"):
+    if node is None:
         # 404 for "no such node" and "not your node" alike. Splitting them would
         # make this route an existence oracle for node UUIDs — and an unguarded
         # insert of an unknown UUID raises ForeignKeyViolationError, which is an
@@ -189,19 +198,33 @@ async def get_pending_commands(
 
 
 @router.get("/commands/in-flight-deploy")
-async def in_flight_deploy(node_id: UUID, since: datetime) -> dict:
+async def in_flight_deploy(node_id: UUID, tenant_id: str, since: datetime) -> dict:
     """True if a ``deploy`` command for this node is still in flight
-    (status pending/acked, created_at >= since)."""
-    in_flight = await _svc.fleet_has_recent_in_flight_deploy(node_id=node_id, since=since)
+    (status pending/acked, created_at >= since), within ``tenant_id``.
+
+    ``tenant_id`` is a **required** query parameter. Without it this answered
+    for any node whose UUID the caller could name, from a service that
+    authenticates nothing — so another tenant's rollouts were observable as
+    they happened.
+    """
+    in_flight = await _svc.fleet_has_recent_in_flight_deploy(
+        node_id=node_id, tenant_id=tenant_id, since=since
+    )
     return {"in_flight": in_flight}
 
 
 @router.get("/commands/deploy-attempt-count")
-async def deploy_attempt_count(node_id: UUID, target_version: str, since: datetime) -> dict:
+async def deploy_attempt_count(node_id: UUID, tenant_id: str, target_version: str, since: datetime) -> dict:
     """Count auto-upgrade ``deploy`` commands for this node at
-    ``target_version`` since ``since`` — ALL statuses."""
+    ``target_version`` since ``since`` — ALL statuses, within ``tenant_id``.
+
+    ``tenant_id`` is **required**, as on ``in-flight-deploy``. Unscoped, this
+    also answered "is this node moving to version X" for a caller-named
+    version, which made it an oracle for another tenant's release schedule.
+    """
     count = await _svc.fleet_count_recent_deploys_for_target(
         node_id=node_id,
+        tenant_id=tenant_id,
         target_version=target_version,
         since=since,
     )

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -9241,9 +9241,25 @@ class PostgresService:
         self,
         *,
         node_id: UUID,
+        tenant_id: str,
     ) -> FleetNode | None:
+        """One node, scoped to its tenant. ``None`` when either half misses.
+
+        ``tenant_id`` is required. No caller could reach another tenant's node
+        through this before — two derive ``node_id`` from the tenant-scoped
+        ``fleet_get_node_id``, and ``create_command`` compared
+        ``node.tenant_id`` after the fetch — so this removes an unscoped
+        primitive rather than a live hole. It is the form that survives the
+        next caller: a predicate cannot be forgotten the way a follow-up
+        comparison can.
+        """
         async with get_session() as session:
-            return await session.get(FleetNode, node_id)
+            return await session.scalar(
+                select(FleetNode).where(
+                    FleetNode.id == node_id,
+                    FleetNode.tenant_id == tenant_id,
+                )
+            )
 
     async def fleet_list_nodes(
         self,
@@ -9290,14 +9306,6 @@ class PostgresService:
 
     # -- Commands --
 
-    async def fleet_get_command_by_id(
-        self,
-        *,
-        command_id: UUID,
-    ) -> FleetCommand | None:
-        async with get_session() as session:
-            return await session.get(FleetCommand, command_id)
-
     async def fleet_get_pending_commands(
         self,
         *,
@@ -9326,6 +9334,7 @@ class PostgresService:
         self,
         *,
         node_id: UUID,
+        tenant_id: str,
         since: datetime,
     ) -> bool:
         """True if a ``deploy`` command for this node is still in flight.
@@ -9334,6 +9343,12 @@ class PostgresService:
         ``created_at >= since``. Used by the auto-upgrade gate to suppress
         queueing duplicate deploys when a previous one has been sent to
         the plugin but never reported back as completed/failed.
+
+        Scoped on the node/tenant PAIR for the same reason
+        ``fleet_get_pending_commands`` is: a ``node_id``-only predicate reads as
+        tenant-safe and is not. Unscoped, this answered for any node whose UUID
+        the caller could name, which disclosed another tenant's rollouts as they
+        happened.
         """
         # Primary (writer) session, not get_read_session: this is a read-after-write
         # deploy-dedup gate — a replica read under lag could miss a just-queued command
@@ -9343,6 +9358,7 @@ class PostgresService:
                 select(FleetCommand.id)
                 .where(
                     FleetCommand.node_id == node_id,
+                    FleetCommand.tenant_id == tenant_id,
                     FleetCommand.command == "deploy",
                     FleetCommand.status.in_(("pending", "acked")),
                     FleetCommand.created_at >= since,
@@ -9355,6 +9371,7 @@ class PostgresService:
         self,
         *,
         node_id: UUID,
+        tenant_id: str,
         target_version: str,
         since: datetime,
     ) -> int:
@@ -9365,6 +9382,10 @@ class PostgresService:
         statuses is deliberate: the nastiest mode is ``status=done`` with
         no version progress, which a status filter would miss. Keyed on
         ``target_version`` so a NEW release starts a fresh budget.
+
+        Scoped on the node/tenant pair. Unscoped, this both counted another
+        tenant's attempts and answered "is this node moving to version X" for a
+        caller-named version — an oracle for someone else's release schedule.
         """
         # Primary (writer) session, not get_read_session: the attempt budget must
         # count deploys queued by a prior heartbeat (replica lag would under-count
@@ -9373,6 +9394,7 @@ class PostgresService:
             result = await session.execute(
                 select(func.count(FleetCommand.id)).where(
                     FleetCommand.node_id == node_id,
+                    FleetCommand.tenant_id == tenant_id,
                     FleetCommand.command == "deploy",
                     FleetCommand.payload["target_version"].astext == target_version,
                     FleetCommand.created_at >= since,

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -93,30 +93,6 @@
       "note": "Verified: data['tenant_id'] is stored directly on the FleetNode row."
     },
     {
-      "id": "method:fleet_count_recent_deploys_for_target",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read"
-    },
-    {
-      "id": "method:fleet_get_command_by_id",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read"
-    },
-    {
-      "id": "method:fleet_get_node_by_id",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read"
-    },
-    {
-      "id": "method:fleet_has_recent_in_flight_deploy",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read"
-    },
-    {
       "id": "method:fleet_upsert_node",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -276,18 +252,6 @@
       "evidence": "reads tenant_id with .get() and never rejects a missing one",
       "category": "id-addressed-read",
       "note": "Scopes to the entity's OWN tenant when omitted \u2014 self-authorizing."
-    },
-    {
-      "id": "route:GET /api/v1/storage/fleet/commands/deploy-attempt-count",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-read"
-    },
-    {
-      "id": "route:GET /api/v1/storage/fleet/commands/in-flight-deploy",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-read"
     },
     {
       "id": "route:GET /api/v1/storage/healthz",

--- a/core-storage-api/tests/test_fleet_reads_tenant_scope.py
+++ b/core-storage-api/tests/test_fleet_reads_tenant_scope.py
@@ -1,0 +1,223 @@
+"""The fleet read paths must be told which tenant they are reading for.
+
+The read form of GHSA-wgvw-28pq-jc36 on the fleet tables. Four service methods
+keyed on ``node_id`` or ``command_id`` alone, with no tenant predicate, and two
+routes that took a node UUID straight off the query string and never mentioned a
+tenant at all.
+
+The two routes are the reachable half, and what they disclose is another
+tenant's deployment activity:
+
+* ``GET /fleet/commands/in-flight-deploy`` answers whether a deploy is currently
+  in flight for a node — so anyone who can reach the port can watch another
+  tenant's rollouts happen.
+* ``GET /fleet/commands/deploy-attempt-count`` answers how many deploys have
+  been queued for a node at a named ``target_version``, which also makes it an
+  oracle for which versions another tenant is moving to: ask for a version and a
+  non-zero count confirms it.
+
+``fleet_get_node_by_id`` is the third method. It is **not** reachable across
+tenants today — all three of its callers guard, two by deriving ``node_id`` from
+the tenant-scoped ``fleet_get_node_id`` and the third (``create_command``) by
+comparing ``node.tenant_id`` after the fetch. Scoping it removes the unscoped
+primitive rather than a live hole, and turns ``create_command``'s manual
+comparison into a predicate, which is the form that cannot be forgotten by the
+next caller. That distinction is deliberate here: this file does not claim a
+cross-tenant read that does not exist.
+
+The fourth, ``fleet_get_command_by_id``, had no callers anywhere in the
+repository and is deleted rather than scoped — the third time that question has
+paid on this backlog, after #1091 and #1161.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def _node(client: AsyncClient, tenant_id: str, node_name: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/fleet/nodes",
+        json={
+            "tenant_id": tenant_id,
+            "fleet_id": "f1",
+            "node_name": node_name,
+            "hostname": "h1",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _deploy(client: AsyncClient, tenant_id: str, node_id: str, version: str = "2.4.0") -> None:
+    resp = await client.post(
+        f"{PREFIX}/fleet/commands",
+        json={
+            "tenant_id": tenant_id,
+            "node_id": node_id,
+            "command": "deploy",
+            "payload": {"target_version": version},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def _since() -> str:
+    return (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+
+
+class TestInFlightDeployTenantScope:
+    async def test_another_tenants_deploy_is_not_visible(self, client: AsyncClient) -> None:
+        """The attack: watching a rollout you do not own."""
+        victim = f"fl-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"fl-attacker-{uuid.uuid4().hex[:8]}"
+        node_id = await _node(client, victim, f"node-{uuid.uuid4().hex[:6]}")
+        await _deploy(client, victim, node_id)
+
+        resp = await client.get(
+            f"{PREFIX}/fleet/commands/in-flight-deploy",
+            params={"node_id": node_id, "since": _since(), "tenant_id": attacker},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["in_flight"] is False, "another tenant's deploy was disclosed"
+
+    async def test_the_owning_tenant_still_sees_its_deploy(self, client: AsyncClient) -> None:
+        """The regression guard: scoping must not blind the legitimate caller.
+
+        Without this, returning False unconditionally would pass the test above
+        while breaking the deploy-dedup gate the endpoint exists to serve.
+        """
+        tenant = f"fl-{uuid.uuid4().hex[:8]}"
+        node_id = await _node(client, tenant, f"node-{uuid.uuid4().hex[:6]}")
+        await _deploy(client, tenant, node_id)
+
+        resp = await client.get(
+            f"{PREFIX}/fleet/commands/in-flight-deploy",
+            params={"node_id": node_id, "since": _since(), "tenant_id": tenant},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["in_flight"] is True
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """No tenant used to mean "any node"; FastAPI now rejects it as missing."""
+        tenant = f"fl-{uuid.uuid4().hex[:8]}"
+        node_id = await _node(client, tenant, f"node-{uuid.uuid4().hex[:6]}")
+        await _deploy(client, tenant, node_id)
+
+        resp = await client.get(
+            f"{PREFIX}/fleet/commands/in-flight-deploy",
+            params={"node_id": node_id, "since": _since()},
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+
+
+class TestDeployAttemptCountTenantScope:
+    async def test_another_tenants_attempts_are_not_counted(self, client: AsyncClient) -> None:
+        """Also an oracle for which version another tenant is rolling out."""
+        victim = f"fl-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"fl-attacker-{uuid.uuid4().hex[:8]}"
+        node_id = await _node(client, victim, f"node-{uuid.uuid4().hex[:6]}")
+        await _deploy(client, victim, node_id, version="9.9.9")
+
+        resp = await client.get(
+            f"{PREFIX}/fleet/commands/deploy-attempt-count",
+            params={
+                "node_id": node_id,
+                "target_version": "9.9.9",
+                "since": _since(),
+                "tenant_id": attacker,
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["count"] == 0, "another tenant's deploy attempts were disclosed"
+
+    async def test_the_owning_tenant_still_counts_its_attempts(self, client: AsyncClient) -> None:
+        """The attempt budget (CAURA-000) must still see its own deploys."""
+        tenant = f"fl-{uuid.uuid4().hex[:8]}"
+        node_id = await _node(client, tenant, f"node-{uuid.uuid4().hex[:6]}")
+        await _deploy(client, tenant, node_id, version="9.9.9")
+        await _deploy(client, tenant, node_id, version="9.9.9")
+
+        resp = await client.get(
+            f"{PREFIX}/fleet/commands/deploy-attempt-count",
+            params={
+                "node_id": node_id,
+                "target_version": "9.9.9",
+                "since": _since(),
+                "tenant_id": tenant,
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["count"] == 2
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        tenant = f"fl-{uuid.uuid4().hex[:8]}"
+        node_id = await _node(client, tenant, f"node-{uuid.uuid4().hex[:6]}")
+
+        resp = await client.get(
+            f"{PREFIX}/fleet/commands/deploy-attempt-count",
+            params={"node_id": node_id, "target_version": "9.9.9", "since": _since()},
+        )
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+
+
+class TestCreateCommandNodeOwnership:
+    async def test_a_foreign_node_is_still_refused(self, client: AsyncClient) -> None:
+        """Regression guard for the check that became a predicate.
+
+        ``create_command`` used to fetch the node unscoped and compare
+        ``node.tenant_id`` afterwards. The fetch is scoped now, so the
+        comparison is gone; this pins the behaviour it was providing, which is
+        the whole reason that comparison existed — an insert naming another
+        tenant's node satisfies the FK and would otherwise be collected by that
+        node on its next heartbeat.
+        """
+        victim = f"fl-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"fl-attacker-{uuid.uuid4().hex[:8]}"
+        node_id = await _node(client, victim, f"node-{uuid.uuid4().hex[:6]}")
+
+        resp = await client.post(
+            f"{PREFIX}/fleet/commands",
+            json={
+                "tenant_id": attacker,
+                "node_id": node_id,
+                "command": "deploy",
+                "payload": {"target_version": "1.0.0"},
+            },
+        )
+
+        assert resp.status_code == 404, resp.text
+
+    async def test_the_owning_tenant_can_still_queue(self, client: AsyncClient) -> None:
+        """The scoped fetch must not refuse the legitimate insert."""
+        tenant = f"fl-{uuid.uuid4().hex[:8]}"
+        node_id = await _node(client, tenant, f"node-{uuid.uuid4().hex[:6]}")
+
+        resp = await client.post(
+            f"{PREFIX}/fleet/commands",
+            json={
+                "tenant_id": tenant,
+                "node_id": node_id,
+                "command": "deploy",
+                "payload": {"target_version": "1.0.0"},
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["node_id"] == node_id

--- a/tests/test_fleet_heartbeat_auto_upgrade.py
+++ b/tests/test_fleet_heartbeat_auto_upgrade.py
@@ -141,6 +141,11 @@ class _FakeStorage:
         self.created_commands: list[dict] = []
         self.in_flight_fn = None
         self.count_fn = None
+        # Tenants the gate actually handed to storage, in call order. Recorded
+        # rather than asserted inline because the caller wraps both calls in a
+        # fail-open ``except`` — see
+        # ``test_auto_upgrade_gate_passes_the_tenant_to_storage``.
+        self.seen_tenants: list[str] = []
 
     async def get_pending_commands(self, _tenant_id, _node_name):
         return list(self.pending_commands)
@@ -149,12 +154,14 @@ class _FakeStorage:
         self.created_commands.append(data)
         return {"id": "fake-cmd-1"}
 
-    async def fleet_in_flight_deploy(self, *, node_id, since):
+    async def fleet_in_flight_deploy(self, *, node_id, tenant_id, since):
+        self.seen_tenants.append(tenant_id)
         if self.in_flight_fn is not None:
             return await self.in_flight_fn(node_id=node_id, since=since)
         return False
 
-    async def fleet_deploy_attempt_count(self, *, node_id, target_version, since):
+    async def fleet_deploy_attempt_count(self, *, node_id, tenant_id, target_version, since):
+        self.seen_tenants.append(tenant_id)
         if self.count_fn is not None:
             return await self.count_fn(
                 node_id=node_id, target_version=target_version, since=since
@@ -411,6 +418,48 @@ def test_has_recent_deploy_from_list_handles_non_dict_entries():
         )
         is True
     )
+
+
+@pytest.mark.asyncio
+async def test_auto_upgrade_gate_passes_the_tenant_to_storage(monkeypatch):
+    """The tenant must actually reach storage, not merely be available here.
+
+    This pins the WIRING, not the predicate, and it needs its own test because
+    both calls in ``_maybe_queue_auto_upgrade`` are wrapped in a fail-open
+    ``except Exception`` that falls back to ALLOW. Drop ``tenant_id`` from
+    either call and the ``TypeError`` from ``_FakeStorage`` is swallowed there,
+    the gate proceeds, and every other test in this file still passes — a
+    tenant scope that reports success while doing nothing.
+
+    Asserting on what storage RECEIVED is what makes that visible: an argument
+    that never arrives records nothing.
+
+    ``node_id`` must be a real UUID. The same fail-open ``except`` also
+    swallows the ``ValueError`` from ``UUID("node-uuid-1")``, so the
+    placeholder used elsewhere in this file never reaches storage at all —
+    which is its own demonstration of how much that handler hides.
+    """
+    monkeypatch.setattr(fleet_mod, "MIN_RECOMMENDED_PLUGIN_VERSION", "2.4.0")
+    monkeypatch.setattr(fleet_mod, "MIN_AUTO_DEPLOY_PLUGIN_VERSION", "0.0.0")
+
+    async def _enabled(_tid):
+        return True
+
+    monkeypatch.setattr(fleet_mod, "_auto_upgrade_enabled_for_tenant", _enabled)
+    sc = _FakeStorage()
+    await fleet_mod._maybe_queue_auto_upgrade(
+        sc=sc,
+        body=_body("2.3.5"),
+        pending_commands=sc.pending_commands,
+        node_id="00000000-0000-0000-0000-000000000001",
+    )
+
+    # Both gates consulted, both told which tenant is asking.
+    assert sc.seen_tenants == ["tenant-1", "tenant-1"], (
+        "the in-flight and attempt-budget checks must both receive the tenant; "
+        f"storage saw {sc.seen_tenants}"
+    )
+    assert len(sc.created_commands) == 1, "the happy path must still queue"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ph3_storage_documents_fleet.py
+++ b/tests/test_ph3_storage_documents_fleet.py
@@ -299,7 +299,7 @@ async def test_fleet_in_flight_deploy(sc):
 
     # Pending within the window → in flight.
     await _add_deploy_command(svc, tenant, node_id, status="pending", created_at=now)
-    assert await sc.fleet_in_flight_deploy(node_id=node_id, since=since) is True
+    assert await sc.fleet_in_flight_deploy(node_id=node_id, tenant_id=tenant, since=since) is True
 
 
 async def test_fleet_in_flight_deploy_acked_counts(sc):
@@ -311,7 +311,7 @@ async def test_fleet_in_flight_deploy_acked_counts(sc):
 
     # Acked within the window also counts as in flight.
     await _add_deploy_command(svc, tenant, node_id, status="acked", created_at=now)
-    assert await sc.fleet_in_flight_deploy(node_id=node_id, since=since) is True
+    assert await sc.fleet_in_flight_deploy(node_id=node_id, tenant_id=tenant, since=since) is True
 
 
 async def test_fleet_in_flight_deploy_false_when_older_or_none(sc):
@@ -322,17 +322,17 @@ async def test_fleet_in_flight_deploy_false_when_older_or_none(sc):
     since = now - timedelta(minutes=10)
 
     # No commands at all → not in flight.
-    assert await sc.fleet_in_flight_deploy(node_id=node_id, since=since) is False
+    assert await sc.fleet_in_flight_deploy(node_id=node_id, tenant_id=tenant, since=since) is False
 
     # A pending deploy older than the window is abandoned → not in flight.
     await _add_deploy_command(
         svc, tenant, node_id, status="pending", created_at=now - timedelta(minutes=30)
     )
-    assert await sc.fleet_in_flight_deploy(node_id=node_id, since=since) is False
+    assert await sc.fleet_in_flight_deploy(node_id=node_id, tenant_id=tenant, since=since) is False
 
     # A done deploy (terminal) within the window is not in flight.
     await _add_deploy_command(svc, tenant, node_id, status="done", created_at=now)
-    assert await sc.fleet_in_flight_deploy(node_id=node_id, since=since) is False
+    assert await sc.fleet_in_flight_deploy(node_id=node_id, tenant_id=tenant, since=since) is False
 
 
 async def test_fleet_deploy_attempt_count_all_statuses_per_target(sc):
@@ -354,12 +354,20 @@ async def test_fleet_deploy_attempt_count_all_statuses_per_target(sc):
     )
 
     count = await sc.fleet_deploy_attempt_count(
-        node_id=node_id, target_version="2.4.0", since=since
+        node_id=node_id, tenant_id=tenant, target_version="2.4.0", since=since
     )
     assert count == 3, "counts all statuses for this target within the window"
 
     # Zero for a brand-new target → fresh budget.
     fresh = await sc.fleet_deploy_attempt_count(
-        node_id=node_id, target_version="9.9.9", since=since
+        node_id=node_id, tenant_id=tenant, target_version="9.9.9", since=since
     )
     assert fresh == 0
+
+    # And zero for a tenant that does not own the node — the client carries the
+    # scope end-to-end, not just the service method. Cheap to assert here
+    # because this test already has a real node and real commands behind it.
+    foreign = await sc.fleet_deploy_attempt_count(
+        node_id=node_id, tenant_id=_t(), target_version="2.4.0", since=since
+    )
+    assert foreign == 0


### PR DESCRIPTION
## Summary

- Require `tenant_id` on `GET /fleet/commands/in-flight-deploy` and `GET /fleet/commands/deploy-attempt-count`, and bind all three surviving fleet read methods to the node/tenant pair.
- **Delete** `fleet_get_command_by_id` rather than scope it — it had no callers.
- Thread the tenant through the storage client and the auto-upgrade gate in `core-api`.
- Remove all six entries from the tenant-scope allowlist.

## Related Issue

Closes #1170.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## What was reachable, and what wasn't

Stated separately because only two of the six were live holes, and a PR that blurs that is harder to review.

**Reachable.** Both routes took a node UUID off the query string and named no tenant. `in-flight-deploy` answers whether a deploy is currently in flight for a node, so another tenant's rollouts were observable as they happened. `deploy-attempt-count` answers how many deploys were queued for a node at a **caller-named** `target_version` — as well as the count, that makes it an oracle for someone else's release schedule: name a version, and a non-zero count confirms it.

**Not reachable.** `fleet_get_node_by_id` could not be reached cross-tenant: `get_node` and `delete_node` derive `node_id` from the tenant-scoped `fleet_get_node_id`, and `create_command` compared `node.tenant_id` after the fetch. Scoping it removes an unscoped primitive and turns that manual comparison into a predicate — the form the next caller cannot forget — but no test here demonstrates a cross-tenant read, because there wasn't one.

## The deletion

`fleet_get_command_by_id` had **no callers anywhere** — every file type, no dynamic dispatch — and was a bare `session.get(FleetCommand, command_id)` sitting directly above `fleet_get_pending_commands`, whose own comment warns that keying on `node_id` alone *"looks tenant-safe and is not"*.

Asking "does this need to exist?" before scoping has now removed three unscoped reads for the cost of a search each — `entity_delete_entity_links` (#1091), `entity_get_entity_links_for_memories` (#1161), and this. That is a cheaper lesson than the scoping work, and worth making legible to whoever audits this next.

## The hazard this PR is really about

Both `core-api` call sites are wrapped in `try/except Exception` that **falls back to ALLOW**, so the auto-upgrade cannot be wedged by a transient DB error. That means a mis-wired argument does not fail — it silently disables the gate. A tenant scope that reports success while doing nothing.

So the wiring gets its own test, asserting what storage **received** rather than what the caller had available. On the parent:

```text
E  AssertionError: the in-flight and attempt-budget checks must both receive the tenant; storage saw []
E  assert [] == ['tenant-1', 'tenant-1']
```

Writing it turned up a second instance of the same swallowing: `node_id="node-uuid-1"` in the existing tests is not a valid UUID, so `UUID(node_id)` raises `ValueError`, the same handler eats it, and **those tests never reach storage at all**. The new test uses a real UUID; the others are left alone as out of scope.

## Design notes

- **`tenant_id: str`, deliberately not `str | Unscoped`.** The `Unscoped` sentinel exists so a genuinely cross-tenant call must spell `tenant_id=UNSCOPED` rather than default into one. No caller here needs that escape hatch, and where it is unnecessary `str` is stronger — it makes unscoped unspellable rather than merely explicit.
- **`create_command` now uses `_require`.** Scoping the fetch alone left a missing tenant surfacing as "Node not found": fail-closed, but it says the wrong thing, and it left the route unreadable to the gate's AST pass — which is exactly the `blind-spot` category. The gate caught this mid-change (`route:POST /fleet/commands takes no binding tenant scope and is not in the allowlist`), which is the check doing its job on its own author.
- While editing that block I found a **stale comment**: it claimed `fleet_get_pending_commands` keys on `node_id` alone, which stopped being true when that method was scoped to the pair. Rewritten.
- `read=False` (primary, not replica) survives on both client methods — read-after-write correctness for the deploy-dedup gate and the attempt budget.

## How Has This Been Tested?

New tests fail on the parent commit — 4 of the 8 storage tests (the other 4 are happy-path and `create_command` guards that already passed), plus the wiring test:

```text
FAILED TestInFlightDeployTenantScope::test_another_tenants_deploy_is_not_visible
FAILED TestInFlightDeployTenantScope::test_omitted_tenant_id_is_rejected
FAILED TestDeployAttemptCountTenantScope::test_another_tenants_attempts_are_not_counted
FAILED TestDeployAttemptCountTenantScope::test_omitted_tenant_id_is_rejected
FAILED test_auto_upgrade_gate_passes_the_tenant_to_storage
```

With the fix:

| check | result |
|---|---|
| `core-storage-api/tests/` | 291 passed |
| root `tests/` | 5760 passed, 4 skipped, 1 xfailed |
| `core-api/tests/` | 52 passed |
| `core-worker/tests/` | 80 passed |
| `ruff check` / `ruff format --check` — core-api/src, core-storage-api/src, core-storage-api/tests | all pass |
| `mypy src/` — core-storage-api (85), core-api (203) | both clean |
| `tenant_scope_gate.py --base origin/main` | exit 0 |

Gate output, using the per-move reporting from #1166:

```text
  added (0)
  removed — fixed (5)
  removed — gone (1):
      - method:fleet_get_command_by_id [id-addressed-read]
  removed — still unscoped (0)
      id-addressed-read: 12 -> 6
```

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally
- [ ] I have updated relevant documentation (no user-facing surface changed; internal storage endpoints)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (not user-facing; release-please derives this from the conventional commit)

## Additional Notes

- Allowlist 84 → 78. `id-addressed-read` 12 → 6, leaving the entities group and the two `tenant-usage` entries.
- Four existing client tests in `tests/test_ph3_storage_documents_fleet.py` gained the new argument; one also gained a foreign-tenant assertion, since it already had a real node and real commands behind it and the end-to-end path was worth pinning once.
