### PR TITLE
events: flip memory publishers to caura topics

### DIFF
--- a/common/events/memory_enrich_request.py
+++ b/common/events/memory_enrich_request.py
@@ -88,10 +88,12 @@ class MemoryEnrichRequest(BaseModel):
     #      tools that ``json.dumps()`` the model) gets ``"***"``.
     # Wire-format keys still travel in the Pub/Sub message body — the
     # CAURA-595 design (Q1=C) accepts this in exchange for a
-    # stateless worker; the wire-level mitigation is IAM (minimum
-    # subscriber bindings on ``memclaw.memory.enrich-requested``, no
-    # wildcard read grants on the topic, no audit-log mining of
-    # payloads). PR-D's bootstrap script enforces those grants.
+    # stateless worker; the wire-level IAM includes a publisher binding
+    # on the target topic and a subscriber binding on the dedicated
+    # subscription. Enterprise Terraform derives matching twin resource
+    # bindings from the legacy mappings. The production worker also retains
+    # project-level Pub/Sub roles (tracked in caura-enterprise#1449), so the
+    # scoped bindings are not yet the sole enforcement boundary.
     openai_api_key: str | None = Field(default=None, repr=False)
     anthropic_api_key: str | None = Field(default=None, repr=False)
     openrouter_api_key: str | None = Field(default=None, repr=False)

--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -194,12 +194,15 @@ def family(topic: str) -> str:
 # evidence the flip works; the end-to-end signal is the staging deploy's
 # control-plane check. Do not report a green gate as a working flip.
 #
-# ``memory`` is next and is ready on the same evidence — 16/16 twin durable
-# subscriptions, no ephemerals. Its one blocker is cleared: the declared
-# ``.created`` topic was removed rather than provisioned, because it existed in
-# neither environment, appeared in no events manifest, and had no publisher or
-# subscriber in either repo. Provisioning it would have created topics that
-# nothing emits to and nothing reads.
+# ``memory`` flipped 2026-09-01 — the fourth programme family and second
+# SHARED one. This set is authored here and manually mirrored into enterprise;
+# the copies are deliberately not generated or synced. Immediately before the
+# edit, the live remeasurement found 12/12 running deployables dual-on and
+# 16/16 active twin durables (8/environment) attached to their matching twin
+# topics, with no ephemerals. The gates still read configuration only: green is
+# necessary, not delivery proof. Its former blocker is cleared: the unused
+# ``.created`` declaration was removed rather than provisioned. The ``Memory``
+# enum members deliberately remain on the retired brand until contraction.
 #
 # ``pipeline`` must NOT enter this set while it has zero live topics in either
 # environment: publishing to a topic that does not exist is silent loss, so
@@ -208,7 +211,7 @@ def family(topic: str) -> str:
 # leak. ``audit`` LAST, unconditionally — those rows are hash-chained, and a
 # lost or reordered audit event is the one failure here that replay cannot
 # repair.
-FLIPPED_FAMILIES: frozenset[str] = frozenset({"lifecycle"})
+FLIPPED_FAMILIES: frozenset[str] = frozenset({"lifecycle", "memory"})
 
 
 def all_topics() -> tuple[str, ...]:

