### PR TITLE
fix(storage): scope the entity-by-id reads to the caller's tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1330,8 +1330,10 @@ class CoreStorageClient:
     async def create_entity(self, data: dict) -> dict:
         return await self._post("/entities", data)  # type: ignore[return-value]
 
-    async def get_entity(self, entity_id: str) -> dict | None:
-        return await self._get(f"/entities/{entity_id}")
+    async def get_entity(self, entity_id: str, tenant_id: str) -> dict | None:
+        # Same contract as ``get_memory``: the row is addressed by a bare UUID,
+        # so the tenant has to travel with it or storage has no predicate.
+        return await self._get(f"/entities/{entity_id}", tenant_id=tenant_id)
 
     async def update_entity(self, entity_id: str, tenant_id: str, data: dict) -> dict | None:
         # Same contract as ``update_memory`` above, for the same reason.
@@ -1450,14 +1452,13 @@ class CoreStorageClient:
             read=True,
         )
 
-    async def get_entity_with_linked_memories(self, entity_id: str) -> dict | None:
-        return await self._get(f"/entities/{entity_id}/with-memories")
+    async def get_entity_with_linked_memories(self, entity_id: str, tenant_id: str) -> dict | None:
+        return await self._get(f"/entities/{entity_id}/with-memories", tenant_id=tenant_id)
 
