### PR TITLE
chore(storage): delete the unreachable fleet_add_node

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -9230,13 +9230,6 @@ class PostgresService:
             await session.flush()
             return result.scalar_one()
 
-    async def fleet_add_node(self, data: dict) -> FleetNode:
-        async with get_session() as session:
-            node = FleetNode(**data)
-            session.add(node)
-            await session.flush()
-            return node
-
     async def fleet_get_node_id(
         self,
         *,

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -80,13 +80,6 @@
       "note": "Verified: data['tenant_id'] is stored on FleetCommand after the route confirms the node has that tenant."
     },
     {
-      "id": "method:fleet_add_node",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "opaque-body-write",
-      "note": "Verified: data['tenant_id'] is stored directly on the FleetNode row."
-    },
-    {
       "id": "method:fleet_upsert_node",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",


### PR DESCRIPTION
## What

Delete `PostgresService.fleet_add_node`, which has no callers, and the `tenant_scope_allowlist.json` entry that came with it.

Its only two references in the whole tree were its own definition and the allowlist entry:

```
core-storage-api/src/core_storage_api/services/postgres_service.py:9233:    async def fleet_add_node(self, data: dict) -> FleetNode:
core-storage-api/tenant_scope_allowlist.json:83:      "id": "method:fleet_add_node",
```

No route, no test, no other service. `fleet_upsert_node` is the live path and is the one `routers/fleet.py` reaches. `FleetNode` is still referenced 40× in the same module, so no import goes stale.

## Why

Found while sizing #1180 — it was one of the 36 `opaque-body-write` acceptances, accepted on the strength of a note (*"data['tenant_id'] is stored directly on the FleetNode row"*) describing code nothing can reach.

Deleting the method deletes the entry with it, so the allowlist **shrinks 72 → 71** and `opaque-body-write` goes **36 → 35**. The ratchet permits shrinking; nothing here grows.

The gate reports it under `removed — gone`, not `removed — still unscoped`, which is the distinction that matters: the method is absent from live code rather than merely dropped from the list.

```
  removed — gone (1):
      - method:fleet_add_node [opaque-body-write]
  categories (before -> after):
      opaque-body-write: 36 -> 35
tenant-scope gate: 189 routes + 186 service methods, 304 bound to a tenant, 71 allowlisted.
```

Same disposition as the merged #1161, #1163 and #1168. **No behaviour change** — this is dead code, so there is nothing to test. No test is added for the same reason those three added none; the gate's own `removed — gone` line is the assertion that it is unreachable.

## Gates

Run with the venv on `PATH` and `UV_FROZEN=1`; `ruff check` and `ruff format --check` run **separately** at each of CI's exact scopes, discovery-based, no `--config`.

- `python scripts/tenant_scope_gate.py --base origin/main` — as above; 0 added, 0 recategorised
- `python scripts/tenant_scope_gate.py --write` — regenerated the allowlist rather than hand-editing it; diff is exactly the seven lines of the one entry
- `pytest tests/test_tenant_scope_gate.py` — **113 passed**
- `pytest core-storage-api/tests/ -k fleet` — **47 passed**, 262 deselected
- `mypy src/` in `core-storage-api` — no issues in 85 source files
- `ruff check` — `core-api/src/`, `core-storage-api/src/`, `core-storage-api/tests/`, `common/`, `core-operations/{src,tests}/`, `core-worker/{src,tests}/` — all clean
- `ruff format --check` — same scopes plus the isolated `common/__init__.py common/structlog_config.py common/serve.py` — all formatted
- `python3 scripts/legacy_name_ratchet.py --base origin/main` — `No new lines.`
- `python3 scripts/do_not_touch_sentinel.py` — all 46 protected strings survive
- `uv.lock` and `plugin/package-lock.json` untouched — `git status` shows only the two files above

One signed-off commit, rebased onto `origin/main` immediately before push, and the gate and both test suites re-run after the rebase.

## Relationship to #1199

Independent — different files, different branches, both cut from `origin/main`. #1199 makes the six `insights/*` routes' tenant binding visible to the gate, deleting their entries (allowlist −6). If both land the allowlist is **72 → 65** and `opaque-body-write` **36 → 29**. Neither depends on the other and they can merge in either order.
