### PR TITLE
feat(llm): migrate VertexLLMProvider to google-genai, unlock Gemini 3.x

### DIFF
--- a/common/llm/providers/vertex.py
+++ b/common/llm/providers/vertex.py
@@ -1,34 +1,26 @@
-"""Vertex AI LLM provider.
+"""Vertex AI LLM provider (Gemini via Workload Identity / ADC).
 
-Wraps the Google Cloud Vertex AI SDK. Since the SDK is synchronous,
-all calls are wrapped in ``asyncio.to_thread()`` to avoid blocking
-the event loop.
+Wraps the ``google-genai`` SDK in Vertex mode (``vertexai=True``) —
+project/location auth via Application Default Credentials, no API key.
+Migrated off ``vertexai.generative_models`` (deprecated June 2025,
+removed June 2026): the legacy SDK only speaks the v1 API, where the
+Gemini 3.x catalog is not published, and its region allowlist predates
+the ``us``/``eu`` multi-regions the 3.x Flash-Lite models are served
+from — so it structurally cannot reach any Gemini 3 model.
 
-CAURA-333: ``VertexEmbeddingProvider`` was removed (broken — never passed
-``output_dimensionality`` to the SDK, so writes failed against pgvector's
-1024-dim column). Only the LLM-side provider remains.
+Multi-region endpoint quirk: ``us``/``eu`` are served from the bare
+``aiplatform.googleapis.com`` host (same as ``global``), but the SDK
+builds ``{location}-aiplatform.googleapis.com`` for any non-``global``
+location — and ``us-aiplatform.googleapis.com`` is rejected with
+``400 Invalid hostname``. ``_MULTI_REGION_LOCATIONS`` below pins the
+base URL for those locations (verified live 2026-08-30/31: both
+``gemini-3.5-flash-lite`` and ``gemini-3.1-flash-lite`` 200 on
+``locations/us`` via the bare host, 404 on ``global`` and on regional
+``us-central1``).
 