--- a/tests/test_events/test_factory.py
+++ b/tests/test_events/test_factory.py
@@ -14,11 +14,11 @@ pytestmark = pytest.mark.asyncio
 def dual_subscribe_on(monkeypatch: pytest.MonkeyPatch) -> None:
     """The dual-subscribe setting every deployed service actually runs with.
 
-    Since ``lifecycle`` was flipped, a Pub/Sub bus constructed with the flag off
-    is refused at construction — a flipped family would otherwise publish under
-    a name the bus does not bind, which delivers nothing and raises nothing. The
-    tests below are about the FACTORY's backend selection and its
-    ``max_messages`` plumbing, not about the flag, so they take the setting all
+    Since ``memory`` is flipped but not yet contracted, a Pub/Sub bus constructed
+    with the flag off is refused at construction — a flipped family would
+    otherwise publish under a name the bus does not bind, which delivers nothing
+    and raises nothing. The tests below cover the FACTORY's backend selection and
+    its ``max_messages`` plumbing, not the flag, so they take the setting all
     12 pubsub-backed deployables were confirmed running at their live revision.
     Setting the env var rather than emptying ``FLIPPED_FAMILIES`` keeps the real
     flag-parsing path under test; the parse rule itself is covered in

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -36,7 +36,7 @@ EMBEDDED_EVENT_BYTES = json.dumps({"event_type": EMBEDDED_TOPIC}).encode()
 @pytest.fixture
 def bus() -> PubSubEventBus:
     # ``dual_subscribe=True`` here and at every other construction in this file.
-    # With ``lifecycle`` flipped, the construction guard refuses ``dual=False``
+    # With ``memory`` flipped, the construction guard refuses ``dual=False``
     # (a flipped family would publish under a name the bus does not bind), so
     # the default is no longer constructible in this repo. None of the tests
     # here are ABOUT that default — they cover topic prefixing, tunables, env
@@ -71,9 +71,7 @@ async def test_publish_encodes_envelope_as_json(bus: PubSubEventBus) -> None:
 
     bus._publisher.publish.assert_called_once()
     topic_path, data = bus._publisher.publish.call_args[0]
-    assert (
-        topic_path == f"projects/proj/topics/{frozen_topic('memory.embed-requested')}"
-    )
+    assert topic_path == "projects/proj/topics/caura.memory.embed-requested"
     parsed = json.loads(data.decode())
     assert parsed["event_type"] == Topics.Memory.EMBED_REQUESTED
     assert parsed["tenant_id"] == "t1"
@@ -90,7 +88,7 @@ async def test_topic_prefix_scopes_publish(bus: PubSubEventBus) -> None:
     )
     await bus.publish(Topics.Memory.EMBEDDED, event)
     topic_path, _ = bus._publisher.publish.call_args[0]
-    assert topic_path == f"projects/proj/topics/prod--{EMBEDDED_TOPIC}"
+    assert topic_path == "projects/proj/topics/prod--caura.memory.embedded"
 
 
 def test_topic_name_prefix_and_no_op() -> None:

--- a/tests/test_events/test_topic_rename_cutover.py
+++ b/tests/test_events/test_topic_rename_cutover.py
@@ -10,10 +10,10 @@ Two properties carry the whole step, and both are asserted here rather than
 described:
 
 * **Publishing moves one family at a time.** ``lifecycle`` flipped on
-  2026-08-28; every other family still targets the name it targeted before. The
-  per-family assertions below are what stop a further family riding along in a
-  diff that looks like it only touched one line — each flip has to restate the
-  set, which is the point.
+  2026-08-28 and ``memory`` on 2026-09-01; every other family still targets the
+  name it targeted before. The per-family assertions below are what stop a
+  further family riding along in a diff that looks like it only touched one
+  line — each flip has to restate the set, which is the point.
 * **Never dual-publish.** One publish call produces exactly one message. The
   alternative cutover — publish to both names for a while — delivers every event
   twice to every subscriber bound to both, which is the failure the ordering
@@ -24,10 +24,10 @@ opposite ones and a missing twin fails differently in each.
 
 THE CONTRACT CHANGES WHAT A DEFAULT-CONSTRUCTED BUS MEANS AGAIN. ``lifecycle``
 stays in ``FLIPPED_FAMILIES``, but all nine of its enum members now carry the
-current name. ``renamed`` is therefore the identity for every member, so
-``publish_name`` and ``subscribe_names(dual=False)`` agree and the construction
-guard permits the default again. Tests about *the flag's parse rule* still take
-the ``nothing_flipped`` fixture so their precondition cannot depend on cutover
+current name. ``memory`` is deliberately still pre-contract: its members carry
+the legacy names, so its publisher flip makes the construction guard require
+dual-subscribe again. Tests about *the flag's parse rule* still take the
+``nothing_flipped`` fixture so their precondition cannot depend on cutover
 state; flip and contract assertions use the real set below.
 """
 
