### PR TITLE
feat(api): report the credential kind from /whoami

### DIFF
--- a/core-api/src/core_api/routes/health.py
+++ b/core-api/src/core_api/routes/health.py
@@ -74,6 +74,20 @@ async def whoami(request: Request) -> dict:
             "readable_tenant_ids": readable,
             "capabilities": capabilities or None,
             "auth_mode": request.headers.get("x-auth-mode") or None,
+            # Credential provenance the gateway already resolves (the same
+            # header ``auth.py`` and the MCP middleware read). Saves a caller
+            # guessing why an install-scoped key behaves differently from a
+            # plain agent key.
+            #
+            # Echo, like ``capabilities`` and ``auth_mode`` beside it — this
+            # endpoint reports what the gateway asserted about the caller and
+            # LOOKS NOTHING UP. That is what keeps it safe without a perimeter
+            # check: there is no auth dependency and no shared-secret
+            # verification here, so a field that resolved caller-supplied ids
+            # against storage would let anyone read another tenant's
+            # attributes. Keep additions to this handler echo-only until that
+            # check exists (issue: /whoami perimeter).
+            "key_kind": (request.headers.get("x-caura-credential-kind") or "").lower() or None,
         }
     if settings.is_standalone:
         from core_api.standalone import get_standalone_tenant_id
@@ -87,6 +101,7 @@ async def whoami(request: Request) -> dict:
             "readable_tenant_ids": [sid] if sid else [],
             "capabilities": None,
             "auth_mode": None,
+            "key_kind": None,
         }
     return {
         "tenant_id": None,
@@ -96,6 +111,7 @@ async def whoami(request: Request) -> dict:
         "readable_tenant_ids": [],
         "capabilities": None,
         "auth_mode": None,
+        "key_kind": None,
     }
 
 

--- a/tests/test_api_whoami.py
+++ b/tests/test_api_whoami.py
@@ -40,3 +40,64 @@ async def test_whoami_standalone_or_anonymous(client):
     data = resp.json()
     assert data["via_gateway"] is False
     assert data["auth_source"] in {"standalone", "anonymous"}
+
+
+# --- key_kind ---------------------------------------------------------------
+#
+# The gateway already resolves credential provenance and sends it as
+# ``x-caura-credential-kind`` (``auth.py`` and the MCP middleware both read it).
+# Surfacing it saves a caller guessing why an install-scoped key behaves
+# differently from a plain agent key.
+#
+# ECHO ONLY, and that is load-bearing rather than lazy: ``/whoami`` has no auth
+# dependency and no gateway-shared-secret check, so it is safe precisely because
+# it looks nothing up. A field that resolved caller-supplied ids against storage
+# would let anyone read another tenant's attributes — which is why
+# ``trust_level`` is NOT here and is blocked on a perimeter fix.
+
+
+async def test_whoami_reports_key_kind_from_the_gateway(client):
+    resp = await client.get(
+        "/api/v1/whoami",
+        headers={
+            "X-Tenant-ID": "probe-tenant",
+            "X-Agent-ID": "probe-agent",
+            "X-Caura-Credential-Kind": "Install_Credential",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    # Normalised, matching how ``auth.py`` compares it.
+    assert resp.json()["key_kind"] == "install_credential"
+
+
+async def test_whoami_key_kind_is_none_when_the_gateway_sends_none(client):
+    resp = await client.get("/api/v1/whoami", headers={"X-Tenant-ID": "probe-tenant"})
+    assert resp.status_code == 200
+    assert resp.json()["key_kind"] is None
+
+
+async def test_whoami_key_kind_present_on_every_branch(client):
+    """Stable shape: a caller reads the key without branching on auth_source."""
+    resp = await client.get("/api/v1/whoami")
+    assert resp.status_code == 200
+    assert "key_kind" in resp.json()
+
+
+async def test_whoami_still_looks_nothing_up(client):
+    """An unknown tenant/agent is echoed, not resolved — no storage, no 404.
+
+    Pins the property that makes the missing perimeter check survivable. If
+    someone adds a lookup here, this stops being true and the endpoint becomes
+    a cross-tenant probe.
+    """
+    resp = await client.get(
+        "/api/v1/whoami",
+        headers={
+            "X-Tenant-ID": "tenant-that-does-not-exist",
+            "X-Agent-ID": "agent-that-does-not-exist",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["tenant_id"] == "tenant-that-does-not-exist"
+    assert data["agent_id"] == "agent-that-does-not-exist"


### PR DESCRIPTION
Item 10 of the REST/MCP parity smoke report's queue (P3) — the fields the
original `whoami` recommendation asked for that the shipped probe does not
carry: `trust_level`, `key_kind`, `limits`.

This adds **the one of the three that can be added safely today**, and files
the blocker for the other two.

## `key_kind` — added

`x-caura-credential-kind` is already resolved by the gateway and read by
`auth.py:553` and the MCP middleware. Surfacing it saves a caller guessing why
an install-scoped key behaves differently from a plain agent key. Emitted on
every branch (`gateway-header`, `standalone`, `anonymous`) so the shape is
stable and a client need not branch on `auth_source` to read it. Normalised to
lowercase, matching how `auth.py` compares it.

## `trust_level` — deliberately not added

Re-verified on `main`: `/whoami` has **no auth dependency and no
gateway-shared-secret check** — zero `Depends` in the whole module. It reads
`x-tenant-id` / `x-agent-id` straight off the request.

That is safe today for exactly one reason: the endpoint is a pure echo. You
tell it your tenant id, it tells you your tenant id back. Nothing is resolved,
so nothing can be disclosed.

`trust_level` breaks that. It needs `get_agent(agent_id, tenant_id)` against
storage, keyed on **caller-supplied** identifiers on an **unauthenticated**
endpoint — which would let anyone enumerate `(tenant_id, agent_id)` pairs and
read back each one's trust level, and would put a DB round-trip behind an open
route.

The MCP middleware guards precisely this shape and explains why: the
header-trust path *"accepts X-Tenant-ID / X-Agent-ID … with no credential of
its own, so when a shared secret is configured the request must prove it came
through the gateway."* `/whoami` has no such check.

So the ordering is: **perimeter check first, then the field.** Filed separately
with the sequencing — that issue is worth acting on regardless of whether these
fields ever land, because the endpoint is currently safe by accident of what it
does not do and nothing in the code said so.

## `limits` — not available in core-api

`usage_service`'s module docstring is explicit that core-api never reads
`allowed` and that enforcement travels out-of-band via `x-org-read-only`. There
are no limit values here to return. Would need a meter-hook call (a network
round-trip on a probe endpoint) or the gateway plumbing the numbers as headers
— a design question, not a missing line.

## Tests

Four cases added to `tests/test_api_whoami.py`.

Confirmed failing without the fix: reverting `core-api/src` fails three of
them. The fourth, `test_whoami_still_looks_nothing_up`, passes either way **by
design** — it pins the property that makes the missing perimeter check
survivable (an unknown tenant/agent is echoed, not resolved), so it fails the
day someone adds a lookup. It is a guard, not a proof of this change.

Full suite green locally: 5829 passed, 4 skipped, 1 xfailed. `ruff check`,
`ruff format --check`, `mypy`, and the broker OpenAPI check all clean.
