### PR TITLE
feat(mcp): make a capped top_k visible and name list rows items

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -867,10 +867,26 @@ async def caura_recall(
         # C31/D1 — ``items`` is the canonical list key everywhere; ``results``
         # stays as a permanent dual-emit alias (same list object, two keys) so
         # existing consumers keep working. ``count`` per the contract.
+        # ``top_k`` over ``MAX_SEARCH_TOP_K`` is capped here rather than
+        # rejected — REST /search 422s on the same input (``schemas.py``,
+        # ``le=MAX_SEARCH_TOP_K``), and silent capping stays the friendlier
+        # default for an agent surface. But it has to be VISIBLE: with no
+        # error, no flag and no total, a client that asked for 50 and got 20
+        # cannot tell a capped page from an exhausted result set, and will
+        # conclude the tenant holds 20 matching memories. The tool description
+        # documents the cap, which is not a runtime signal — agents do not read
+        # parameter descriptions before believing a result set is complete.
+        #
+        # Reports only that the REQUESTED top_k was lowered. A full page at an
+        # uncapped ``top_k`` is still not proof of exhaustion; that would need a
+        # total, which this surface does not compute.
         payload: dict = {
             "results": _rows,
             "items": _rows,
             "count": len(_rows),
+            "truncated": top_k > capped_top_k,
+            "requested_top_k": top_k,
+            "effective_top_k": capped_top_k,
         }
         if diagnostic:
             counts = diagnostic_ctx.get("counts", {}) or {}
@@ -885,7 +901,10 @@ async def caura_recall(
                 },
                 "all_candidates": diagnostic_ctx.get("all_candidates", []) or [],
             }
