### PR TITLE
fix(storage): scope the report read to the caller's tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2782,8 +2782,14 @@ class CoreStorageClient:
     async def create_report(self, data: dict) -> dict:
         return await self._post("/reports", data)  # type: ignore[return-value]
 
-    async def get_report(self, report_id: str, *, read: bool = True) -> dict | None:
-        """Fetch one analysis report.
+    async def get_report(self, report_id: str, tenant_id: str, *, read: bool = True) -> dict | None:
+        """Fetch one analysis report, within a tenant.
+
+        ``tenant_id`` is positional and required, matching ``update_report``
+        below: a report id alone used to be enough to READ any tenant's report,
+        as it once was to finalize one (#1082 / #1167). Positional rather than
+        keyword-only because there is no ``data`` dict here for a stray copy to
+        hide in.
 
         ``read`` defaults to True — the replica is right for the read paths that
         display a report. Pass ``read=False`` for a read-your-write, where replica
@@ -2793,7 +2799,7 @@ class CoreStorageClient:
         there re-runs a multi-minute LLM job. Same reason
         ``find_by_content_hash`` pins the writer.
         """
-        return await self._get(f"/reports/{report_id}", read=read)
+        return await self._get(f"/reports/{report_id}", read=read, tenant_id=tenant_id)
 
     async def update_report(self, report_id: str, data: dict, *, tenant_id: str) -> dict | None:
         """Finalize a report. ``tenant_id`` scopes the UPDATE and is required.

--- a/core-api/src/core_api/routes/crystallizer.py
+++ b/core-api/src/core_api/routes/crystallizer.py
@@ -1,13 +1,16 @@
 """Memory Crystallizer routes."""
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from core_api import errors
 from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
+from core_api.errors import coded_detail
 from core_api.schemas import STRICT_WRITE_BODY
 from core_api.services.crystallizer_service import start_crystallization
 
@@ -132,21 +135,65 @@ async def list_reports(
 )
 async def get_report(
     report_id: UUID,
+    # ``Annotated[...] = None`` rather than the ``= Query(None)`` spelling used
+    # elsewhere in this tree, because this handler is one of the very few called
+    # DIRECTLY by tests rather than over HTTP — including the audit-finding-#22
+    # regression below it. With ``= Query(None)`` such a call receives the
+    # ``Query`` object itself, which is truthy and would sail past the check
+    # below as if it were a tenant: a value that looks like a scope and is not,
+    # which is the shape of mistake this whole PR is about. This way the
+    # function's default is a real ``None`` however it is invoked.
+    tenant_id: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Tenant that owns the report. Defaults to the calling credential's own "
+                "tenant; required for credentials that have none (admin keys), and used "
+                "to name one of the other tenants a cross-tenant read key may read."
+            ),
+        ),
+    ] = None,
     auth: AuthContext = Depends(get_auth_context),
 ):
     """Get a full crystallization report by ID."""
     sc = get_storage_client()
-    report = await sc.get_report(str(report_id))
+    # Storage requires the owning tenant (#1167): it authenticates nothing, so a
+    # bare report UUID was enough to read any tenant's report off 0.0.0.0:8002.
+    # Which tenant to ask for has to be decided here, and it is a genuine
+    # decision because a report id does not say who owns it:
+    #
+    #   * a tenant-scoped credential asks about its own tenant by default;
+    #   * a cross-tenant read key names one of the tenants it may read — that
+    #     capability existed before this change and is preserved, not narrowed;
+    #   * an admin key has NO tenant of its own, so it must name one. That is
+    #     the one behaviour this change takes away, and it matches what the
+    #     sibling ``GET /reports`` in this package already requires of admin
+    #     keys.
+    scope = tenant_id or auth.tenant_id
+    if not scope:
+        # 400, not 401: the credential IS authenticated, this request just names
+        # no tenant — the distinction #987 drew on the skills-inbox routes.
+        raise HTTPException(
+            status_code=400,
+            detail=coded_detail(
+                errors.AUTH_TENANT_REQUIRED,
+                "This credential has no tenant of its own, so the report's tenant must be named.",
+                remediation="Retry with ?tenant_id=<owning tenant>.",
+            ),
+        )
+    # Compares two strings the caller already knows, before any lookup, so the
+    # 403 it can raise says something about the credential and nothing about
+    # whether the report — or the named tenant — exists.
+    auth.enforce_readable_tenant(scope)
+    report = await sc.get_report(str(report_id), scope)
     if not report:
         raise HTTPException(status_code=404, detail="Report not found")
