### PR TITLE
docs(mcp): tell integrators to size tool timeouts for caura_insights

### DIFF
--- a/docs/integration-without-plugin.md
+++ b/docs/integration-without-plugin.md
@@ -299,6 +299,40 @@ for why the two differ.
   model — it was being discarded before, so the fix is to remove it or move it
   under `metadata`, not to retry.
 - **Streaming client hangs on initialize.** If hitting `/mcp` (no slash) caused a hang on older builds, append the trailing slash or upgrade — current builds serve both paths without redirect.
+- **`caura_insights` is cut off by your client's default tool timeout.** It is
+  LLM-backed and runs roughly 7–9 s — an order of magnitude slower than the
+  other tools — while many MCP clients default to a 5–10 s tool timeout. There
+  is no cheap/counts-only mode and no partial result, so a client that times out
+  loses the whole call. Raise the timeout for this tool to ~30 s. See
+  [Tool latency](#tool-latency) below.
+
+---
+
+## Tool latency
+
+Set your MCP client's tool timeout from the slowest tool you actually call, not
+from an average.
+
+| Tool | Observed | Notes |
+|---|---|---|
+| `caura_insights` | **6.8 s and 8.7 s** | LLM-backed synthesis. No `depth`/quick mode and no partial results — a timeout loses the entire call. |
+| `caura_write` (MCP) | 0.86 s | Inline enrichment on the default write mode. |
+| REST calls, warmed | 0.7–1.4 s | Storage-routed; no LLM on the request path. |
+
+A 30 s tool timeout covers all of these with margin. A 5–10 s default — common
+in MCP clients — will truncate `caura_insights` specifically.
+
+Two caveats on these numbers, so they are read for what they are. They come from
+**two runs** of the parity smoke against production on 2026-08-24, not from a
+sustained benchmark — treat them as an order of magnitude, not an SLA. And the
+first call of a session is unrepresentative: that run measured a 16 s first
+write, which later investigation did **not** explain (core-api holds a
+min-instance floor, so it was not a scale-from-zero cold start). Warm the
+connection before timing anything.
+
+`caura_recall` with `include_brief=true` adds a second LLM round-trip on top of
+the search; it is not in the table because this pass did not measure it
+separately. Time it yourself before choosing a timeout if you rely on it.
 
 ---
 

--- a/tests/test_docs_tool_latency_claims.py
+++ b/tests/test_docs_tool_latency_claims.py
@@ -1,0 +1,61 @@
+"""The tool-latency section of the integration guide states checkable facts.
+
+``docs/integration-without-plugin.md`` tells integrators to raise their MCP
+client's tool timeout to ~30 s because ``caura_insights`` runs 6.8–8.7 s with
+"no ``depth``/quick mode and no partial results — a timeout loses the entire
+call". That is advice a reader acts on, and it stops being true the moment
+someone adds a cheap mode.
+
+A doc claim about behaviour is worth exactly as much as the thing that notices
+when it goes stale, so the two checkable halves are pinned here: the parameter
+that would make the claim wrong, and the cross-reference that would silently
+break.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from core_api import mcp_server
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+DOC = Path(__file__).parents[1] / "docs" / "integration-without-plugin.md"
+
+
+async def test_insights_still_has_no_cheap_mode():
+    """If a ``depth``/``quick`` parameter lands, the timeout advice is stale.
+
+    Not a vote against adding one — it is the report's recommended real fix.
+    This just makes adding it update the doc in the same change instead of
+    leaving integrators sizing timeouts for a constraint that no longer exists.
+    """
+    tools = await mcp_server.mcp.list_tools()
+    insights = next(t for t in tools if t.name == "caura_insights")
+    params = set((insights.inputSchema.get("properties") or {}).keys())
+
+    assert not params & {"depth", "quick", "mode"}, (
+        "caura_insights gained a cheap-mode parameter. Update the Tool latency "
+        f"section of {DOC.name}, which tells integrators there is none."
+    )
+
+
+def test_tool_latency_section_is_linked_and_present():
+    """The pitfall entry links to the section by anchor; keep them together."""
+    text = DOC.read_text()
+
+    assert "## Tool latency" in text
+    assert "(#tool-latency)" in text, "the caura_insights pitfall links to this anchor"
+
+
+def test_latency_table_names_the_slow_tool():
+    """Guards against the table being trimmed to the point of losing its subject."""
+    text = DOC.read_text()
+    section = text.split("## Tool latency", 1)[1]
+
+    assert "caura_insights" in section
+    # The advice is only actionable with a concrete number to size against.
+    assert re.search(r"\d+(\.\d+)?\s*s", section), "the table must keep at least one timing"


### PR DESCRIPTION
Item 7 of the REST/MCP parity smoke report's queue (P3).

## The gap

`caura_insights` ran 6,829 ms and 8,728 ms across two runs — roughly 10× the
next slowest tool. It is LLM-backed so the latency is inherent, but it offers no
`depth`/quick mode and no partial results, while many MCP clients default to a
5–10 s tool timeout. A client on that default loses the entire call.

Re-verified on current `main`: no `depth`/`quick`/`mode` parameter exists
(`caura_insights` exposes exactly `focus`, `scope`, `fleet_id`, `agent_id`), and
nothing documents the latency.

## Why this is docs, not the tool description

The report suggested the tool description, with `depth` as the real fix. I went
with the docs, for two reasons — one measured, one about audience.

**It does not fit.** The `tools/list` token budget is deliberately tight:
`CEILING_TOKENS` is 5350 against a current 5321, and the constant's own comment
records that the last change spent half the remaining margin and says *"Trim
before adding, or move the ceiling with a reason of your own."* I measured it
rather than guessing:

| description | tokens | vs 5350 ceiling |
|---|---|---|
| current | 5321 | — |
| `+ "LLM-backed and slow: typically 7-9s, so allow a 30s tool timeout."` | 5355 | **over by 5** |
| trimmed to `"LLM-backed: usually 7-9s, so allow a 30s timeout."` | 5352 | **over by 2** |

Tool-surface tokens are paid on every agent call, and `tests/fixtures/README.md`
says to raise the ceiling "only when a feature genuinely needs it".

**The advice is addressed to someone who cannot read it there.** "Allow a 30 s
timeout" is acted on by the human configuring the MCP client — not by the model
reading `tools/list`, which cannot change its own client's timeout. The
integration guide is where that reader already is.

So the latency now lives in `docs/integration-without-plugin.md`: a pitfall
entry beside the other MCP session-setup pitfalls, and a `## Tool latency`
section with a table sized for the slowest tool actually called.

`depth` remains the real fix and is untouched here — this is the interim the
report explicitly sanctions.

## Only measured numbers

The table publishes what was actually observed and nothing else. `caura_recall`
with `include_brief=true` is called out as **unmeasured** rather than given an
invented figure. Two caveats are stated in the doc itself: these are two smoke
runs, not a sustained benchmark; and the 16 s first write from that run is
flagged as **unexplained** rather than repeated as a cold start, because
core-api holds a min-instance floor of 10 and so cannot have scaled from zero
(checked read-only against the live Cloud Run config).

## Tests

`tests/test_docs_tool_latency_claims.py` — 3 cases. A doc claim about behaviour
is worth what the thing that notices it going stale is worth, so the checkable
halves are pinned:

- the timeout advice is only true while there is no cheap mode, so a test fails
  if `caura_insights` gains a `depth`/`quick`/`mode` parameter — pointing at the
  doc, so adding one updates it in the same change;
- the pitfall entry links to `#tool-latency` by anchor, so the heading and the
  table's timings cannot be removed silently.

Confirmed load-bearing: renaming the heading to `## Tool speed` fails two of the
three.

Full suite green locally: 5828 passed, 4 skipped, 1 xfailed.
