### PR TITLE
fix(storage): scope the report-by-id read to the caller's tenant

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2782,8 +2782,8 @@ class CoreStorageClient:
     async def create_report(self, data: dict) -> dict:
         return await self._post("/reports", data)  # type: ignore[return-value]
 
-    async def get_report(self, report_id: str, *, read: bool = True) -> dict | None:
-        """Fetch one analysis report.
+    async def get_report(self, report_id: str, tenant_id: str, *, read: bool = True) -> dict | None:
+        """Fetch one analysis report within ``tenant_id``.
 
         ``read`` defaults to True — the replica is right for the read paths that
         display a report. Pass ``read=False`` for a read-your-write, where replica
@@ -2793,7 +2793,7 @@ class CoreStorageClient:
         there re-runs a multi-minute LLM job. Same reason
         ``find_by_content_hash`` pins the writer.
         """
-        return await self._get(f"/reports/{report_id}", read=read)
+        return await self._get(f"/reports/{report_id}", read=read, tenant_id=tenant_id)
 
     async def update_report(self, report_id: str, data: dict, *, tenant_id: str) -> dict | None:
         """Finalize a report. ``tenant_id`` scopes the UPDATE and is required.

--- a/core-api/src/core_api/routes/crystallizer.py
+++ b/core-api/src/core_api/routes/crystallizer.py
@@ -132,22 +132,41 @@ async def list_reports(
 )
 async def get_report(
     report_id: UUID,
+    tenant_id: str,
     auth: AuthContext = Depends(get_auth_context),
 ):
-    """Get a full crystallization report by ID."""
+    """Get a full crystallization report by ID, from ``tenant_id``.
+
+    The caller names the tenant; the credential decides whether it may read it.
+    ``enforce_readable_tenant`` — not ``enforce_tenant``, which is the WRITE
+    gate and pins to the home tenant — so a cross-tenant read key still reaches
+    any tenant in its ``readable_tenant_ids``, and an admin key any tenant at
+    all. That set is derived from the credential, never from the request, which
+    is what keeps this from being the "caller names its own scope" shape.
+
+    **Report existence still collapses to 404** (audit finding #22). The 403
+    raised below is keyed on the NAMED TENANT and is independent of
+    ``report_id``: it says only "this credential may not read tenant T", which
+    the caller already knows about its own key. Every question about a report —
+    absent, or present in a tenant this request did not name — answers 404, so
+    a random UUID reveals nothing. There is a regression test for exactly this
+    matrix in ``tests/test_api_crystallizer.py``.
+
+    ``tenant_id`` is required for admin callers too. ``AuthContext`` for an
+    admin key has ``tenant_id=None``, so there is no tenant to infer, and
+    storage now demands one; naming it is the API change this endpoint takes in
+    exchange for storage no longer answering to a bare primary key.
+    """
+    auth.enforce_readable_tenant(tenant_id)
     sc = get_storage_client()
-    report = await sc.get_report(str(report_id))
+    # No post-fetch tenant comparison: storage scopes the fetch to the tenant
+    # authorized above, so a report outside it is already a 404 on the line
+    # below. The comparison that stood here ran AFTER storage had handed the
+    # row over — it protected this route's callers while leaving the storage
+    # route itself answering to a bare id, which is the half an attacker who
+    # can reach port 8002 does not go through.
+    report = await sc.get_report(str(report_id), tenant_id)
     if not report:
-        raise HTTPException(status_code=404, detail="Report not found")
-    # Collapse foreign-tenant (403) into not-found (404) so callers
-    # can't probe for the existence of reports in other tenants by
-    # distinguishing 403 from 404 on random UUIDs (audit finding #22).
-    # Cross-tenant read keys (``readable_tenant_ids`` widened past the
-    # home tenant) are honoured here — the set always contains
-    # ``auth.tenant_id`` by construction (``AuthContext`` line 85-90),
-    # so the 404 mask still hides reports the caller has no read
-    # access to.
-    if not auth.is_admin and report.get("tenant_id") not in auth.readable_tenant_ids:
         raise HTTPException(status_code=404, detail="Report not found")
     return {
         "id": str(report.get("id", "")),

--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -254,7 +254,7 @@ async def execute_reserved_report(
     # already finished — and then the whole multi-minute run happens again, which
     # is the exact duplication this check exists to prevent. Same class as H-02
     # (#812), where replica lag on a back-channel read-back dropped the trigger.
-    existing = await sc.get_report(report_id, read=False)
+    existing = await sc.get_report(report_id, tenant_id, read=False)
     if existing is None:
         # Nothing to execute against. Reserving one here would hand back an id the
         # caller never asked for, so this drops — and the publisher's row going

--- a/core-storage-api/src/core_storage_api/routers/reports.py
+++ b/core-storage-api/src/core_storage_api/routers/reports.py
@@ -31,7 +31,10 @@ async def find_running_report(
     report_id = await _svc.report_find_running(tenant_id, fleet_id)
     if report_id is None:
         raise HTTPException(status_code=404, detail="No running report found")
-    report = await _svc.report_get_by_id(report_id)
+    # ``report_id`` already came from the tenant-scoped ``report_find_running``,
+    # so this fetch could not cross tenants; passing the tenant costs nothing
+    # and leaves no unscoped call of this method behind.
+    report = await _svc.report_get_by_id(report_id, tenant_id)
     if report is None:
         raise HTTPException(status_code=404, detail="No running report found")
     return orm_to_dict(report, REPORT_FIELDS)
@@ -129,8 +132,21 @@ async def prune_agent_activity_digests(request: Request) -> dict:
 
 
 @router.get("/{report_id}")
-async def get_report(report_id: UUID) -> dict:
-    report = await _svc.report_get_by_id(report_id)
+async def get_report(report_id: UUID, tenant_id: str) -> dict:
+    """One report, within ``tenant_id``.
+
+    The read half of the pair whose write half is ``PATCH`` below. ``tenant_id``
+    is a **required** query parameter: omitting it used to mean "fetch by
+    primary key", which on a service that authenticates nothing meant anyone who
+    could reach the port and knew a UUID read the report behind it.
+
+    A report in another tenant and a report that does not exist both 404, so
+    this cannot be used to probe for report ids across tenants (audit finding
+    #22). The caller-facing route in ``core-api`` preserves that; see the
+    comment on ``GET /crystallize/reports/{report_id}`` there for where its 403
+    comes from and why it reveals nothing about any report.
+    """
+    report = await _svc.report_get_by_id(report_id, tenant_id)
     if report is None:
         raise HTTPException(status_code=404, detail="Report not found")
     return orm_to_dict(report, REPORT_FIELDS)

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -10169,9 +10169,22 @@ class PostgresService:
     async def report_get_by_id(
         self,
         report_id: UUID,
+        tenant_id: str,
     ) -> CrystallizationReport | None:
+        """One report within ``tenant_id``. ``None`` when either half misses.
+
+        The read half of the pair whose write half was fixed in #1082: a bare
+        ``session.get`` handed whoever held a report UUID the row behind it,
+        including the ``summary`` / ``hygiene`` / ``health`` / ``usage_data`` /
+        ``issues`` / ``crystallization`` blobs, from a service that
+        authenticates nothing.
+        """
         async with get_session() as session:
-            return await session.get(CrystallizationReport, report_id)
+            stmt = select(CrystallizationReport).where(
+                CrystallizationReport.id == report_id,
+                CrystallizationReport.tenant_id == tenant_id,
+            )
+            return (await session.execute(stmt)).scalar_one_or_none()
 
     async def report_find_running(
         self,

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -172,12 +172,6 @@
       "note": "Verified: data['tenant_id'] survives model-field filtering and is stored on CrystallizationReport."
     },
     {
-      "id": "method:report_get_by_id",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "id-addressed-read"
-    },
-    {
       "id": "method:tenant_usage_increment",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -274,12 +268,6 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "no-tenant-data"
-    },
-    {
-      "id": "route:GET /api/v1/storage/reports/{report_id}",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "id-addressed-read"
     },
     {
       "id": "route:GET /api/v1/storage/tenants/active",

--- a/core-storage-api/tests/test_report_read_tenant_scope.py
+++ b/core-storage-api/tests/test_report_read_tenant_scope.py
@@ -1,0 +1,114 @@
+"""``GET /reports/{report_id}`` must be told which tenant's report it returns.
+
+The read half of the pair whose write half is ``test_report_update_tenant_scope``
+(#1082). The route took a bare UUID and ``report_get_by_id`` was
+``session.get(CrystallizationReport, report_id)`` --- a primary-key fetch with no
+tenant predicate --- so a caller who knew an id read the row behind it through a
+service that authenticates nothing.
+
+What that row holds is the point. A crystallization report carries
+``tenant_id`` and ``fleet_id`` plus six JSONB blobs: ``summary``, ``hygiene``,
+``health``, ``usage_data``, ``issues`` and ``crystallization``. Together they are
+a standing description of another tenant's memory estate --- its health scores,
+its hygiene problems, its token spend, and an enumerated issue list. The write
+sibling could substitute that content; this one hands it over.
+
+``tenant_id`` is required now --- 422 when absent, rather than falling back to
+"fetch by primary key" --- and is part of the SELECT predicate, so another
+tenant's report is indistinguishable from one that does not exist.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = [pytest.mark.asyncio]
+
+
+async def _report(client: AsyncClient, tenant_id: str) -> str:
+    resp = await client.post(
+        f"{PREFIX}/reports",
+        json={"tenant_id": tenant_id, "trigger": "manual"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+class TestReportReadTenantScope:
+    async def test_another_tenants_report_is_not_readable(self, client: AsyncClient) -> None:
+        """The attack, stated as the request an attacker would send."""
+        victim = f"rep-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"rep-attacker-{uuid.uuid4().hex[:8]}"
+        report_id = await _report(client, victim)
+
+        resp = await client.get(f"{PREFIX}/reports/{report_id}", params={"tenant_id": attacker})
+
+        assert resp.status_code == 404, resp.text
+        # Not merely "no 200": the disclosure is the body, so pin that none of
+        # it came back. A future regression that 404s but still serialises the
+        # row into the error detail would pass a status-only assertion.
+        assert victim not in resp.text
+
+    async def test_omitted_tenant_id_is_rejected(self, client: AsyncClient) -> None:
+        """No tenant used to mean "fetch by primary key"; it is now a 422."""
+        tenant = f"rep-{uuid.uuid4().hex[:8]}"
+        report_id = await _report(client, tenant)
+
+        resp = await client.get(f"{PREFIX}/reports/{report_id}")
+
+        assert resp.status_code == 422, resp.text
+        assert "tenant_id" in resp.text
+
+    async def test_own_report_is_readable(self, client: AsyncClient) -> None:
+        """The supported call still works."""
+        tenant = f"rep-{uuid.uuid4().hex[:8]}"
+        report_id = await _report(client, tenant)
+
+        resp = await client.get(f"{PREFIX}/reports/{report_id}", params={"tenant_id": tenant})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"] == report_id
+        assert body["tenant_id"] == tenant
+        assert body["status"] == "running"
+
+    async def test_a_foreign_id_is_indistinguishable_from_a_missing_one(self, client: AsyncClient) -> None:
+        """Both 404, so the endpoint is not an existence oracle for report UUIDs.
+
+        This is the storage-level half of audit finding #22. The caller-facing
+        route in ``core-api`` keeps the same property for its own callers; the
+        403 it can raise is keyed on the named tenant rather than on
+        ``report_id``, and ``tests/test_api_crystallizer.py`` pins that matrix.
+        """
+        victim = f"rep-victim-{uuid.uuid4().hex[:8]}"
+        attacker = f"rep-attacker-{uuid.uuid4().hex[:8]}"
+        report_id = await _report(client, victim)
+
+        params = {"tenant_id": attacker}
+        foreign = await client.get(f"{PREFIX}/reports/{report_id}", params=params)
+        missing = await client.get(f"{PREFIX}/reports/{uuid.uuid4()}", params=params)
+
+        assert foreign.status_code == missing.status_code == 404
+        assert foreign.json() == missing.json()
+
+    async def test_the_running_report_lookup_still_resolves(self, client: AsyncClient) -> None:
+        """``GET /reports/running`` chains through the method this PR scoped.
+
+        It calls ``report_find_running`` and then ``report_get_by_id`` with the
+        id that came back. The second call gained a tenant argument; if it were
+        threaded wrong, the pair would 404 on a report the first half had just
+        found --- a break that no test above would see, because they all address
+        the route by id.
+        """
+        tenant = f"rep-{uuid.uuid4().hex[:8]}"
+        report_id = await _report(client, tenant)
+
+        resp = await client.get(f"{PREFIX}/reports/running", params={"tenant_id": tenant})
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["id"] == report_id

--- a/core-storage-api/tests/test_report_update_tenant_scope.py
+++ b/core-storage-api/tests/test_report_update_tenant_scope.py
@@ -49,14 +49,42 @@ async def _report(client: AsyncClient, tenant_id: str) -> str:
 async def _read(client: AsyncClient, report_id: str) -> dict:
     """Read the row back regardless of tenant, to assert what actually persisted.
 
-    Deliberately goes through ``GET /reports/{report_id}``, which is still
-    unscoped (allowlisted ``id-addressed-read``) and so answers for any tenant
-    --- that is what makes it a usable oracle here. When that route gains a
-    required tenant, this helper needs one too.
+    Reads ``crystallization_reports`` through the ORM rather than through
+    ``GET /reports/{report_id}``, which it used to use. The note that stood here
+    said this helper would need a tenant the day that route took one; it now
+    does, and giving it one would have been the wrong repair --- the same
+    conclusion ``test_entity_update_tenant_scope`` reached when its route was
+    scoped. Every assertion below asks "is the row still in the tenant that
+    owned it, holding the values it had", so an oracle scoped to a tenant can
+    only answer about rows already known to be in it, and could not observe a
+    row that moved namespace. That is precisely the failure
+    ``test_another_tenants_report_is_not_completed`` exists to catch, and the
+    last assertion in it (``row["tenant_id"] == victim``) is the one that would
+    go silently untested. Tenant-blind by construction, and so immune to any
+    further scoping of the route.
+
+    ``client`` is unused but kept in the signature so the call sites read the
+    same and the raw read stays swappable.
     """
-    resp = await client.get(f"{PREFIX}/reports/{report_id}")
-    assert resp.status_code == 200, resp.text
-    return resp.json()
+    from common.models import CrystallizationReport
+    from core_storage_api.services.postgres_service import get_session
+
+    async with get_session() as session:
+        report = await session.get(CrystallizationReport, uuid.UUID(report_id))
+    assert report is not None, f"report {report_id} vanished"
+    return {
+        "id": str(report.id),
+        "tenant_id": report.tenant_id,
+        "status": report.status,
+        "completed_at": report.completed_at,
+        "duration_ms": report.duration_ms,
+        "summary": report.summary,
+        "hygiene": report.hygiene,
+        "health": report.health,
+        "usage_data": report.usage_data,
+        "issues": report.issues,
+        "crystallization": report.crystallization,
+    }
 
 
 def _completion(**extra: object) -> dict:

--- a/tests/test_api_crystallizer.py
+++ b/tests/test_api_crystallizer.py
@@ -143,7 +143,7 @@ async def test_get_report_by_id(client):
     report_id = reports[0]["id"]
 
     resp = await client.get(
-        f"/api/v1/crystallize/reports/{report_id}",
+        f"/api/v1/crystallize/reports/{report_id}?tenant_id={tenant_id}",
         headers=headers,
     )
     assert resp.status_code == 200
@@ -156,10 +156,10 @@ async def test_get_report_by_id(client):
 
 async def test_get_report_not_found(client):
     """GET /api/crystallize/reports/{id} returns 404 for non-existent report."""
-    _, headers = get_test_auth()
+    tenant_id, headers = get_test_auth()
     fake_id = "00000000-0000-0000-0000-000000000000"
     resp = await client.get(
-        f"/api/v1/crystallize/reports/{fake_id}",
+        f"/api/v1/crystallize/reports/{fake_id}?tenant_id={tenant_id}",
         headers=headers,
     )
     assert resp.status_code == 404
@@ -170,6 +170,12 @@ async def test_get_report_foreign_tenant_returns_404_not_403():
     must see 404 (same as a missing report), not 403 — otherwise an
     attacker could enumerate report_ids across tenants by distinguishing
     the two status codes (audit finding #22).
+
+    The shape of this changed when storage stopped answering to a bare
+    primary key. The caller now names a tenant, and the only tenant it may
+    name is its own — so the way to reach another tenant's report is to ask
+    for it under YOUR tenant, and storage's predicate misses. The row never
+    leaves storage, where before it was fetched and then discarded here.
     """
     from unittest.mock import AsyncMock, patch
     from uuid import uuid4
@@ -179,18 +185,14 @@ async def test_get_report_foreign_tenant_returns_404_not_403():
     from core_api.auth import AuthContext
     from core_api.routes.crystallizer import get_report
 
-    foreign_report = {
-        "id": str(uuid4()),
-        "tenant_id": "tenant-A",  # owned by tenant A
-        "fleet_id": None,
-    }
     caller = AuthContext(tenant_id="tenant-B", is_admin=False)
 
     sc_mock = AsyncMock()
-    sc_mock.get_report = AsyncMock(return_value=foreign_report)
+    # Storage is scoped: asked for tenant-B, a tenant-A report is not a row.
+    sc_mock.get_report = AsyncMock(return_value=None)
     with patch("core_api.routes.crystallizer.get_storage_client", return_value=sc_mock):
         try:
-            await get_report(report_id=uuid4(), auth=caller)
+            await get_report(report_id=uuid4(), tenant_id="tenant-B", auth=caller)
         except HTTPException as e:
             assert e.status_code == 404, (
                 f"Foreign-tenant report read must surface as 404; got {e.status_code}"
@@ -200,19 +202,65 @@ async def test_get_report_foreign_tenant_returns_404_not_403():
             raise AssertionError(
                 "Expected HTTPException(404) for foreign-tenant report"
             )
+    # The tenant reached storage: without it the fetch is by primary key again
+    # and the 404 above would be answering a question nobody scoped.
+    assert sc_mock.get_report.await_args.args[1] == "tenant-B"
 
 
-async def test_get_report_foreign_tenant_admin_bypass():
-    """Admin keys keep their cross-tenant read ability (no 404 mask)."""
+async def test_get_report_403_is_keyed_on_the_tenant_not_the_report():
+    """The oracle contract of audit finding #22, stated as its whole matrix.
+
+    Requiring a ``tenant_id`` introduces a 403 on a path that previously had
+    only 404s, and a 403 that varied with ``report_id`` would be exactly the
+    enumeration oracle finding #22 closed. It does not vary:
+    ``enforce_readable_tenant`` runs BEFORE the fetch and sees only the named
+    tenant, so an unreadable tenant answers 403 for every id — including ids
+    that do not exist anywhere — and every question about a report's existence
+    still collapses to 404.
+
+    What the 403 discloses is "this credential may not read tenant T", which
+    the caller already knew about its own key.
+    """
     from unittest.mock import AsyncMock, patch
     from uuid import uuid4
+
+    from fastapi import HTTPException
 
     from core_api.auth import AuthContext
     from core_api.routes.crystallizer import get_report
 
-    foreign_report = {
+    caller = AuthContext(tenant_id="tenant-B", is_admin=False)
+    sc_mock = AsyncMock()
+    sc_mock.get_report = AsyncMock(return_value=None)
+
+    async def _status(tenant_id: str, report_id) -> int:
+        with patch("core_api.routes.crystallizer.get_storage_client", return_value=sc_mock):
+            try:
+                await get_report(report_id=report_id, tenant_id=tenant_id, auth=caller)
+            except HTTPException as e:
+                return e.status_code
+        return 200
+
+    real_looking = uuid4()
+    nonexistent = uuid4()
+
+    # Unreadable tenant: same 403 whichever id is named, so the id is not
+    # being answered. This is the assertion that makes it not an oracle.
+    assert await _status("tenant-A", real_looking) == 403
+    assert await _status("tenant-A", nonexistent) == 403
+    # ...and it fires before storage is consulted at all.
+    assert sc_mock.get_report.await_count == 0
+
+    # Readable tenant: absent rows are 404, as they always were.
+    assert await _status("tenant-B", nonexistent) == 404
+
+
+def _report_payload(tenant_id: str) -> dict:
+    from uuid import uuid4
+
+    return {
         "id": str(uuid4()),
-        "tenant_id": "tenant-A",
+        "tenant_id": tenant_id,
         "fleet_id": None,
         "trigger": "manual",
         "status": "completed",
@@ -222,14 +270,64 @@ async def test_get_report_foreign_tenant_admin_bypass():
         "issues": [],
         "crystallization": {},
     }
+
+
+async def test_get_report_foreign_tenant_admin_bypass():
+    """Admin keys keep their cross-tenant read ability — by NAMING the tenant.
+
+    An admin ``AuthContext`` has ``tenant_id=None``, so there is no tenant to
+    infer and storage now demands one. The capability is unchanged; what changed
+    is that the admin says which tenant it is reading, instead of the ability
+    falling out of an unscoped fetch. That is the whole of the API change this
+    endpoint takes.
+    """
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from core_api.auth import AuthContext
+    from core_api.routes.crystallizer import get_report
+
     admin = AuthContext(tenant_id=None, is_admin=True)
 
     sc_mock = AsyncMock()
-    sc_mock.get_report = AsyncMock(return_value=foreign_report)
+    sc_mock.get_report = AsyncMock(return_value=_report_payload("tenant-A"))
     with patch("core_api.routes.crystallizer.get_storage_client", return_value=sc_mock):
-        result = await get_report(report_id=uuid4(), auth=admin)
+        result = await get_report(report_id=uuid4(), tenant_id="tenant-A", auth=admin)
     # Admin sees the full payload.
     assert result["tenant_id"] == "tenant-A"
+    # And the tenant it named is what storage was asked for.
+    assert sc_mock.get_report.await_args.args[1] == "tenant-A"
+
+
+async def test_get_report_honours_a_cross_tenant_read_key():
+    """A widened read key reaches its non-home readable tenants.
+
+    ``enforce_readable_tenant``, not ``enforce_tenant``: the latter is the WRITE
+    gate and pins to the home tenant, so copying it onto this read path would
+    403 a credential that is entitled to the row. ``readable_tenant_ids`` comes
+    from the credential and never from the request, which is what keeps this
+    from being the "caller names its own scope" shape rejected as option C on
+    #1167.
+    """
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from core_api.auth import AuthContext
+    from core_api.routes.crystallizer import get_report
+
+    caller = AuthContext(
+        tenant_id="tenant-B",
+        is_admin=False,
+        readable_tenant_ids=["tenant-B", "tenant-A"],
+    )
+
+    sc_mock = AsyncMock()
+    sc_mock.get_report = AsyncMock(return_value=_report_payload("tenant-A"))
+    with patch("core_api.routes.crystallizer.get_storage_client", return_value=sc_mock):
+        result = await get_report(report_id=uuid4(), tenant_id="tenant-A", auth=caller)
+
+    assert result["tenant_id"] == "tenant-A"
+    assert sc_mock.get_report.await_args.args[1] == "tenant-A"
 
 
 async def test_get_latest_report_empty_returns_200_null(client):


### PR DESCRIPTION
## Summary

- Require `tenant_id` on `GET /reports/{report_id}` and put it in `report_get_by_id`'s predicate.
- core-api's `GET /crystallize/reports/{report_id}` takes a `tenant_id` and gates it with **`enforce_readable_tenant`**, not `enforce_tenant`; the post-fetch comparison goes.
- Removes the last two `id-addressed-read` allowlist entries — **the category is now empty.**

## Related Issue

Closes #1167.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## What was reachable

`report_get_by_id` was `session.get(CrystallizationReport, report_id)` — a primary-key fetch with no tenant predicate — under a route that took a bare UUID. `core-storage-api` authenticates no request and docker-compose publishes it on `0.0.0.0:8002`, so a report id was the whole of the authorization.

The payload is what makes it worth the fix. A report carries `tenant_id` and `fleet_id` plus six JSONB blobs — `summary`, `hygiene`, `health`, `usage_data`, `issues`, `crystallization`. Together they are a standing description of another tenant's memory estate: health scores, hygiene problems, token spend, and an enumerated issue list. #1082 fixed the write half of this pair, which could *substitute* that content; this one handed it over.

## The decision this needed, and why it wasn't the obvious fix

#1167 was filed rather than fixed because the obvious repair breaks two tested behaviours. core-api authorized **after** the fetch:

```python
report = await sc.get_report(str(report_id))
if not auth.is_admin and report.get("tenant_id") not in auth.readable_tenant_ids:
    raise HTTPException(status_code=404, detail="Report not found")
```

That is a check against a **set**, and admin keys have no tenant at all (`AuthContext(tenant_id=None, is_admin=True)`).

**`enforce_readable_tenant`, not `enforce_tenant`.** The sibling precedent on `GET /reports` uses the latter, and copying it here would have reintroduced the problem: `enforce_tenant`'s own docstring opens *"Raise if the caller may not write to `requested_tenant`"* and it pins to the home tenant, so a cross-tenant read key naming one of its *other* readable tenants gets a 403 on a row it is entitled to. `enforce_readable_tenant` is the read-shaped equivalent, already covered by `tests/test_auth_context.py` for home / widened / unrelated / admin. Why the sibling can use the write gate: `GET /reports` is an aggregate whose breadth is a separate explicit `scope='own'|'org'` axis, so pinning the *named* tenant to home is coherent there. A single report fetched by id has no such axis.

`readable_tenant_ids` is derived from the credential (`auth.py:86-91`) and never from the request, which is what keeps this from being the `grant-in-lieu-of-tenant` shape — the caller names *one* tenant; the credential decides whether it may.

**The post-fetch comparison is deleted, not kept as defence in depth.** It protected this route's callers while leaving the storage route answering to a bare id — and the storage route is the half an attacker on port 8002 does not go through. Leaving it would be a second, weaker check on a path that no longer needs one.

## The 403 is not a new oracle

Requiring a tenant introduces a 403 on a path that previously had only 404s, and audit finding #22 exists because distinguishing 403 from 404 on random UUIDs is how you enumerate reports across tenants. So this is pinned rather than asserted:

| request | result | what it reveals |
|---|---|---|
| id + a tenant the credential may read, report absent | 404 | nothing |
| id + a tenant the credential may read, report in another tenant | 404 (predicate misses) | nothing |
| id + a tenant the credential may **not** read | 403 | only that this credential cannot read tenant T |

`enforce_readable_tenant` runs **before** the fetch and sees only the named tenant, so the 403 is independent of `report_id` — `test_get_report_403_is_keyed_on_the_tenant_not_the_report` asserts the same 403 for a plausible id and a nonexistent one, and that storage is not consulted at all in that branch. Report existence still collapses to 404 in every case.

## The oracle that had to change

`core-storage-api/tests/test_report_update_tenant_scope.py`'s `_read` helper deliberately used this unscoped route to read rows back "regardless of tenant", with a comment saying it would need a tenant the day the route took one.

**Giving it a tenant would have been the wrong repair** — the same conclusion #1174 reached on the entity side an hour earlier. Every assertion in that file asks "is the row still in the tenant that owned it, holding the values it had", so a tenant-scoped oracle can only answer about rows already known to be in that tenant and could not observe a row that **moved namespace** — which is exactly what `test_another_tenants_report_is_not_completed` exists to catch, and whose last assertion (`row["tenant_id"] == victim`) would have gone silently untested. It now reads the row through the ORM: tenant-blind by construction, and immune to any further scoping of the route.

## How Has This Been Tested?

New storage tests, verified against the parent commit — 3 of the 5 fail there, the other 2 being the happy path and a chained-call regression guard that were never meant to fail:

```text
FAILED test_report_read_tenant_scope.py::test_another_tenants_report_is_not_readable
FAILED test_report_read_tenant_scope.py::test_omitted_tenant_id_is_rejected
FAILED test_report_read_tenant_scope.py::test_a_foreign_id_is_indistinguishable_from_a_missing_one
3 failed, 7 passed
```

The four core-api tests also fail on the parent, but honestly: they fail as `TypeError` because `tenant_id` does not exist there. They pin the contract of the new shape rather than demonstrating a parent bug — the behavioural proof is the three storage failures above.

| check | result |
|---|---|
| `core-storage-api/tests/` | 306 passed |
| root `tests/` | 5795 passed, 4 skipped, 1 xfailed |
| `core-api/tests/` | 52 passed |
| `core-worker/tests/` | 80 passed |
| `core-operations/tests/` | 50 passed |
| `ruff check` — core-api/src, core-storage-api/src, core-storage-api/tests, common, core-operations, core-worker | all pass |
| `ruff format --check` — same scopes | all pass |
| `mypy src/` — core-storage-api (85), core-api (203) | both clean |
| broker OpenAPI baseline | up to date (8 operations) |
| `tenant_scope_gate.py --base origin/main` | exit 0 |

One unrelated flake appeared in a full-suite run: `test_memory_update_rejects_unknown_field` (#1137 — `DUPLICATE_MEMORY` / `semantic_similarity`, 409 vs 201). It passed 4/4 on rerun and in the identical full-suite run before the rebase; it touches memory writes, which this PR does not.

Gate output:

```text
  added (0)
  removed — fixed (2):
      - method:report_get_by_id [id-addressed-read]
      - route:GET /api/v1/storage/reports/{report_id} [id-addressed-read]
      id-addressed-read: 2 -> 0
```

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally
- [ ] I have updated relevant documentation — `GET /crystallize/reports/{report_id}` is not listed in `docs/public-api-stability.md` or `docs/api-reference.md` (only the `/crystallize/reports` list route is), and it is not in the frozen broker contract, so no documented surface changed
- [ ] I have updated `CHANGELOG.md` under `Unreleased` (release-please derives this from the conventional commit)

## Additional Notes

- **`id-addressed-read` is now empty.** That is the category the allowlist's own doc calls *"THIS IS THE BACKLOG… the shape of GHSA-wgvw-28pq-jc36"*. It stood at 14 entries when the ratchet went in. Allowlist 74 → 72.
- What remains on the board is 3 entries in two different categories: the `blind-spot` `tenant-usage/increment` guard, and the two `grant-in-lieu-of-tenant` `tenant_usage_query` entries (#1095).
- `find_running_report` gained the tenant at no cost — its `report_id` already came from the tenant-scoped `report_find_running`, so it was never reachable cross-tenant. Passing it leaves no unscoped call of the method behind, and `test_the_running_report_lookup_still_resolves` pins that chain, which no id-addressed test would have caught.
- `sc.get_report(..., read=False)` in `execute_reserved_report` keeps `read=False`; the read-your-write across a delivery boundary (H-02 / #812) is load-bearing and unchanged.
