### PR TITLE
chore(storage): file the tenant-usage increment write as opaque-body-write

### DIFF
--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -471,8 +471,8 @@
       "id": "route:POST /api/v1/storage/tenant-usage/increment",
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
-      "category": "blind-spot",
-      "note": "Scoped per row: 'if not r.get(\"tenant_id\") or not r.get(\"operation\"): raise 422'. The AST pass cannot follow the derivation \u2014 r comes from 'for i, row in enumerate(rows)' then 'r = dict(row)', and the tracker follows subscript/get chains only, not loop targets or dict() copies."
+      "category": "opaque-body-write",
+      "note": "Verified: every row carries tenant_id, required per row before the batch is written ('if not r.get(\"tenant_id\") or not r.get(\"operation\"): raise 422'), and that field is stored and participates in the usage-counter conflict key. Reclassified from blind-spot, which describes a BINDING scope the AST cannot read; there is no binding tenant here to hide. The batch is cross-tenant by construction \u2014 usage_meter accumulates counts across every tenant in the process and flushes them as one request \u2014 so the tenant rides per row in the payload, which is this category. Matches method:tenant_usage_increment, already filed here, and the sibling row-list writes /audit-logs/bulk, /entities/bulk-upsert and /memories/bulk."
     },
     {
       "id": "route:POST /api/v1/storage/tenant-usage/query",

--- a/core-storage-api/tests/test_tenant_usage.py
+++ b/core-storage-api/tests/test_tenant_usage.py
@@ -52,6 +52,56 @@ def _row(tenant: str, operation: str, period: str, count: int) -> dict:
     }
 
 
+class TestIncrementRequiresATenantPerRow:
+    """The write half's per-row guard, which is what its classification rests on.
+
+    ``POST /tenant-usage/increment`` is filed ``opaque-body-write`` in
+    ``tenant_scope_allowlist.json``: the batch is cross-tenant by design, so
+    there is no binding tenant parameter and the scope rides in each row
+    instead. That category's whole claim is *"the binding is real but lives in
+    the row being written"* — which holds only while a row without a
+    ``tenant_id`` is refused.
+
+    Nothing pinned that. The rest of this file covers the read half, so the
+    guard could have been deleted and the only signal would have been the
+    allowlist note quietly becoming false. These two cases are the classification's
+    premise, written down so it fails loudly instead.
+    """
+
+    async def test_a_row_without_a_tenant_id_is_refused(self, client: AsyncClient):
+        tenant, operation = f"t-{_uid()}", f"op-{_uid()}"
+        r = await client.post(
+            f"{PREFIX}/tenant-usage/increment",
+            json={
+                "rows": [
+                    _row(tenant, operation, AUGUST, 1),
+                    {"operation": operation, "period_start": AUGUST, "count": 5},
+                ]
+            },
+        )
+
+        assert r.status_code == 422, r.text
+        # The offending row is named. ``_require`` would drop this index — see
+        # the rejected alternative in this PR's description.
+        assert "row 1" in r.text
+        assert "tenant_id" in r.text
+        # The whole batch is refused, so the well-formed row in it did not land
+        # either: the guard runs over every row before any write is attempted.
+        assert await _query(client, tenant_ids=[tenant], period_start=AUGUST) == {"periods": []}
+
+    async def test_a_row_without_an_operation_is_refused(self, client: AsyncClient):
+        tenant = f"t-{_uid()}"
+
+        r = await client.post(
+            f"{PREFIX}/tenant-usage/increment",
+            json={"rows": [{"tenant_id": tenant, "period_start": AUGUST, "count": 5}]},
+        )
+
+        assert r.status_code == 422, r.text
+        assert "row 0" in r.text
+        assert await _query(client, tenant_ids=[tenant], period_start=AUGUST) == {"periods": []}
+
+
 async def test_counts_sum_across_the_orgs_tenants(client: AsyncClient):
     """An org owns several tenants and is billed as one. Reporting a single
     tenant's counts would under-bill by however many tenants it has."""


### PR DESCRIPTION
`route:POST /api/v1/storage/tenant-usage/increment` was the allowlist's only `blind-spot` entry. **It is a misfile, not a backlog item** — and the review of the first revision was right that a bare recategorisation asserts things the diff cannot show, so **the classification's premise is now pinned by tests.**

### Why it was never `blind-spot`

`blind-spot` means *"the path IS scoped, but by an idiom the AST pass cannot read"* — a **binding** tenant scope hidden behind an inline guard. This route has no binding tenant to hide. `usage_meter` accumulates `self._counts[(tenant_id, operation, period)]` across every tenant in the process and flushes them as one request, and both layers say so:

> **`routers/tenant_usage.py:19-21`** — The table is intentionally CROSS-TENANT / RLS-free: one batch carries many tenants' counters, so this endpoint applies NO per-tenant scoping — each row names its own `tenant_id`.

> **`services/postgres_service.py:3962-3964`** — Cross-tenant and RLS-free by design (migration 039) — one batch carries many tenants' counters and each row names its own `tenant_id`.

A tenant riding **per row in the payload** is the definition of `opaque-body-write`.