@@ -49,11 +49,12 @@ from common.events.factory import get_event_bus, reset_event_bus_for_testing
 def nothing_flipped(monkeypatch: pytest.MonkeyPatch) -> None:
     """Decouple flag-parse tests from the current family cutover state.
 
-    Contracting ``lifecycle`` makes ``dual=False`` constructible again, but the
-    tests using this fixture ask a separate question — whether blank parses as
-    off and whether the Pub/Sub backend defaults to one name. Emptying the set
-    keeps those tests independent of whichever family is flipped next while
-    leaving the bus, factory and parser themselves untouched.
+    Contracting ``lifecycle`` made ``dual=False`` constructible again; the
+    uncontracted ``memory`` flip makes the real set require dual-subscribe once
+    more. Tests using this fixture ask a separate question — whether blank
+    parses as off and whether the Pub/Sub backend defaults to one name. Emptying
+    the set keeps those tests independent of cutover state while leaving the
+    bus, factory and parser themselves untouched.
 
     The alternative, passing ``dual_subscribe=True``, would silently change what
     those tests assert — they would stop covering the default path, which is the
@@ -65,7 +66,7 @@ def nothing_flipped(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 def bus() -> PubSubEventBus:
     # dual on: this is what all 12 pubsub-backed deployables actually run, and
-    # it remains the required operational setting for the other families.
+    # it is the required operational setting for the memory flip.
     b = PubSubEventBus(
         project_id="proj", subscription_prefix="test", dual_subscribe=True
     )
@@ -125,7 +126,7 @@ def test_subscribe_names_dual_returns_both_without_duplicates() -> None:
     )
 
 
-# ── publishing is unchanged: the property that makes step 2 shippable ─
+# ── publishing moves one family at a time ────────────────────────────
 
 
 # Hand-spelled rather than derived from ``topics_mod``. Deriving it would make
@@ -134,7 +135,7 @@ def test_subscribe_names_dual_returns_both_without_duplicates() -> None:
 # has to be stated in exactly two places — the module, and this literal — and the
 # equality in ``test_exactly_the_flipped_families_are_flipped`` is what turns the
 # second one into a deliberate stop rather than a chore.
-FLIPPED = frozenset({"lifecycle"})
+FLIPPED = frozenset({"lifecycle", "memory"})
 # Hand-spelled independently of ``Topics.Lifecycle`` so a new member requires an
 # explicit contract decision. An already-contracted family has no legacy twin to
 # bind: its current-topic infrastructure must exist before a new member ships.
@@ -189,15 +190,18 @@ def test_exactly_the_flipped_families_are_flipped() -> None:
     the worst outcome available in this cutover, because it also looks like
     progress.
 
-    ``memory`` is the natural next family and is otherwise ready on the same
-    evidence, but it declares ``.created``, which exists in neither environment
-    — a smaller instance of what disqualifies ``pipeline``. Provision or remove
-    that member before flipping it, so the flip carries no exception.
+    ``memory`` joined on 2026-09-01 — the second SHARED family, mirrored into
+    caura-enterprise in the same cycle. Its absent ``.created`` declaration had
+    already been removed. The live re-measurement found 12/12 running Pub/Sub
+    deployables dual-subscribing and 16/16 active durable twins attached to the
+    matching twin topics (8 per environment), with no ephemerals. Its enum
+    members remain on the legacy names because contraction is the next step,
+    not part of this flip.
     """
     assert topics_mod.FLIPPED_FAMILIES == FLIPPED
     assert "audit" not in topics_mod.FLIPPED_FAMILIES
     assert "pipeline" not in topics_mod.FLIPPED_FAMILIES
-    assert "memory" not in topics_mod.FLIPPED_FAMILIES
+    assert "org" not in topics_mod.FLIPPED_FAMILIES
 
 
 def test_known_families_are_derived_from_the_enums() -> None:
