### PR TITLE
fix(ci): authenticate release-please changelog exemption

### DIFF
--- a/docs/plans/legacy-name-ratchet-engine.md
+++ b/docs/plans/legacy-name-ratchet-engine.md
@@ -63,7 +63,7 @@ is exactly these five fields:
 | Field | Type | Meaning |
 |---|---|---|
 | `default_base` | validated ref string | Gate comparison ref when `--base` is omitted. |
-| `release_please_changelogs` | boolean | Permit generated changelog lines only on release-please's own branch. |
+| `release_please_changelogs` | boolean | Exempt whole files whose basename starts with `CHANGELOG` (case-insensitive), only on an authenticated release-please pull request. |
 | `mirror_paths` | list of root-relative paths | Generated mirrors gated in their authoring repository. |
 | `mirror_manifest` | root-relative path or `null` | Existing vendored-file manifest whose keys are mirror paths. |
 | `marker_inventory_meta_paths` | list of root-relative paths | Paths omitted only from marker analytics. |
@@ -84,6 +84,21 @@ only analytics omit their self-referential markers.
 `openclaw-fleet-tester` keeps `release_please_changelogs=true` during the
 mechanical port even though the flag is currently dead there. Removing it is a
 separate behavior change requiring separate approval.
+
+The exemption authenticates the pull request from GitHub's event payload, not
+from its branch name alone. The source branch must use release-please's prefix,
+the immutable pull-request author id must be the Caura deploy bot
+(`265395343`), and the head and base repository ids must match. The bot id and
+repository ids are assigned by GitHub rather than supplied by a contributor, so
+a fork author cannot opt into the exemption by naming a branch. Missing,
+malformed, or non-`pull_request` event context receives no exemption. All three
+repositories with the flag enabled run this gate on `pull_request`, not
+`pull_request_target`.
+
+Once authenticated, the exemption is file-wide: the engine skips every matched
+line in each path whose basename starts with `CHANGELOG` (case-insensitive). It
+does not identify individual generated lines. No path outside that basename
+predicate is exempt.
 
 ## Report contract
 

--- a/docs/plans/rebrand-sunset-plan.md
+++ b/docs/plans/rebrand-sunset-plan.md
@@ -186,7 +186,7 @@ log fields — found 2026-06-11, months late. That file carries `identical` poli
 **When you change a vendored file here, open the enterprise pull request in the same
 sitting.** A `manual` policy makes the mirror your responsibility, not the gate's.
 
-### The release-please branch exemption remains repo-specific
+### The release-please pull-request exemption remains repo-specific
 
 The canonical engine contains the release-please handling; the
 `release_please_changelogs` configuration field decides whether it is active in
@@ -195,6 +195,13 @@ audit found live release automation only in `caura` and `caura-enterprise`.
 `openclaw-fleet-tester` nevertheless retains `true` through the mechanical port
 as an explicitly documented known-dead flag; removing it is a separate behavior
 change. Recheck those three signals before changing any repository's value.
+
+A matching branch name is selection, not authentication: a contributor chooses
+the source branch of a pull request. The exemption additionally requires the
+GitHub event payload to identify the immutable Caura deploy-bot author id and a
+head repository identical to the base repository. Missing or malformed event
+context fails closed, so local runs and other trigger types retain full
+coverage.
 
 ### The lifecycle probes share a contract, not an implementation
 

--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -130,6 +130,7 @@ EXEMPT_MARKER = "legacy-name-ok"
 FLOOR_MARKER = "legacy-name-floor"
 
 _CONFIG_PATH = "scripts/legacy_name_ratchet.json"