-        if top_k > MAX_SEARCH_TOP_K:
+        if payload["truncated"]:
+            # Kept alongside the structured fields above, not replaced by them:
+            # the prose renders in a chat surface, and dropping a field a client
+            # may already read would be a breaking change for no gain.
             payload["warning"] = f"top_k was capped at the maximum allowed value of {MAX_SEARCH_TOP_K}."
         if include_brief:
             payload["brief"] = await summarize_memories(
@@ -2569,9 +2588,21 @@ async def caura_list(
                     surface="caura_list",
                     result_count_by_tenant=counts,
                 )
+            # C31/D1 — ``items`` is the canonical list key everywhere, and
+            # ``caura_recall`` already dual-emits it beside ``results``. This
+            # envelope did not, so REST ``MemoryList.items`` and MCP
+            # ``results`` named the same list two ways and no client could
+            # share a response parser across the surfaces. Same list object,
+            # two keys; ``results`` stays as a permanent alias.
             return _with_latency(
                 json.dumps(
-                    {"count": len(items), "results": items, "next_cursor": next_cursor, "scope": scope},
+                    {
+                        "count": len(items),
+                        "results": items,
+                        "items": items,
+                        "next_cursor": next_cursor,
+                        "scope": scope,
+                    },
                     default=str,
                 ),
                 t0,

--- a/tests/test_mcp_envelope_and_truncation.py
+++ b/tests/test_mcp_envelope_and_truncation.py
@@ -1,0 +1,171 @@
+"""MCP payload shape: capped ``top_k`` is visible, and lists name their rows ``items``.
+
+Two findings from the REST/MCP parity smoke, both instances of a surface doing
+something the caller cannot observe.
+
+**Truncation.** ``top_k`` above ``MAX_SEARCH_TOP_K`` is a 422 on REST
+``/search`` (``schemas.py``, ``le=MAX_SEARCH_TOP_K``) and a silent cap on
+``caura_recall``. Same limit, opposite contract. Silent capping is the right
+default for an agent surface — the report is explicit that MCP should not be
+"fixed" by making it throw — but with no error, no flag and no total, a client
+that asked for 40 and got 20 cannot tell a capped page from an exhausted
+result set, and concludes the tenant holds 20 matching memories. The tool
+description documents the cap; a description is not a runtime signal.
+
+**Envelope.** REST ``MemoryList`` names its rows ``items``; ``caura_list``
+named the same list ``results``, so no client could share a response parser
+across the two surfaces. ``caura_recall`` already dual-emits both keys (C31/D1);
+this extends the same permanent alias to ``caura_list``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from core_api import mcp_server
+from core_api.constants import MAX_SEARCH_TOP_K
+from tests._mcp_test_helpers import parse_envelope, stub_storage_client
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class _MemoryStub:
+    def __init__(self, mid: str):
+        self.mid = mid
+
+    def model_dump(self, mode: str = "python"):  # noqa: ARG002
+        return {"id": self.mid}
+
+
+class _FakeConfig:
+    recall_boost = False
+    graph_expand = False
+    entity_retrieval = True
+
+
+async def _fake_resolve_config(tenant_id):  # noqa: ARG001
+    return _FakeConfig()
+
+
+def _wire_recall(monkeypatch):
+    monkeypatch.setattr(mcp_server, "resolve_config", _fake_resolve_config)
+    return stub_storage_client(monkeypatch, get_agent=None)
+
+
+def _out_stub(mid: str):
+    class _Out:
+        def model_dump(self, mode="python"):  # noqa: ARG002
+            return {"id": mid}
+
+    return _Out()
+
+
+# ---------------------------------------------------------------------------
+# Truncation is reported as data, not only as prose
+# ---------------------------------------------------------------------------
+
+
+async def test_recall_over_cap_reports_structured_truncation(mcp_env, monkeypatch):
+    """The divergence the smoke pinned: 40 requested, 20 served, and now it says so."""
+    requested = MAX_SEARCH_TOP_K + 20
+    search_mock = mcp_env["service"]("search_memories")
+    search_mock.return_value = [_MemoryStub(f"m-{i}") for i in range(MAX_SEARCH_TOP_K)]
+    _wire_recall(monkeypatch)
+
+    payload = parse_envelope(await mcp_server.caura_recall(query="x", top_k=requested))
+
+    assert payload["truncated"] is True
+    assert payload["requested_top_k"] == requested
+    assert payload["effective_top_k"] == MAX_SEARCH_TOP_K
+    # The cap the service was actually asked for, not just what we reported.
+    assert search_mock.await_args.kwargs["top_k"] == MAX_SEARCH_TOP_K
+
+
+async def test_recall_within_cap_reports_not_truncated(mcp_env, monkeypatch):
+    """The contrast case — without it, a hardcoded ``truncated: true`` would pass."""
+    mcp_env["service"]("search_memories").return_value = [_MemoryStub("m-1")]
+    _wire_recall(monkeypatch)
+
+    payload = parse_envelope(await mcp_server.caura_recall(query="x", top_k=5))
+
+    assert payload["truncated"] is False
+    assert payload["requested_top_k"] == 5
+    assert payload["effective_top_k"] == 5
+
+
+async def test_truncation_fields_are_always_present(mcp_env, monkeypatch):
+    """Always emitted, so absence never has to be read as false.
+
+    ``caura_keystones`` already returns ``truncated`` unconditionally; this is
+    the same shape. A flag that appears only in the truncated case is one a
+    client can only interpret correctly if it already knows the contract.
+    """
+    mcp_env["service"]("search_memories").return_value = []
+    _wire_recall(monkeypatch)
+
+    payload = parse_envelope(await mcp_server.caura_recall(query="x"))
+
+    assert {"truncated", "requested_top_k", "effective_top_k"} <= payload.keys()
+
+
+async def test_recall_over_cap_keeps_the_human_warning(mcp_env, monkeypatch):
+    """The prose stays for chat rendering — the structured fields are additive.
+
+    Dropping a field an existing client may read would be a breaking change
+    for no gain.
+    """
+    mcp_env["service"]("search_memories").return_value = []
+    _wire_recall(monkeypatch)
+
+    payload = parse_envelope(await mcp_server.caura_recall(query="x", top_k=1000))
+
+    assert f"capped at the maximum allowed value of {MAX_SEARCH_TOP_K}" in payload["warning"]
+
+
+# ---------------------------------------------------------------------------
+# ``caura_list`` names its rows both ways
+# ---------------------------------------------------------------------------
+
+
+async def test_list_dual_emits_items_and_results(mcp_env, monkeypatch):
+    """Both keys, same rows — a REST-shaped parser reads ``items`` and works."""
+    rows = [{"id": str(uuid4()), "created_at": datetime.now(timezone.utc).isoformat()} for _ in range(2)]
+    stub_storage_client(monkeypatch, list_memories_by_filters=rows)
+    monkeypatch.setattr(mcp_server, "_memory_to_out", lambda m: _out_stub(m["id"]))
+
+    payload = parse_envelope(await mcp_server.caura_list(limit=5))
+
+    assert payload["items"] == payload["results"]
+    assert len(payload["items"]) == 2
+    assert payload["count"] == 2
+
+
+async def test_list_items_present_when_empty(mcp_env, monkeypatch):
+    """An empty page still carries both keys, so a parser never KeyErrors."""
+    stub_storage_client(monkeypatch, list_memories_by_filters=[])
+
+    payload = parse_envelope(await mcp_server.caura_list())
+
+    assert payload["items"] == []
+    assert payload["results"] == []
+
+
+async def test_list_items_reflects_the_served_slice(mcp_env, monkeypatch):
+    """``items`` is the paged slice, not the over-fetched row set.
+
+    ``caura_list`` requests ``limit + 1`` rows to detect ``has_more``. A naive
+    alias bound to the raw storage rows would leak the probe row into ``items``
+    while ``results`` stayed correct — and the two keys would disagree.
+    """
+    rows = [{"id": str(uuid4()), "created_at": datetime.now(timezone.utc).isoformat()} for _ in range(3)]
+    stub_storage_client(monkeypatch, list_memories_by_filters=rows)
+    monkeypatch.setattr(mcp_server, "_memory_to_out", lambda m: _out_stub(m["id"]))
+
+    payload = parse_envelope(await mcp_server.caura_list(limit=2))
+
+    assert len(payload["items"]) == 2
+    assert payload["items"] == payload["results"]
+    assert payload["next_cursor"] is not None

--- a/tests/test_mcp_list.py
+++ b/tests/test_mcp_list.py
@@ -8,7 +8,9 @@ Covers:
 - ``include_deleted`` only honored at trust ≥ 3 (silently ignored below).
 - Invalid cursor / ISO dates.
 - Cursor vs sort/order constraint (only created_at/desc).
-- Happy path (zero rows) shape: ``{count, results, next_cursor, scope}``.
+- Happy path (zero rows) shape: ``{count, results, items, next_cursor, scope}``
+  — ``items`` dual-emits the same list as ``results`` (see
+  ``tests/test_mcp_envelope_and_truncation.py``).
 """
 
 from __future__ import annotations
@@ -319,7 +321,13 @@ async def test_list_happy_path_empty_results(mcp_env, monkeypatch):
     stub_storage_client(monkeypatch, list_memories_by_filters=[])
     out = await mcp_server.caura_list()
     payload = parse_envelope(out)
-    assert payload == {"count": 0, "results": [], "next_cursor": None, "scope": "agent"}
+    assert payload == {
+        "count": 0,
+        "results": [],
+        "items": [],
+        "next_cursor": None,
+        "scope": "agent",
+    }
 
 
 async def test_list_happy_path_with_rows_and_next_cursor(mcp_env, monkeypatch):


### PR DESCRIPTION
Items 2 and 9 of the REST/MCP parity smoke report's "What to fix next" queue,
done together because both touch the MCP recall/list payload shape.

Both are the same defect the report's through-line names: a surface doing
something the caller cannot observe.

## Capped `top_k` (item 2)

`top_k` above `MAX_SEARCH_TOP_K` is an HTTP 422 on REST `/search`
(`schemas.py`, `le=MAX_SEARCH_TOP_K`) and a silent cap on `caura_recall`
(`capped_top_k = min(top_k, MAX_SEARCH_TOP_K)`). Same limit, opposite contract.

The silent cap stays — the report is explicit that MCP should not be "fixed"
by making it throw, because silent capping is the friendlier default for an
agent surface. It just has to be *visible*. Today a client that asks for 40 and
gets 20 cannot tell a capped page from an exhausted result set: no error, no
flag, no total. It concludes the tenant holds 20 matching memories.

The tool description does say values above 20 are capped. A description is not
a runtime signal, and agents do not read parameter descriptions before
believing a result set is complete.

**Re-verification note.** The report recorded this as "no `truncated` flag in
the recall payload". That has drifted: a prose `warning` string was added at
`mcp_server.py:888` since the report's 2026-08-31 pass. So the finding is
narrower than filed but not closed — a prose sentence is not a machine signal,
and sniffing it is exactly the substring-matching anti-pattern item 3 of the
same report complains about.

Now emitted:

```json
{"truncated": true, "requested_top_k": 40, "effective_top_k": 20}
```

**Unconditionally**, matching the shape `caura_keystones` already returns. A
flag that appears only in the truncated case is one a client can read correctly
only if it already knows the contract.

The prose `warning` is kept alongside rather than replaced: it renders in a
chat surface, and dropping a field an existing client may read would break it
for no gain.

Scope honesty: these fields report only that the *requested* `top_k` was
lowered. A full page at an uncapped `top_k` is still not proof of exhaustion —
that would need a total, which this surface does not compute.

## List envelope (item 9)

REST `MemoryList` names its rows `items`; `caura_list` named the same list
`results`, so no client could share a response parser across the two surfaces.

**Re-verification note.** The report filed this as a general recall/list
divergence. Half of it has already landed: `caura_recall` dual-emits `items`
beside `results` (C31/D1, `mcp_server.py:867-874`, commented as a permanent
alias). Only `caura_list` was left. This extends the same permanent alias
there, bound to the served slice rather than the over-fetched `limit + 1` rows.

`caura_list` also caps `limit` at 50 silently. Left alone deliberately: it
returns `next_cursor`, so a truncated page there is already discoverable — the
"capped page vs exhausted set" ambiguity that motivates the recall fix does not
arise.

## Tests

`tests/test_mcp_envelope_and_truncation.py` — 7 cases, plus the exact-shape
assertion in `tests/test_mcp_list.py` updated (it pinned the envelope, so
updating it is part of the change).

Confirmed failing without the fix: reverting the `core-api/src` changes fails 7
of the 8. The eighth, `test_recall_over_cap_keeps_the_human_warning`, passes
either way **by design** — the `warning` field already existed, and that test
guards it from being removed rather than proving the fix.

Behaviour is pinned, not field presence: a hardcoded `truncated: true` fails
the within-cap case, and the `items`/`results` equality test fails if the alias
is bound to the over-fetched rows instead of the served slice.

Full suite green locally: 5804 passed, 4 skipped, 1 xfailed. `ruff check`,
`ruff format --check`, and `mypy` clean at CI's scopes.
