### PR TITLE
feat(api): report whether a search bumped recall_count

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -1698,6 +1698,12 @@
             },
             "title": "Items",
             "type": "array"
+          },
+          "recall_tracked": {
+            "default": false,
+            "description": "Whether this search bumped recall_count for the memories it returned. False means they were not reinforced: the caller presented no agent identity (a tenant-scoped key that did not set filter_agent_id — recall_count stays 0 for that caller and recall_boost never engages), the call set diagnostic=true, or nothing matched.",
+            "title": "Recall Tracked",
+            "type": "boolean"
           }
         },
         "required": [

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -829,6 +829,11 @@ async def caura_recall(
         # the var empty; ``search_memories`` falls back to the home tenant only.
         # C31/D12 — diagnostic trace context, filled by the pipeline when requested.
         diagnostic_ctx: dict = {}
+        # Same field REST /search reports. Emitted on both surfaces so adding
+        # it does not itself become a parity gap: MCP always carries an agent
+        # identity, but ``diagnostic=true`` and an empty result set still make
+        # this False here.
+        recall_ctx: dict = {}
         results = await search_memories(
             tenant_id=tenant_id,
             query=query,
@@ -849,6 +854,7 @@ async def caura_recall(
             diagnostic=diagnostic,
             diagnostic_ctx=diagnostic_ctx if diagnostic else None,
             min_similarity=min_similarity,
+            recall_ctx=recall_ctx,
         )
         # Cross-tenant read audit (F2): emit one event per source tenant when
         # the credential widened beyond home. Async queue — non-blocking.
@@ -880,6 +886,9 @@ async def caura_recall(
         # Reports only that the REQUESTED top_k was lowered. A full page at an
         # uncapped ``top_k`` is still not proof of exhaustion; that would need a
         # total, which this surface does not compute.
+        #
+        # ``recall_tracked`` is the same field REST /search reports — see the
+        # ``recall_ctx`` note above.
         payload: dict = {
             "results": _rows,
             "items": _rows,
@@ -887,6 +896,7 @@ async def caura_recall(
             "truncated": top_k > capped_top_k,
             "requested_top_k": top_k,
             "effective_top_k": capped_top_k,
+            "recall_tracked": bool(recall_ctx.get("recall_tracked")),
         }
         if diagnostic:
             counts = diagnostic_ctx.get("counts", {}) or {}

--- a/core-api/src/core_api/pipeline/steps/search/track_recalls.py
+++ b/core-api/src/core_api/pipeline/steps/search/track_recalls.py
@@ -50,6 +50,13 @@ class TrackRecalls:
         # or ``auth.agent_id``), so genuine agent recalls — including cross-agent
         # ones that omit ``filter_agent_id`` — still count. Results are returned
         # unchanged either way; only the counter bump is skipped. (Gap A26.)
+        #
+        # ``recall_tracked`` is set on every path below so the surfaces can
+        # report what this search actually did rather than re-deriving the
+        # policy at the route. A re-derived predicate would already be wrong:
+        # the legacy ``_search_memories_legacy`` path bumps unconditionally,
+        # and the "no rows" case below is invisible from the caller's inputs.
+        ctx.data["recall_tracked"] = False
         if not ctx.data.get("caller_agent_id"):
             return None
         # D12 — a diagnostic call is inspection, not use: the caller is asking
@@ -67,4 +74,8 @@ class TrackRecalls:
                     tenant_id=ctx.data["tenant_id"],
                 )
             )
+            # Dispatched, not completed — the bump is fire-and-forget, so this
+            # reports "this search asked for a bump", which is the fact a
+            # caller needs to tell a pinned-at-zero counter from a working one.
+            ctx.data["recall_tracked"] = True
         return None

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1747,6 +1747,9 @@ async def _search_inner(
     # the typed ``SearchResponse.diagnostic`` block below. Results themselves
     # are unchanged by diagnostic mode, and no recall_count is bumped.
     diagnostic_ctx: dict = {}
+    # Filled by TrackRecalls (via search_memories) with whether this search
+    # dispatched a recall_count bump — reported to the caller below.
+    recall_ctx: dict = {}
     try:
         config = await resolve_config(body.tenant_id)
         # Widen the read predicate when the caller authenticated with
@@ -1774,6 +1777,7 @@ async def _search_inner(
             diagnostic=body.diagnostic,
             diagnostic_ctx=diagnostic_ctx if body.diagnostic else None,
             min_similarity=body.min_similarity,
+            recall_ctx=recall_ctx,
         )
     except HTTPException:
         # Auth / tenant errors raised downstream are expected outcomes,
@@ -1795,11 +1799,13 @@ async def _search_inner(
                     "error": not success,
                 },
             )
+    recall_tracked = bool(recall_ctx.get("recall_tracked"))
     if not body.diagnostic:
-        return SearchResponse(items=results)
+        return SearchResponse(items=results, recall_tracked=recall_tracked)
     counts = diagnostic_ctx.get("counts", {}) or {}
     return SearchResponse(
         items=results,
+        recall_tracked=recall_tracked,
         diagnostic=SearchDiagnostic(
             retrieval_strategy=diagnostic_ctx.get("retrieval_strategy"),
             top_k_requested=diagnostic_ctx.get("diagnostic_original_top_k"),

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -580,6 +580,26 @@ class SearchResponse(BaseModel):
     """Envelope for search results — matches PaginatedMemoryResponse shape."""
 
     items: list[MemoryOut]
+    # Whether this search dispatched a ``recall_count`` bump for the rows it
+    # returned. False means the returned memories were NOT reinforced, and the
+    # three reasons are all invisible from the request alone: the caller
+    # presented no agent identity (a tenant-scoped key with no
+    # ``filter_agent_id`` — the counter is then pinned at 0 for that caller
+    # forever, and ``recall_boost`` never engages), the call set
+    # ``diagnostic=true``, or the search matched nothing. Before this field the
+    # first case was a permanent, silent behaviour that a client could only
+    # discover by watching a counter never move.
+    recall_tracked: bool = Field(
+        default=False,
+        description=(
+            "Whether this search bumped recall_count for the memories it "
+            "returned. False means they were not reinforced: the caller "
+            "presented no agent identity (a tenant-scoped key that did not set "
+            "filter_agent_id — recall_count stays 0 for that caller and "
+            "recall_boost never engages), the call set diagnostic=true, or "
+            "nothing matched."
+        ),
+    )
     # D12 — present only when the request set ``diagnostic=true``.
     diagnostic: SearchDiagnostic | None = None
 

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -4493,6 +4493,7 @@ async def search_memories(
     readable_tenant_ids: list[str] | None = None,
     source: str = "search",
     min_similarity: float | None = None,
+    recall_ctx: dict | None = None,
 ) -> list[MemoryOut]:
     # Diagnostic mode requires the pipeline path for score introspection
     if _USE_PIPELINE_SEARCH or diagnostic:
@@ -4516,9 +4517,17 @@ async def search_memories(
             readable_tenant_ids=readable_tenant_ids,
             source=source,
             min_similarity=min_similarity,
+            recall_ctx=recall_ctx,
         )
     logger.warning("legacy search path invoked; this path is deprecated and scheduled for removal")
-    return await _search_memories_legacy(
+    # The legacy path bumps recall_count unconditionally (no caller-agent gate,
+    # no diagnostic gate) — see the ``increment_recall`` call at the end of
+    # ``_search_memories_legacy``. Reporting the pipeline's policy here would
+    # be a lie for whoever flips ``_USE_PIPELINE_SEARCH`` back during a hotfix,
+    # which is the divergence trap this file already warns about in
+    # ``_search_memories_legacy``'s BlankQuery handler. So report what this
+    # path does: it bumps whenever it returned rows.
+    legacy_results = await _search_memories_legacy(
         tenant_id,
         query,
         fleet_ids=fleet_ids,
@@ -4535,6 +4544,9 @@ async def search_memories(
         search_profile=search_profile,
         min_similarity=min_similarity,
     )
+    if recall_ctx is not None:
+        recall_ctx["recall_tracked"] = bool(legacy_results)
+    return legacy_results
 
 
 async def _search_memories_pipeline(
@@ -4557,6 +4569,7 @@ async def _search_memories_pipeline(
     readable_tenant_ids: list[str] | None = None,
     source: str = "search",
     min_similarity: float | None = None,
+    recall_ctx: dict | None = None,
 ) -> list[MemoryOut]:
     """Pipeline-based search_memories -- same logic, decomposed into timed steps."""
     from core_api.pipeline.compositions.search import build_search_pipeline
@@ -4618,6 +4631,15 @@ async def _search_memories_pipeline(
         diagnostic_ctx["counts"] = ctx.data.get("diagnostic_counts", {})
         sp_applied = ctx.data.get("search_params") or {}
         diagnostic_ctx["min_similarity_applied"] = sp_applied.get("min_similarity")
+
+    if recall_ctx is not None:
+        # Written by TrackRecalls on every path it takes. Defaulting to False
+        # when the key is absent keeps the honest failure direction: a caller
+        # told "not tracked" investigates and finds a working counter, whereas
+        # a caller wrongly told "tracked" goes on believing a permanently
+        # pinned counter is fine — the exact silent-zero this field exists to
+        # end.
+        recall_ctx["recall_tracked"] = bool(ctx.data.get("recall_tracked"))
 
     return ctx.data["results"]
 

--- a/tests/test_search_recall_tracked_flag.py
+++ b/tests/test_search_recall_tracked_flag.py
@@ -1,0 +1,254 @@
+"""``/search`` reports whether it bumped ``recall_count`` (``recall_tracked``).
+
+TrackRecalls deliberately skips the ``recall_count`` bump for a recall that
+carries no caller agent identity (gap A26, pinned by
+``test_track_recalls_agentless.py``). That skip is correct, but it was also
+completely invisible: a tenant-scoped key — which has ``auth.agent_id = None``
+and so presents no identity unless it also sets ``filter_agent_id``, which
+would additionally narrow results to that agent's own rows — saw
+``recall_count`` pinned at 0 forever and ``recall_boost`` never engage, with
+nothing in the response saying so. The only way to discover it was to watch a
+counter never move.
+
+``recall_tracked`` reports what the search actually did. The value comes from
+TrackRecalls itself rather than being re-derived at the route, because the
+route cannot see two of the three reasons a bump is skipped (an empty result
+set, and the legacy search path's unconditional bump).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from core_api import mcp_server
+from core_api.services import memory_service
+from tests._mcp_test_helpers import parse_envelope, stub_storage_client
+from tests.conftest import get_test_auth
+
+
+@pytest.fixture
+def pipeline_search(monkeypatch):
+    """Pin the production (pipeline) search path for the REST cases below.
+
+    Not defensive boilerplate: ``tests/pipeline/test_search_pipeline.py`` sets
+    ``memory_service._USE_PIPELINE_SEARCH = False`` without restoring it, so
+    every test that runs after it in the same session silently exercises the
+    deprecated legacy path — which bumps ``recall_count`` unconditionally and
+    would therefore report ``recall_tracked: true`` for the agentless case
+    these tests exist to pin. Pinning the flag here makes each case assert the
+    behaviour of a named path instead of whatever ran last.
+    """
+    monkeypatch.setattr(memory_service, "_USE_PIPELINE_SEARCH", True)
+
+
+def _tenant() -> str:
+    return f"test-tenant-recall-tracked-{uuid.uuid4().hex[:8]}"
+
+
+async def _write(client, headers, tenant_id, agent_id, content):
+    resp = await client.post(
+        "/api/v1/memories",
+        headers=headers,
+        json={"tenant_id": tenant_id, "agent_id": agent_id, "content": content},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+@pytest.mark.integration
+async def test_agentless_search_reports_recall_not_tracked(client, pipeline_search):
+    """The finding: a tenant-scoped caller gets no bump, and now hears about it.
+
+    The admin/tenant key used by the test auth helper has no ``agent_id``, so
+    this is the exact shape of the integration that sat on a permanently
+    zero ``recall_count``.
+    """
+    tenant_id = _tenant()
+    headers = get_test_auth(tenant_id)[1]
+    content = f"Deploys are gated on a green staging smoke {uuid.uuid4().hex}"
+    await _write(client, headers, tenant_id, "deploy-bot", content)
+
+    resp = await client.post(
+        "/api/v1/search",
+        headers=headers,
+        json={"tenant_id": tenant_id, "query": content, "top_k": 5},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["items"], "the search must return the row it is asked about"
+    assert body["recall_tracked"] is False
+
+
+@pytest.mark.integration
+async def test_agent_scoped_search_reports_recall_tracked(client, pipeline_search):
+    """The contrast case: a caller identity is present, so the bump is dispatched."""
+    tenant_id = _tenant()
+    headers = get_test_auth(tenant_id)[1]
+    agent_id = f"agent-{uuid.uuid4().hex[:8]}"
+    content = f"Rollbacks are one command and never a redeploy {uuid.uuid4().hex}"
+    await _write(client, headers, tenant_id, agent_id, content)
+
+    resp = await client.post(
+        "/api/v1/search",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "query": content,
+            "top_k": 5,
+            "filter_agent_id": agent_id,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["items"], "the search must return the row it is asked about"
+    assert body["recall_tracked"] is True
+
+
+@pytest.mark.integration
+async def test_diagnostic_search_reports_recall_not_tracked(client, pipeline_search):
+    """D12 — a diagnostic call is inspection, not use, so it must not reinforce.
+
+    Reported honestly even though a caller identity IS present, which is the
+    case a predicate re-derived from ``filter_agent_id`` alone would get wrong.
+    """
+    tenant_id = _tenant()
+    headers = get_test_auth(tenant_id)[1]
+    agent_id = f"agent-{uuid.uuid4().hex[:8]}"
+    content = f"The oncall rotation hands over on Tuesdays {uuid.uuid4().hex}"
+    await _write(client, headers, tenant_id, agent_id, content)
+
+    resp = await client.post(
+        "/api/v1/search",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "query": content,
+            "top_k": 5,
+            "filter_agent_id": agent_id,
+            "diagnostic": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["items"], "the search must return the row it is asked about"
+    assert body["recall_tracked"] is False
+
+
+@pytest.mark.integration
+async def test_empty_result_set_reports_recall_not_tracked(client, pipeline_search):
+    """No rows means nothing was reinforced, identity or not.
+
+    The route cannot derive this from the request, which is why the value is
+    reported by TrackRecalls rather than recomputed from the caller's inputs.
+    """
+    tenant_id = _tenant()
+    headers = get_test_auth(tenant_id)[1]
+    agent_id = f"agent-{uuid.uuid4().hex[:8]}"
+
+    resp = await client.post(
+        "/api/v1/search",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "query": f"nothing in this empty tenant matches {uuid.uuid4().hex}",
+            "top_k": 5,
+            "filter_agent_id": agent_id,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["items"] == []
+    assert body["recall_tracked"] is False
+
+
+@pytest.mark.integration
+async def test_legacy_path_reports_its_own_unconditional_bump(client, monkeypatch):
+    """The deprecated legacy path bumps with no caller-agent gate, and says so.
+
+    ``_search_memories_legacy`` calls ``increment_recall`` for every row it
+    returns, with none of TrackRecalls' gates. Reporting the pipeline's policy
+    for it would be a lie to whoever flips ``_USE_PIPELINE_SEARCH`` back during
+    a hotfix — the same divergence trap this file's BlankQuery handler already
+    warns about. So the agentless search that reports ``false`` above reports
+    ``true`` here, because that is what this path actually does.
+    """
+    monkeypatch.setattr(memory_service, "_USE_PIPELINE_SEARCH", False)
+    tenant_id = _tenant()
+    headers = get_test_auth(tenant_id)[1]
+    content = f"Staging mirrors prod except for the mail sink {uuid.uuid4().hex}"
+    await _write(client, headers, tenant_id, "deploy-bot", content)
+
+    resp = await client.post(
+        "/api/v1/search",
+        headers=headers,
+        json={"tenant_id": tenant_id, "query": content, "top_k": 5},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["items"], "the search must return the row it is asked about"
+    assert body["recall_tracked"] is True
+
+
+# ---------------------------------------------------------------------------
+# MCP parity — ``caura_recall`` reports the same field
+#
+# Emitted on both surfaces so that adding it does not itself open a new
+# REST/MCP divergence, which is the failure mode the parity smoke exists to
+# catch. These pin that MCP forwards what the pipeline reported rather than
+# hardcoding a value: the same handler returns True and False depending only
+# on what ``search_memories`` wrote into ``recall_ctx``.
+# ---------------------------------------------------------------------------
+
+
+class _MemoryStub:
+    def __init__(self, mid: str):
+        self.mid = mid
+
+    def model_dump(self, mode: str = "python"):  # noqa: ARG002
+        return {"id": self.mid}
+
+
+class _FakeConfig:
+    recall_boost = False
+    graph_expand = False
+    entity_retrieval = True
+
+
+async def _fake_resolve_config(tenant_id):  # noqa: ARG001
+    return _FakeConfig()
+
+
+def _wire(monkeypatch):
+    monkeypatch.setattr(mcp_server, "resolve_config", _fake_resolve_config)
+    return stub_storage_client(monkeypatch, get_agent=None)
+
+
+def _search_writing(tracked: bool):
+    """Stand in for ``search_memories``, filling ``recall_ctx`` as the pipeline does."""
+
+    async def _search(*args, recall_ctx=None, **kwargs):  # noqa: ARG001
+        if recall_ctx is not None:
+            recall_ctx["recall_tracked"] = tracked
+        return [_MemoryStub("m-1")]
+
+    return _search
+
+
+@pytest.mark.unit
+async def test_mcp_recall_forwards_recall_tracked_true(mcp_env, monkeypatch):
+    mcp_env["service"]("search_memories").side_effect = _search_writing(True)
+    _wire(monkeypatch)
+
+    payload = parse_envelope(await mcp_server.caura_recall(query="anything"))
+    assert payload["recall_tracked"] is True
+
+
+@pytest.mark.unit
+async def test_mcp_recall_forwards_recall_tracked_false(mcp_env, monkeypatch):
+    mcp_env["service"]("search_memories").side_effect = _search_writing(False)
+    _wire(monkeypatch)
+
+    payload = parse_envelope(await mcp_server.caura_recall(query="anything"))
+    assert payload["recall_tracked"] is False


### PR DESCRIPTION
Item 1 of the REST/MCP parity smoke report's "What to fix next" queue.

## The gap

`TrackRecalls` skips the `recall_count` bump when a recall carries no caller
agent identity (gap A26). The skip is correct and deliberate — the counter
feeds `recall_boost` back into ranking, so probe traffic must not inflate it —
and `tests/test_track_recalls_agentless.py` pins it as policy.

What it was not is *observable*. A tenant-scoped key has `auth.agent_id = None`,
and its only way to present an identity is `filter_agent_id`, which
unavoidably also narrows results to that agent's own authored rows. So a
tenant-key integration sees `recall_count` pinned at 0 forever and
`recall_boost` never engage — and nothing in the response says so. The only
way to discover it is to watch a counter never move.

That the behaviour is now tested-and-intentional makes surfacing it *more*
urgent, not less: it is permanent, and still silent.

## The change

`recall_tracked` on the search response — true when a bump was dispatched for
the returned rows, false when it was skipped. All three reasons for false are
invisible from the request alone: no caller identity, `diagnostic=true`, or an
empty result set.

Emitted on **both** REST `/search` and MCP `caura_recall`, so adding it does
not itself open a new surface divergence — which is the failure mode this
report exists to catch.

### Why the value is reported, not re-derived

The obvious cheap version is a predicate at the route over `filter_agent_id`
and `diagnostic`. That would be wrong in two ways the caller cannot see:

- an **empty result set** bumps nothing, and the route would claim it did;
- the deprecated `_search_memories_legacy` path bumps **unconditionally**, with
  none of TrackRecalls' gates.

So the value comes from TrackRecalls itself, threaded out through an optional
`recall_ctx` dict that mirrors the existing `diagnostic_ctx` out-param. The
legacy branch reports what *it* does rather than the pipeline's policy —
reporting the pipeline's answer there would be a lie to whoever flips
`_USE_PIPELINE_SEARCH` back during a hotfix, which is the divergence trap
`memory_service.py` already warns about in its own `BlankQuery` handler.

Absent key defaults to `false`, which is the honest failure direction: a caller
wrongly told "not tracked" investigates and finds a working counter, whereas a
caller wrongly told "tracked" goes on believing a permanently pinned counter is
fine — the exact silent-zero this field exists to end.

## Scope

This is the **interim, cheap** half. The root cause — `/search` has one knob
(`filter_agent_id`) doing three jobs: author filter, visibility identity, and
trust/fleet gate target — is unchanged. Splitting identity from filtering is
the real fix; it touches auth resolution, TrackRecalls, and the `/memories/stats`
route's one-knob rejection, and is being written up as a design proposal rather
than folded in here.

## Tests

`tests/test_search_recall_tracked_flag.py` — 7 cases.

Confirmed failing without the fix: reverting the `core-api/src` changes and
re-running fails all four REST cases. They pin **behaviour, not field
presence** — a hardcoded `true` fails three of them, a hardcoded `false` fails
the fourth.

The REST cases pin the search path explicitly via a fixture. That is not
defensive boilerplate: `tests/pipeline/test_search_pipeline.py:606` sets
`memory_service._USE_PIPELINE_SEARCH = False` and never restores it (no
`try/finally`, no `monkeypatch`), so every test running after it in the same
session silently exercises the deprecated legacy path. Verified directly with a
probe assertion. That leak is pre-existing and out of scope here — worth its
own fix, since it means part of the suite is not testing the production search
path at all.

Full suite green locally: 5804 passed, 4 skipped, 1 xfailed. `ruff check`,
`ruff format --check`, and `mypy` clean at CI's scopes.
