### PR TITLE
feat(write): report where a memory's weight came from

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/merge_enrichment_fields.py
+++ b/core-api/src/core_api/pipeline/steps/write/merge_enrichment_fields.py
@@ -48,6 +48,22 @@ class MergeEnrichmentFields:
         # skip), so this flag needs no worker-side finalisation.
         memory_type_agent_set = memory_type is not None
 
+        # Same question for ``weight``, and it matters more than it looks.
+        # ``weight`` is 15% of the base rank score (``SIMILARITY_BLEND`` is
+        # 0.85), so when the caller omits it and the enrichment LLM picks one,
+        # identical content can rank differently run to run — two throwaway
+        # ``fact`` memories written seconds apart were observed getting 0.30
+        # and 0.50. Nothing in the response said which values were chosen by a
+        # model, so a team chasing non-reproducible ranking had no way to tell
+        # an LLM guess from a deliberate number.
+        #
+        # Three-valued rather than a boolean, because "not the caller" hides
+        # the distinction that matters for reproducibility: ``default`` is
+        # deterministic (``DEFAULT_MEMORY_WEIGHT``, used when enrichment is off
+        # or failed) while ``llm`` is not. Captured BEFORE the merge below,
+        # like ``memory_type_agent_set``.
+        weight_source = "caller" if weight is not None else "default"
+
         # CAURA-701: caller-supplied deprecated types (currently ``semantic``)
         # bypass the enrichment-LLM demotion in ``_validate_enrichment`` because
         # a non-``None`` ``data.memory_type`` short-circuits the fill-gaps branch
@@ -61,8 +77,9 @@ class MergeEnrichmentFields:
             # LLM fills gaps; agent-provided values always win
             if memory_type is None:
                 memory_type = enrichment.memory_type
-            if weight is None:
+            if weight is None and enrichment.weight is not None:
                 weight = enrichment.weight
+                weight_source = "llm"
             title = enrichment.title or None
             if enrichment.summary:
                 set_system_value(metadata, "summary", enrichment.summary, caller_keys=caller_keys)
@@ -107,6 +124,7 @@ class MergeEnrichmentFields:
             set_system_value(metadata, "enrichment_pending", True, caller_keys=caller_keys)
 
         set_system_value(metadata, "memory_type_agent_set", memory_type_agent_set, caller_keys=caller_keys)
