### PR TITLE
test(crystallizer): pin that the report-read 403 cannot probe for reports

### DIFF
--- a/tests/test_api_crystallizer.py
+++ b/tests/test_api_crystallizer.py
@@ -202,6 +202,76 @@ async def test_get_report_foreign_tenant_returns_404_not_403():
             )
 
 
+async def test_get_report_403_cannot_be_used_to_probe_for_reports():
+    """The 403 must not vary with whether the report exists (audit finding #22).
+
+    The test above covers the case where the caller names a tenant it MAY read.
+    This one covers the other half, which #1167 introduced: naming a tenant the
+    credential may NOT read is a 403, on a route that previously had only 404s.
+    A 403 that depended on the report would be the enumeration oracle finding
+    #22 closed — ask about a tenant you cannot read, and the status tells you
+    whether the id exists there.
+
+    It does not depend on the report, and the reason is positional:
+    ``enforce_readable_tenant`` runs BEFORE the fetch, so it compares two
+    strings the caller already knows and never learns anything about the row.
+
+    **That ordering is the whole guarantee, and it is the kind of thing an
+    ordinary refactor moves.** Hoisting the lookup, or sliding the auth call
+    down past the ``if not report`` to avoid a redundant check on the happy
+    path, both reintroduce the oracle — verified by doing it: with the call
+    moved after the fetch, every other test in this file and all of
+    ``test_auth_context.py`` still pass, while an unreadable tenant answers 403
+    for a report that exists and 404 for one that does not.
+
+    Both assertions below are load-bearing. The first states the property; the
+    second states the mechanism, and fails on the reorder even if some future
+    shape makes the statuses coincide by accident.
+
+    Second concrete instance of the shape in #847 — an audit finding
+    reintroducible by a change that reads as a cleanup, with nothing watching.
+    """
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from fastapi import HTTPException
+
+    from core_api.auth import AuthContext
+    from core_api.routes.crystallizer import get_report
+
+    caller = AuthContext(tenant_id="tenant-B", is_admin=False)
+    unreadable = "tenant-A"
+
+    async def _probe(storage_answer):
+        """Ask about ``unreadable``; return (status, times storage was called)."""
+        sc_mock = AsyncMock()
+        sc_mock.get_report = AsyncMock(return_value=storage_answer)
+        status = 200
+        with patch(
+            "core_api.routes.crystallizer.get_storage_client", return_value=sc_mock
+        ):
+            try:
+                await get_report(report_id=uuid4(), tenant_id=unreadable, auth=caller)
+            except HTTPException as e:
+                status = e.status_code
+        return status, sc_mock.get_report.await_count
+
+    # A report that exists in the unreadable tenant, and one that does not.
+    present, present_calls = await _probe({"id": str(uuid4()), "tenant_id": unreadable})
+    absent, absent_calls = await _probe(None)
+
+    assert present == absent == 403, (
+        "the response to an unreadable tenant must not depend on whether the report "
+        f"exists: got {present} when present and {absent} when absent — that difference "
+        "is an existence oracle for report ids in other tenants (audit finding #22)"
+    )
+    assert present_calls == absent_calls == 0, (
+        "enforce_readable_tenant must run BEFORE the fetch; storage was consulted "
+        f"{present_calls or absent_calls} time(s) for a tenant the caller may not read, "
+        "which is what lets the response carry information about the row"
+    )
+
+
 async def test_get_report_foreign_tenant_admin_bypass():
     """Admin keys keep their cross-tenant read ability — by naming the tenant.
 


### PR DESCRIPTION
## Summary

One regression test. **No production code changes** — #1178 is correct as merged; the property it relies on just has nothing watching it.

## The gap

#1167 gave `GET /crystallize/reports/{report_id}` a `tenant_id`, which introduced a **403 on a route that previously had only 404s**. Audit finding #22 exists because distinguishing 403 from 404 on random UUIDs is how you enumerate reports across tenants, so that 403 has to be independent of the report — and it is, for a positional reason stated in a comment:

> Compares two strings the caller already knows, before any lookup, so the 403 it can raise says something about the credential and nothing about whether the report — or the named tenant — exists.

That is exactly right, and **the ordering is the whole guarantee.** `enforce_readable_tenant` must run *before* `sc.get_report`. Nothing enforced it.

## Verified, not argued

Moving the call to after the fetch — the kind of edit that reads as a cleanup, since the retained post-fetch check makes the auth call look redundant on the happy path:

```python
report = await sc.get_report(str(report_id), scope)
if not report:
    raise HTTPException(status_code=404, detail="Report not found")
auth.enforce_readable_tenant(scope)          # <- moved down
```

**Everything nearby still passes:** 13/13 in `tests/test_api_crystallizer.py`, 19/19 in `tests/test_auth_context.py`. And the endpoint is an existence oracle again:

```text
report EXISTS in an unreadable tenant -> 403
report ABSENT in an unreadable tenant -> 404
```

With this test present, that mutation produces exactly one failure:

```text
E  AssertionError: the response to an unreadable tenant must not depend on whether
   the report exists: got 403 when present and 404 when absent — that difference is
   an existence oracle for report ids in other tenants (audit finding #22)
E  assert 403 == 404

FAILED tests/test_api_crystallizer.py::test_get_report_403_cannot_be_used_to_probe_for_reports
1 failed, 32 passed
```

Against `origin/main` unmodified it passes, and both probes answer 403.

## Two assertions, both load-bearing

- **The property** — the status does not vary with whether the report exists.
- **The mechanism** — storage is not consulted *at all* for a tenant the caller may not read (`await_count == 0`). This is the more direct statement of the ordering, and it still fails on the reorder even if some future shape made the two statuses coincide by accident.

## Why this is filed as a test and not a code change

The reachable behaviour is correct today. What is missing is the thing that would notice if it stopped being correct — and the change that breaks it does not look like a security change, which is the whole difficulty.

This is a second concrete instance of the shape in #847 (*"audit findings recur inside the PRs that fix them"*). The first batch there was **a fixed bug class reappearing in new code**; this is a narrower variant — **a fixed finding reachable again through a pure refactor of the fixing code, with the invariant living in a comment.** Offered as a data point and a possible template for what #847 proposes; deliberately **not** sizing #847 here.

## How Has This Been Tested?

| check | result |
|---|---|
| `tests/test_api_crystallizer.py` | 14 passed (13 + the new one) |
| `tests/test_auth_context.py` | 19 passed |
| root `tests/` | 5796 passed, 4 skipped, 1 xfailed |
| mutation: auth call moved after the fetch | **1 failed** (this test), 32 passed — it is the only guard |
| `tenant_scope_gate.py --base origin/main` | exit 0 (no allowlist change) |

`tests/test_memory_update_rejects_unknown_field` failed once in a full-suite run and passed 4/4 on rerun — the known #1137 dedup flake, on a path this PR does not touch.

`ruff` is not run over root `tests/` in CI, and this file carries pre-existing import-sort and formatting findings. I left those alone rather than reformat a file I am adding 70 lines to, but the added block is clean under both `ruff check` and `ruff format`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes
- [x] `ruff check` / `ruff format` clean over the added block
- [x] `mypy` — no source changed
- [x] `pytest` passes locally
- [ ] Documentation — none; no behaviour changed
- [ ] `CHANGELOG.md` — not user-facing
