### PR TITLE
feat(mcp): return objects from caura_manage transition and delete

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1428,7 +1428,32 @@ async def caura_manage(
                     resource_id=uid,
                     detail={"old_status": old_status, "new_status": status},
                 )
-                return _with_latency(f"Memory {memory_id} status updated: {old_status} -> {status}", t0)
+                # Structured, not prose. ``op=read``/``op=update`` return
+                # serialized objects and every refusal returns a JSON error
+                # envelope, so a prose sentence here left one tool with three
+                # return shapes and forced callers to sniff the type — and then
+                # to sniff the TEXT, because a string is the success case only
+                # if it does not happen to contain "Error". A predicate like
+                # that passes for years and silently inverts the day someone
+                # rewords a message.
+                #
+                # Keys copied from REST ``PATCH /memories/{id}/status``
+                # (``memory_id``/``old_status``/``new_status``, see
+                # ``openapi_responses.MemoryStatusPatchResponse``) so the two
+                # surfaces are parseable by one client.
+                return _with_latency(
+                    json.dumps(
+                        {
+                            "memory_id": str(uid),
+                            "old_status": old_status,
+                            "new_status": status,
+                            # The old prose, kept for chat rendering.
+                            "message": f"Memory {memory_id} status updated: {old_status} -> {status}",
+                        },
+                        default=str,
+                    ),
+                    t0,
+                )
             if op == "update":
                 # C3/C8: reject agent-supplied server-reserved types on update,
                 # mirroring the single-write guard above. No-op when memory_type
@@ -1485,7 +1510,24 @@ async def caura_manage(
                         t0,
                     )
             await soft_delete_memory(uid, tenant_id)