+        set_system_value(metadata, "weight_source", weight_source, caller_keys=caller_keys)
 
         ctx.data["memory_fields"] = {
             "memory_type": memory_type,

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -1988,12 +1988,18 @@ async def create_memories_bulk(
         # honour an existing value; otherwise the type is agent-set iff the item
         # carried one.
         metadata.setdefault("memory_type_agent_set", item.memory_type is not None)
+        # Provenance of ``weight``, same three values as the single-write path
+        # (MergeEnrichmentFields). Bulk items go through this merge rather than
+        # the pipeline, so the flag has to be set here too or a bulk write would
+        # report nothing while a single write reports a source.
+        weight_source = "caller" if weight is not None else "default"
 
         if enrichment:
             if memory_type is None:
                 memory_type = enrichment.memory_type
-            if weight is None:
+            if weight is None and enrichment.weight is not None:
                 weight = enrichment.weight
+                weight_source = "llm"
             title = enrichment.title or None
             if enrichment.summary:
                 metadata["summary"] = enrichment.summary
@@ -2010,6 +2016,8 @@ async def create_memories_bulk(
                 if enrichment.pii_types:
                     metadata["pii_types"] = enrichment.pii_types
             metadata["business_relevance"] = enrichment.business_relevance
+
+        metadata["weight_source"] = weight_source
 
         if memory_type is None:
             memory_type = DEFAULT_MEMORY_TYPE

--- a/core-api/src/core_api/services/system_metadata.py
+++ b/core-api/src/core_api/services/system_metadata.py
@@ -45,6 +45,7 @@ PLATFORM_ONLY_KEYS: frozenset[str] = frozenset(
         "enrichment_pending",
         "embedding_pending",
         "memory_type_agent_set",
+        "weight_source",
         "pii_flagged_by",
     }
 )

--- a/tests/test_weight_source_provenance.py
+++ b/tests/test_weight_source_provenance.py
@@ -1,0 +1,131 @@
+"""A write reports where its ``weight`` came from (``weight_source``).
+
+When the caller omits ``weight``, it is filled by the enrichment LLM. That is
+not cosmetic: ``SIMILARITY_BLEND = 0.85`` makes weight 15% of the base rank
+score, so identical content can rank differently run to run. Two throwaway
+``fact`` memories written seconds apart were observed getting 0.30 and 0.50 —
+and nothing in the response said either number came from a model, so a team
+chasing non-reproducible ranking had no way to tell an LLM guess from a
+deliberate value.
+
+Three values rather than a boolean, because "not the caller" hides the
+distinction that matters for reproducibility:
+
+    caller   — the write supplied it; fully deterministic
+    llm      — the enrichment model chose it; NOT reproducible
+    default  — ``DEFAULT_MEMORY_WEIGHT``; deterministic
+
+Mirrors ``memory_type_agent_set`` (CAURA-703), which records the same
+provenance question for ``memory_type``, and is registered in the same
+``PLATFORM_ONLY_KEYS`` set so a caller cannot forge it.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from core_api.constants import DEFAULT_MEMORY_WEIGHT
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.write.merge_enrichment_fields import MergeEnrichmentFields
+from core_api.services.system_metadata import PLATFORM_ONLY_KEYS, sanitize_caller_metadata
+
+pytestmark = [pytest.mark.unit]
+
+
+class _Input:
+    def __init__(self, weight=None):
+        self.memory_type = None
+        self.weight = weight
+        self.metadata = None
+        self.ts_valid_start = None
+        self.ts_valid_end = None
+        self.status = None
+
+
+class _Enrichment:
+    def __init__(self, weight=None):
+        self.memory_type = "fact"
+        self.weight = weight
+        self.title = None
+        self.summary = None
+        self.tags = None
+        self.llm_ms = None
+        self.ts_valid_start = None
+        self.ts_valid_end = None
+        self.contains_pii = False
+        self.pii_types = None
+        self.business_relevance = None
+
+
+async def _run(*, caller_weight=None, enrichment=None):
+    ctx = PipelineContext(data={"input": _Input(caller_weight), "enrichment": enrichment})
+    await MergeEnrichmentFields().execute(ctx)
+    return ctx.data["memory_fields"]
+
+
+def _source(fields) -> str:
+    return fields["metadata"]["_system"]["weight_source"]
+
+
+async def test_caller_supplied_weight_is_reported_as_caller():
+    fields = await _run(caller_weight=0.7, enrichment=_Enrichment(weight=0.3))
+
+    assert fields["weight"] == 0.7, "a caller-supplied weight always wins"
+    assert _source(fields) == "caller"
+
+
+async def test_llm_supplied_weight_is_reported_as_llm():
+    """The case the finding is about — a value no one chose and nothing flagged."""
+    fields = await _run(caller_weight=None, enrichment=_Enrichment(weight=0.3))
+
+    assert fields["weight"] == 0.3
+    assert _source(fields) == "llm"
+
+
+async def test_default_weight_is_reported_as_default():
+    """Enrichment off or failed — deterministic, and distinguishable from ``llm``.
+
+    A boolean would collapse this with the LLM case, losing exactly the fact a
+    team wanting reproducible ranking needs.
+    """
+    fields = await _run(caller_weight=None, enrichment=None)
+
+    assert fields["weight"] == DEFAULT_MEMORY_WEIGHT
+    assert _source(fields) == "default"
+
+
+async def test_enrichment_without_a_weight_is_default_not_llm():
+    """Enrichment ran but returned no weight — the LLM chose nothing.
+
+    Reporting ``llm`` here would claim a model picked a value it did not, and
+    would mark a deterministic default as irreproducible.
+    """
+    fields = await _run(caller_weight=None, enrichment=_Enrichment(weight=None))
+
+    assert fields["weight"] == DEFAULT_MEMORY_WEIGHT
+    assert _source(fields) == "default"
+
+
+async def test_zero_weight_from_the_caller_still_counts_as_caller():
+    """0.0 is a choice, not an absence — the check is ``is not None``.
+
+    A truthiness test here would silently reattribute a deliberate 0.0 to the
+    LLM and overwrite it.
+    """
+    fields = await _run(caller_weight=0.0, enrichment=_Enrichment(weight=0.9))
+
+    assert fields["weight"] == 0.0
+    assert _source(fields) == "caller"
+
+
+def test_weight_source_cannot_be_forged_by_a_caller():
+    """Platform-only, like ``memory_type_agent_set``.
+
+    Without this a caller could stamp ``weight_source: "caller"`` on a row whose
+    weight a model actually chose — the provenance would be worse than absent,
+    because it would look authoritative.
+    """
+    assert "weight_source" in PLATFORM_ONLY_KEYS
+    assert sanitize_caller_metadata({"weight_source": "caller", "mine": 1}) == {"mine": 1}


### PR DESCRIPTION
Item 6 of the REST/MCP parity smoke report's queue (P3) — the reporting half.

## The gap

`pipeline/steps/write/merge_enrichment_fields.py`: when the caller omits
`weight`, it comes from the enrichment LLM.

That is not cosmetic. `SIMILARITY_BLEND = 0.85` makes weight **15% of the base
rank score**, so identical content can rank differently run to run. In the
2026-08-24 run, two throwaway `fact` memories written seconds apart got **0.30
and 0.50**. It also made an evolve comparison look like a REST/MCP divergence —
`new_weight` 0.15 vs 0.35 on an identical `delta=-0.15` — when both surfaces
were arithmetically correct and only the starting weights differed.

Nothing in the write said which values a model had chosen, so a team chasing
non-reproducible ranking could not tell an LLM guess from a deliberate number.

Re-verified on `main`: the assignment is unchanged and `weight_source` appears
nowhere in the repo.

## The change

`weight_source`, recorded per write:

| value | meaning | reproducible? |
|---|---|---|
| `caller` | the write supplied it | yes |
| `llm` | the enrichment model chose it | **no** |
| `default` | `DEFAULT_MEMORY_WEIGHT` | yes |

**Three values, not a boolean.** "Not the caller" collapses exactly the
distinction reproducibility turns on: a default is repeatable and an LLM pick
is not.

### It's a port, not a new pattern

`memory_type_agent_set` (CAURA-703) already answers this same provenance
question for `memory_type` — same `set_system_value` call, same
`PLATFORM_ONLY_KEYS` registration. This follows it exactly, including the
platform-only registration: a forgeable `weight_source: "caller"` sitting on an
LLM-chosen weight would be **worse than no field**, because it would look
authoritative.

Set on the bulk path too (`create_memories_bulk` merges outside the pipeline),
which would otherwise report nothing where a single write reports a source.

### Two behaviour-preserving details

- The enrichment branch now checks `enrichment.weight is not None` before
  assigning. Outcome is identical — a `None` fell through to the default either
  way — but it stops the flag claiming `llm` for a value the model never
  supplied.
- The caller check is `is not None`, not truthiness, so an explicit `0.0` is
  reported as `caller` rather than being reattributed to the LLM *and
  overwritten*. Pinned by its own test, because a truthiness bug here would be
  silent and would change stored data.

## Scope

This is the **reporting** half of the report's recommendation. The tenant
setting for pinning a deterministic default is deliberately not included — that
is a configuration surface and a product decision, whereas this makes the
existing behaviour observable, which is what unblocks anyone trying to diagnose
it today. Same shape as item 1: prefer making a behaviour observable over
leaving it undocumented.

The report's related note — `weight_adjustments` from evolve having no clamp
indicator — is untouched and still open.

## Tests

`tests/test_weight_source_provenance.py` — 6 cases, confirmed failing without
the fix (all 6). They pin behaviour rather than presence: each of the three
values is asserted for a distinct input, so no hardcoded value passes.

Full suite green locally: 5831 passed, 4 skipped, 1 xfailed. `ruff check`,
`ruff format --check`, `mypy`, and the broker OpenAPI check all clean.