### Every claim in the note, and where to check it

Answering the first review directly — it noted the claims could not be verified from a JSON-only diff, which was fair.

| claim in the note | verify at | verdict |
|---|---|---|
| per-row `tenant_id` required before the batch is written | `routers/tenant_usage.py:118-122` | holds |
| that field participates in the usage-counter conflict key | `services/postgres_service.py:3981-3985` — `index_elements=[tenant_id, operation, period_start]` | holds |
| the batch is cross-tenant by construction | `services/usage_meter.py:89`, plus both docstrings above | holds |
| `method:tenant_usage_increment` is already `opaque-body-write` | `tenant_scope_allowlist.json` | holds |
| the three sibling row-list writes are `opaque-body-write` | `/audit-logs/bulk`, `/entities/bulk-upsert`, `/memories/bulk` | holds |

I inherited the conflict-key phrasing from the existing note on the service method and **verified it rather than repeating it** — it is true, `tenant_id` is the first index element.

### The premise is now enforced, not asserted

`opaque-body-write`'s claim is *"the binding is real but lives in the row being written"*. That holds only while a row without a `tenant_id` is refused — and **nothing pinned that.** `test_tenant_usage.py` covered only the read half, so the guard could have been deleted and the only signal would have been this note quietly becoming false. Two cases now cover it.

**They are deliberately not status-code assertions.** With the guard removed the request *still* returns 422, via the generic `except (TypeError, KeyError)` fallback as `{"detail": "invalid tenant-usage row: KeyError"}` — so a test asserting only the status would pass either way and pin nothing. Both assert the row index and the field name.

**Failing without the fix.** Removing the per-row guard:

```
FAILED ...TestIncrementRequiresATenantPerRow::test_a_row_without_a_tenant_id_is_refused
FAILED ...TestIncrementRequiresATenantPerRow::test_a_row_without_an_operation_is_refused
2 failed, 7 passed in 0.41s
```

with `assert 'row 0' in '{"detail":"invalid tenant-usage row: KeyError"}'` — i.e. the batch is still refused, but no longer says which row or why. The router was restored byte-identical afterwards (`git diff -- core-storage-api/src/` empty).

### The rejected alternative — measured, not argued

`blind-spot`'s own text prescribes *"rewriting the guard to use `_require` and deleting the entry"*. I implemented that first to test it. **It works:** making `r` request-derived and swapping in `_require(r, "tenant_id")` flips the gate — `blind-spot 1 → 0`, one fewer entry, reported as *"no longer needs to be [allowlisted]"*.

**It should still not be done:**

- **It changes no behaviour.** Same 422 on a falsy value. The same request can still write counter rows for 1000 arbitrary tenants, unchecked, before and after.
- **It makes the gate report something untrue** — "bound to a tenant" would count a binding scope that does not exist. The instrument gets worse without the code getting better.
- **It regresses the error**, dropping the `row {i}` prefix (`_validation.py:17`) — which is exactly the assertion the new tests rely on for their teeth. The alternative would have made this PR's own tests vacuous.

The prescription is right for a genuine `blind-spot` and wrong here: **the diagnosis was wrong, not the remedy.** This was argued both ways before landing — I proposed the reclassification, the coordinating session argued for the guard rewrite from the category doc, and reversed after checking the sibling classifications. Both positions are in the commit message so review can take the other side.

### Effect

**Allowlist stays 72. Paths bound to a tenant stay 304.** Nothing netted — the gate reports a move:

```
~ route:POST /api/v1/storage/tenant-usage/increment [blind-spot -> opaque-body-write]
  blind-spot: 1 -> 0
  opaque-body-write: 35 -> 36
```

The `blind-spot` category definition stays in `_categories` for future use — an empty category is not a dead one.

With `id-addressed-read` cleared by [#1181](https://github.com/caura-ai/caura/pull/1181), this leaves the **entire tenant-scope backlog at two entries**, both `grant-in-lieu-of-tenant` and both under [#1095](https://github.com/caura-ai/caura/issues/1095) — where I have posted a design analysis and stopped, because it needs a maintainer's decision rather than a PR's side effect.

### Verification

Rebased onto `049904c6` after #1181 and #1177 landed; regenerated and re-verified on the rebased tree rather than carried over.

- `core-storage-api/tests/`: **308 passed** (2 new).
- Root `tests/`: **5796 passed**, 4 skipped, 1 xfailed.
- `ruff check` at CI's 6 scopes and `ruff format --check` at its 5, run separately, discovery-based: clean.
- `mypy` core-storage-api (85 files): no issues. *(core-api is untouched by this branch.)*
- Tenant-scope gate vs `origin/main`: green, reported as a recategorisation. Regenerated with `--write` to confirm the hand-written `category` and `note` survive — they do, and no other entry moved.
- Legacy-name ratchet: no new lines. Do-not-touch sentinel: all 46 protected strings survive.

Run against a dedicated local pgvector instance provisioned CI's way. **Not checked:** anything requiring CI's own environment — the Actions matrix, the coverage-floors step, the enterprise re-vendor path.