-⚠ THE SDK IMPORTS IN THIS MODULE ARE DEFERRED ON PURPOSE, against the
-repo's top-level-imports rule. Stated here because this file is cited as
-the precedent for the pattern (``gemini.py``: "same pattern as
-VertexLLMProvider with vertexai") and was the one copy that never said
-why — so it reads as an oversight and gets re-flagged.
-
-The reason is optional dependencies, not circular imports.
-``google-cloud-aiplatform`` is an EXTRA for core-worker
-(``vertex = [...]`` in its ``pyproject.toml``), and only a hard dependency
-for core-api. Hoisting these to module scope makes
-``common.llm.providers.vertex`` unimportable wherever the extra is absent
-— verified by blocking ``vertexai`` and ``google.cloud.aiplatform`` on the
-import path: the module still imports cleanly today and
-``VertexLLMProvider`` is still reachable, while a top-level import raises
-``ModuleNotFoundError``. Deferred, an install without Vertex fails only if
-it actually CALLS Vertex, which is what an optional provider should do.
-
-``_platform.py`` imports this module lazily too, inside a ``try``, for the
-same reason — and ``registry.py`` deliberately omits it from the top-level
-provider imports it does for fake/gemini/openai. All three are one
-decision; changing any of them alone breaks it.
+The SDK is synchronous, so all calls are wrapped in
+``asyncio.to_thread()`` to avoid blocking the event loop (same pattern
+as ``GeminiLLMProvider``).
 """
 
 from __future__ import annotations
@@ -36,13 +28,21 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 import time
+from typing import Any
 
 from common.llm.constants import LLM_JSON_MAX_OUTPUT_TOKENS
 from common.llm.providers._shape_error import ProviderResponseShapeError
 from common.llm.providers._truncation import raise_if_truncated
 
 logger = logging.getLogger(__name__)
+
+# Multi-region locations served from the bare aiplatform host. Regional
+# locations (us-central1, ...) and ``global`` resolve correctly via the
+# SDK's own endpoint logic and must NOT be overridden.
+_MULTI_REGION_LOCATIONS = frozenset({"us", "eu"})
+_BARE_VERTEX_BASE_URL = "https://aiplatform.googleapis.com/"
 
 
 # CAURA-651: Gemini (via Vertex) occasionally returns a JSON array at
@@ -67,11 +67,7 @@ class VertexResponseShapeError(ProviderResponseShapeError):
 
 
 class VertexLLMProvider:
-    """LLM provider using Vertex AI Generative Models (Gemini).
-
-    Matches the existing ``_vertex_enrich_sync`` and
-    ``_vertex_contradiction_check_sync`` patterns from the codebase.
-    """
+    """LLM provider using Vertex AI Gemini models via google-genai."""
 
     def __init__(
         self,
@@ -82,6 +78,21 @@ class VertexLLMProvider:
         self._project_id = project_id
         self._location = location
         self._model = model
+        # Built lazily on first call: constructing the provider must not
+        # require ADC (the platform singleton is instantiated at app
+        # startup and in tests, where credentials may be absent), and
+        # google.auth discovery belongs on the call path with the other
+        # network work. Tests inject a fake by assigning ``_client``.
+        # ``Any`` because the concrete ``genai.Client`` type cannot be
+        # imported at module scope (optional-SDK rule — see module
+        # docstring and test_optional_provider_sdks_stay_optional).
+        self._client: Any = None
+        # ``complete_*`` run in ``asyncio.to_thread`` workers, so
+        # concurrent first calls on a shared instance (the platform
+        # singleton) race ``_get_client`` from different threads —
+        # without the lock each would build (and authenticate) its own
+        # client and the losers' HTTP pools would linger until GC.
+        self._client_lock = threading.Lock()
 
     @property
     def provider_name(self) -> str:
@@ -91,25 +102,44 @@ class VertexLLMProvider:
     def model(self) -> str:
         return self._model
 
+    def _get_client(self):
+        # Double-checked locking: the unlocked read keeps the steady
+        # state lock-free; the locked re-check makes concurrent first
+        # calls build exactly one client.
+        if self._client is None:
+            with self._client_lock:
+                if self._client is None:
+                    # Imported lazily so `google-genai` remains an optional
+                    # runtime dependency (same pattern as GeminiLLMProvider).
+                    from google import genai
+                    from google.genai import types
+
+                    client_kwargs: dict = {
+                        "vertexai": True,
+                        "project": self._project_id,
+                        "location": self._location,
+                    }
+                    if self._location in _MULTI_REGION_LOCATIONS:
+                        client_kwargs["http_options"] = types.HttpOptions(
+                            base_url=_BARE_VERTEX_BASE_URL
+                        )
+                    self._client = genai.Client(**client_kwargs)
+        return self._client
+
     def _complete_json_sync(
         self,
         prompt: str,
         *,
         temperature: float = 0.0,
     ) -> dict:
-        """Synchronous JSON completion via Vertex AI GenerativeModel."""
-        # Lazy on purpose — see the module docstring. NOT an oversight
-        # against the top-level-imports rule.
-        from google.cloud import aiplatform
-        from vertexai.generative_models import GenerationConfig, GenerativeModel
-
-        aiplatform.init(project=self._project_id, location=self._location)
-        model = GenerativeModel(self._model)
+        """Synchronous JSON completion via google-genai (Vertex mode)."""
+        from google.genai import types
 
         t0 = time.perf_counter()
-        response = model.generate_content(
-            prompt,
-            generation_config=GenerationConfig(
+        response = self._get_client().models.generate_content(
+            model=self._model,
+            contents=prompt,
+            config=types.GenerateContentConfig(
                 response_mime_type="application/json",
                 temperature=temperature,
                 # Runaway guard: without a ceiling, a looping generation
@@ -152,25 +182,26 @@ class VertexLLMProvider:
         temperature: float = 0.3,
         max_tokens: int = 1000,
     ) -> str:
-        """Synchronous text completion via Vertex AI GenerativeModel."""
-        # Lazy on purpose — see the module docstring.
-        from google.cloud import aiplatform
-        from vertexai.generative_models import GenerationConfig, GenerativeModel
-
-        aiplatform.init(project=self._project_id, location=self._location)
-        model = GenerativeModel(self._model)
+        """Synchronous text completion via google-genai (Vertex mode)."""
+        from google.genai import types
 
         t0 = time.perf_counter()
-        response = model.generate_content(
-            prompt,
-            generation_config=GenerationConfig(
+        response = self._get_client().models.generate_content(
+            model=self._model,
+            contents=prompt,
+            config=types.GenerateContentConfig(
                 temperature=temperature,
                 max_output_tokens=max_tokens,
             ),
         )
         llm_ms = int((time.perf_counter() - t0) * 1000)
         logger.info("Vertex complete_text (%s) took %dms", self._model, llm_ms)
-        return response.text or ""
+        try:
+            return response.text or ""
+        except ValueError as exc:
+            raise ValueError(
+                f"Vertex model {self._model} returned no usable content (possible safety block): {exc}"
+            ) from exc
 
     async def complete_json(
         self,
@@ -184,9 +215,9 @@ class VertexLLMProvider:
         """Async wrapper around synchronous Vertex AI JSON completion.
 
         ``seed`` / ``response_schema`` / ``reasoning_effort`` are
-        accepted-and-ignored (OpenAI
-        structured-output kwargs) — see ``GeminiProvider.complete_json``
-        for why rejecting them silently broke entity extraction (C1).
+        accepted-and-ignored (OpenAI structured-output / reasoning
+        kwargs) — see ``GeminiProvider.complete_json`` for why rejecting
+        them silently broke entity extraction (C1).
         """
         return await asyncio.to_thread(
             self._complete_json_sync, prompt, temperature=temperature

--- a/core-worker/pyproject.toml
+++ b/core-worker/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 # Standalone OSS installs use the in-process bus (no Pub/Sub at all —
 # core-api dispatches directly to the consumer in the same process).
 pubsub = ["google-cloud-pubsub>=2.39.1,<3"]
-vertex = ["google-cloud-aiplatform>=1.163.0,<2"]
+vertex = ["google-genai>=2.17.0"]
 local = ["sentence-transformers>=5.7.0,<6"]
 # Datadog APM tracer (CAURA-0000). Opt-in: installed only in SaaS builds via
 # --build-arg DD_APM_ENABLED=true (--extra datadog); OSS/on-prem carry no

--- a/core-worker/uv.lock
+++ b/core-worker/uv.lock
@@ -301,7 +301,7 @@ test = [
     { name = "pytest-cov" },
 ]
 vertex = [
-    { name = "google-cloud-aiplatform" },
+    { name = "google-genai" },
 ]
 
 [package.metadata]
@@ -310,8 +310,8 @@ requires-dist = [
     { name = "core-worker", extras = ["test", "pubsub"], marker = "extra == 'dev'" },
     { name = "ddtrace", marker = "extra == 'datadog'", specifier = ">=4.12.2" },
     { name = "fastapi", specifier = ">=0.141.1,<1" },
-    { name = "google-cloud-aiplatform", marker = "extra == 'vertex'", specifier = ">=1.163.0,<2" },
     { name = "google-cloud-pubsub", marker = "extra == 'pubsub'", specifier = ">=2.39.1,<3" },
+    { name = "google-genai", marker = "extra == 'vertex'", specifier = ">=2.17.0" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27,<1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.3.0,<3.0" },
@@ -500,34 +500,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -582,15 +582,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -660,75 +651,20 @@ grpc = [
 
 [[package]]
 name = "google-auth"
-version = "2.54.0"
+version = "2.57.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/f6/494e18317546d7def90c957b71d68b025d24f0e22e486c2606bc57765c48/google_auth-2.54.0.tar.gz", hash = "sha256:130f6fd5e3f497fdad897a23ed9489973437edf561238c4b92a4d02c435f8af9", size = 343161, upload-time = "2026-06-12T18:03:17.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/64/55f316b729f92a552d26e00aa3b1542b2e149d0a5efe2842afff0cac7af7/google_auth-2.57.0.tar.gz", hash = "sha256:9b4f96d6a1feb5f7201231f47cfb3de08d8f176f8a61f9e461555116e95a8789", size = 370794, upload-time = "2026-08-25T19:18:26.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/c5/d53bddd2c0949833fcb4ea06f9d5dd1c40575a1a4214cd1021eff57ba301/google_auth-2.54.0-py3-none-any.whl", hash = "sha256:784e9837f92244141250470d47c893df50cbab485ce491aca5e9deb558ad2b48", size = 249878, upload-time = "2026-06-12T18:02:57.58Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f3/8508a702c094af5f6e89773f4dfdeee74913df0f41a02c21b5e7dc3d75cd/google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59", size = 259728, upload-time = "2026-08-24T21:55:08.449Z" },
 ]
 
 [package.optional-dependencies]
 requests = [
     { name = "requests" },
-]
-
-[[package]]
-name = "google-cloud-aiplatform"
-version = "1.163.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "docstring-parser" },
-    { name = "google-api-core", extra = ["grpc"] },
-    { name = "google-auth" },
-    { name = "google-cloud-bigquery" },
-    { name = "google-cloud-resource-manager" },
-    { name = "google-cloud-storage" },
-    { name = "google-genai" },
-    { name = "packaging" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/ea/257c5fc5d04bff5b237a10761c89564828e98c2c80aedb1531465c80bedb/google_cloud_aiplatform-1.163.0.tar.gz", hash = "sha256:b570d22b145504e66f3f50f4bdeeae3c818ba46f330276566e80a42937ff53ef", size = 11235221, upload-time = "2026-07-28T17:34:06.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/4b/8e45c1b9e404d42c66bf231d62eae5236855fa428a0d5c6d02ac72dc4514/google_cloud_aiplatform-1.163.0-py2.py3-none-any.whl", hash = "sha256:23855d261aadcf949fa6102f94d0d0dbd9af879dc4e3f651e7f4e27296af8cca", size = 9401645, upload-time = "2026-07-28T17:34:02.71Z" },
-]
-
-[[package]]
-name = "google-cloud-bigquery"
-version = "3.41.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", extra = ["grpc"] },
-    { name = "google-auth" },
-    { name = "google-cloud-core" },
-    { name = "google-resumable-media" },
-    { name = "packaging" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/13/6515c7aab55a4a0cf708ffd309fb9af5bab54c13e32dc22c5acd6497193c/google_cloud_bigquery-3.41.0.tar.gz", hash = "sha256:2217e488b47ed576360c9b2cc07d59d883a54b83167c0ef37f915c26b01a06fe", size = 513434, upload-time = "2026-03-30T22:50:55.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/33/1d3902efadef9194566d499d61507e1f038454e0b55499d2d7f8ab2a4fee/google_cloud_bigquery-3.41.0-py3-none-any.whl", hash = "sha256:2a5b5a737b401cbd824a6e5eac7554100b878668d908e6548836b5d8aaa4dcaa", size = 262343, upload-time = "2026-03-30T22:48:45.444Z" },
-]
-
-[[package]]
-name = "google-cloud-core"
-version = "2.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core" },
-    { name = "google-auth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
 ]
 
 [[package]]
@@ -752,65 +688,8 @@ wheels = [
 ]
 
 [[package]]
-name = "google-cloud-resource-manager"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", extra = ["grpc"] },
-    { name = "google-auth" },
-    { name = "grpc-google-iam-v1" },
-    { name = "grpcio" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/1a/13060cabf553d52d151d2afc26b39561e82853380d499dd525a0d422d9f0/google_cloud_resource_manager-1.17.0.tar.gz", hash = "sha256:0f486b62e2c58ff992a3a50fa0f4a96eef7750aa6c971bb373398ccb91828660", size = 464971, upload-time = "2026-03-26T22:17:29.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/f7/661d7a9023e877a226b5683429c3662f75a29ef45cb1464cf39adb689218/google_cloud_resource_manager-1.17.0-py3-none-any.whl", hash = "sha256:e479baf4b014a57f298e01b8279e3290b032e3476d69c8e5e1427af8f82739a5", size = 404403, upload-time = "2026-03-26T22:15:26.57Z" },
-]
-
-[[package]]
-name = "google-cloud-storage"
-version = "3.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core" },
-    { name = "google-auth" },
-    { name = "google-cloud-core" },
-    { name = "google-crc32c" },
-    { name = "google-resumable-media" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/58/72/86f94e1639a8bcd9d33e8e01b49afcaa1c3a13bda7683c681717e0901e15/google_cloud_storage-3.12.0.tar.gz", hash = "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be", size = 17338620, upload-time = "2026-06-12T18:03:29.215Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl", hash = "sha256:3880773754ddf7c27567b04e2a4d193950b6b99429f37b9097d873686e95b09c", size = 340605, upload-time = "2026-06-12T18:03:12.677Z" },
-]
-
-[[package]]
-name = "google-crc32c"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
-    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
-    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
-    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
-    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
-    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
-    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
-]
-
-[[package]]
 name = "google-genai"
-version = "2.8.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -824,21 +703,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/52/0244e310812f3063d09d60b30ae29ab7df9343bd005744cd5eeaa6ba39b4/google_genai-2.8.0.tar.gz", hash = "sha256:37a9b3cb127d763e7f4ca47452ae3562c87728773bd1b149f7b559c239da2bc1", size = 564955, upload-time = "2026-06-03T22:55:38.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/a7/a45f64f22ab9302b55fcbeb32acb6f313690a7748629b01e451aad1817a3/google_genai-2.21.0.tar.gz", hash = "sha256:0ecc11c6a5b9f5e3cc58e77ae5fead00c6719f8a1b2b654b803f514a9a6b64c0", size = 677301, upload-time = "2026-08-31T21:49:14.508Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/de/747ad1aa49e902da9a4699081c282a1ed8ceed3b4d295fd99a6d286e09e4/google_genai-2.8.0-py3-none-any.whl", hash = "sha256:4da0a223a100f4b37f609a68b835e3326ab0fa313314dc0fd9d34e76ee293844", size = 832497, upload-time = "2026-06-03T22:55:36.598Z" },
-]
-
-[[package]]
-name = "google-resumable-media"
-version = "2.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-crc32c" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d7/c2419dd5fedd5803ce09810e4e39561a0a13a960b3f48d2581c12e42af3e/google_genai-2.21.0-py3-none-any.whl", hash = "sha256:36b575034be46a03acd603a852e22a6359f2cdd6b26bb1d65d9b7e0cc7ab3648", size = 1080223, upload-time = "2026-08-31T21:49:12.699Z" },
 ]
 
 [[package]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,12 @@ alembic>=1.14,<2
 pydantic>=2.0,<3
 pydantic-settings>=2.15.0,<3
 google-cloud-aiplatform>=2.0.1,<3
-google-genai>=2.12.1
+# Floor matches core-api/pyproject.toml and core-worker's ``vertex``
+# extra so this local-dev install path resolves the same SDK range the
+# services do. (Not a feature floor: ``HttpOptions(base_url=...)``,
+# which VertexLLMProvider's multi-region handling uses, predates even
+# 1.74.0 — verified by constructing it there.)
+google-genai>=2.17.0
 # Used directly by core_api.clients.identity_token (Cloud Run ID-token
 # fetch) — explicit here instead of relying on google-cloud-aiplatform's
 # transitive pull, so a future GCP-SDK cleanup can't silently break it.

--- a/tests/test_llm_json_truncation.py
+++ b/tests/test_llm_json_truncation.py
@@ -112,67 +112,117 @@ class TestRaiseIfTruncated:
 # ---------------------------------------------------------------------------
 
 
-class _FakeGenerativeModel:
-    """Captures the GenerationConfig and returns a canned response."""
-
-    last_config = None
-    canned_response = None
-
-    def __init__(self, model_name):
-        self.model_name = model_name
-
-    def generate_content(self, prompt, generation_config=None):
-        type(self).last_config = generation_config
-        return type(self).canned_response
-
-
-@pytest.fixture()
-def _patched_vertex(monkeypatch):
-    import vertexai.generative_models as gm
-
-    monkeypatch.setattr(gm, "GenerativeModel", _FakeGenerativeModel)
-    # aiplatform.init does network-free client setup, but stub it anyway
-    # so tests never touch ADC.
-    from google.cloud import aiplatform
-
-    monkeypatch.setattr(aiplatform, "init", lambda **kw: None)
-    _FakeGenerativeModel.last_config = None
-    _FakeGenerativeModel.canned_response = None
-    return _FakeGenerativeModel
-
-
 class TestVertexCompleteJson:
-    def _provider(self):
-        return VertexLLMProvider(
-            project_id="test-proj", location="us-central1", model="gemini-2.5-flash-lite"
+    def _provider(self, location="us-central1"):
+        p = VertexLLMProvider(
+            project_id="test-proj", location=location, model="gemini-2.5-flash-lite"
+        )
+        # Inject the fake client the same way the Gemini tests do —
+        # the provider builds its real google-genai client lazily, so
+        # tests never touch ADC.
+        p._client = SimpleNamespace(models=_FakeGenaiModels())
+        return p
+
+    @pytest.mark.asyncio
+    async def test_happy_path_parses_and_caps_output(self):
+        p = self._provider()
+        p._client.models.canned_response = _response(json.dumps({"ok": True}))
+        result = await p.complete_json("prompt")
+        assert result == {"ok": True}
+        assert (
+            p._client.models.last_config.max_output_tokens
+            == LLM_JSON_MAX_OUTPUT_TOKENS
         )
 
     @pytest.mark.asyncio
-    async def test_happy_path_parses_and_caps_output(self, _patched_vertex):
-        _patched_vertex.canned_response = _response(json.dumps({"ok": True}))
-        result = await self._provider().complete_json("prompt")
-        assert result == {"ok": True}
-        cfg = _patched_vertex.last_config
-        # vertexai's GenerationConfig keeps kwargs on a private raw config;
-        # to_dict() is the stable public view across SDK versions.
-        cfg_dict = cfg.to_dict() if hasattr(cfg, "to_dict") else vars(cfg)
-        assert int(cfg_dict.get("max_output_tokens", 0)) == LLM_JSON_MAX_OUTPUT_TOKENS
-
-    @pytest.mark.asyncio
-    async def test_truncated_response_raises_clear_error(self, _patched_vertex):
-        _patched_vertex.canned_response = _response(
+    async def test_truncated_response_raises_clear_error(self):
+        p = self._provider()
+        p._client.models.canned_response = _response(
             '{"entities": [{"name": "tru', _FinishReason.MAX_TOKENS
         )
         with pytest.raises(ValueError, match="truncated at max_output_tokens"):
-            await self._provider().complete_json("prompt")
+            await p.complete_json("prompt")
 
     @pytest.mark.asyncio
-    async def test_untruncated_bad_json_still_json_error(self, _patched_vertex):
+    async def test_untruncated_bad_json_still_json_error(self):
         # A genuine parse failure (finish_reason=STOP) must keep raising
         # JSONDecodeError — the truncation guard must not swallow it.
-        _patched_vertex.canned_response = _response("not-json")
+        p = self._provider()
+        p._client.models.canned_response = _response("not-json")
         with pytest.raises(json.JSONDecodeError):
-            await self._provider().complete_json("prompt")
+            await p.complete_json("prompt")
+
+    def test_multi_region_location_pins_bare_host(self, monkeypatch):
+        # ``us``/``eu`` are served from the bare aiplatform host; the SDK's
+        # own endpoint logic builds ``us-aiplatform.googleapis.com``, which
+        # the API rejects as an invalid hostname. The provider must pin
+        # base_url for multi-regions and must NOT for global/regional.
+        captured = {}
+
+        class _FakeClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        import google.genai as genai_mod
+
+        monkeypatch.setattr(genai_mod, "Client", _FakeClient)
+        p = VertexLLMProvider(project_id="p", location="us", model="m")
+        p._get_client()
+        assert captured["vertexai"] is True and captured["location"] == "us"
+        assert captured["http_options"].base_url == "https://aiplatform.googleapis.com/"
+
+        captured.clear()
+        p2 = VertexLLMProvider(project_id="p", location="global", model="m")
+        p2._get_client()
+        assert "http_options" not in captured
+
+    def test_client_is_lazy_and_cached(self, monkeypatch):
+        calls = []
+
+        class _FakeClient:
+            def __init__(self, **kwargs):
+                calls.append(kwargs)
+
+        import google.genai as genai_mod
+
+        monkeypatch.setattr(genai_mod, "Client", _FakeClient)
+        p = VertexLLMProvider(project_id="p", location="global", model="m")
+        assert calls == []  # construction must not build the client
+        p._get_client()
+        p._get_client()
+        assert len(calls) == 1  # built once, reused
+
+    def test_concurrent_first_calls_build_one_client(self, monkeypatch):
+        # ``complete_*`` run in asyncio.to_thread workers, so first calls
+        # can race ``_get_client`` from several threads on the shared
+        # platform singleton. The lock must collapse that to exactly one
+        # client build.
+        import threading as _threading
+        import time as _time
+
+        calls = []
+        start = _threading.Barrier(8)
+
+        class _SlowFakeClient:
+            def __init__(self, **kwargs):
+                _time.sleep(0.05)  # widen the race window
+                calls.append(kwargs)
+
+        import google.genai as genai_mod
+
+        monkeypatch.setattr(genai_mod, "Client", _SlowFakeClient)
+        p = VertexLLMProvider(project_id="p", location="global", model="m")
+
+        def _worker():
+            start.wait()
+            p._get_client()
+
+        threads = [_threading.Thread(target=_worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_optional_provider_sdks_stay_optional.py
+++ b/tests/test_optional_provider_sdks_stay_optional.py
@@ -4,10 +4,10 @@
 against this repo's top-level-imports rule. That is deliberate, and it is
 load-bearing rather than stylistic:
 
-* ``google-cloud-aiplatform`` is an EXTRA for core-worker
-  (``vertex = [...]``), and only a hard dependency for core-api.
-* ``google-genai`` does not appear in core-worker's ``pyproject.toml`` at
-  ALL — not required, not optional. core-worker never has it.
+* ``google-genai`` (which now backs BOTH providers — vertex.py in ADC
+  mode, gemini.py in API-key mode) is an EXTRA for core-worker
+  (``vertex = [...]``), and only a hard dependency for core-api. An
+  OSS / on-prem core-worker built without the extra has neither.
 
 So hoisting either import to module scope makes that provider module
 unimportable in core-worker, and ``common/llm/_platform.py`` imports
@@ -33,8 +33,8 @@ CASES = [
     pytest.param(
         "common.llm.providers.vertex",
         "VertexLLMProvider",
-        ("vertexai", "google.cloud.aiplatform"),
-        id="vertex-without-aiplatform",
+        ("google.genai",),
+        id="vertex-without-genai",
     ),
     pytest.param(
         "common.llm.providers.gemini",


### PR DESCRIPTION
## Why

The legacy `vertexai.generative_models` SDK (deprecated June 2025, removal date June 2026) structurally cannot reach any Gemini 3 model:

1. Its `validate_region` allowlist predates the `us`/`eu` **multi-regions** — `aiplatform.init(location="us")` raises `ValueError` before any request is built.
2. The Gemini 3.x **-lite** models are served *only* on those multi-regions (verified live 2026-08-30/31: `gemini-3.5-flash-lite` and `gemini-3.1-flash-lite` → 200 on `locations/us` via the bare `aiplatform.googleapis.com` host; 404 on `global` and on regional `us-central1`).
3. Multi-regions use the **bare host** — the SDK-built `us-aiplatform.googleapis.com` is rejected with `400 Invalid hostname`.

## What

Rewrites `VertexLLMProvider` on **google-genai** (`vertexai=True`, ADC — mirroring `GeminiLLMProvider`, which already uses the same SDK in API-key mode), with a `base_url` pin for `location ∈ {us, eu}` and untouched endpoint logic for `global`/regional.

**Byte-compatible public surface**: class name, constructor, `provider_name`, `complete_json`/`complete_text` signatures, `VertexResponseShapeError`, the CAURA-651 shape guard, the max-output-tokens truncation guard (#1009), and the exact log lines dashboards key on. The client is built **lazily** so construction (startup, tests) needs no ADC.

**Deps**: core-api already has google-genai; core-worker's `vertex` extra now points at google-genai instead of google-cloud-aiplatform (lock regenerated — the aiplatform/storage stack drops out of the worker image, net −133 lock lines).

## Behavior change for current prod config: none

Same env config (`gemini-2.5-flash-lite` @ `us-central1`), same request parameters, same billing SKU — verified live with the migrated provider (token-injected ADC):

| location / model | result |
|---|---|
| `us-central1` / gemini-2.5-flash-lite (current prod) | ✅ 1341ms, valid JSON |
| `global` / gemini-2.5-flash-lite | ✅ 843ms |
| **`us` / gemini-3.1-flash-lite** (upgrade target) | ✅ 1454ms, valid JSON |
| `complete_text` on us/3.1-flash-lite | ✅ |

After this merges, moving any deployment to Gemini 3.x-lite is a pure config change (`PLATFORM_LLM_MODEL` + `PLATFORM_LLM_GCP_LOCATION=us`).

## Testing

- `test_llm_json_truncation.py` rewritten for the genai client shape + 2 new tests: multi-region base_url pinning (and its absence for global) and lazy/cached client construction.
- `test_optional_provider_sdks_stay_optional.py`: vertex case now hides `google.genai` (the module must import without the SDK — worker installs it only via the `vertex` extra).
- Full affected set green: 144 passed (truncation, optional-SDK, gemini, platform-providers, provider-protocols). Ruff clean.
- Note: `gemini-3.1-flash-lite` showed **zero thinking tokens** on JSON calls (usageMetadata-verified), so no thinking config is plumbed; revisit if a thinking-default model is adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)