### PR TITLE
fix(core-api): refresh editable lock version

### DIFF
--- a/core-api/uv.lock
+++ b/core-api/uv.lock
@@ -375,7 +375,7 @@ wheels = [
 
 [[package]]
 name = "core-api"
-version = "2.27.0"
+version = "2.41.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- Refresh the editable core-api entry in core-api/uv.lock from 2.27.0 to the current project version, 2.41.1.
- Change no dependency package, resolved version, source, marker, or artifact.
- Leave core-operations untouched as the control.

## Cause and measured scope

This repository has four independent service locks, not a uv workspace. Release Please manages the three service pyproject versions but no lock entries. OSS PR 1200 supplied direct recurrence evidence while this work was in progress: it moved the three project versions from 2.41.0 to 2.41.1 and changed none of the locks.

Exact uv 0.9.26 showed that core-api staleness is only the editable self-version. The committed diff is one deletion and one insertion. core-operations remains 1.0.0 in both pyproject.toml and uv.lock and passes the same lock check because it is absent from the release extra-files list. That control pairing isolates the release configuration as the cause.

## Validation

- Exact uv 0.9.26: uv lock --check passes for core-api; untouched core-operations also passes.
- Current CI install path, with UV_FROZEN=1: editable install of core-storage-api dev, core-api dev, core-operations dev, and core-worker dev succeeded.
- The current uv pip install path does not consume these independent locks. It validates installed compatibility; uv lock --check independently validates lock freshness.
- Root/API suite: 5,832 passed, 4 skipped, 1 expected failure, 16 benchmark tests deselected.
- Coverage floors: core-api 85%; core-storage-api 67%.
- Ruff check and Ruff format --check: all exact CI scopes clean.
- Mypy: all six CI scopes clean.
- Exact uv 0.9.26 builds: all four packages succeeded.
- Legacy-name ratchet: No new lines.
- Do-not-touch sentinel: All 46 protected strings survive.

## Package AQ

This PR repairs one of three stale locks. It does not unblock AQ alone. The three lock PRs restore current locked-install viability; the separate release configuration PR prevents the next release from recreating the block. AQ is unblocked only after that set is merged.