### PR TITLE
test(core-storage-api): give the storage suite its own database by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,26 @@ This starts PostgreSQL + pgvector, Redis, and the core API with hot reload.
 pytest tests/ -v
 ```
 
+`core-storage-api` has a second suite that needs a **separate database**:
+
+```bash
+createdb memclaw_storage && psql -d memclaw_storage -c 'CREATE EXTENSION IF NOT EXISTS vector'  # legacy-name-floor: the database ci.yml already provisions; a pasteable command naming anything else is wrong
+pytest core-storage-api/tests/ -v
+```
+
+Two databases, because the suites provision incompatibly and cannot share one:
+`tests/` builds its schema with `Base.metadata.create_all`, while
+`core-storage-api/tests/` runs the real Alembic chain. Run them against one
+database and nothing fails loudly — `create_all` leaves tables with no
+`alembic_version`, so the Alembic side stamps head and skips every migration,
+and any migration-only table (one with no ORM model, e.g. `tenant_suppression`)
+is missing from a database whose stamp claims it is current. Run them the other
+way round and the migrated schema is the one that gets polluted.
+
+Each suite defaults to its own database, so no environment variable is needed;
+`DATABASE_URL` (storage suite) and `TEST_DATABASE_URL` (root suite) override
+them. CI provisions and passes both explicitly.
+
 See `README.md` for more deployment options and environment variable details.
 
 ## Workflow

--- a/core-storage-api/tests/conftest.py
+++ b/core-storage-api/tests/conftest.py
@@ -11,9 +11,26 @@ import uuid
 
 # Set test environment BEFORE any app imports touch Settings
 os.environ.setdefault("TESTING", "1")
+# A database of this suite's OWN, not the one ``tests/`` uses. The two suites
+# provision incompatibly: ``tests/conftest.py`` calls
+# ``Base.metadata.create_all``, this one runs the real Alembic chain via
+# ``init_database()``. Sharing one database does not fail loudly — it
+# under-provisions silently. ``create_all`` going first leaves tables with no
+# ``alembic_version``, so ``init_database()`` stamps head and skips every
+# migration, and each migration-only table (``tenant_suppression``, which has
+# no ORM model) is simply absent from a database whose stamp claims head.
+#
+# CI passes DATABASE_URL explicitly and provisions the same name itself
+# (.github/workflows/ci.yml, "Create the storage-suite database"), so this
+# ``setdefault`` is a no-op there. It exists so a local run is isolated by
+# default rather than by remembering to export the variable — the isolation
+# was real in CI and absent everywhere else.
+#
+# Create it once, alongside the database ``tests/`` uses:
+#     createdb memclaw_storage && psql -d memclaw_storage -c 'CREATE EXTENSION IF NOT EXISTS vector'  # legacy-name-floor: the database ci.yml already provisions; a pasteable command naming anything else is wrong
 os.environ.setdefault(
     "DATABASE_URL",
-    "postgresql+asyncpg://memclaw:changeme@127.0.0.1:5432/memclaw",  # legacy-name-ok: local test DB
+    "postgresql+asyncpg://memclaw:changeme@127.0.0.1:5432/memclaw_storage",  # legacy-name-ok: local test DB
 )
 os.environ.setdefault("LOG_LEVEL", "WARNING")
 os.environ.setdefault("CORE_STORAGE_SHARED_SECRET", "test-storage-secret")

--- a/core-storage-api/tests/test_config.py
+++ b/core-storage-api/tests/test_config.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from urllib.parse import urlsplit
+
 import pytest
 
-from core_storage_api.config import LOCAL_DATABASE_URL, Settings
+from core_storage_api.config import LOCAL_DATABASE_URL, Settings, settings
 
 ALLOYDB_NAMES = (
     "ALLOYDB_HOST",
@@ -123,6 +125,34 @@ def test_unconfigured_database_keeps_the_local_default(monkeypatch: pytest.Monke
     _clear_database_env(monkeypatch)
 
     assert Settings(_env_file=None).database_url.get_secret_value() == LOCAL_DATABASE_URL
+
+
+def test_this_suite_does_not_share_the_root_suites_database() -> None:
+    """This suite must never resolve to the database ``tests/`` provisions.
+
+    The two provision incompatibly — ``Base.metadata.create_all`` there, the
+    real Alembic chain here — and sharing one database fails silently rather
+    than loudly: ``create_all`` leaves tables with no ``alembic_version``, so
+    ``init_database()`` stamps head and skips every migration, and a
+    migration-only table like ``tenant_suppression`` is absent from a database
+    whose stamp claims head. Nothing raises; the suite just runs against a
+    schema that is quietly short.
+
+    Asserted against the running configuration rather than against a literal,
+    so it holds however the database was selected — CI's explicit
+    ``DATABASE_URL``, a developer's export, or this suite's own conftest
+    default. The root suite's name is duplicated from ``tests/conftest.py``
+    because a conftest is not importable as a module from another suite; it is
+    the one value here that must be kept in step by hand.
+    """
+    root_suite_database = "memclaw"  # legacy-name-ok: mirrors tests/conftest.py TEST_DB_URL
+
+    configured = urlsplit(settings.database_url.get_secret_value()).path.lstrip("/")
+
+    assert configured != root_suite_database, (
+        f"the storage suite is pointed at {configured!r}, the database tests/ provisions with "
+        "create_all; give it one of its own (see CONTRIBUTING.md)"
+    )
 
 
 def test_storage_secret_loads_from_file_and_stays_out_of_serialization(

--- a/core-storage-api/tests/test_entity_link_routes_tenant_scope.py
+++ b/core-storage-api/tests/test_entity_link_routes_tenant_scope.py
@@ -44,10 +44,11 @@ def _tenant() -> str:
     ``_setup_schema`` teardown cleans with ``tenant_id LIKE 'test-tenant-%'``
     (and reaches this table through the ``memories`` subquery), so a tenant
     minted with any other prefix is never reclaimed — which is how #858 left
-    9,186 rows behind. Locally this suite's default ``DATABASE_URL`` points at
-    the same database that sweep runs against, so the prefix is what gets these
-    rows collected; in CI the storage suite is given a database of its own and
-    nothing sweeps either way.
+    9,186 rows behind. This suite now defaults to a database of its own, in CI
+    and locally alike, so that sweep no longer reaches these rows either way and
+    the prefix is a convention this module keeps rather than a live guard. Point
+    ``DATABASE_URL`` back at the root suite's database and the prefix is load-
+    bearing again — which is the reason to keep minting it.
 
     Local to this module rather than ``tests.conftest.new_tenant_id``, which is
     the root suite's fixture file and not importable from this one. Same prefix

--- a/core-storage-api/tests/test_memory_entity_links_tenant_scope.py
+++ b/core-storage-api/tests/test_memory_entity_links_tenant_scope.py
@@ -39,10 +39,11 @@ def _tenant() -> str:
     ``_setup_schema`` teardown cleans with ``tenant_id LIKE 'test-tenant-%'``
     (and reaches this table through the ``memories`` subquery), so a tenant
     minted with any other prefix is never reclaimed — which is how #858 left
-    9,186 rows behind. Locally this suite's default ``DATABASE_URL`` points at
-    the same database that sweep runs against, so the prefix is what gets these
-    rows collected; in CI the storage suite is given a database of its own and
-    nothing sweeps either way.
+    9,186 rows behind. This suite now defaults to a database of its own, in CI
+    and locally alike, so that sweep no longer reaches these rows either way and
+    the prefix is a convention this module keeps rather than a live guard. Point
+    ``DATABASE_URL`` back at the root suite's database and the prefix is load-
+    bearing again — which is the reason to keep minting it.
 
     Local to this module rather than ``tests.conftest.new_tenant_id``, which is
     the root suite's fixture file and not importable from this one. Same prefix


### PR DESCRIPTION
## The problem

The two Python suites provision incompatibly and cannot share a database:

| suite | provisioning |
|---|---|
| `tests/` | `Base.metadata.create_all` |
| `core-storage-api/tests/` | the real Alembic chain, via `init_database()` |

Sharing one database **does not fail loudly.** `create_all` going first leaves tables carrying no `alembic_version`, so `init_database()` stamps head and skips the entire chain. Every migration-only table — one with no ORM model, e.g. `tenant_suppression` — is then absent from a database whose stamp claims it is current.

Measured directly on a scratch database, running the root suite first and then the storage suite:

```
collided:          stamp=041  tables=27  tenant_suppression=MISSING
properly migrated: stamp=041  tables=28  tenant_suppression=present
```

Nothing raises. The suite just runs against a schema that is quietly short.

## Why this is a fix and not a repair

CI already solves this, at `.github/workflows/ci.yml` → "Create the storage-suite database", by provisioning `memclaw_storage` and passing it explicitly. That comment describes the mirror-image failure too.

But `memclaw_storage` appeared in three lines of `ci.yml` and **nowhere else in the repository** — no CONTRIBUTING entry, no conftest docstring. A contributor or agent running `core-storage-api/tests/` locally got the shared database and no indication a second one was expected. An isolation that exists only in the workflow file is a step-order convention, not isolation.

## The change

Default the storage suite's own `DATABASE_URL` to `memclaw_storage`, the name CI already provisions. The conftest sets it through `os.environ.setdefault`, so **CI's explicit value still wins and that job is unchanged.**

`LOCAL_DATABASE_URL` in `core_storage_api/config.py` is deliberately **not** touched. Two things depend on it that are easy to miss, both verified rather than assumed:

- `Settings` has no `POSTGRES_*` assembly path — only an explicit `DATABASE_URL`, a complete `ALLOYDB_*` set, or that fallback. The CI "Run migrations" step runs `alembic upgrade head` with only `POSTGRES_*` set, so it resolves through `LOCAL_DATABASE_URL`. Repointing it would send that step at a database not created until ~75 lines later in the job.
- `AGENT-INSTALL.md` writes a `.env` with only `POSTGRES_*`, creates database `memclaw` at step 5, then runs `alembic upgrade head` at step 6 — which would target a database step 5 never created.

Moving that constant would break both **and** would not have isolated this suite anyway, since the conftest's `setdefault` shadows it.

## Verification

Both suites, both orders, against separate databases:

| order | root suite | storage suite |
|---|---|---|
| root → storage | 5797 passed | 309 passed |
| storage → root | 5797 passed | 309 passed |

Both databases end at `stamp=041, tables=28`, with `tenant_suppression` present.

Also run at CI's exact scopes: `ruff check` / `ruff format --check` on `core-storage-api/tests/` (clean), `mypy src/` in `core-storage-api` (85 files, clean), and `scripts/legacy_name_ratchet.py --base origin/main` (passes; the two pasteable `createdb` lines carry `legacy-name-floor` markers, as they name the database CI already provisions).

The new regression test was confirmed to **fail** against the unfixed conftest and pass with it.

## Also updated

Two tenant-prefix docstrings stated that locally the storage suite shared the root suite's database, so that suite's sweep reclaimed these rows — the #858 leak guard. That is no longer true in either environment, and they now say so, along with what would make the prefix load-bearing again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)