### PR TITLE
fix(storage): make the insights routes' tenant binding visible to the gate

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/insights.py
+++ b/core-storage-api/src/core_storage_api/routers/insights.py
@@ -28,17 +28,25 @@ router = APIRouter(tags=["Insights"])
 _svc = PostgresService()
 
 
-def _scope_args(body: dict) -> tuple[str, str | None, str, str]:
-    """Pull the four scope params common to the 6 analytic reads.
+def _scope_args(body: dict) -> tuple[str | None, str, str]:
+    """Pull the three NON-BINDING scope params common to the 6 analytic reads.
 
-    ``tenant_id`` + ``agent_id`` + ``scope`` are required; ``fleet_id`` is
-    optional (but the underlying ``_scope_filters`` raises ValueError → 500 if
-    scope='fleet' arrives without it — the core-api request validators block
-    that combination before it reaches storage)."""
-    tenant_id = _require(body, "tenant_id")
+    ``tenant_id`` is deliberately not read here. It is the binding scope, and
+    the tenant-scope gate reads each route handler's OWN AST; a ``_require``
+    resolved one frame down inside a helper is invisible to it, so all six of
+    these routes sat on ``tenant_scope_allowlist.json`` describing a binding
+    that was there the whole time. Each handler now calls
+    ``_require(body, "tenant_id")`` itself, which puts the binding where the
+    gate and a reader both look for it. Keep it that way: folding it back in
+    here silently re-adds six allowlist entries.
+
+    ``agent_id`` + ``scope`` are required; ``fleet_id`` is optional (but the
+    underlying ``_scope_filters`` raises ValueError → 500 if scope='fleet'
+    arrives without it — the core-api request validators block that
+    combination before it reaches storage)."""
     agent_id = _require(body, "agent_id")
     scope = _require(body, "scope")
-    return tenant_id, body.get("fleet_id"), agent_id, scope
+    return body.get("fleet_id"), agent_id, scope
 
 
 def _max_memories(body: dict) -> int:
@@ -79,7 +87,8 @@ def _window_start(body: dict) -> datetime | None:
 @router.post("/insights/contradictions")
 async def insights_contradictions(request: Request) -> list[dict]:
     body: dict = await request.json()
