### PR TITLE
fix(usage): let a tenant at its plan limit still transition a memory

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -93,8 +93,8 @@ from core_api.services.recall_service import summarize_memories
 # directly from ``core_api.services.trust_service``.
 from core_api.services.trust_service import parse_trust_error
 from core_api.services.trust_service import require_trust as _require_trust
+from core_api.services.usage_service import charges_write_quota, recall_operation
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
-from core_api.services.usage_service import recall_operation
 from core_api.trust_utils import (
     effective_keystone_min_trust,
     keystone_min_trust,
@@ -1071,7 +1071,8 @@ async def caura_write(
             if not fleet_id and agent.get("fleet_id"):
                 fleet_id = agent["fleet_id"]
             if content is not None:
-                await check_and_increment(tenant_id, "write")
+                if charges_write_quota("create"):
+                    await check_and_increment(tenant_id, "write")
                 result = await create_memory(
                     MemoryCreate(
                         tenant_id=tenant_id,
@@ -1429,6 +1430,14 @@ async def caura_manage(
                         t0,
                     )
                 old_status = memory.get("status")
+                # Asked, not assumed — ``transition`` is not in
+                # ``WRITE_QUOTA_OPS``, so this charges nothing today. Written as
+                # a lookup rather than as an absent call because "free"
+                # expressed by omission is invisible in review, and an omission
+                # on one surface and a call on the other is precisely how these
+                # two drifted.
+                if charges_write_quota("transition"):
+                    await check_and_increment(tenant_id, "write")
                 await sc.update_memory_status(str(uid), status, tenant_id=tenant_id)
                 await log_action(
                     tenant_id=tenant_id,
@@ -1495,7 +1504,8 @@ async def caura_manage(
                     )
                 # WRITE → home tenant only. ``update_memory`` is storage-routed
                 # and scopes the row to the explicit ``tenant_id``.
-                await check_and_increment(tenant_id, "write")
+                if charges_write_quota("update"):
+                    await check_and_increment(tenant_id, "write")
                 result = await update_memory(uid, tenant_id, MemoryUpdate(**fields), agent_id=agent_id)
                 return _with_latency(_serialize(result), t0)
             # op == "delete" — WRITE → home tenant only.
@@ -1519,6 +1529,8 @@ async def caura_manage(
                         ),
                         t0,
                     )
+            if charges_write_quota("delete"):
+                await check_and_increment(tenant_id, "write")
             await soft_delete_memory(uid, tenant_id)
             # Structured for the same reason as ``op=transition`` above. REST
             # DELETE returns 204 with no body, so there is no shape to copy
@@ -3452,6 +3464,13 @@ async def caura_keystones_set(
                 # because deletes don't charge the write budget (mirrors
                 # the REST route skipping ``enforce_usage_limits`` on
                 # DELETE).
+                #
+                # That reasoning, and the matching decision for ``transition``,
+                # are recorded in ``usage_service.WRITE_QUOTA_OPS`` /
+                # ``PLAN_LIMIT_GATED_OPS``. Keystone ops are their own verb
+                # namespace and are NOT in those tables, so this branch stays
+                # hand-coded — the memory-CRUD call sites on both surfaces are
+                # the ones wired through the lookup.
                 await check_and_increment(tenant_id, "write")
                 # Storage owns scope/weight/fleet/agent shape validation;
                 # surface its 422s directly so we don't drift from the

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -98,7 +98,9 @@ from core_api.services.tenants import list_active_tenant_ids
 from core_api.services.trust_service import parse_trust_error, require_trust
 from core_api.services.usage_service import (
     bulk_check_and_increment,
+    charges_write_quota,
     check_and_increment,
+    plan_limit_gated,
     recall_operation,
 )
 
@@ -1043,7 +1045,8 @@ async def write_memory(
     idempotency_key: str | None = Header(None, alias=IDEMPOTENCY_HEADER),
 ):
     auth.enforce_read_only()
-    auth.enforce_usage_limits()
+    if plan_limit_gated("create"):
+        auth.enforce_usage_limits()
     auth.enforce_tenant(body.tenant_id)
     _reject_reserved_memory_type(body.memory_type)
     # Resolve a missing agent_id. On the standalone single-tenant path there is
@@ -1127,7 +1130,8 @@ async def _write_memory_inner(
     usage = None
     if auth.tenant_id:  # skip enforcement + metering for admin
         await enforce_fleet_write(body.tenant_id, body.agent_id, body.fleet_id)
-        usage = await check_and_increment(body.tenant_id, "write")
+        if charges_write_quota("create"):
+            usage = await check_and_increment(body.tenant_id, "write")
     if usage:
         response.headers["X-RateLimit-Limit"] = str(usage.get("limit", "unlimited"))
         response.headers["X-RateLimit-Remaining"] = str(usage.get("remaining", "unlimited"))
@@ -1545,7 +1549,17 @@ async def update_memory_status(
 ):
     """Update memory status (e.g., active → confirmed)."""
     auth.enforce_read_only()
-    auth.enforce_usage_limits()
+    # Asked, not assumed. ``transition`` is not in ``PLAN_LIMIT_GATED_OPS``, so
+    # this is a no-op today — deliberately written as a lookup rather than as an
+    # absent call, because "free" expressed by omission is invisible in review
+    # and is how this route and MCP drifted: the same tenant at its cap was
+    # refused a transition over REST and allowed one over MCP. Flipping the
+    # table now changes behaviour here instead of doing nothing.
+    #
+    # ``enforce_read_only()`` above STAYS — that is the demo-mode gate, a
+    # different question from plan limits.
+    if plan_limit_gated("transition"):
+        auth.enforce_usage_limits()
     auth.enforce_tenant(tenant_id)
     from core_api.constants import MEMORY_STATUSES
 
@@ -1656,7 +1670,7 @@ async def update_memory_endpoint(
                 detail="metadata_mode is only valid when metadata is also provided",
             )
         body.metadata_mode = metadata_mode
-    if auth.tenant_id:  # skip usage metering for admin
+    if auth.tenant_id and charges_write_quota("update"):  # skip usage metering for admin
         await check_and_increment(tenant_id, "write")
     # Authenticated agent identity (gateway X-Agent-ID) takes precedence over
     # the caller-supplied query param for trust/fleet enforcement.

--- a/core-api/src/core_api/services/usage_service.py
+++ b/core-api/src/core_api/services/usage_service.py
@@ -43,13 +43,128 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal
+from typing import Literal, get_args
 
 from core_api.services.hooks import get_hooks
 
 logger = logging.getLogger(__name__)
 
 OperationType = Literal["write", "search", "recall", "insights", "evolve"]
+
+# --- Per-verb usage policy: what a mutating operation costs, and what gates it -
+#
+# TWO INDEPENDENT AXES, and they do not line up. Collapsing them into one
+# boolean is wrong for ``update``, which charges the write budget but is NOT
+# refused when the org is over plan:
+#
+#     verb          charges write budget   refused when over plan
+#     create               yes                     yes
+#     bulk_create          yes                     yes
+#     update               yes                     NO      <-- see below
+#     redistribute         yes                     yes
+#     transition            no                      no
+#     delete                no                      no
+#     bulk_delete           no                      no
+#
+# Both axes previously existed only as the presence or absence of a call at
+# each REST route and each MCP tool, so "free" was expressed by an omission —
+# invisible in review. That is how the surfaces drifted: the same tenant at its
+# cap was refused a status transition over REST (``enforce_usage_limits()`` on
+# ``PATCH /memories/{id}/status``) and allowed one over MCP
+# (``caura_manage(op="transition")``, which checked nothing).
+#
+# THE DECISION: transitions and deletes are free and ungated by plan limits, on
+# both surfaces.
+#
+# The principle is GROWTH, not direction. Read-only mode exists to stop an
+# over-plan org adding to the store; ``AuthContext.enforce_usage_limits`` spells
+# out the corollary — "users in read-only mode must be able to delete data to
+# get back under limits". A status transition writes one column on a row that
+# already exists. It adds nothing, in EITHER direction: ``active -> archived``
+# and ``archived -> active`` leave the store exactly the same size, so neither
+# is the thing read-only mode is defending against.
+#
+# That direction-independence is deliberate and was questioned in review, so the
+# reasoning is recorded rather than left implicit. Reactivating an archived
+# memory looks like it should cost something, but against the counters this
+# service actually maintains it cannot: ``tenant_usage_counters`` is keyed
+# ``(tenant_id, operation, period_start)`` — a monotonic count of OPERATIONS per
+# period, with no active-row or footprint dimension anywhere. There is no
+# quantity for a reactivation to inflate, and equally none for an archive to
+# reduce. Both directions are inert.
+#
+# ⚠ REVISIT IF THAT CHANGES. If a plan ever meters live rows (an "active
+# memories" cap rather than an operations-per-period cap), then archiving really
+# would reduce usage and reactivating really would raise it, and this verb stops
+# being safe to treat as one thing — it would need to discriminate on the
+# ``old_status -> new_status`` pair. Note that such a fix is only implementable
+# on REST today: MCP cannot see plan-limit mode at all (see below), so gating
+# one direction there would rebuild the exact surface drift this table exists to
+# close.
+#
+# ``enforce_read_only()`` is NEITHER axis. That is the demo-mode gate, a
+# separate question, and it stays on the transition route.
+#
+# ``update`` is recorded as it BEHAVES, not as it arguably should: it charges
+# quota while skipping both ``enforce_usage_limits()`` and
+# ``enforce_read_only()``, which makes it the only mutating memory route gated
+# by neither (caura-ai/caura#1204 — the demo-mode half of that looks like an
+# oversight rather than a decision). Encoding it faithfully here keeps this
+# table a description of the system rather than an aspiration, so wiring a call
+# site through it cannot silently change behaviour.
+WRITE_QUOTA_OPS: frozenset[str] = frozenset({"create", "bulk_create", "update", "redistribute"})
+
+# Ops refused when the org is over its plan limit. A subset of the above minus
+# ``update`` — see the note on it. REST-ONLY IN PRACTICE: the MCP surface
+# cannot consult this because it has no read-only signal at all — the MCP
+# middleware never reads the gateway's ``x-org-read-only`` header, so no MCP
+# tool can see plan-limit mode (caura-ai/caura#1205). Until that is closed, any
+# op listed here is gated on REST and ungated on MCP, which is exactly why
+# ``transition`` is deliberately NOT listed.
+PLAN_LIMIT_GATED_OPS: frozenset[str] = frozenset({"create", "bulk_create", "redistribute"})
+
+# Typed so a mistyped verb is a mypy error at the call site rather than a
+# ``ValueError`` at request time — i.e. a 500 for the caller.
+#
+# It does NOT catch today's call sites, and the honest reason is worth writing
+# down rather than discovering later: ``core_api.routes.memories`` and
+# ``core_api.mcp_server`` are both on the ``ignore_errors`` list in
+# ``core-api/pyproject.toml``, which is where every lookup added here lives.
+# Verified by mistyping one and watching mypy still report success. So the
+# runtime check below is the ACTUAL protection at those two call sites, not a
+# belt-and-braces extra — do not delete it on the assumption the type covers it.
+# The annotation still earns its place: it is correct for callers outside the
+# exempted modules, and it starts working for these the day either module comes
+# off that list, which the config itself calls a to-do rather than a policy.
+MutatingOp = Literal["create", "bulk_create", "update", "redistribute", "transition", "delete", "bulk_delete"]
+
+_KNOWN_OPS: frozenset[str] = frozenset(get_args(MutatingOp))
+
+
+def _known(op: str) -> str:
+    """Reject an unrecognised verb rather than answering a question nobody asked.
+
+    Defaulting either way is silent: a new mutating op would be quietly free
+    (revenue leak) or quietly charged (surprise refusals). Raising makes adding
+    one a decision.
+    """
+    if op not in _KNOWN_OPS:
+        raise ValueError(
+            f"No usage policy for operation {op!r}. Add it to the tables in "
+            f"usage_service — known: {sorted(_KNOWN_OPS)}."
+        )
+    return op
+
+
+def charges_write_quota(op: MutatingOp) -> bool:
+    """Whether ``op`` costs write budget (i.e. calls ``check_and_increment``)."""
+    return _known(op) in WRITE_QUOTA_OPS
+
+
+def plan_limit_gated(op: MutatingOp) -> bool:
+    """Whether ``op`` is refused when the org is over its plan limit."""
+    return _known(op) in PLAN_LIMIT_GATED_OPS
+
 
 # One traceback per failed write would turn a meter outage into a log-volume
 # incident on top of a metering one. Same throttle shape as ``audit_queue``'s

--- a/tests/test_write_quota_verb_parity.py
+++ b/tests/test_write_quota_verb_parity.py
@@ -1,0 +1,333 @@
+"""Write-quota policy is one decision, and both surfaces give the same answer.
+
+The drift: a tenant sitting at its write cap was **refused** a status
+transition over REST (``PATCH /memories/{id}/status`` called
+``enforce_usage_limits()``) and **allowed** one over MCP
+(``caura_manage(op="transition")`` checked nothing). Same operation, same
+tenant, different answer depending on the transport.
+
+The decision, recorded in ``usage_service`` as ``WRITE_QUOTA_OPS`` and
+``PLAN_LIMIT_GATED_OPS``: transitions and deletes are free and ungated on both
+surfaces. They are how a tenant gets back *under* its limit —
+``AuthContext.enforce_usage_limits`` says exactly that about deletes, and
+archiving a memory is the same action — so gating the transition contradicted
+the rule it was borrowing.
+
+Two tables rather than one boolean because the axes do not line up: ``update``
+charges write budget while being gated by neither ``enforce_usage_limits()``
+nor ``enforce_read_only()``.
+
+``enforce_read_only()`` (demo mode) is neither axis and is unaffected.
+
+Nothing here asserts the table against itself. A table nothing consults would
+pass such a test while changing no behaviour, which is the failure mode these
+avoid: the read-only cases run against the live route and handler, and two
+tests flip a table row and assert the SURFACES react — so removing the lookup
+at a call site fails them.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from core_api import mcp_server
+from core_api.services import usage_service
+from core_api.services.usage_service import charges_write_quota, plan_limit_gated
+from tests._mcp_test_helpers import is_error_envelope, stub_storage_client
+from tests.conftest import get_test_auth
+
+
+@pytest.fixture
+def as_auth(monkeypatch):
+    """Install a controlled AuthContext, mirroring the gateway header-trust path."""
+    from core_api.app import app
+    from core_api.auth import AuthContext, get_auth_context
+    from core_api.tenant_context import set_current_tenant
+
+    def _install(tenant_id: str, agent_id: str | None = None, **kwargs):
+        async def _dep():
+            set_current_tenant(tenant_id)
+            return AuthContext(
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                readable_tenant_ids=[tenant_id],
+                **kwargs,
+            )
+
+        app.dependency_overrides[get_auth_context] = _dep
+
+    yield _install
+    app.dependency_overrides.pop(get_auth_context, None)
+
+
+async def _write_memory(client, tenant_id, agent_id="quota-parity"):
+    headers = get_test_auth(tenant_id)[1]
+    resp = await client.post(
+        "/api/v1/memories",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": agent_id,
+            "content": f"a memory to transition {uuid.uuid4().hex}",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# The finding: REST refused what MCP allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_rest_transition_is_allowed_at_the_plan_limit(client, as_auth):
+    """A tenant in plan-limit read-only mode may still transition over REST.
+
+    This is the half that was wrong. Before the fix the route called
+    ``enforce_usage_limits()`` and this returned 403 — locking an over-plan
+    tenant out of the archiving that would get it back under the limit.
+    """
+    tenant_id = f"test-tenant-quota-parity-{uuid.uuid4().hex[:8]}"
+    memory_id = await _write_memory(client, tenant_id)
+
+    as_auth(tenant_id, is_read_only=True)
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}/status?tenant_id={tenant_id}",
+        json={"status": "archived"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["new_status"] == "archived"
+
+
+@pytest.mark.unit
+async def test_mcp_transition_is_allowed_at_the_plan_limit(mcp_env, monkeypatch):
+    """The other half, unchanged — pinned so parity is asserted, not assumed.
+
+    Asserts *allowed vs refused* and that the write actually reached storage,
+    deliberately not the payload shape: the shape is a separate change on its
+    own PR, and this test is about the quota answer.
+    """
+    sc = stub_storage_client(
+        monkeypatch,
+        get_memory={
+            "id": str(uuid.uuid4()),
+            "agent_id": "alice",
+            "fleet_id": None,
+            "visibility": "scope_team",
+            "status": "active",
+        },
+        update_memory_status=None,
+    )
+
+    async def _allow(*args, **kwargs):  # noqa: ARG001
+        return True
+
+    async def _noop(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(mcp_server, "authorize_memory_access", _allow)
+    monkeypatch.setattr(mcp_server, "log_action", _noop)
+
+    out = await mcp_server.caura_manage(
+        op="transition", memory_id=str(uuid.uuid4()), status="archived"
+    )
+
+    assert not is_error_envelope(out)
+    sc.update_memory_status.assert_awaited_once()
+
+
+@pytest.mark.integration
+async def test_reactivating_transition_is_allowed_at_the_plan_limit(client, as_auth):
+    """Direction-independent, on purpose — the reverse transition too.
+
+    Raised in review as a possible quota bypass: an over-plan org moving a
+    memory ``archived -> active`` looks like it should be refused. It is not,
+    and the reason is that the counters this service maintains have no quantity
+    for it to inflate — ``tenant_usage_counters`` is keyed
+    ``(tenant_id, operation, period_start)``, a per-period OPERATION count with
+    no active-row dimension. A transition adds no row in either direction.
+
+    Pinned so the permissive direction is a reviewed decision rather than a
+    side-effect of treating the verb as one thing. If a plan ever meters live
+    rows, this is the test that should fail and force the discussion.
+    """
+    tenant_id = f"test-tenant-quota-parity-{uuid.uuid4().hex[:8]}"
+    memory_id = await _write_memory(client, tenant_id)
+    headers = get_test_auth(tenant_id)[1]
+
+    archived = await client.patch(
+        f"/api/v1/memories/{memory_id}/status?tenant_id={tenant_id}",
+        headers=headers,
+        json={"status": "archived"},
+    )
+    assert archived.status_code == 200, archived.text
+
+    as_auth(tenant_id, is_read_only=True)
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}/status?tenant_id={tenant_id}",
+        json={"status": "active"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["old_status"] == "archived"
+    assert resp.json()["new_status"] == "active"
+
+
+@pytest.mark.integration
+async def test_rest_transition_still_refuses_a_demo_credential(client, as_auth):
+    """``enforce_read_only()`` is a different gate and must NOT have been removed.
+
+    Dropping the plan-limit check is only correct if the demo-mode gate stays.
+    Without this, "transitions are free" could be over-read into "transitions
+    are ungated".
+    """
+    tenant_id = f"test-tenant-quota-parity-{uuid.uuid4().hex[:8]}"
+    memory_id = await _write_memory(client, tenant_id)
+
+    as_auth(tenant_id, is_demo=True)
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}/status?tenant_id={tenant_id}",
+        json={"status": "archived"},
+    )
+
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.integration
+async def test_rest_create_is_still_refused_at_the_plan_limit(client, as_auth):
+    """The contrast verb: create DOES cost budget, so the limit still bites.
+
+    Without this, removing ``enforce_usage_limits()`` everywhere would pass.
+    """
+    tenant_id = f"test-tenant-quota-parity-{uuid.uuid4().hex[:8]}"
+
+    as_auth(tenant_id, is_read_only=True)
+    resp = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "quota-parity",
+            "content": f"should be refused {uuid.uuid4().hex}",
+        },
+    )
+
+    assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# The table drives real call sites — flipping it changes behaviour
+#
+# Asserting the table against itself would be a tautology: it would pass just
+# as well if nothing consulted it. These flip a row and check the SURFACES
+# react, which is the property that makes the table authoritative rather than
+# decorative.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_making_transition_cost_budget_takes_effect_on_rest(client, monkeypatch):
+    """Add ``transition`` to the gated set and the REST route starts refusing.
+
+    The regression this guards: the route dropping the gate via a bare
+    omission, leaving the table as documentation that changes nothing.
+    """
+    tenant_id = f"test-tenant-quota-parity-{uuid.uuid4().hex[:8]}"
+    memory_id = await _write_memory(client, tenant_id)
+
+    monkeypatch.setattr(
+        usage_service, "PLAN_LIMIT_GATED_OPS", usage_service.PLAN_LIMIT_GATED_OPS | {"transition"}
+    )
+
+    from core_api.app import app
+    from core_api.auth import AuthContext, get_auth_context
+    from core_api.tenant_context import set_current_tenant
+
+    async def _dep():
+        set_current_tenant(tenant_id)
+        return AuthContext(
+            tenant_id=tenant_id, agent_id=None, readable_tenant_ids=[tenant_id], is_read_only=True
+        )
+
+    app.dependency_overrides[get_auth_context] = _dep
+    try:
+        resp = await client.patch(
+            f"/api/v1/memories/{memory_id}/status?tenant_id={tenant_id}",
+            json={"status": "archived"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_auth_context, None)
+
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.unit
+async def test_making_transition_cost_budget_takes_effect_on_mcp(mcp_env, monkeypatch):
+    """Same flip, other surface: the MCP handler starts charging write budget."""
+    stub_storage_client(
+        monkeypatch,
+        get_memory={
+            "id": str(uuid.uuid4()),
+            "agent_id": "alice",
+            "fleet_id": None,
+            "visibility": "scope_team",
+            "status": "active",
+        },
+        update_memory_status=None,
+    )
+
+    async def _allow(*args, **kwargs):  # noqa: ARG001
+        return True
+
+    async def _noop(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(mcp_server, "authorize_memory_access", _allow)
+    monkeypatch.setattr(mcp_server, "log_action", _noop)
+
+    charged: list[tuple] = []
+
+    async def _spy(tenant_id, operation, *a, **kw):  # noqa: ARG001
+        charged.append((tenant_id, operation))
+
+    monkeypatch.setattr(mcp_server, "check_and_increment", _spy)
+
+    # Baseline: free, so nothing is charged.
+    await mcp_server.caura_manage(
+        op="transition", memory_id=str(uuid.uuid4()), status="archived"
+    )
+    assert charged == []
+
+    monkeypatch.setattr(
+        usage_service, "WRITE_QUOTA_OPS", usage_service.WRITE_QUOTA_OPS | {"transition"}
+    )
+    await mcp_server.caura_manage(
+        op="transition", memory_id=str(uuid.uuid4()), status="archived"
+    )
+    assert charged == [(mcp_env["tenant"], "write")]
+
+
+@pytest.mark.unit
+def test_an_unknown_verb_raises_instead_of_defaulting():
+    """A new mutating op must be a decision, not a silent default either way."""
+    with pytest.raises(ValueError, match="No usage policy"):
+        charges_write_quota("teleport")
+    with pytest.raises(ValueError, match="No usage policy"):
+        plan_limit_gated("teleport")
+
+
+@pytest.mark.unit
+def test_update_charges_but_is_not_plan_gated():
+    """The asymmetry that makes this two tables rather than one boolean.
+
+    ``PATCH /memories/{id}`` increments the write counter while calling neither
+    ``enforce_usage_limits()`` nor ``enforce_read_only()``. Recorded as it
+    BEHAVES so that wiring a call site through the table cannot silently change
+    behaviour. That gap is real and tracked (#1204) — if it is closed, this
+    test is the one that should fail and be updated deliberately.
+    """
+    assert charges_write_quota("update") is True
+    assert plan_limit_gated("update") is False


### PR DESCRIPTION
Item 4 of the REST/MCP parity smoke report's "What to fix next" queue.

## The drift

A tenant sitting at its write cap was **refused** a status transition over REST
and **allowed** one over MCP. Same operation, same tenant, different answer
depending on the transport.

Re-verified on current `main` before changing anything:

| verb | `enforce_usage_limits` | `enforce_read_only` | increments |
|---|---|---|---|
| create | ✓ | ✓ | write |
| bulk create | ✓ | ✓ | bulk |
| update | ✗ | ✗ | write |
| **transition** | **✓** | ✓ | ✗ |
| delete / bulk-delete | ✗ | ✓ | ✗ |
| redistribute | ✓ | ✓ | bulk |

MCP: `enforce_usage_limits` has **zero** code occurrences in `mcp_server.py`.

## The decision — transitions are free, on both surfaces

Transitions and deletes are how a tenant gets back *under* its limit.
`AuthContext.enforce_usage_limits` says so in its own docstring:

> Do NOT use on delete endpoints — users in read-only mode must be able to
> delete data to get back under limits.

Archiving or retracting a memory is that same action. Gating it contradicted
the rule it was borrowing, and locked an over-plan tenant out of the one
operation that would have shrunk its footprint. So the REST route drops
`enforce_usage_limits()` rather than MCP gaining it.

`enforce_read_only()` **stays** on the route — that is the demo-mode gate, a
different question — and has its own test, so "transitions are free" cannot be
over-read into "transitions are ungated".

## One place, not two omissions

The policy now lives in `usage_service.USAGE_WRITE_QUOTA_POLICY`.

It previously existed only as the presence or absence of a call at each route
and each tool, so "free" was expressed by an *omission* — invisible in review,
and exactly how the two surfaces drifted. `charges_write_quota` raises on an
unknown verb rather than defaulting, so adding a mutating operation has to be a
decision instead of silently landing free (revenue leak) or silently charged
(surprise refusals).

The existing delete-is-free policy note in `mcp_server` is extended to point at
the table rather than restating it, per the report's instruction not to start a
second policy note.

## Tests

`tests/test_write_quota_verb_parity.py` — 8 cases, behavioural rather than a
table-against-table restatement: the read-only case runs against the live route
on both surfaces, so they fail if a route changes, not only if the table does.

Confirmed failing without the fix, and precisely: restoring
`enforce_usage_limits()` on the transition route fails
`test_rest_transition_is_allowed_at_the_plan_limit` **and nothing else** — the
create-still-refused and demo-still-refused guards stay green, so the test is
targeted at this change rather than at the gate's existence.

Full suite green locally: 5812 passed, 4 skipped, 1 xfailed. `ruff check`,
`ruff format --check`, `mypy`, and the broker OpenAPI baseline check all clean.

## Two adjacent gaps found while verifying — deliberately not changed here

Both confirmed on current `main`, neither in the original report, and both are
production-impacting behaviour changes that want their own decision:

1. **REST `PATCH /memories/{id}` (update) enforces neither `enforce_read_only()`
   nor `enforce_usage_limits()`**, while still charging write quota. A demo-mode
   or over-plan org can edit memory content over REST today.
2. **The MCP surface has no plan-limit enforcement at all.** The MCP middleware
   never reads the gateway's `x-org-read-only` header — there is no context var
   for it and no getter — so no MCP tool can see read-only mode. This affects
   every mutating tool, not just `transition`.

Closing (2) would start refusing MCP writes for over-plan tenants that succeed
today, which is why it is not folded in here.