-    # Collapse foreign-tenant (403) into not-found (404) so callers
-    # can't probe for the existence of reports in other tenants by
-    # distinguishing 403 from 404 on random UUIDs (audit finding #22).
-    # Cross-tenant read keys (``readable_tenant_ids`` widened past the
-    # home tenant) are honoured here — the set always contains
-    # ``auth.tenant_id`` by construction (``AuthContext`` line 85-90),
-    # so the 404 mask still hides reports the caller has no read
-    # access to.
+    # Kept, though the scoped fetch above now makes it unreachable in normal
+    # operation. Collapsing foreign-tenant (403) into not-found (404) is what
+    # stops a caller probing for reports in other tenants by distinguishing the
+    # two on random UUIDs (audit finding #22), and the two checks fail
+    # independently: drop the ``scope`` argument and this still masks; drop this
+    # and storage still refuses. Neither is a reason to remove the other.
     if not auth.is_admin and report.get("tenant_id") not in auth.readable_tenant_ids:
         raise HTTPException(status_code=404, detail="Report not found")
     return {

--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -254,7 +254,7 @@ async def execute_reserved_report(
     # already finished — and then the whole multi-minute run happens again, which
     # is the exact duplication this check exists to prevent. Same class as H-02
     # (#812), where replica lag on a back-channel read-back dropped the trigger.
-    existing = await sc.get_report(report_id, read=False)
+    existing = await sc.get_report(report_id, tenant_id, read=False)
     if existing is None:
         # Nothing to execute against. Reserving one here would hand back an id the
         # caller never asked for, so this drops — and the publisher's row going

--- a/core-storage-api/src/core_storage_api/routers/reports.py
+++ b/core-storage-api/src/core_storage_api/routers/reports.py
@@ -31,7 +31,11 @@ async def find_running_report(
     report_id = await _svc.report_find_running(tenant_id, fleet_id)
     if report_id is None:
         raise HTTPException(status_code=404, detail="No running report found")
-    report = await _svc.report_get_by_id(report_id)
+    # ``report_find_running`` already matched on this tenant, so the id is this
+    # tenant's by construction. Passed anyway rather than relied on: a predicate
+    # derived from the row you are addressing is satisfied by construction, and
+    # this route is not where the next reader will look for the guarantee.
+    report = await _svc.report_get_by_id(report_id, tenant_id)
     if report is None:
         raise HTTPException(status_code=404, detail="No running report found")
     return orm_to_dict(report, REPORT_FIELDS)
@@ -129,8 +133,21 @@ async def prune_agent_activity_digests(request: Request) -> dict:
 
 
 @router.get("/{report_id}")
-async def get_report(report_id: UUID) -> dict:
-    report = await _svc.report_get_by_id(report_id)
+async def get_report(report_id: UUID, tenant_id: str) -> dict:
+    """One report, by id. ``tenant_id`` is the report's owning tenant.
+
+    Required, not optional: this took a bare UUID, so anyone who could reach the
+    port and knew an id read another tenant's report — its ``summary``,
+    ``hygiene``, ``health``, ``usage_data``, ``issues`` and ``crystallization``
+    blobs, plus its ``tenant_id`` and ``fleet_id``. Absent ⇒ 422, never "answer
+    for whichever tenant owns the row".
+
+    One 404 for both "no such report" and "not this tenant's report", so the
+    route cannot be used to test whether a report id exists somewhere else. That
+    collapse is the same one core-api's ``GET /crystallize/reports/{id}`` makes
+    deliberately (audit finding #22); it now holds one layer lower too.
+    """
+    report = await _svc.report_get_by_id(report_id, tenant_id)
     if report is None:
         raise HTTPException(status_code=404, detail="Report not found")
     return orm_to_dict(report, REPORT_FIELDS)

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -10169,9 +10169,30 @@ class PostgresService:
     async def report_get_by_id(
         self,
         report_id: UUID,
+        tenant_id: str,
     ) -> CrystallizationReport | None:
+        """One report, by id, within a tenant.
+
+        ``tenant_id`` is required rather than optional: this was
+        ``session.get(CrystallizationReport, report_id)`` — a bare primary-key
+        fetch — so a caller who knew an id got the row, whichever tenant owned
+        it, along with the ``summary`` / ``hygiene`` / ``health`` /
+        ``usage_data`` / ``issues`` / ``crystallization`` blobs. #1082 fixed the
+        write half of this pair; this is the read half (#1167).
+
+        A `select` rather than `session.get`, because `get` takes a primary key
+        and cannot take a predicate. The cost is losing the identity-map short
+        circuit, which this path never relied on: each call opens its own
+        session.
+        """
         async with get_session() as session:
-            return await session.get(CrystallizationReport, report_id)
+            result = await session.execute(
+                select(CrystallizationReport).where(
+                    CrystallizationReport.id == report_id,
+                    CrystallizationReport.tenant_id == tenant_id,
+                )
+            )
+            return result.scalar_one_or_none()
 
     async def report_find_running(
         self,

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -172,12 +172,6 @@
       "note": "Verified: data['tenant_id'] survives model-field filtering and is stored on CrystallizationReport."
     },
     {
-      "id": "method:report_get_by_id",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read"
-    },
-    {
       "id": "method:tenant_usage_increment",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -274,12 +268,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "no-tenant-data"
-    },
-    {
-      "id": "route:GET /api/v1/storage/reports/{report_id}",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-read"
     },
     {
       "id": "route:GET /api/v1/storage/tenants/active",

--- a/core-storage-api/tests/test_report_read_tenant_scope.py
+++ b/core-storage-api/tests/test_report_read_tenant_scope.py
@@ -1,0 +1,137 @@
+"""``GET /reports/{report_id}`` must be told whose report it is returning.
+
+The read half of the pair #1082 fixed the write half of (#1167). The route took a
+bare UUID and ``report_get_by_id`` was ``session.get(CrystallizationReport,
+report_id)`` — a primary-key fetch with no tenant predicate — so on a service
+that authenticates no request (GHSA-wgvw-28pq-jc36), published by docker-compose
+on 0.0.0.0:8002, knowing an id was enough to read the row.
+
+What the row carries is the reason this is worth a fix rather than a note:
+``tenant_id`` and ``fleet_id``, plus the ``summary``, ``hygiene``, ``health``,
+``usage_data``, ``issues`` and ``crystallization`` blobs. That is a tenant's
+memory-hygiene posture, its open issues and its usage figures in one response.
+Disclosure only — nothing here writes — but it is the whole report, not a count.
+
+Two things get pinned separately, because they fail for different reasons:
+
+* **The predicate.** A stranger asking about someone else's report gets 404
+  while the owner gets 200. Reverting ``CrystallizationReport.tenant_id ==
+  tenant_id`` breaks this and nothing else here.
+* **The requirement.** Omitting ``tenant_id`` is a 422, not a fallback to the
+  old unscoped fetch. This is the half that a caller's forgetfulness reaches,
+  and making the parameter optional would restore the hole while every test
+  above kept passing.
+
+And the 404 is the same 404 in both directions — foreign report and absent
+report are indistinguishable — so the route cannot be used to test whether a
+report id exists in some other tenant. That collapse is deliberate (audit
+finding #22, where core-api makes the same one a layer up) and is asserted on
+the response bodies, not just the status codes.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _tenant() -> str:
+    """A tenant id unique to one test and visible to the root suite's sweep.
+
+    The ``test-tenant-`` prefix is not cosmetic: ``_setup_schema`` there cleans
+    with ``tenant_id LIKE 'test-tenant-%'``, so a tenant minted with any other
+    prefix is never reclaimed — which is how #858 left 9,186 rows behind.
+    """
+    return f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+
+async def _report(client: AsyncClient, tenant_id: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/reports",
+        json={"tenant_id": tenant_id, "trigger": "manual"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+class TestReportReadTenantScope:
+    async def test_another_tenants_report_is_not_returned(self, client: AsyncClient) -> None:
+        """The attack, stated as the request an attacker would send."""
+        victim, attacker = _tenant(), _tenant()
+        report_id = await _report(client, victim)
+
+        theirs = await client.get(f"{PREFIX}/reports/{report_id}", params={"tenant_id": attacker})
+
+        assert theirs.status_code == 404, theirs.text
+
+    async def test_the_owner_still_reads_its_own_report(self, client: AsyncClient) -> None:
+        """The other side of the same predicate, and not a formality.
+
+        Asserted separately so the test above cannot pass because the fixture
+        failed to create anything: a 404 for the attacker means nothing unless
+        the owner gets a 200 for the same id.
+        """
+        owner = _tenant()
+        report_id = await _report(client, owner)
+
+        mine = await client.get(f"{PREFIX}/reports/{report_id}", params={"tenant_id": owner})
+
+        assert mine.status_code == 200, mine.text
+        body = mine.json()
+        assert body["id"] == report_id
+        assert body["tenant_id"] == owner
+        # The blobs the disclosure was about are still served to their owner.
+        for key in ("summary", "hygiene", "health", "issues", "crystallization"):
+            assert key in body, f"missing {key!r} — the owner's own read lost a field"
+
+    async def test_an_omitted_tenant_is_rejected(self, client: AsyncClient) -> None:
+        """The bug: a bare UUID was the whole request.
+
+        A 422 rather than a fallback. Optional-with-a-fallback is the shape this
+        route's two siblings had — ``/entities/{id}/relations`` and
+        ``/entities/{id}/with-memories`` scoped to the addressed row's OWN tenant
+        when the parameter was omitted, which is a predicate satisfied by
+        construction for whatever id the caller supplies.
+        """
+        owner = _tenant()
+        report_id = await _report(client, owner)
+
+        resp = await client.get(f"{PREFIX}/reports/{report_id}")
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+
+    async def test_a_foreign_id_is_indistinguishable_from_a_missing_one(self, client: AsyncClient) -> None:
+        """Both 404 with the same body, so this is not an existence oracle."""
+        victim, attacker = _tenant(), _tenant()
+        report_id = await _report(client, victim)
+
+        foreign = await client.get(f"{PREFIX}/reports/{report_id}", params={"tenant_id": attacker})
+        missing = await client.get(f"{PREFIX}/reports/{uuid.uuid4()}", params={"tenant_id": attacker})
+
+        assert foreign.status_code == missing.status_code == 404
+        assert foreign.json() == missing.json()
+
+    async def test_find_running_still_resolves_its_own_report(self, client: AsyncClient) -> None:
+        """``GET /reports/running`` reaches the same method and must keep working.
+
+        It is the second caller of ``report_get_by_id`` and the one that had a
+        tenant all along — it obtains the id from the tenant-scoped
+        ``report_find_running`` first. Covered here because "the scoped fetch
+        broke the crystallization lock lookup" is a silent failure: a 404 from
+        this route reads as "no run in flight", which releases the short-circuit
+        that serialises crystallization.
+        """
+        owner = _tenant()
+        report_id = await _report(client, owner)
+
+        resp = await client.get(f"{PREFIX}/reports/running", params={"tenant_id": owner})
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["id"] == report_id

--- a/core-storage-api/tests/test_report_update_tenant_scope.py
+++ b/core-storage-api/tests/test_report_update_tenant_scope.py
@@ -46,15 +46,22 @@ async def _report(client: AsyncClient, tenant_id: str) -> str:
     return resp.json()["id"]
 
 
-async def _read(client: AsyncClient, report_id: str) -> dict:
-    """Read the row back regardless of tenant, to assert what actually persisted.
+async def _read(client: AsyncClient, report_id: str, tenant_id: str) -> dict:
+    """Read the row back as its OWNER, to assert what actually persisted.
 
-    Deliberately goes through ``GET /reports/{report_id}``, which is still
-    unscoped (allowlisted ``id-addressed-read``) and so answers for any tenant
-    --- that is what makes it a usable oracle here. When that route gains a
-    required tenant, this helper needs one too.
+    This helper used to send no tenant, because ``GET /reports/{report_id}`` was
+    itself unscoped and so answered for anybody --- and it said so, ending "when
+    that route gains a required tenant, this helper needs one too". #1167 gave it
+    one, so here it is.
+
+    The tenant passed is always the report's owner, never the attacker's, and
+    that is what keeps this an oracle rather than a mirror of the check under
+    test. A successful cross-tenant PATCH would rewrite the victim's row in
+    place --- ``tenant_id`` is not among the columns it writes --- so the owner's
+    own read still sees the damage. Verified by reverting the write predicate,
+    not assumed: with it gone, all three cases below fail here.
     """
-    resp = await client.get(f"{PREFIX}/reports/{report_id}")
+    resp = await client.get(f"{PREFIX}/reports/{report_id}", params={"tenant_id": tenant_id})
     assert resp.status_code == 200, resp.text
     return resp.json()
 
@@ -87,7 +94,7 @@ class TestReportUpdateTenantScope:
         )
 
         assert resp.status_code == 404, resp.text
-        row = await _read(client, report_id)
+        row = await _read(client, report_id, victim)
         assert row["status"] == "running", "the victim's report was finalized"
         assert row["completed_at"] is None
         assert row["duration_ms"] is None
@@ -113,7 +120,7 @@ class TestReportUpdateTenantScope:
 
         assert resp.status_code == 422, resp.text
         assert "tenant_id" in resp.text
-        assert (await _read(client, report_id))["status"] == "running"
+        assert (await _read(client, report_id, tenant))["status"] == "running"
 
     async def test_own_report_is_completed(self, client: AsyncClient) -> None:
         """The supported call still works, with every blob it is meant to write."""
@@ -134,7 +141,7 @@ class TestReportUpdateTenantScope:
         )
 
         assert resp.status_code == 200, resp.text
-        row = await _read(client, report_id)
+        row = await _read(client, report_id, tenant)
         assert row["status"] == "completed"
         assert row["duration_ms"] == 1234
         assert row["completed_at"] is not None

--- a/tests/test_api_crystallizer.py
+++ b/tests/test_api_crystallizer.py
@@ -203,7 +203,14 @@ async def test_get_report_foreign_tenant_returns_404_not_403():
 
 
 async def test_get_report_foreign_tenant_admin_bypass():
-    """Admin keys keep their cross-tenant read ability (no 404 mask)."""
+    """Admin keys keep their cross-tenant read ability — by naming the tenant.
+
+    The capability is unchanged: an admin credential still reads any tenant's
+    report and is not 404-masked. What changed with #1167 is that it must say
+    which tenant, because storage now requires one and an admin key has no
+    tenant of its own to fall back on. The sibling ``GET /reports`` in this
+    package already asks admin keys for the same thing.
+    """
     from unittest.mock import AsyncMock, patch
     from uuid import uuid4
 
@@ -227,9 +234,86 @@ async def test_get_report_foreign_tenant_admin_bypass():
     sc_mock = AsyncMock()
     sc_mock.get_report = AsyncMock(return_value=foreign_report)
     with patch("core_api.routes.crystallizer.get_storage_client", return_value=sc_mock):
-        result = await get_report(report_id=uuid4(), auth=admin)
+        result = await get_report(report_id=uuid4(), tenant_id="tenant-A", auth=admin)
     # Admin sees the full payload.
     assert result["tenant_id"] == "tenant-A"
+    # And the tenant it named is the one storage was asked about — not a
+    # placeholder, and not omitted. Positional, matching the client signature.
+    assert sc_mock.get_report.await_args.args[1] == "tenant-A"
+
+
+async def test_get_report_admin_without_a_tenant_is_a_400():
+    """An admin key that names no tenant gets a request error, not an unscoped read.
+
+    This is the one behaviour #1167 takes away, so it is pinned rather than left
+    to the absence of a test. 400 and not 401: the credential IS authenticated
+    (the distinction #987 drew on the skills-inbox routes), and not 404 either —
+    nothing was looked up, so there is nothing to mask.
+
+    Storage is asserted untouched. Reaching it with ``tenant_id=None`` is the
+    failure mode that matters: the query string would carry the literal
+    ``None``, which matches no row, and the endpoint would answer 404 for every
+    report an admin ever asked for.
+    """
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from fastapi import HTTPException
+
+    from core_api.auth import AuthContext
+    from core_api.routes.crystallizer import get_report
+
+    admin = AuthContext(tenant_id=None, is_admin=True)
+    sc_mock = AsyncMock()
+    sc_mock.get_report = AsyncMock(return_value=None)
+
+    with patch("core_api.routes.crystallizer.get_storage_client", return_value=sc_mock):
+        try:
+            await get_report(report_id=uuid4(), tenant_id=None, auth=admin)
+        except HTTPException as e:
+            assert e.status_code == 400, f"admin with no tenant must be a 400; got {e.status_code}"
+            assert e.detail["code"] == "TENANT_REQUIRED"
+        else:
+            raise AssertionError("Expected HTTPException(400) for an admin key naming no tenant")
+
+    sc_mock.get_report.assert_not_awaited()
+
+
+async def test_get_report_defaults_to_the_credentials_own_tenant():
+    """A tenant-scoped credential needs no query param and gets its own tenant.
+
+    The compatibility half of the change: every caller that worked before this
+    still works, because ``tenant_id`` is optional on the wire and resolves to
+    ``auth.tenant_id``. Only credentials with no tenant of their own have to
+    start naming one.
+    """
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from core_api.auth import AuthContext
+    from core_api.routes.crystallizer import get_report
+
+    own_report = {
+        "id": str(uuid4()),
+        "tenant_id": "tenant-B",
+        "fleet_id": None,
+        "trigger": "manual",
+        "status": "completed",
+        "summary": {},
+        "hygiene": {},
+        "health": {},
+        "issues": [],
+        "crystallization": {},
+    }
+    caller = AuthContext(tenant_id="tenant-B", is_admin=False)
+
+    sc_mock = AsyncMock()
+    sc_mock.get_report = AsyncMock(return_value=own_report)
+    with patch("core_api.routes.crystallizer.get_storage_client", return_value=sc_mock):
+        result = await get_report(report_id=uuid4(), auth=caller)
+
+    assert result["tenant_id"] == "tenant-B"
+    assert sc_mock.get_report.await_args.args[1] == "tenant-B"
 
 
 async def test_get_latest_report_empty_returns_200_null(client):


### PR DESCRIPTION
## Summary

- Require `tenant_id` on `GET /api/v1/storage/reports/{report_id}` and bind `report_get_by_id` to it.
- Make `tenant_id` **optional** on core-api's `GET /crystallize/reports/{report_id}`, resolving to the credential's own tenant — so no existing tenant-scoped caller changes.
- Rescope the cross-tenant read oracle in `test_report_update_tenant_scope.py`, which deliberately used this route *because* it was unscoped.
- Remove the last two `id-addressed-read` entries from the allowlist.

Closes #1167.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [x] Breaking change — **for admin keys only**, see below
- [ ] Documentation update
- [ ] Refactor / internal cleanup

## The defect

The route took a bare UUID and the method was `session.get(CrystallizationReport, report_id)` — a primary-key fetch with no tenant predicate. `core-storage-api` authenticates no request (GHSA-wgvw-28pq-jc36) and docker-compose publishes it on `0.0.0.0:8002`, so knowing an id was enough to read the row: `tenant_id`, `fleet_id`, and the `summary` / `hygiene` / `health` / `usage_data` / `issues` / `crystallization` blobs. A tenant's hygiene posture, open issues and usage figures in one response.

Disclosure, not integrity — nothing here writes. #1082 fixed the write half of this pair.

**Does the method need to exist?** Yes — asked first, per #1091. Two live callers: this route, and `GET /reports/running`, which obtains its id from the tenant-scoped `report_find_running` and could pass a tenant for free. The route is what forced the decision.

## The fork #1167 left open

The issue documented three options and said the choice had to come before code, because core-api authorizes *after* the fetch: an admin key has no tenant of its own to send, and the check is against `readable_tenant_ids`, a **set** that may be wider than the home tenant.

**Option A, in the form that costs least.** Required at storage, optional at core-api:

| caller | before | after |
|---|---|---|
| tenant-scoped credential | works | **unchanged** — no new parameter |
| cross-tenant read key, secondary tenant | works | names the tenant; `auth.enforce_readable_tenant` validates it |
| admin key (no home tenant) | works | **must name a tenant** |

Option C is ruled out by preserving the cross-tenant capability rather than narrowing it — the widened read stays available, it is just named and checked. Option B was not taken because it grows the allowlist by one and needs a maintainer override; the list may shrink and may not grow, and there was a way to clear both entries without spending that.

The admin change is the only thing taken away, and it is what the sibling `GET /reports` in the same package already requires of admin keys: *"agent creds can only report on their own tenant; admin keys may target any tenant."*

## Blast radius of the API change

- **Not** in `core-api/openapi.broker.json` (8 operations, checked) — no baseline to regenerate, no oasdiff exposure.
- **Not** in the REST table of `docs/public-api-stability.md`; `/crystallize/reports` is listed, the by-id route is not. No doc anywhere names it.
- The new parameter is optional, so it is additive on the wire; its `description` reaches `/api/openapi.json` from the handler.
- `scripts/smoke_test.py` already sent `params={"tenant_id": TENANT}` to this route, which the route ignored. It now means something.

## 403 vs 404

`enforce_readable_tenant` can answer 403 where the old route answered 404. It compares two strings the caller already knows, **before any lookup**, so it says something about the credential and nothing about whether the report — or the named tenant — exists. The 404 mask over report existence (audit finding #22) is untouched, and now holds at storage too: foreign report and absent report return the same status *and the same body*, asserted.

The post-fetch check in core-api is kept even though the scoped fetch makes it unreachable in normal operation. The two fail independently: drop the `scope` argument and it still masks; drop it and storage still refuses.

## `Annotated`, deliberately

`Annotated[str | None, Query(...)] = None` rather than the `= Query(None)` spelling used elsewhere in that tree. This handler is one of the very few called **directly** by tests rather than over HTTP — including the audit-finding-#22 regression. Under `= Query(None)` such a call receives the `Query` object, which is truthy and would sail past the guard as if it were a tenant: a value that looks like a scope and is not, which is the shape of mistake this PR is about. This way the two pre-existing security tests needed no edit at all.

## The oracle that had to change — and did not go vacuous

#1167 flagged this and it is the part worth reviewing closely. `test_report_update_tenant_scope.py::_read` read rows back through **this route** precisely because it was unscoped, and said so: *"when that route gains a required tenant, this helper needs one too."*

It now passes the report's **owner**, never the attacker. That keeps it an oracle rather than a mirror of the check under test: a successful cross-tenant PATCH rewrites the victim's row in place — `tenant_id` is not among the columns it writes — so the owner's own read still sees the damage.

Demonstrated rather than argued. With #1082's UPDATE predicate reverted and **only the status assertion relaxed**, so nothing but the helper can fail:

```text
core-storage-api/tests/test_report_update_tenant_scope.py:98:
    assert row["status"] == "running", "the victim's report was finalized"
E   AssertionError: the victim's report was finalized
E   assert 'completed' == 'running'
```

## Verified by reverting one thing at a time

| reverted | fails |
|---|---|
| read predicate `CrystallizationReport.tenant_id == tenant_id` | `test_another_tenants_report_is_not_returned` (`assert 200 == 404`), `test_a_foreign_id_is_indistinguishable_from_a_missing_one` |
| the **requirement**, made optional (`tenant_id: str \| None = None`) | `test_an_omitted_tenant_is_rejected` (`assert 404 == 422`) |
| core-api's resolved scope → home tenant | `test_get_report_foreign_tenant_admin_bypass` (`assert '' == 'tenant-A'`), `test_get_report_by_id` (`assert 404 == 200`) |
| #1082's write predicate | 3 in `test_report_update_tenant_scope.py`, incl. the quote above |

Each revert fails only its own cases, so none is masking another. The requirement gets its own case because optional-with-a-fallback restores the hole while every predicate test keeps passing — that is exactly the shape the two entity routes had before #1174 (`tenant_id or entity.tenant_id`).

## Numbers

| | before | after |
|---|---|---|
| allowlist total | 74 | **72** |
| `id-addressed-read` | 2 | **0** — category gone from the gate summary |

Regenerated with `scripts/tenant_scope_gate.py --write` in the same commit. All 38 hand-written notes survived unchanged and every entry kept its category; the gate classifies both as `removed — fixed`.

**This clears the `id-addressed-read` backlog.** The remaining backlog is `grant-in-lieu-of-tenant` (2) and `blind-spot` (1).

## Verification

Against `origin/main` at `627db009`, re-run after the rebase:

- root suite — 5796 passed, 4 skipped, 16 deselected, 1 xfailed
- `core-storage-api/tests/` — 306 passed
- `ruff check` and `ruff format --check` clean at CI's scopes; mypy clean on core-api (203 files) and core-storage-api (85)
- broker OpenAPI baseline up to date; legacy-name ratchet reports no new lines; all 46 sentinel strings survive
- `scripts/check_readme_quickstart.py` fails locally for want of a running server — **confirmed identical on clean `origin/main`**, so not this change

## Out-of-repo consumers — checked

One exists, and it is fine. `caura-enterprise/frontend/app/(dashboard)/manage/_components/crystallizer-tab.tsx` polls `/api/crystallize/reports/${res.report_id}` (and again on expand) with **no** `tenant_id`. It does not break, and the reason is the gateway rather than luck:

- the browser calls a same-origin relative path, so the credential that reaches core-api is whatever the enterprise gateway attaches, not what the page holds;
- `gateway/nginx.conf.template`'s catch-all `location /api/` rewrites to `/api/v1/`, runs the `/_auth` subrequest — *"resolve session cookie / JWT / API key → X-Tenant-ID"* — and sets `proxy_set_header X-Tenant-ID $tenant_id`;
- so `AuthContext.tenant_id` is populated for those calls and the optional parameter resolves to it.

No hit for this route in caura-ops, caura-daemon, caura-onprem, caura-onprem-installer, gateway, caura-test-automation or caura-github. The in-repo caller (`scripts/smoke_test.py`) already sends `tenant_id`.

`caura-enterprise/frontend/site/openapi.snapshot.json` carries this path and will show the new optional parameter on its next refresh. That snapshot is the enterprise repo's own gate, not this PR's, and an added optional query parameter is not a breaking diff.

## Not verified

CI's own environment — the Actions matrix — and whether any deployment reaches this route with an admin credential that carries no tenant. Every path I could trace supplies one.