-    tenant_id, fleet_id, agent_id, scope = _scope_args(body)
+    tenant_id = _require(body, "tenant_id")
+    fleet_id, agent_id, scope = _scope_args(body)
     return await _svc.insights_query_contradictions(
         tenant_id=tenant_id,
         fleet_id=fleet_id,
@@ -92,7 +101,8 @@ async def insights_contradictions(request: Request) -> list[dict]:
 @router.post("/insights/failures")
 async def insights_failures(request: Request) -> list[dict]:
     body: dict = await request.json()
-    tenant_id, fleet_id, agent_id, scope = _scope_args(body)
+    tenant_id = _require(body, "tenant_id")
+    fleet_id, agent_id, scope = _scope_args(body)
     return await _svc.insights_query_failures(
         tenant_id=tenant_id,
         fleet_id=fleet_id,
@@ -106,7 +116,8 @@ async def insights_failures(request: Request) -> list[dict]:
 @router.post("/insights/stale")
 async def insights_stale(request: Request) -> list[dict]:
     body: dict = await request.json()
-    tenant_id, fleet_id, agent_id, scope = _scope_args(body)
+    tenant_id = _require(body, "tenant_id")
+    fleet_id, agent_id, scope = _scope_args(body)
     # The two age thresholds are computed on the caller's clock (core-api) and
     # sent as ISO strings; bind as datetimes server-side.
     for key in ("thirty_days_ago", "fourteen_days_ago"):
@@ -132,7 +143,8 @@ async def insights_stale(request: Request) -> list[dict]:
 @router.post("/insights/divergence")
 async def insights_divergence(request: Request) -> list[dict]:
     body: dict = await request.json()
-    tenant_id, fleet_id, agent_id, scope = _scope_args(body)
+    tenant_id = _require(body, "tenant_id")
+    fleet_id, agent_id, scope = _scope_args(body)
     return await _svc.insights_query_divergence(
         tenant_id=tenant_id,
         fleet_id=fleet_id,
@@ -145,7 +157,8 @@ async def insights_divergence(request: Request) -> list[dict]:
 @router.post("/insights/patterns")
 async def insights_patterns(request: Request) -> list[dict]:
     body: dict = await request.json()
-    tenant_id, fleet_id, agent_id, scope = _scope_args(body)
+    tenant_id = _require(body, "tenant_id")
+    fleet_id, agent_id, scope = _scope_args(body)
     return await _svc.insights_query_patterns(
         tenant_id=tenant_id,
         fleet_id=fleet_id,
@@ -166,7 +179,8 @@ async def insights_discover_sample(request: Request) -> list[dict]:
     the window. Absent → legacy newest-first, keeping older core-api
     callers working."""
     body: dict = await request.json()
-    tenant_id, fleet_id, agent_id, scope = _scope_args(body)
+    tenant_id = _require(body, "tenant_id")
+    fleet_id, agent_id, scope = _scope_args(body)
     sample_size = body.get("sample_size")
     if not isinstance(sample_size, int) or sample_size < 1:
         raise HTTPException(status_code=422, detail="sample_size (int >= 1) is required")

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -371,48 +371,6 @@
       "category": "no-tenant-data"
     },
     {
-      "id": "route:POST /api/v1/storage/insights/contradictions",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "opaque-body-write",
-      "note": "Verified: _scope_args calls the fail-closed _require(body, 'tenant_id') and passes it to the query."
-    },
-    {
-      "id": "route:POST /api/v1/storage/insights/discover-sample",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "opaque-body-write",
-      "note": "Verified: _scope_args calls the fail-closed _require(body, 'tenant_id') and passes it to the query."
-    },
-    {
-      "id": "route:POST /api/v1/storage/insights/divergence",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "opaque-body-write",
-      "note": "Verified: _scope_args calls the fail-closed _require(body, 'tenant_id') and passes it to the query."
-    },
-    {
-      "id": "route:POST /api/v1/storage/insights/failures",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "opaque-body-write",
-      "note": "Verified: _scope_args calls the fail-closed _require(body, 'tenant_id') and passes it to the query."
-    },
-    {
-      "id": "route:POST /api/v1/storage/insights/patterns",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "opaque-body-write",
-      "note": "Verified: _scope_args calls the fail-closed _require(body, 'tenant_id') and passes it to the query."
-    },
-    {
-      "id": "route:POST /api/v1/storage/insights/stale",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "opaque-body-write",
-      "note": "Verified: _scope_args calls the fail-closed _require(body, 'tenant_id') and passes it to the query."
-    },
-    {
       "id": "route:POST /api/v1/storage/memories",
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",


### PR DESCRIPTION
## What

The six analytic insight reads resolved their binding `tenant_id` through the `_scope_args` helper. The tenant-scope gate reads **each route handler's own AST**, so a `_require` one frame down inside a helper is invisible to it — and all six landed on `tenant_scope_allowlist.json` under `opaque-body-write`, describing a binding that was there the whole time.

Hoist `_require(body, "tenant_id")` into each handler; leave the two non-binding requires (`agent_id`, `scope`) and the optional `fleet_id` in the helper.

```python
-    tenant_id, fleet_id, agent_id, scope = _scope_args(body)
+    tenant_id = _require(body, "tenant_id")
+    fleet_id, agent_id, scope = _scope_args(body)
```

**Validation order is unchanged** — tenant, then agent, then scope — so no 422 changes which field it names first.

## Why this rather than the recategorisation I proposed in #1180

I sized this in #1180 as *"→ `blind-spot`, or delete the entries outright"* and called the recategorisation the zero-risk option. **That was wrong, and I would not have caught it without reading the gate:**

- **`blind-spot` is itself a backlog category** — `BACKLOG_CATEGORIES` in `scripts/tenant_scope_gate.py:216-218`. Moving six entries into it *grows* the backlog by six. Since #1166 the gate reports recategorisations as standalone moves precisely so that cannot read as progress.
- **The category does not describe these routes.** Its own text is *"scoped … by an idiom the AST pass cannot read — an inline `if not isinstance(...): raise` **rather than the shared `_require` guard**"*, and it ends *"Prefer rewriting the guard to use `_require` and deleting the entry."* These routes already use `_require`. The remedy the category itself prescribes is this PR.

So the entries **delete** rather than move. That is what the allowlist's shrink-only ratchet wants.

## Why it is safe

The gate already recognises `_require` — `POST /fleet/commands` uses the same guard directly and is scored REQUIRED and unlisted. The only difference was the helper frame.

**There is a natural experiment inside this one file.** `supersede-priors`, `restore-priors` and `activity-gate` already call `_require(body, "tenant_id")` inline, and they are exactly the three insight routes that were **never** allowlisted. The six that went through the helper are exactly the six that were. This PR makes the six match the three.

`_scope_args` is module-private with no callers outside `insights.py` (`git grep _scope_args` returns only this file), so the arity change reaches nothing else.

## Result

```
  removed — fixed (6):
      - route:POST /api/v1/storage/insights/contradictions [opaque-body-write]
      - route:POST /api/v1/storage/insights/discover-sample [opaque-body-write]
      - route:POST /api/v1/storage/insights/divergence [opaque-body-write]
      - route:POST /api/v1/storage/insights/failures [opaque-body-write]
      - route:POST /api/v1/storage/insights/patterns [opaque-body-write]
      - route:POST /api/v1/storage/insights/stale [opaque-body-write]
  added (0)   removed — gone (0)   removed — still unscoped (0)   recategorised (0)
      opaque-body-write: 36 -> 30
tenant-scope gate: 189 routes + 187 service methods, 310 bound to a tenant, 66 allowlisted.
```

`removed — fixed`, not `still unscoped`: the routes are genuinely scoped now as far as the gate can prove. **Allowlist 72 → 66**, bound-to-a-tenant 304 → 310, and `opaque-body-write` stops being exactly half the list.

## Tests

**No new test, deliberately** — behaviour is unchanged, so any test I added would pass with and without the change and would not be worth its line count. The existing coverage is already the right coverage and it is load-bearing:

- `tests/test_ph5b_insights_storage.py::test_missing_tenant_422` and `::test_missing_agent_422` both POST to `/insights/patterns` — one of the six routes changed here.
- **I confirmed that test is not vacuous.** Replacing the hoisted guard with `body.get("tenant_id")` in `insights_patterns` turns `test_missing_tenant_422` red (`1 failed, 1 passed`); restoring it returns 39 passed. So the 422 contract this PR must preserve is genuinely pinned.

The stronger regression guard is the gate itself: fold the `_require` back into the helper and the six routes re-report as unscoped, which fails CI because the allowlist cannot grow. The helper docstring says so at the point someone would be tempted.

## Gates

Venv on `PATH`, `UV_FROZEN=1`. `ruff check` and `ruff format --check` run **separately** at each of CI's exact scopes, discovery-based, no `--config`.

- `python scripts/tenant_scope_gate.py --base origin/main` — output above
- `python scripts/tenant_scope_gate.py --write` — regenerated rather than hand-edited; diff is exactly the six entries (42 lines)
- `pytest tests/test_ph5b_insights_storage.py tests/test_tenant_scope_gate.py` — **152 passed**
- `pytest core-storage-api/tests/` — **309 passed** (full suite)
- `mypy src/` in `core-storage-api` — no issues in 85 source files
- `ruff check` — `core-api/src/`, `core-storage-api/src/`, `core-storage-api/tests/`, `common/`, `core-operations/{src,tests}/`, `core-worker/{src,tests}/` — all clean
- `ruff format --check` — same scopes plus isolated `common/__init__.py common/structlog_config.py common/serve.py` — all formatted
- `python3 scripts/legacy_name_ratchet.py --base origin/main` — `No new lines.`
- `python3 scripts/do_not_touch_sentinel.py` — all 46 protected strings survive
- `uv.lock` / `plugin/package-lock.json` untouched

One signed-off commit, rebased onto `origin/main` immediately before push, with the gate and both suites re-run after the rebase.

## Relationship to #1198

Independent — different files, different branches, both cut from `origin/main`. #1198 deletes the unreachable `fleet_add_node` (allowlist −1). If both land the allowlist is **72 → 65** and `opaque-body-write` **36 → 29**. Neither depends on the other and they can merge in either order.
