### PR TITLE
docs(plugin): name the edge-auth condition, not a host

### DIFF
--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -733,9 +733,17 @@ def _generate_skill_install_script(
 
     ``api_key`` — when non-empty, embedded into the script and forwarded
     as ``-H "X-API-Key: ..."`` on the internal curl calls. Required for
-    edge-auth-gated deploys (memclaw.net's nginx rejects unauthenticated
-    requests on every path). Empty when the deploy is standalone / lets
-    the skill file be fetched without a key.
+    edge-auth-gated deploys, where the edge rejects unauthenticated
+    requests on **every** path — the skill file included, which is why the
+    installer needs a key to fetch what is otherwise a static document.
+    Empty when the deploy is standalone / lets the skill file be fetched
+    without a key.
+
+    This used to name one host as the example of an edge-auth-gated deploy.
+    It no longer distinguishes anything: the hosted deploy answers ``401``
+    on ``/api/v1/skill/<skill>`` under either of its names, so the gate is a
+    property of the deployment rather than of a domain. Naming the condition
+    is what a caller can act on; naming a host was only ever a proxy for it.
     """
     safe_api_url = shlex.quote(api_url)
     safe_api_key = shlex.quote(api_key)


### PR DESCRIPTION
## Summary

Closes a standing question about `core-api/src/core_api/routes/plugin.py:736` by answering it rather than choosing a marker for it.

The installer docstring said an `api_key` is required for *"edge-auth-gated deploys (memclaw.net's nginx rejects unauthenticated requests on every path)"*. That line was written **2026-06-23 in `a6f9ad15`**, when that host *was* the production deploy — accurate then, a stale example now.

## Measured, not assumed

Unauthenticated, following no redirects, no credentials sent:

```
memclaw.net/                       301 -> https://caura.ai/
memclaw.net/api/v1/skill/memclaw   401
memclaw.net/api/v1/health          401
caura.ai/api/v1/skill/memclaw      401
caura.ai/api/v1/health             401
```

Two things follow:

1. **The gate is a property of the deployment, not of a domain.** The hosted deploy answers `401` on the skill path under *either* of its names, so naming one host distinguishes nothing a caller can act on.
2. **Only the root redirects.** `/api/v1/*` does not — so that host is a served API surface today, not a pure redirect. Worth knowing separately from this change.

## Why this was stuck

The line was left counted by the ratchet on purpose, because **neither available marker was true**:

- a **floor** marker asserts the rename will never reach the line — nobody could substantiate that;
- an **alias** marker asserts the line bears a compatibility alias — it does not;
- the only precedent in the tree (`contradiction_detector.py:1920`) covers a **dated historical record** — *"Wet-tested on memclaw.net 2026-05-26"* — which this is not. It is a present-tense claim about live infrastructure.

Rewording is accurate on its own terms, and the counted line goes away as a **side effect** rather than as the goal. The docstring also gains the fact that actually explains the parameter: the gate covers the skill file itself, which is why an installer needs a key to fetch what is otherwise a static document.

## Not claimed

No `nginx` config for either host exists in this repo, so I have not verified that the edge is nginx specifically — only what it returns. The reworded text no longer asserts the mechanism, just the observable behaviour.

## Verification

```
legacy-name ratchet                          0 added, 0 annotated, 1 removed (-1 net)
do-not-touch sentinel                        all 46 protected strings survive
ruff check core-api/src/                     passed
ruff format --check core-api/src/            203 files already formatted
mypy core-api                                203 files, clean
pytest tests/test_install_skill_endpoint.py  16 passed
```

Docstring-only; no runtime behaviour changes.