-            return _with_latency(f"Memory {memory_id} deleted.", t0)
+            # Structured for the same reason as ``op=transition`` above. REST
+            # DELETE returns 204 with no body, so there is no shape to copy
+            # here; ``memory_id`` matches the transition key rather than the
+            # bare ``id`` so one tool does not name the same thing two ways.
+            # ``deleted`` reports that the delete succeeded, not that the row is
+            # gone — this is a soft delete, which is why the smoke asserts the
+            # read-back 404 rather than trusting the acknowledgement.
+            return _with_latency(
+                json.dumps(
+                    {
+                        "memory_id": str(uid),
+                        "deleted": True,
+                        "message": f"Memory {memory_id} deleted.",
+                    },
+                    default=str,
+                ),
+                t0,
+            )
         except HTTPException as e:
             logger.warning("MCP tool error (%s): %s", e.status_code, e.detail)
             return _with_latency(

--- a/tests/test_mcp_manage.py
+++ b/tests/test_mcp_manage.py
@@ -132,7 +132,12 @@ async def test_manage_transition_happy_path(mcp_env, monkeypatch):
     out = await mcp_server.caura_manage(
         op="transition", memory_id=VALID_UID, status="archived"
     )
-    assert "active -> archived" in strip_latency(out)
+    payload = parse_envelope(out)
+    assert payload["memory_id"] == VALID_UID
+    assert payload["old_status"] == "active"
+    assert payload["new_status"] == "archived"
+    # The prose survives for chat rendering, in a field of its own.
+    assert "active -> archived" in payload["message"]
     sc.update_memory_status.assert_awaited_once()
 
 
@@ -160,7 +165,10 @@ async def test_manage_update_happy_path(mcp_env):
 async def test_manage_delete_happy_path(mcp_env):
     mcp_env["service"]("soft_delete_memory").return_value = None
     out = await mcp_server.caura_manage(op="delete", memory_id=VALID_UID)
-    assert f"Memory {VALID_UID} deleted" in strip_latency(out)
+    payload = parse_envelope(out)
+    assert payload["memory_id"] == VALID_UID
+    assert payload["deleted"] is True
+    assert f"Memory {VALID_UID} deleted" in payload["message"]
     mcp_env["service_mocks"]["soft_delete_memory"].assert_awaited_once()
 
 

--- a/tests/test_mcp_manage_structured_returns.py
+++ b/tests/test_mcp_manage_structured_returns.py
@@ -1,0 +1,183 @@
+"""``caura_manage`` returns one shape per outcome, not prose for some ops.
+
+The defect: ``op=read`` and ``op=update`` returned serialized objects, refusals
+from every op returned a JSON error envelope, and ``op=transition`` and
+``op=delete`` returned a human sentence. One tool, three return shapes — so a
+caller had to sniff the type to tell success from failure, and then sniff the
+*text*, because a string is the success case only if it does not happen to
+contain "Error".
+
+The parity smoke had to resort to exactly that::
+
+    ok = (isinstance(mcp_out, dict) and mcp_out.get("status") == "outdated") or \\
+         (isinstance(mcp_out, str) and "outdated" in mcp_out and "Error" not in mcp_out)
+
+``"Error" not in mcp_out`` as a success predicate passes for years and then
+silently inverts the day someone rewords a message.
+
+Both ops now return objects. ``op=transition`` copies REST ``PATCH
+/memories/{id}/status`` key-for-key (``memory_id`` / ``old_status`` /
+``new_status``, see ``openapi_responses.MemoryStatusPatchResponse``) so one
+client can parse both surfaces. REST DELETE returns 204 with no body, so
+``op=delete`` has no shape to copy; it reuses ``memory_id`` rather than a bare
+``id`` so one tool does not name the same thing two ways. The old prose is
+preserved in ``message`` for chat rendering.
+"""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from core_api import mcp_server
+from tests._mcp_test_helpers import as_text, parse_envelope, stub_storage_client
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+VALID_UID = str(uuid4())
+
+
+def _memory_row(status="active"):
+    return {
+        "id": VALID_UID,
+        "agent_id": "alice",
+        "fleet_id": None,
+        "visibility": "scope_team",
+        "status": status,
+        "content": "hello",
+    }
+
+
+def _async_return(value):
+    async def _inner(*args, **kwargs):  # noqa: ARG001
+        return value
+
+    return _inner
+
+
+def _wire_transition(monkeypatch, status="active"):
+    sc = stub_storage_client(
+        monkeypatch, get_memory=_memory_row(status), update_memory_status=None
+    )
+    monkeypatch.setattr(mcp_server, "authorize_memory_access", _async_return(True))
+    monkeypatch.setattr(mcp_server, "log_action", _async_return(None))
+    return sc
+
+
+async def test_transition_returns_an_object_not_prose(mcp_env, monkeypatch):
+    _wire_transition(monkeypatch)
+
+    out = await mcp_server.caura_manage(
+        op="transition", memory_id=VALID_UID, status="archived"
+    )
+
+    payload = parse_envelope(out)
+    assert isinstance(payload, dict)
+    assert payload["memory_id"] == VALID_UID
+    assert payload["old_status"] == "active"
+    assert payload["new_status"] == "archived"
+
+
+async def test_delete_returns_an_object_not_prose(mcp_env):
+    mcp_env["service"]("soft_delete_memory").return_value = None
+
+    out = await mcp_server.caura_manage(op="delete", memory_id=VALID_UID)
+
+    payload = parse_envelope(out)
+    assert isinstance(payload, dict)
+    assert payload["memory_id"] == VALID_UID
+    assert payload["deleted"] is True
+
+
+async def test_transition_keys_match_the_rest_status_route(mcp_env, monkeypatch):
+    """Same key names as ``MemoryStatusPatchResponse``, so one parser covers both.
+
+    Pinned against the model rather than a literal list, so renaming a field on
+    the REST side fails here instead of silently reopening the divergence.
+    """
+    from core_api.openapi_responses import MemoryStatusPatchResponse
+
+    _wire_transition(monkeypatch)
+
+    payload = parse_envelope(
+        await mcp_server.caura_manage(
+            op="transition", memory_id=VALID_UID, status="archived"
+        )
+    )
+
+    assert set(MemoryStatusPatchResponse.model_fields) <= payload.keys()
+
+
+async def test_success_is_distinguishable_from_refusal_without_reading_text(
+    mcp_env, monkeypatch
+):
+    """The point of the change: a structural predicate, not a substring one.
+
+    Success and refusal are now both JSON objects, told apart by the presence
+    of an ``error`` key — no ``isinstance`` sniffing, and nothing that inverts
+    when a message is reworded.
+    """
+    mcp_env["service"]("soft_delete_memory").return_value = None
+    ok = parse_envelope(await mcp_server.caura_manage(op="delete", memory_id=VALID_UID))
+
+    mcp_env["service"]("soft_delete_memory").side_effect = HTTPException(
+        status_code=403, detail="insufficient trust"
+    )
+    refused = parse_envelope(
+        await mcp_server.caura_manage(op="delete", memory_id=VALID_UID)
+    )
+
+    assert "error" not in ok
+    assert ok["deleted"] is True
+    assert "error" in refused
+    assert refused["error"]["code"] == "FORBIDDEN"
+
+
+async def test_prose_survives_in_a_message_field(mcp_env, monkeypatch):
+    """Kept for chat rendering — the sentence moved, it did not disappear."""
+    _wire_transition(monkeypatch)
+    transition = parse_envelope(
+        await mcp_server.caura_manage(
+            op="transition", memory_id=VALID_UID, status="archived"
+        )
+    )
+    assert "active -> archived" in transition["message"]
+
+    mcp_env["service"]("soft_delete_memory").return_value = None
+    deleted = parse_envelope(
+        await mcp_server.caura_manage(op="delete", memory_id=VALID_UID)
+    )
+    assert f"Memory {VALID_UID} deleted" in deleted["message"]
+
+
+async def test_every_manage_success_op_parses_as_json(mcp_env, monkeypatch):
+    """No op returns a bare string any more — the shape count drops to two.
+
+    ``read``/``update`` already returned objects; ``transition``/``delete`` were
+    the two that did not. Asserting over all four is what makes this a contract
+    for the tool rather than two isolated fixes.
+    """
+    _wire_transition(monkeypatch)
+    outs = [
+        await mcp_server.caura_manage(op="read", memory_id=VALID_UID),
+        await mcp_server.caura_manage(
+            op="transition", memory_id=VALID_UID, status="archived"
+        ),
+    ]
+
+    class _Out:
+        def model_dump(self, mode="python"):  # noqa: ARG002
+            return {"id": VALID_UID, "content": "new text"}
+
+    mcp_env["service"]("update_memory").return_value = _Out()
+    outs.append(
+        await mcp_server.caura_manage(op="update", memory_id=VALID_UID, content="new text")
+    )
+    mcp_env["service"]("soft_delete_memory").return_value = None
+    outs.append(await mcp_server.caura_manage(op="delete", memory_id=VALID_UID))
+
+    for out in outs:
+        assert isinstance(json.loads(as_text(out)), dict)


### PR DESCRIPTION
Item 3 of the REST/MCP parity smoke report's "What to fix next" queue.

## The gap

`caura_manage` returned a serialized object for `op=read` and `op=update`, a
JSON error envelope for every refusal, and a **human sentence** for
`op=transition` and `op=delete`:

- `mcp_server.py:1412` — `f"Memory {memory_id} status updated: {old_status} -> {status}"`
- `mcp_server.py:1469` — `f"Memory {memory_id} deleted."`

One tool, three return shapes. A caller had to sniff the type to tell success
from failure — and then sniff the *text*, because a string is the success case
only if it does not happen to contain "Error". The parity smoke had to write
exactly that:

```python
ok = (isinstance(mcp_out, dict) and mcp_out.get("status") == "outdated") or \
     (isinstance(mcp_out, str) and "outdated" in mcp_out and "Error" not in mcp_out)
```

`"Error" not in mcp_out` as a success predicate passes for years and then
silently inverts the day someone rewords a message.

Re-verified against current `main` before changing anything: both f-strings
still present, at the lines above.

## The change

- `op=transition` → `{"memory_id", "old_status", "new_status", "message"}`
- `op=delete` → `{"memory_id", "deleted": true, "message"}`

**Key names come from the code, not the report.** The report suggested `id`;
REST `PATCH /memories/{id}/status` actually returns `memory_id` / `old_status`
/ `new_status` (`openapi_responses.MemoryStatusPatchResponse`). Copying REST's
real keys is what lets one client parse both surfaces, so that is what this
does. A test pins the MCP payload against `MemoryStatusPatchResponse` itself
rather than a literal list, so renaming a field on the REST side fails here
instead of silently reopening the divergence.

REST `DELETE` returns 204 with no body, so `op=delete` has no shape to copy. It
reuses `memory_id` rather than a bare `id` so one tool does not name the same
thing two ways.

`deleted: true` reports that the delete *succeeded*, not that the row is gone —
this is a soft delete, which is why the smoke asserts the read-back 404 rather
than trusting the acknowledgement. Called out in a comment so the field is not
misread later.

The old prose is preserved in a `message` field for chat rendering, per the
report's own recommendation.

## Tests

`tests/test_mcp_manage_structured_returns.py` (6 cases) plus the two existing
happy-path tests in `tests/test_mcp_manage.py`, which substring-matched the
prose — the anti-pattern this change exists to retire — and now assert the
structured keys.

Confirmed failing without the fix: reverting `core-api/src` fails all 8.

The case worth naming is
`test_success_is_distinguishable_from_refusal_without_reading_text`: success
and refusal are now both JSON objects told apart by the presence of an `error`
key. That is the property the report was actually asking for — a structural
predicate instead of a substring one — and it is what the smoke's `ok = ...`
line can be replaced with.

Full suite green locally: 5803 passed, 4 skipped, 1 xfailed. `ruff check`,
`ruff format --check`, and `mypy` clean at CI's scopes.