@@ -277,12 +281,12 @@ def test_publish_name_is_the_identity_for_every_unflipped_family() -> None:
         assert topics_mod.publish_name(topic) == str(topic)
 
 
-async def test_publish_targets_the_unrenamed_topic(bus: PubSubEventBus) -> None:
+async def test_publish_targets_the_memory_twin(bus: PubSubEventBus) -> None:
     await bus.publish(
         Topics.Memory.EMBED_REQUESTED, Event(event_type=Topics.Memory.EMBED_REQUESTED)
     )
     topic_path, _ = bus._publisher.publish.call_args[0]
-    assert topic_path == f"projects/proj/topics/{Topics.Memory.EMBED_REQUESTED}"
+    assert topic_path == "projects/proj/topics/caura.memory.embed-requested"
 
 
 async def test_dual_subscribe_does_not_dual_publish(bus: PubSubEventBus) -> None:
@@ -298,7 +302,7 @@ async def test_dual_subscribe_does_not_dual_publish(bus: PubSubEventBus) -> None
 
     assert bus._publisher.publish.call_count == 1
     topic_path, data = bus._publisher.publish.call_args[0]
-    assert topic_path == f"projects/proj/topics/{Topics.Memory.EMBEDDED}"
+    assert topic_path == "projects/proj/topics/caura.memory.embedded"
     # The envelope is untouched too: event_type is payload, not routing.
     assert json.loads(data.decode())["event_type"] == str(Topics.Memory.EMBEDDED)
 