-    async def get_outgoing_relations(self, entity_id: str, tenant_id: str | None = None) -> list[dict]:
-        params: dict[str, Any] = {}
-        if tenant_id is not None:
-            params["tenant_id"] = tenant_id
-        return await self._get_list(f"/entities/{entity_id}/relations", **params)
+    async def get_outgoing_relations(self, entity_id: str, tenant_id: str) -> list[dict]:
+        # ``tenant_id`` was optional here and storage fell back to the addressed
+        # row's own tenant when it was omitted, so the optionality was the hole.
+        return await self._get_list(f"/entities/{entity_id}/relations", tenant_id=tenant_id)
 
     async def create_relation(self, data: dict) -> dict:
         return await self._post("/entities/relations", data)  # type: ignore[return-value]

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1677,9 +1677,9 @@ async def _fetch_entity_context(sc, memory_id: str, tenant_id: str) -> list[dict
     Two storage round-trips at worst:
       1. ``get_entity_links_for_memories([memory_id])`` — batch endpoint;
          returns ``{memory_id: [{entity_id, role}, ...]}``.
-      2. ``get_entity(entity_id)`` per link, fan-out via ``asyncio.gather``
-         — Path C is post-commit async so the round-trip parallelism is
-         latency-invisible to the write path.
+      2. ``get_entity(entity_id, tenant_id)`` per link, fan-out via
+         ``asyncio.gather`` — Path C is post-commit async so the round-trip
+         parallelism is latency-invisible to the write path.
 
     Returns ``[]`` (not ``None``) when the memory has no resolved links;
     the caller treats empty as the skip-retraction signal so this
@@ -1703,7 +1703,7 @@ async def _fetch_entity_context(sc, memory_id: str, tenant_id: str) -> list[dict
         if not entity_id:
             return None
         try:
-            entity = await sc.get_entity(str(entity_id))
+            entity = await sc.get_entity(str(entity_id), tenant_id)
         except Exception as e:
             logger.warning(
                 "Path C entity-context fetch failed (entity %s) for memory %s: %s",

--- a/core-api/src/core_api/services/entity_service.py
+++ b/core-api/src/core_api/services/entity_service.py
@@ -135,11 +135,15 @@ async def upsert_entity(
 
 async def get_entity(entity_id: UUID, tenant_id: str, caller_agent_id: str | None = None) -> EntityOut | None:
     sc = get_storage_client()
-    result = await sc.get_entity_with_linked_memories(str(entity_id))
+    result = await sc.get_entity_with_linked_memories(str(entity_id), tenant_id)
     if not result:
         return None
 
     entity = result.get("entity", {})
+    # Kept although storage now applies the same predicate. This comparison used
+    # to be the ONLY thing scoping this read — the defect class being that the
+    # guarantee lived in one caller — and the two fail independently: this one
+    # covers a storage regression, the predicate covers any other caller.
     if entity.get("tenant_id") != tenant_id:
         return None
 

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -621,8 +621,12 @@ async def set_embeddings(request: Request) -> dict:
 
 
 @router.get("/{entity_id}")
-async def get_entity(entity_id: UUID) -> dict:
-    entity = await _svc.entity_get_by_id(entity_id)
+async def get_entity(entity_id: UUID, tenant_id: str) -> dict:
+    # Read guard, the mirror of ``PATCH /entities/{entity_id}`` above: the route
+    # took a bare UUID and returned the whole row, so knowing an id was enough to
+    # read another tenant's entity. ``tenant_id`` is a required query parameter —
+    # omitting it is a 422, not a fetch by primary key.
+    entity = await _svc.entity_get_by_id(entity_id, tenant_id)
     if entity is None:
         raise HTTPException(status_code=404, detail="Entity not found")
     return orm_to_dict(entity, ENTITY_FIELDS)
@@ -647,13 +651,17 @@ async def update_entity(entity_id: UUID, request: Request) -> dict:
 @router.get("/{entity_id}/with-memories")
 async def get_entity_with_linked_memories(
     entity_id: UUID,
-    tenant_id: str | None = None,
+    tenant_id: str,
 ) -> dict:
-    entity = await _svc.entity_get_by_id(entity_id)
+    # ``tenant_id`` was optional and fell back to ``entity.tenant_id`` — the
+    # tenant of the row being addressed. That is not a check: it is satisfied by
+    # construction for any id, and an attacker closes it by simply omitting the
+    # parameter. The allowlist note calling it "self-authorizing" is retired
+    # with it. Required now; the downstream link read was already scoped.
+    entity = await _svc.entity_get_by_id(entity_id, tenant_id)
     if entity is None:
         raise HTTPException(status_code=404, detail="Entity not found")
-    t_id = tenant_id or entity.tenant_id
-    rows = await _svc.entity_get_linked_memories(entity_id, t_id)
+    rows = await _svc.entity_get_linked_memories(entity_id, tenant_id)
     return {
         "entity": orm_to_dict(entity, ENTITY_FIELDS),
         "linked_memories": [
@@ -669,13 +677,15 @@ async def get_entity_with_linked_memories(
 @router.get("/{entity_id}/relations")
 async def get_outgoing_relations(
     entity_id: UUID,
-    tenant_id: str | None = None,
+    tenant_id: str,
 ) -> list[dict]:
-    entity = await _svc.entity_get_by_id(entity_id)
+    # Same retired fallback as ``/with-memories`` above, and the disclosure here
+    # is wider: the response carries each target entity in full, so an unscoped
+    # call walked one hop out into another tenant's graph.
+    entity = await _svc.entity_get_by_id(entity_id, tenant_id)
     if entity is None:
         raise HTTPException(status_code=404, detail="Entity not found")
-    t_id = tenant_id or entity.tenant_id
-    rows = await _svc.relation_get_outgoing(entity_id, t_id)
+    rows = await _svc.relation_get_outgoing(entity_id, tenant_id)
     return [
         {
             "relation": orm_to_dict(rel, RELATION_FIELDS),

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -5135,9 +5135,24 @@ class PostgresService:
     # Entity CRUD
     # ------------------------------------------------------------------
 
-    async def entity_get_by_id(self, entity_id: UUID) -> Entity | None:
+    async def entity_get_by_id(self, entity_id: UUID, tenant_id: str) -> Entity | None:
+        """Fetch one entity, bound to the tenant that asked for it.
+
+        ``session.get`` addressed the row by primary key alone, which is the
+        shape of GHSA-wgvw-28pq-jc36 — knowing a UUID is not the same as being
+        entitled to the row behind it. ``Entity.tenant_id`` is indexed and
+        ``nullable=False``, so the predicate is a plain conjunct on the same
+        lookup rather than a second round-trip.
+
+        A foreign id returns ``None`` and its routes 404, which is what a
+        missing id already returned. That is deliberate: rejecting with a 403
+        would confirm the row exists in someone else's tenant, so filtering
+        leaks strictly less than refusing.
+        """
         async with get_session() as session:
-            return await session.get(Entity, entity_id)
+            return await session.scalar(
+                select(Entity).where(Entity.id == entity_id, Entity.tenant_id == tenant_id)
+            )
 
     async def entity_find_exact(
         self,

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -73,12 +73,6 @@
       "note": "Verified: every item carries tenant_id, which scopes updates, inserts, race recovery, and winner lookups."
     },
     {
-      "id": "method:entity_get_by_id",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read"
-    },
-    {
       "id": "method:fleet_add_command",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -232,26 +226,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "no-tenant-data"
-    },
-    {
-      "id": "route:GET /api/v1/storage/entities/{entity_id}",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-read"
-    },
-    {
-      "id": "route:GET /api/v1/storage/entities/{entity_id}/relations",
-      "verdict": "OPTIONAL",
-      "evidence": "reads tenant_id with .get() and never rejects a missing one",
-      "category": "id-addressed-read",
-      "note": "Scopes to the entity's OWN tenant when omitted \u2014 self-authorizing."
-    },
-    {
-      "id": "route:GET /api/v1/storage/entities/{entity_id}/with-memories",
-      "verdict": "OPTIONAL",
-      "evidence": "reads tenant_id with .get() and never rejects a missing one",
-      "category": "id-addressed-read",
-      "note": "Scopes to the entity's OWN tenant when omitted \u2014 self-authorizing."
     },
     {
       "id": "route:GET /api/v1/storage/healthz",

--- a/core-storage-api/tests/test_entity_read_tenant_scope.py
+++ b/core-storage-api/tests/test_entity_read_tenant_scope.py
@@ -1,0 +1,241 @@
+"""The entity-by-id reads must be told which tenant is asking.
+
+The read form of GHSA-wgvw-28pq-jc36 on the entity graph, and the read sibling
+of ``PATCH /entities/{entity_id}`` (#1119). Three routes shared
+``entity_get_by_id``, which fetched by primary key with no predicate at all:
+
+* ``GET /entities/{entity_id}`` --- the whole entity row.
+* ``GET /entities/{entity_id}/with-memories`` --- the row plus its memories.
+* ``GET /entities/{entity_id}/relations`` --- the row's edges plus each target
+  entity in full, so one hop out into the graph.
+
+The last two took an *optional* ``tenant_id`` and fell back to
+``entity.tenant_id`` --- the tenant of the row being addressed --- when it was
+omitted. That is not a check: it is satisfied by construction for whatever id
+the caller supplies, and an attacker closes it by leaving the parameter off.
+Both carried an allowlist note calling that fallback "self-authorizing", which
+is why the omitted-parameter cases below are the sharpest tests in the file:
+they are the exact request the note said was safe.
+
+**Disclosure, not integrity.** Nothing here mutates a row. What leaks is the
+entity's own fields, the memories linked to it, and its outgoing edges.
+
+**Filter, not reject.** A foreign id returns the same 404 as an id that does
+not exist, so these routes are not an existence oracle for entity UUIDs ---
+a 403 would confirm the row is real and simply owned by someone else.
+``test_a_foreign_id_is_indistinguishable_from_a_missing_one`` pins it. Every
+path here addresses exactly one id, so filtering and rejecting differ only in
+the status code; the partial-match question that a bulk id lookup raises does
+not arise, and #1162 already answered that one with "filter".
+
+Each assertion below checks the victim's data is ABSENT from the response, not
+merely that the call failed --- a status-code-only test would still pass if a
+future refactor 404'd while leaking the row in the body.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX, _memory_payload
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _tenant() -> str:
+    """A tenant id unique to one test and visible to the end-of-run sweep.
+
+    Same prefix contract as the sibling suites: the root suite's
+    ``_setup_schema`` teardown cleans with ``tenant_id LIKE 'test-tenant-%'``,
+    so a tenant minted with any other prefix is never reclaimed --- which is
+    how #858 left 9,186 rows behind. Local to this module rather than
+    ``tests.conftest.new_tenant_id``, which is the root suite's fixture file
+    and not importable from here.
+    """
+    return f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+
+async def _entity(client: AsyncClient, tenant_id: str, name: str | None = None) -> dict:
+    resp = await client.post(
+        f"{PREFIX}/entities",
+        json={
+            "tenant_id": tenant_id,
+            "entity_type": "person",
+            "canonical_name": name or f"ReadScope-{uuid.uuid4().hex[:8]}",
+            "attributes": {"secret": "victim-only"},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _memory(client: AsyncClient, tenant_id: str) -> str:
+    fleet_id = f"test-fleet-{uuid.uuid4().hex[:8]}"
+    resp = await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _link(client: AsyncClient, tenant_id: str, memory_id: str, entity_id: str) -> None:
+    resp = await client.post(
+        f"{PREFIX}/entities/links",
+        json={
+            "tenant_id": tenant_id,
+            "memory_id": memory_id,
+            "entity_id": entity_id,
+            "role": "subject",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def _relation(client: AsyncClient, tenant_id: str, from_id: str, to_id: str) -> None:
+    resp = await client.post(
+        f"{PREFIX}/entities/relations",
+        json={
+            "tenant_id": tenant_id,
+            "from_entity_id": from_id,
+            "relation_type": "works_with",
+            "to_entity_id": to_id,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+class TestGetEntityByIdRead:
+    async def test_a_foreign_entity_is_not_disclosed(self, client: AsyncClient) -> None:
+        """The attack, stated as the request an attacker would send."""
+        victim, attacker = _tenant(), _tenant()
+        row = await _entity(client, victim, name=f"Victim-{uuid.uuid4().hex[:8]}")
+
+        resp = await client.get(f"{PREFIX}/entities/{row['id']}", params={"tenant_id": attacker})
+
+        assert resp.status_code == 404, resp.text
+        assert row["canonical_name"] not in resp.text
+        assert "victim-only" not in resp.text
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """No tenant used to mean "fetch by primary key"; it is now a 422."""
+        row = await _entity(client, _tenant(), name=f"Victim-{uuid.uuid4().hex[:8]}")
+
+        resp = await client.get(f"{PREFIX}/entities/{row['id']}")
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+        assert row["canonical_name"] not in resp.text
+
+    async def test_own_entity_is_returned(self, client: AsyncClient) -> None:
+        """The supported call still works."""
+        tenant = _tenant()
+        row = await _entity(client, tenant)
+
+        resp = await client.get(f"{PREFIX}/entities/{row['id']}", params={"tenant_id": tenant})
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["id"] == row["id"]
+        assert resp.json()["canonical_name"] == row["canonical_name"]
+
+    async def test_a_foreign_id_is_indistinguishable_from_a_missing_one(self, client: AsyncClient) -> None:
+        """Both 404 identically, so this is not an existence oracle."""
+        victim, attacker = _tenant(), _tenant()
+        row = await _entity(client, victim)
+
+        foreign = await client.get(f"{PREFIX}/entities/{row['id']}", params={"tenant_id": attacker})
+        missing = await client.get(f"{PREFIX}/entities/{uuid.uuid4()}", params={"tenant_id": attacker})
+
+        assert foreign.status_code == missing.status_code == 404
+        assert foreign.json() == missing.json()
+
+
+class TestEntityWithMemoriesRead:
+    async def test_a_foreign_entity_and_its_memories_are_not_disclosed(self, client: AsyncClient) -> None:
+        victim, attacker = _tenant(), _tenant()
+        row = await _entity(client, victim, name=f"Victim-{uuid.uuid4().hex[:8]}")
+        memory_id = await _memory(client, victim)
+        await _link(client, victim, memory_id, row["id"])
+
+        resp = await client.get(
+            f"{PREFIX}/entities/{row['id']}/with-memories", params={"tenant_id": attacker}
+        )
+
+        assert resp.status_code == 404, resp.text
+        assert row["canonical_name"] not in resp.text
+        assert memory_id not in resp.text
+
+    async def test_omitting_the_tenant_no_longer_self_authorizes(self, client: AsyncClient) -> None:
+        """The request the retired "self-authorizing" note said was safe.
+
+        ``tenant_id or entity.tenant_id`` meant omitting the parameter scoped
+        the read to the addressed row's own tenant --- which is to say, not at
+        all. This returned the victim's entity and every memory linked to it.
+        """
+        victim = _tenant()
+        row = await _entity(client, victim, name=f"Victim-{uuid.uuid4().hex[:8]}")
+        memory_id = await _memory(client, victim)
+        await _link(client, victim, memory_id, row["id"])
+
+        resp = await client.get(f"{PREFIX}/entities/{row['id']}/with-memories")
+
+        assert resp.status_code == 422, resp.text
+        assert row["canonical_name"] not in resp.text
+        assert memory_id not in resp.text
+
+    async def test_own_entity_with_memories_is_returned(self, client: AsyncClient) -> None:
+        tenant = _tenant()
+        row = await _entity(client, tenant)
+        memory_id = await _memory(client, tenant)
+        await _link(client, tenant, memory_id, row["id"])
+
+        resp = await client.get(f"{PREFIX}/entities/{row['id']}/with-memories", params={"tenant_id": tenant})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["entity"]["id"] == row["id"]
+        assert [e["memory"]["id"] for e in body["linked_memories"]] == [memory_id]
+
+
+class TestEntityRelationsRead:
+    async def test_a_foreign_entitys_graph_is_not_disclosed(self, client: AsyncClient) -> None:
+        victim, attacker = _tenant(), _tenant()
+        source = await _entity(client, victim, name=f"Source-{uuid.uuid4().hex[:8]}")
+        target = await _entity(client, victim, name=f"Target-{uuid.uuid4().hex[:8]}")
+        await _relation(client, victim, source["id"], target["id"])
+
+        resp = await client.get(f"{PREFIX}/entities/{source['id']}/relations", params={"tenant_id": attacker})
+
+        assert resp.status_code == 404, resp.text
+        assert target["canonical_name"] not in resp.text
+        assert target["id"] not in resp.text
+
+    async def test_omitting_the_tenant_no_longer_self_authorizes(self, client: AsyncClient) -> None:
+        """Widest of the three: the response carried each target entity in full.
+
+        With the fallback in place this walked one hop out of the addressed row
+        and returned the neighbour's whole record, not just an edge.
+        """
+        victim = _tenant()
+        source = await _entity(client, victim, name=f"Source-{uuid.uuid4().hex[:8]}")
+        target = await _entity(client, victim, name=f"Target-{uuid.uuid4().hex[:8]}")
+        await _relation(client, victim, source["id"], target["id"])
+
+        resp = await client.get(f"{PREFIX}/entities/{source['id']}/relations")
+
+        assert resp.status_code == 422, resp.text
+        assert target["canonical_name"] not in resp.text
+        assert target["id"] not in resp.text
+
+    async def test_own_relations_are_returned(self, client: AsyncClient) -> None:
+        tenant = _tenant()
+        source = await _entity(client, tenant)
+        target = await _entity(client, tenant)
+        await _relation(client, tenant, source["id"], target["id"])
+
+        resp = await client.get(f"{PREFIX}/entities/{source['id']}/relations", params={"tenant_id": tenant})
+
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()
+        assert [r["target"]["id"] for r in rows] == [target["id"]]
+        assert rows[0]["relation"]["relation_type"] == "works_with"

--- a/core-storage-api/tests/test_entity_update_tenant_scope.py
+++ b/core-storage-api/tests/test_entity_update_tenant_scope.py
@@ -47,14 +47,33 @@ async def _entity(client: AsyncClient, tenant_id: str, name: str) -> str:
 async def _read(client: AsyncClient, entity_id: str) -> dict:
     """Read the row back regardless of tenant, to assert what actually persisted.
 
-    Deliberately goes through ``GET /entities/{entity_id}``, which is still
-    unscoped (allowlisted ``id-addressed-read``) and so answers for any tenant
-    --- that is what makes it a usable oracle here. When that route gains a
-    required tenant, this helper needs one too.
+    Reads ``entities`` through the ORM rather than through
+    ``GET /entities/{entity_id}``, which it used to use. The note that stood
+    here said this helper would need a tenant the day that route took one; it
+    now does, and giving it one would have been the wrong repair. Every
+    assertion below asks "is the row still in the tenant that owned it, with
+    the fields it had" --- so an oracle scoped to a tenant answers about rows
+    already known to be in it, and could not observe a row that moved
+    namespace, which is the failure ``test_another_tenants_entity_is_not_updated``
+    exists to catch. Tenant-blind by construction, and so immune to any
+    further scoping of the route.
+
+    ``client`` is unused but kept in the signature so the call sites read the
+    same and the raw read stays swappable.
     """
-    resp = await client.get(f"{PREFIX}/entities/{entity_id}")
-    assert resp.status_code == 200, resp.text
-    return resp.json()
+    from common.models import Entity
+    from core_storage_api.services.postgres_service import get_session
+
+    async with get_session() as session:
+        entity = await session.get(Entity, uuid.UUID(entity_id))
+    assert entity is not None, f"entity {entity_id} vanished"
+    return {
+        "id": str(entity.id),
+        "tenant_id": entity.tenant_id,
+        "fleet_id": entity.fleet_id,
+        "canonical_name": entity.canonical_name,
+        "attributes": entity.attributes,
+    }
 
 
 class TestEntityUpdateTenantScope:
@@ -148,4 +167,5 @@ class TestEntityUpdateTenantScope:
         row = await _read(client, entity_id)
         assert row["id"] == entity_id, "the primary key was repointed"
         assert row["fleet_id"] is None
-        assert (await client.get(f"{PREFIX}/entities/{stolen}")).status_code == 404
+        stolen_resp = await client.get(f"{PREFIX}/entities/{stolen}", params={"tenant_id": tenant})
+        assert stolen_resp.status_code == 404

--- a/core-storage-api/tests/test_integration.py
+++ b/core-storage-api/tests/test_integration.py
@@ -1802,7 +1802,7 @@ class TestEntities:
         assert body["canonical_name"] == name
 
         # GET by id
-        resp2 = await client.get(f"{PREFIX}/entities/{entity_id}")
+        resp2 = await client.get(f"{PREFIX}/entities/{entity_id}", params={"tenant_id": tenant_id})
         assert resp2.status_code == 200
         assert resp2.json()["canonical_name"] == name
 
@@ -2018,9 +2018,14 @@ class TestEntities:
     async def test_get_nonexistent_entity_returns_404(
         self,
         client: AsyncClient,
+        tenant_id: str,
     ) -> None:
+        # A tenant is passed so this stays a 404 test. Without one the route
+        # now 422s on the missing parameter, which would pass an
+        # ``!= 200`` reading of this assertion while testing nothing about
+        # whether a missing row 404s.
         fake_id = str(uuid.uuid4())
-        resp = await client.get(f"{PREFIX}/entities/{fake_id}")
+        resp = await client.get(f"{PREFIX}/entities/{fake_id}", params={"tenant_id": tenant_id})
         assert resp.status_code == 404
 
     async def test_link_to_ghost_entity_409s_without_leaking_driver_text(

--- a/tests/test_a4_13_path_c_retraction.py
+++ b/tests/test_a4_13_path_c_retraction.py
@@ -136,7 +136,7 @@ def _mock_sc_with_retraction_setup(
         }
     )
 
-    async def get_entity(eid: str) -> dict | None:
+    async def get_entity(eid: str, tenant_id: str) -> dict | None:
         if eid == _ent_new:
             return {"id": eid, "canonical_name": "Project X", "entity_type": "project"}
         if eid == _ent_cand:

--- a/tests/test_caura_129_entity_aware_retraction_prompt.py
+++ b/tests/test_caura_129_entity_aware_retraction_prompt.py
@@ -442,7 +442,11 @@ async def test_fetch_entity_context_composes_two_round_trips():
         }
     )
 
-    async def get_entity(eid: str) -> dict | None:
+    async def get_entity(eid: str, tenant_id: str) -> dict | None:
+        # Asserts rather than ignores: the hydration round-trip is by bare
+        # entity id, so the tenant travelling with it is the whole predicate.
+        # A stub that accepted **kwargs would let a caller drop it silently.
+        assert tenant_id == TENANT, f"entity hydration lost the tenant: {tenant_id!r}"
         return {
             ent_a: {"canonical_name": "Project Helios", "entity_type": "project"},
             ent_b: {"canonical_name": "2027-05-01", "entity_type": "date"},
@@ -523,7 +527,7 @@ async def test_fetch_entity_context_swallows_per_entity_error():
         }
     )
 
-    async def get_entity(eid: str) -> dict | None:
+    async def get_entity(eid: str, tenant_id: str) -> dict | None:
         if eid == ent_bad:
             raise RuntimeError("entity-row gone")
         return {"canonical_name": "Fine Entity", "entity_type": "project"}

--- a/tests/test_caura_130_path_c_safety.py
+++ b/tests/test_caura_130_path_c_safety.py
@@ -246,7 +246,7 @@ def _sc_for_forward_path(
     sc.update_memory_status = AsyncMock()
     sc.get_entity_links_for_memories = AsyncMock(return_value=links_by_mem)
 
-    async def get_entity(eid: str):
+    async def get_entity(eid: str, tenant_id: str):
         if entities is not None and eid in entities:
             return entities[eid]
         # Synthesize a minimal entity row keyed by id; tests pass the

--- a/tests/test_caura_131_entity_aware_path_c_detection.py
+++ b/tests/test_caura_131_entity_aware_path_c_detection.py
@@ -88,7 +88,7 @@ def _sc(
     sc.update_memory_status = AsyncMock()
     sc.get_entity_links_for_memories = AsyncMock(return_value=links_by_mem)
 
-    async def get_entity(eid: str):
+    async def get_entity(eid: str, tenant_id: str):
         # ``entities`` decouples canonical_name from entity_id (WT-3:
         # the L3.4 drop is now scoped to SAME-name/different-id, so
         # collision tests must pin the name explicitly).

--- a/tests/test_contradiction_engine_golden.py
+++ b/tests/test_contradiction_engine_golden.py
@@ -195,7 +195,7 @@ def _sc_for_path_c(
         }
     )
 
-    async def get_entity(eid: str) -> dict | None:
+    async def get_entity(eid: str, tenant_id: str) -> dict | None:
         if eid == ent_new:
             return {"id": eid, "canonical_name": "Haifa", "entity_type": "place"}
         if eid == ent_cand:

--- a/tests/test_storage_bulk_endpoints.py
+++ b/tests/test_storage_bulk_endpoints.py
@@ -362,12 +362,12 @@ async def test_bulk_upsert_mixed_create_and_update(sc):
     assert results[1]["entity_id"] == existing["id"]
 
     # Verify the create landed
-    new_entity = await sc.get_entity(results[0]["entity_id"])
+    new_entity = await sc.get_entity(results[0]["entity_id"], tid)
     assert new_entity["canonical_name"] == "brand-new"
     assert new_entity["attributes"] == {"foo": "bar"}
 
     # Verify the update wrote merged attrs
-    updated = await sc.get_entity(existing["id"])
+    updated = await sc.get_entity(existing["id"], tid)
     assert updated["attributes"] == {"merged": True, "_aliases": ["old-name"]}
 
 
@@ -397,7 +397,7 @@ async def test_bulk_upsert_create_race_merges(sc):
     assert results[0]["action"] == "merged"
     assert results[0]["entity_id"] == existing["id"]
 
-    merged = await sc.get_entity(existing["id"])
+    merged = await sc.get_entity(existing["id"], tid)
     assert merged["attributes"] == {"from": "racy-write"}
 
 
@@ -837,7 +837,10 @@ async def test_bulk_upsert_update_cross_tenant_returns_missing(sc):
     tid_a = _t()
     tid_b = _t()
     foreign = await _create_entity(sc, tid_b, "foreign-entity")
-    foreign_pre = await sc.get_entity(foreign["id"])
+    # Read as tid_b, the row's OWN tenant, so the oracle can still see it. Using
+    # tid_a here would 404 and the "unchanged" assertions below would be
+    # asserting on nothing.
+    foreign_pre = await sc.get_entity(foreign["id"], tid_b)
 
     results = await sc.bulk_upsert_entities(
         items=[
@@ -856,7 +859,7 @@ async def test_bulk_upsert_update_cross_tenant_returns_missing(sc):
     assert results[0]["action"] == "missing"
 
     # Foreign tenant's row stays put — attributes and canonical_name unchanged.
-    post = await sc.get_entity(foreign["id"])
+    post = await sc.get_entity(foreign["id"], tid_b)
     assert post["attributes"] == foreign_pre["attributes"]
     assert post["canonical_name"] == foreign_pre["canonical_name"]
 

--- a/tests/test_wt2_entity_canonicalisation.py
+++ b/tests/test_wt2_entity_canonicalisation.py
@@ -468,7 +468,7 @@ async def test_wet_test_replay_one_subject_one_entity_no_duplicate_links(
     assert "analytics service" in (subject.get("attributes") or {}).get("_aliases", [])
 
     # Both memories linked to the ONE subject entity — once each.
-    result = await sc.get_entity_with_linked_memories(subject["id"])
+    result = await sc.get_entity_with_linked_memories(subject["id"], tid)
     linked_ids = [entry.get("memory", entry)["id"] for entry in result["linked_memories"]]
     assert sorted(linked_ids) == sorted([mem1["id"], mem3["id"]])
     assert len(linked_ids) == len(set(linked_ids)), "duplicate link rows"


### PR DESCRIPTION
The last of the entity surface's `id-addressed-read` entries, and the read sibling of [#1119](https://github.com/caura-ai/caura/pull/1119). Three routes shared `entity_get_by_id`, which was `session.get(Entity, entity_id)` — a fetch by primary key with no predicate at all.

| route | what it returned unscoped | allowlist |
|---|---|---|
| `GET /entities/{entity_id}` | the whole entity row | unnoted |
| `GET /entities/{entity_id}/with-memories` | the row plus every memory linked to it | noted "self-authorizing" |
| `GET /entities/{entity_id}/relations` | the row's edges plus **each target entity in full** | noted "self-authorizing" |

**Stated no stronger than it is.** `core-storage-api` authenticates no request (GHSA-wgvw-28pq-jc36) and docker-compose publishes it on `0.0.0.0:8002`, so one UUID was enough to read any of the above. This is disclosure, not integrity — nothing here mutates a row. No issue was filed for these; the wording is mine.

### Retiring two hand-written notes, deliberately

`/with-memories` and `/relations` took an **optional** `tenant_id` and fell back to `entity.tenant_id` — the tenant of the row being addressed:

```python
t_id = tenant_id or entity.tenant_id
```

That is not a check. It holds by construction for whatever id the caller supplies, and an attacker closes it by *omitting the parameter*. Their allowlist note read *"Scopes to the entity's OWN tenant when omitted — self-authorizing."* I am contradicting a note a human wrote, so the evidence rather than the assertion — this is the pre-fix response to `GET /{id}/relations` **with no tenant at all**, victim tenant `test-tenant-d1a36907`:

```json
[{"relation":{...,"relation_type":"works_with"},
  "target":{"id":"e2369576-...","tenant_id":"test-tenant-d1a36907",
            "canonical_name":"Target-e0ee28d1","entity_type":"person",
            "attributes":{"secret":"victim-only"}}}]
```

The neighbour's whole record, one hop out, to a caller who supplied nothing but a UUID. Their *downstream* reads (`entity_get_linked_memories`, `relation_get_outgoing`) were already tenant-scoped — the hole was the entity fetch and the optionality above it, which is exactly what the note did not cover.

These two routes are not among my seven unnoted entries. I took them because `entity_get_by_id` is, and binding it necessarily binds every caller — the alternative is keeping an unscoped fetch alive for them, which defeats the fix. **If a reviewer wants them left as they were, that is the trade to argue with.**

### The guarantee that lived in one caller

`GET /{entity_id}` had no tenant parameter at all. Its only protection was in core-api, *after* the row crossed the wire — `entity_service.get_entity`:

```python
result = await sc.get_entity_with_linked_memories(str(entity_id))
entity = result.get("entity", {})
if entity.get("tenant_id") != tenant_id:
    return None
```

A Python comparison in one caller, on a row storage had already handed over. That comparison **stays** — it and the predicate fail independently, the same both-belts reasoning [#1119](https://github.com/caura-ai/caura/pull/1119) used — but it was never a substitute for a WHERE clause, and any other caller of that route got nothing.

### Filter, not reject — and why it is the safer half here

Stated deliberately, per the choice this sweep has to make consistently. A foreign id returns the same **404** as an id that does not exist, so these routes are not an existence oracle for entity UUIDs; a 403 would confirm the row is real and merely owned by someone else. `test_a_foreign_id_is_indistinguishable_from_a_missing_one` pins that the two responses are byte-identical.

**Every surviving path on this surface addresses exactly one id**, so filter and reject differ only in the status code and the partial-match question never arises. Where it does arise — bulk id lookups — [#1162](https://github.com/caura-ai/caura/pull/1162) already chose *filter*. This is consistent with it. **For the entries that follow this:** written before #1173 landed, the note was that `fleet_get_command_by_id`, `fleet_get_node_by_id` and `report_get_by_id` are all single-id reads and take the same answer unchanged — 404-on-mismatch, no 403 — while the two aggregating `fleet/commands/*` count routes should filter rather than error, matching #1162. #1173 has since settled the fleet half; the reports pair is what is left, and it is the single-id case.

### Does each need to exist? Yes, all three

Asked before choosing a predicate, per [#1091](https://github.com/caura-ai/caura/issues/1091), and established by searching for the method, the client wrapper and the route path separately rather than trusting the route:

- `GET /{entity_id}` → `sc.get_entity` → Path C entity hydration in `contradiction_detector._fetch_entity_context`.
- `/with-memories` → `sc.get_entity_with_linked_memories` → `entity_service.get_entity`.
- `/relations` → `sc.get_outgoing_relations` → `entity_service`'s relation-scope path.

None dead, none duplicated. The one dead member of this cluster was `relations/find`, deleted separately in [#1168](https://github.com/caura-ai/caura/pull/1168).

### The part worth reviewing: an oracle that would have gone vacuous

`core-storage-api/tests/test_entity_update_tenant_scope.py::_read` read the row back through `GET /entities/{entity_id}` **precisely because that route was unscoped**, and carried a note saying it would need a tenant the day the route took one. It now does — and giving it one would have been the wrong repair.

Those tests ask *"is the row still in the tenant that owned it?"* An oracle scoped to a tenant only answers about rows already known to be in it, so `test_another_tenants_entity_is_not_updated` could no longer observe a row that **moved namespace** — the exact failure it exists to catch. `_read` now reads `entities` through the ORM, tenant-blind by construction and immune to any further scoping. Same class of oracle #1162 had to rewrite, same fix.

One related trap caught in passing: `test_scope_columns_are_not_caller_writable` asserted `GET /entities/{stolen}` returns 404. Left alone that becomes a 422 on the missing parameter — still "not 200", so a laxer assertion would have passed while testing nothing. It now passes a tenant.

Six Path C stubs took `get_entity(eid)` positionally and broke on the new argument (15 root-suite failures, all one cause). **One of them now asserts the tenant reaches the hydration call** rather than ignoring it, so the contract is pinned and not merely tolerated.

### Failing without the fix

Three experiments, because the fix has two halves and they are not equally load-bearing.

**Reverting only the predicate** (`Entity.tenant_id == tenant_id` dropped from `entity_get_by_id`, routes still requiring the parameter) — 4 of 10 fail:

```
FAILED ...TestGetEntityByIdRead::test_a_foreign_entity_is_not_disclosed
FAILED ...TestGetEntityByIdRead::test_a_foreign_id_is_indistinguishable_from_a_missing_one
FAILED ...TestEntityWithMemoriesRead::test_a_foreign_entity_and_its_memories_are_not_disclosed
FAILED ...TestEntityRelationsRead::test_a_foreign_entitys_graph_is_not_disclosed
4 failed, 6 passed in 0.48s
```

The first failure prints the leaked row, which is the point — the test proves the foreign row is **absent from the result**, not merely that the call failed:

```
AssertionError: {"entity":{"id":"3d33fa12-...","tenant_id":"test-tenant-ce917fea",
"canonical_name":"Victim-07a001ad","attributes":{"secret":"victim-only"}},"linked_memories":[]}
assert 200 == 404
```

**Reverting only the required parameter** (routes back to `tenant_id: str | None = None` and the fallback, predicate kept) — 2 fail, the two omitted-tenant cases. Reported honestly: they fail on `404 != 422`, **not** on a disclosure, because the surviving predicate catches the leak. That half is real but it is the belt, not the braces.

**Reverting both** — the genuine pre-fix state — fails 7 of 10, everything except the three happy paths, and is where the `/relations` disclosure quoted above comes from.

### Allowlist

**78 → 74 entries; `id-addressed-read` 6 → 2.** Paths bound to a tenant 298 → 302. Regenerated with `python3 scripts/tenant_scope_gate.py --write` in this commit as the gate's stale-entry check requires. **38 hand-written notes preserved, no `category`/`verdict`/`evidence` drift on any surviving entry, nothing added** — the two notes that went are the retired "self-authorizing" pair.

**Rebased onto [#1173](https://github.com/caura-ai/caura/pull/1173)**, which landed the fleet cluster while this was in review — so the two remaining `id-addressed-read` entries are now just the reports pair, another lane's. **The entity/links surface is empty of this category**, closing what #1148/#1152/#1156 started on the write half and #1161/#1162/#1163/#1168 continued on the read half. With #1173 in, `id-addressed-read` is two entries from zero.

### Verification

- `core-storage-api/tests/`: **293 passed** (10 new).
- Root `tests/`: **5759 passed, 4 skipped, 1 xfailed**.
- `ruff check` at CI's 6 scopes and `ruff format --check` at its 5, run **separately**, discovery-based, no `--config`: clean. Both initially flagged this branch (an unsorted import block and two over-wrapped signatures) and were fixed, not waived. Vendored-`common` `--isolated`: 3 files already formatted.
- `mypy` core-api (203 files) and core-storage-api (85 files): no issues.
- Tenant-scope gate vs `origin/main`: green. Legacy-name ratchet: no new lines. Do-not-touch sentinel: all 46 protected strings survive. Broker OpenAPI baseline: up to date (8 operations).

Run against a dedicated local pgvector instance provisioned CI's way — `alembic upgrade head` on the root database, a separate `memclaw_storage` database for the storage suite. The `#1137` flake did not fire in any of the four full root-suite runs on this branch. **Not checked:** anything requiring CI's own environment — the Actions matrix, the coverage-floors step, the enterprise re-vendor path.


---

*Rebased onto #1173 and force-pushed after the first green run; the allowlist was the only conflict (both PRs regenerate it) and was resolved by taking main's and re-running `--write`. Full verification re-run on the rebased tree: storage 301 passed, root 5760 passed / 4 skipped / 1 xfailed, ruff 6+5 scopes clean, mypy clean, gate green, ratchet/sentinel/broker clean.*