+_RELEASE_PLEASE_AUTHOR_ID = 265395343
 _CONFIG_FIELDS = frozenset(
     {
         "default_base",
@@ -644,18 +645,48 @@ def _literal(path: str) -> str:
     return f":(literal){path}"
 
 
-def _release_please_branch() -> bool:
-    """True when CI builds release-please's own PR branch.
+def _release_please_pull_request() -> bool:
+    """True when CI builds a release-please PR created by Caura's deploy bot.
 
     release-please regenerates per-package CHANGELOGs by quoting merged PR
     titles verbatim, so titles that legitimately carried the old brand
     (history — rule 2 says never edit it) resurface as lines this tally
-    cannot tell from fresh minting. Only that bot's branches get the
-    exemption; a human editing a CHANGELOG still answers to the gate.
-    GITHUB_HEAD_REF is set by Actions on pull_request runs and absent
-    locally, so local runs keep full coverage.
+    cannot tell from fresh minting.
+
+    The branch prefix selects the release-please convention but cannot
+    authenticate it: a pull-request author chooses their source branch name.
+    Authentication comes from GitHub's event payload instead. The immutable
+    author id must be Caura's deploy bot, and the head and base repository ids
+    must match so even that bot cannot grant the exemption to a fork. GitHub
+    owns all three ids; the pull-request author cannot supply them.
+
+    Missing, malformed or non-pull-request event context fails closed. Local
+    runs therefore keep full coverage, as do any future workflow triggers that
+    have not deliberately adopted this contract.
     """
-    return os.environ.get("GITHUB_HEAD_REF", "").startswith("release-please--")
+    if os.environ.get("GITHUB_EVENT_NAME") != "pull_request" or not os.environ.get(
+        "GITHUB_HEAD_REF", ""
+    ).startswith("release-please--"):
+        return False
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return False
+    try:
+        event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        pull_request = event["pull_request"]
+        author_id = pull_request["user"]["id"]
+        head_repo_id = pull_request["head"]["repo"]["id"]
+        base_repo_id = pull_request["base"]["repo"]["id"]
+    except (KeyError, OSError, TypeError, ValueError):
+        return False
+
+    ids = (author_id, head_repo_id, base_repo_id)
+    return (
+        all(isinstance(value, int) and not isinstance(value, bool) for value in ids)
+        and author_id == _RELEASE_PLEASE_AUTHOR_ID
+        and head_repo_id == base_repo_id
+    )
 
 
 class Scan(NamedTuple):
@@ -1674,17 +1705,19 @@ def main() -> int:
 
     grown = {}
     excused: dict[str, Counter[str]] = {}
-    generated_changelogs: list[str] = []
-    release_branch = (
-        _ACTIVE_CONFIG.release_please_changelogs and _release_please_branch()
+    exempt_changelogs: list[str] = []
+    release_pull_request = (
+        _ACTIVE_CONFIG.release_please_changelogs and _release_please_pull_request()
     )
     # Sorted: the budget is spent as files are visited, so the order decides which
     # destination is charged when one text lands in several. Arbitrary is fine;
     # unstable is not.
     for path in sorted(head):
-        if release_branch and path.rsplit("/", 1)[-1].upper().startswith("CHANGELOG"):
+        if release_pull_request and path.rsplit("/", 1)[-1].upper().startswith(
+            "CHANGELOG"
+        ):
             if head[path] > base.get(path, 0):
-                generated_changelogs.append(path)
+                exempt_changelogs.append(path)
             continue
         before, n = base.get(path, 0), head[path]
         # Deliberately NOT gated on ``n > before``. A file that drops one branded
@@ -1703,12 +1736,12 @@ def main() -> int:
     _report_removed_exemptions(base_scan.exempt_by_file, head_scan.exempt_by_file)
     _report_excused_moves(excused, base_by_file, head_by_file)
 
-    if generated_changelogs:
+    if exempt_changelogs:
         print(
-            f"{len(generated_changelogs)} generated CHANGELOG file(s) exempt on this "
-            "release-please branch (titles quoted from history):"
+            f"{len(exempt_changelogs)} CHANGELOG file(s) exempt on this "
+            "authenticated release-please pull request (titles quoted from history):"
         )
-        for path in sorted(generated_changelogs):
+        for path in sorted(exempt_changelogs):
             print(f"  {path}")
 
     if not grown:

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -35,6 +35,9 @@ SCRIPT = Path(
 # Assembled rather than written out, so this file does not itself carry the
 # literal the gate scans for and need exempting.
 LEGACY = "mem" + "claw"
+_RELEASE_CONTEXT_ENV = frozenset(
+    {"GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH", "GITHUB_HEAD_REF"}
+)
 
 _DEFAULT_CONFIG: dict[str, object] = {
     "default_base": "HEAD",
@@ -86,13 +89,14 @@ def _run(
 ) -> subprocess.CompletedProcess:
     """Run the script; ``env`` entries are merged over the inherited environment.
 
-    ``GITHUB_HEAD_REF`` is stripped from the inherited environment first. The
-    suite itself runs under Actions on pull_request builds, where that variable
-    names whatever branch the PR happens to be — including release-please's own,
-    which is exactly when its CHANGELOG exemption tests would otherwise flip.
-    Branch context is simulated explicitly via ``env``, never inherited.
+    GitHub's release-context variables are stripped from the inherited
+    environment first. The suite itself runs under Actions on pull_request
+    builds, where those variables describe the PR under test — including
+    release-please's own, which is exactly when its CHANGELOG exemption tests
+    would otherwise flip. Release context is simulated explicitly via ``env``,
+    never inherited.
     """
-    merged = {k: v for k, v in os.environ.items() if k != "GITHUB_HEAD_REF"}
+    merged = {k: v for k, v in os.environ.items() if k not in _RELEASE_CONTEXT_ENV}
     merged.update(env or {})
     command = [sys.executable, str(SCRIPT)]
     if base is not None:
@@ -1641,7 +1645,8 @@ def test_passing_gate_survives_an_unexpected_change_summary_failure(
         raise ValueError("broken matcher")
 
     monkeypatch.chdir(repo)
-    monkeypatch.setenv("GITHUB_HEAD_REF", "release-please--branches--main")
+    for key, value in _release_env(repo).items():
+        monkeypatch.setenv(key, value)
     monkeypatch.setattr(sys, "argv", [str(SCRIPT), "--base", "HEAD"])
     monkeypatch.setitem(main.__globals__, "_change_summary", cannot_summarize)
 
@@ -1700,7 +1705,7 @@ def test_multi_commit_summary_avoids_full_tree_replay(
             _stage(repo, "clean.py", f"VALUE = {i}\n")
             _git(repo, "commit", "-qm", f"unrelated edit {i}")
     trace = repo / "git-trace.log"
-    env = {k: v for k, v in os.environ.items() if k != "GITHUB_HEAD_REF"}
+    env = {k: v for k, v in os.environ.items() if k not in _RELEASE_CONTEXT_ENV}
     env["GIT_TRACE"] = str(trace)
 
     result = subprocess.run(
@@ -2001,25 +2006,55 @@ def test_an_untouched_exemption_is_not_reported(repo: Path) -> None:
     assert "exempt line(s) removed" not in result.stdout
 
 
-# ── release-please's own branches: generated CHANGELOGs are exempt ───────────
+# ── authenticated release-please pull requests: CHANGELOGs are exempt ───────
 #
 # release-please regenerates per-package CHANGELOGs by quoting merged PR titles
 # verbatim, so a title that legitimately carried the old brand (history — rule 2
 # says never edit it) resurfaces as a line the tally cannot tell from fresh
 # minting. The exemption is gated on GITHUB_HEAD_REF naming the bot's own
-# branch, and scoped to CHANGELOG files — nothing else on that branch, and no
-# CHANGELOG anywhere else, is excused.
+# branch, its immutable GitHub author id and a same-repository head. It remains
+# scoped to CHANGELOG files — nothing else on that branch, and no CHANGELOG in
+# an unauthenticated pull request, is excused.
 
-_RELEASE_ENV = {"GITHUB_HEAD_REF": "release-please--branches--main"}
+_RELEASE_PLEASE_AUTHOR_ID = 265395343
 
 
-def test_a_changelog_passes_on_a_release_please_branch(repo: Path) -> None:
+def _release_env(
+    repo: Path,
+    *,
+    author_id: object = _RELEASE_PLEASE_AUTHOR_ID,
+    head_repo_id: object = 1,
+    base_repo_id: object = 1,
+    head_ref: str = "release-please--branches--main",
+    event_name: str = "pull_request",
+) -> dict[str, str]:
+    """A pull-request event with independently selectable trust signals."""
+    event_path = repo / ".git" / "github-event.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "pull_request": {
+                    "user": {"id": author_id},
+                    "head": {"repo": {"id": head_repo_id}},
+                    "base": {"repo": {"id": base_repo_id}},
+                }
+            }
+        )
+    )
+    return {
+        "GITHUB_EVENT_NAME": event_name,
+        "GITHUB_EVENT_PATH": str(event_path),
+        "GITHUB_HEAD_REF": head_ref,
+    }
+
+
+def test_a_changelog_passes_on_an_authenticated_release_please_pr(repo: Path) -> None:
     _stage(repo, "CHANGELOG.md", f"* fix: retire the {LEGACY} gateway (#123)\n")
 
-    result = _run(repo, env=_RELEASE_ENV)
+    result = _run(repo, env=_release_env(repo))
 
     assert result.returncode == 0, result.stdout
-    assert "1 generated CHANGELOG file(s) exempt on this" in result.stdout
+    assert "1 CHANGELOG file(s) exempt on this" in result.stdout
     assert "CHANGELOG.md" in result.stdout
 
 
@@ -2027,7 +2062,7 @@ def test_a_release_changelog_addition_is_not_hidden_from_the_net(repo: Path) -> 
     _stage(repo, "existing.py", 'URL = "https://caura.ai"\n')
     _stage(repo, "CHANGELOG.md", f"* fix: retire the {LEGACY} gateway (#123)\n")
 
-    result = _run(repo, env=_RELEASE_ENV)
+    result = _run(repo, env=_release_env(repo))
 
     assert result.returncode == 0
     assert (
@@ -2042,7 +2077,80 @@ def test_the_same_changelog_fails_off_the_bot_branch(repo: Path) -> None:
     absent — still answers to the gate."""
     _stage(repo, "CHANGELOG.md", f"* fix: retire the {LEGACY} gateway (#123)\n")
 
-    result = _run(repo)
+    result = _run(repo, env=_release_env(repo, head_ref="human-change"))
+
+    assert result.returncode == 1
+    assert "CHANGELOG.md" in result.stdout
+
+
+def test_the_branch_name_does_not_authenticate_an_untrusted_author(repo: Path) -> None:
+    _stage(repo, "CHANGELOG.md", f"* add the {LEGACY} gateway\n")
+
+    result = _run(repo, env=_release_env(repo, author_id=12345))
+
+    assert result.returncode == 1
+    assert "CHANGELOG.md" in result.stdout
+
+
+def test_the_release_bot_does_not_authenticate_a_fork_branch(repo: Path) -> None:
+    _stage(repo, "CHANGELOG.md", f"* add the {LEGACY} gateway\n")
+
+    result = _run(repo, env=_release_env(repo, head_repo_id=2))
+
+    assert result.returncode == 1
+    assert "CHANGELOG.md" in result.stdout
+
+
+def test_the_exemption_is_pull_request_only(repo: Path) -> None:
+    _stage(repo, "CHANGELOG.md", f"* add the {LEGACY} gateway\n")
+
+    result = _run(repo, env=_release_env(repo, event_name="pull_request_target"))
+
+    assert result.returncode == 1
+    assert "CHANGELOG.md" in result.stdout
+
+
+def test_the_exemption_requires_github_event_context(repo: Path) -> None:
+    _stage(repo, "CHANGELOG.md", f"* add the {LEGACY} gateway\n")
+
+    result = _run(
+        repo,
+        env={
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_HEAD_REF": "release-please--branches--main",
+        },
+    )
+
+    assert result.returncode == 1
+    assert "CHANGELOG.md" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("author_id", "head_repo_id", "base_repo_id"),
+    [
+        pytest.param(float(_RELEASE_PLEASE_AUTHOR_ID), 1, 1, id="author-float"),
+        pytest.param(_RELEASE_PLEASE_AUTHOR_ID, 1.0, 1, id="head-repository-float"),
+        pytest.param(_RELEASE_PLEASE_AUTHOR_ID, 1, 1.0, id="base-repository-float"),
+        pytest.param(_RELEASE_PLEASE_AUTHOR_ID, True, True, id="repository-booleans"),
+    ],
+)
+def test_malformed_event_identity_values_fail_closed(
+    repo: Path,
+    author_id: object,
+    head_repo_id: object,
+    base_repo_id: object,
+) -> None:
+    _stage(repo, "CHANGELOG.md", f"* add the {LEGACY} gateway\n")
+
+    result = _run(
+        repo,
+        env=_release_env(
+            repo,
+            author_id=author_id,
+            head_repo_id=head_repo_id,
+            base_repo_id=base_repo_id,
+        ),
+    )
 
     assert result.returncode == 1
     assert "CHANGELOG.md" in result.stdout
@@ -2054,7 +2162,7 @@ def test_the_exemption_is_path_scoped_to_changelogs(repo: Path) -> None:
     _stage(repo, "CHANGELOG.md", f"* fix: retire the {LEGACY} gateway (#123)\n")
     _stage(repo, "new.py", f'KEY = "{LEGACY}-new-service"\n')
 
-    result = _run(repo, env=_RELEASE_ENV)
+    result = _run(repo, env=_release_env(repo))
 
     assert result.returncode == 1
     offenders = result.stdout.split("adds the legacy name in", 1)[1]
@@ -2066,7 +2174,7 @@ def test_release_please_changelogs_can_be_disabled(repo: Path) -> None:
     _write_config(repo, release_please_changelogs=False)
     _stage(repo, "CHANGELOG.md", f"* fix: retire the {LEGACY} gateway (#123)\n")
 
-    result = _run(repo, env=_RELEASE_ENV)
+    result = _run(repo, env=_release_env(repo))
 
     assert result.returncode == 1
     assert "CHANGELOG.md" in result.stdout


### PR DESCRIPTION
## Summary

This closes a live bypass in the legacy-name ratchet's release-please exemption. The old engine treated a `GITHUB_HEAD_REF` prefix as authentication, even though a pull-request author chooses that branch name. On an authenticated release-please pull request the exemption remains exactly as wide as before: every matched line in a file whose basename starts with `CHANGELOG` (case-insensitive) is skipped.

The bypass is exploitable and serious. In public `caura`, a fork contributor could name the source branch `release-please--...`, add arbitrary new legacy-name lines to a `CHANGELOG*` file, and make the ratchet pass. `caura`, `openclaw-fleet-tester`, and `caura-enterprise` all enable the flag and run the gate on `pull_request`, not `pull_request_target`; the tester's flag is currently dead, while the two product repositories have live release automation. No advisory or disclosure outside this repository was made; the disclosure path remains Eldad's decision.

The exemption now requires all of:

- the `pull_request` event type;
- the release-please branch prefix;
- the immutable PR author id of `caura-deploy-bot[bot]` (`265395343`);
- exact-integer head and base repository ids that match.

The identity and repository ids come from GitHub's event payload and are assigned by GitHub, not supplied by the contributor. A fork cannot claim the deploy bot's id, and its repository id differs from the base repository. Missing, malformed, forked, or non-`pull_request` context fails closed. Genuine release PRs remain green: current `caura` release PR #1191 and `caura-enterprise` release PR #1443 were both authored by bot id `265395343` from a same-repository head.

## Related Issue

N/A — Package AM follow-up to the Package AK fleet port.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other

## How Has This Been Tested?

Security regression proof:

- Pre-fix engine: all 8 security-negative cases failed their assertions because the old branch-only engine returned success. The cases cover an untrusted author, trusted bot on a fork, `pull_request_target`, missing event context, and malformed float/boolean identity ids.
- Fixed engine: `UV_FROZEN=1 pytest --noconftest -q tests/test_legacy_name_ratchet.py` → `143 passed`.
- The genuine same-repository deploy-bot release case still passes, the off-branch/authentication cases fail, and the existing path-scope, disabled-config, and net-accounting cases remain green.
- Exact CI root suite: `5808 passed, 4 skipped, 16 deselected, 1 xfailed`.
- Coverage floors: core API `85%`; core storage API `67%` (both declared 50% floors).
- Exact CI Ruff check and separate Ruff format-check scopes passed. The vendored engine and sentinel were not formatted.
- Mypy passed for core API, core storage API, core operations, core worker, common, and scripts (`31` script files).
- `/simplify` review completed; its malformed-ID fail-closed finding was fixed and regression-tested.

Ratchet and sentinel, both before and after:

```text
No new lines.
All 46 protected strings survive.
```

Canonical report before → after:

```text
change:   0 added, 0 annotated, 0 removed, 0 moved, 0 net
gated:    296 lines / 82 files → 296 lines / 82 files
markers:  122 floor, 154 ok → 122 floor, 154 ok
mirrors:  0 lines / 0 files → 0 lines / 0 files
```

## Fleet re-port evidence (movement 2)

This PR is movement 1 only. No downstream copy was edited. I dry-ran the old and fixed canonical engines on each current downstream default ref; the complete JSON report was byte-identical and both gate invocations returned `No new lines.` The fleet re-port should expect the following exact before → after figures:

| Repository (ref) | Flag / trigger state | Gated before → after | Markers (floor / ok) | Sentinel | Expected movement |
|---|---|---:|---:|---:|---:|
| `caura-ops` (`382b085f`) | false | 458 / 100 → 458 / 100 | 27 / 20 | 22 | 0 / 0 / 0 / 0 / 0 net |
| `caura-onprem-installer` (`8cd3fe7e`) | false | 379 / 36 → 379 / 36 | 66 / 194 | 34 | 0 / 0 / 0 / 0 / 0 net |
| `caura-daemon` (`32b22294`) | false | 2042 / 322 → 2042 / 322 | 51 / 25 | 11 | 0 / 0 / 0 / 0 / 0 net |
| `caura-onprem` (`7b02884a`) | false | 453 / 39 → 453 / 39 | 32 / 2 | 30 | 0 / 0 / 0 / 0 / 0 net |
| `caura-test-automation` (`a0ee9f33`) | false | 93 / 23 → 93 / 23 | 52 / 55 | 16 | 0 / 0 / 0 / 0 / 0 net |
| `openclaw-fleet-tester` (`b6d9f9dd`) | true, known-dead release flag; `pull_request` | 95 / 20 → 95 / 20 | 19 / 0 | 21 | 0 / 0 / 0 / 0 / 0 net |
| `caura-enterprise` (`75ff46b8`) | true, live release automation; `pull_request` | 1060 / 173 → 1060 / 173 | 78 / 88 | 34 | 0 / 0 / 0 / 0 / 0 net |

`caura-enterprise` also remains at 1086 present lines / 175 present files, including 26 mirror lines / 2 mirror files. There is no legitimate count movement in any repository. Movement 2 should port the canonical engine bytes only and reproduce these figures.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I have added tests that cover my changes
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally
- [x] I have updated relevant documentation
- [x] `CHANGELOG.md` is not updated because this is an internal CI security fix, not a user-facing change

## Additional Notes

- Exactly one DCO-signed commit, rebased onto current `origin/main` immediately before push.
- Reviewer topology is Claude-only; no Gemini review is configured.
- This PR must not be merged by automation.