@@ -508,10 +512,9 @@ async def test_dual_subscribe_flag_reads_anything_but_an_explicit_yes_as_off(
 def test_nothing_publishes_unbound_in_the_configuration_the_services_run() -> None:
     """The deployed dual-on setting leaves no publisher unbound.
 
-    Contracted lifecycle members are safe with either setting, but dual-on must
-    remain the operational invariant: later flips of the still-uncontracted
-    families depend on it. Every one of the 12 pubsub-backed deployables was
-    confirmed running this setting before the lifecycle flip.
+    Contracted lifecycle members are safe with either setting, while the
+    uncontracted memory flip depends on dual-on. All 12 pubsub-backed
+    deployables were re-confirmed running this setting before the memory flip.
     """
     assert topics_mod.unbound_publish_topics(dual=True) == ()
 
@@ -567,7 +570,9 @@ def test_pubsub_bus_constructs_when_the_flip_is_matched_by_dual_subscribe(
     assert b._dual_subscribe is True
 
 
-def test_the_guard_does_not_fire_once_lifecycle_is_fully_contracted() -> None:
+def test_the_guard_does_not_fire_once_lifecycle_is_fully_contracted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The false positive an emptiness check would cause — the reason this guard
     compares names instead of testing ``FLIPPED_FAMILIES`` for emptiness.
 
@@ -582,8 +587,9 @@ def test_the_guard_does_not_fire_once_lifecycle_is_fully_contracted() -> None:
     This uses the real nine-member family rather than a one-topic simulation so
     one missed literal cannot hide behind the other eight contracted members.
     """
-    # Non-empty FLIPPED_FAMILIES, dual off — and yet nothing is unbound.
-    assert topics_mod.FLIPPED_FAMILIES == frozenset({"lifecycle"})
+    # Isolate the contracted family from the real, still-uncontracted memory
+    # flip: non-empty FLIPPED_FAMILIES, dual off, and nothing is unbound.
+    monkeypatch.setattr(topics_mod, "FLIPPED_FAMILIES", frozenset({"lifecycle"}))
     assert topics_mod.unbound_publish_topics(dual=False) == ()
     PubSubEventBus(project_id="proj", subscription_prefix="test")
 

--- a/tests/test_pubsub_trace_filters.py
+++ b/tests/test_pubsub_trace_filters.py
@@ -311,10 +311,11 @@ async def test_publisher_only_bus_does_not_register_the_filter(
         PubSubEventBus, "_ensure_pubsub_sdk", staticmethod(lambda: object())
     )
 
-    # dual on because ``lifecycle`` is flipped: the construction guard refuses
-    # ``dual=False`` in this repo now. Irrelevant to what this asserts — a
-    # publisher-only bus has no pull loop either way — so it takes the setting
-    # the running services use rather than neutralising the guard.
+    # dual on because ``memory`` is flipped but not yet contracted: the
+    # construction guard refuses ``dual=False`` in this repo now. Irrelevant to
+    # what this asserts — a publisher-only bus has no pull loop either way — so
+    # it takes the setting the running services use rather than neutralising the
+    # guard.
     bus = PubSubEventBus(
         project_id="proj", subscription_prefix="test", dual_subscribe=True
     )


### PR DESCRIPTION
## Summary

Package AT flips only the `memory` family’s publishers to the `caura.*` twins in `caura` by extending `FLIPPED_FAMILIES` to exactly `{"lifecycle", "memory"}`.

This is publisher-flip **step 1**, not enum-contraction step 2. The earlier package wording that called this step 2 was wrong: all four `Topics.Memory` enum values deliberately remain `memclaw.memory.*`; contraction is a later change.

This OSS copy is authoritative for the shared family and was manually mirrored into enterprise in the same sitting. The files are not generated or synced, and the sets intentionally differ because enterprise retains its private `fleet` and `security` families.

Sibling enterprise PR: https://github.com/caura-ai/caura-enterprise/pull/1448

## Live readiness measured before editing

- Enterprise `scripts/check_flip_readiness.py`: 12/12 Pub/Sub-backed running deployables had `EVENT_BUS_DUAL_SUBSCRIBE` enabled.
  - Prod: backfill job plus core-api `00146-ngv`, core-worker `00122-45w`, platform-admin `00127-tgg`, platform-audit `00105-mwn`, platform-auth `00127-7fx`.
  - Staging: backfill job plus core-api `01603-mb6`, core-worker `01416-94v`, platform-admin `01338-5fm`, platform-audit `01330-rb9`, platform-auth `01345-slg`.
- Enterprise `scripts/preflight_dual_subscribe.py` exited 0 in prod and staging: each saw 34 legacy topics and 32 legacy durable subscriptions, topic IAM was reachable, and neither emitted an IAM warning or `NOT verified live`.
- Direct live subscription audit: 16/16 active durable `memory` twins were attached to the matching twin **topic** (8 per environment); zero ephemeral `memory` subscriptions. The 32 `memory` topic resources across both environments contained every legacy/twin topic pair.

Both gates read **configuration**. Neither observes message delivery. Green is necessary, not evidence that the flip works; the staging deploy control-plane check is the end-to-end signal.

## Verification

- Publisher/guard inspection: all four enum values remain `memclaw.memory.*`; all four publish targets are `caura.memory.*`; dual-on has no unbound publishers; dual-off reports exactly those four legacy enum values.
- Focused Pub/Sub/cutover/guard/trace tests: 142 passed, 1 skipped.
- Core-worker: 80 passed. Core-operations: 50 passed.
- Exact CI Ruff discovery scopes: check passed; format passed (360 package files plus 3 isolated vendored-common files).
- Exact CI mypy scopes: all six passed (434 source files total).
- Legacy-name ratchet: `No new lines. 0 annotated, 1 removed, 0 excused moves (-1 net).` The reduction comes from correcting the security/IAM comment for the now-renamed publish path; enterprise stays +0 because its vendored `topics.py` mirror is excluded where authored.
- Do-not-touch sentinel: all 46 protected strings survive.
- Simplification review: clean after correcting stale migration, guard, and IAM commentary and removing unrelated format churn.
- Commit includes the required DCO sign-off.

No topic/subscription deletion, enum contraction, deploy, traffic change, or flip of `pipeline`, `org`, or `audit` is included.
