### PR TITLE
fix(core-worker): refresh editable lock version

### DIFF
--- a/core-worker/uv.lock
+++ b/core-worker/uv.lock
@@ -260,7 +260,7 @@ wheels = [
 
 [[package]]
 name = "core-worker"
-version = "2.27.0"
+version = "2.41.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary

- Refresh the editable core-worker entry in core-worker/uv.lock from 2.27.0 to the current project version, 2.41.1.
- Change no dependency package, resolved version, source, marker, or artifact.
- Leave core-operations untouched as the control.

## Cause and measured scope

This repository has four independent service locks, not a uv workspace. Release Please manages the three service pyproject versions but no lock entries. OSS PR 1200 supplied direct recurrence evidence while this work was in progress: it moved the three project versions from 2.41.0 to 2.41.1 and changed none of the locks.

Exact uv 0.9.26 found no package or version movement for core-worker. A normal relock also proposed ten equivalent cuda-toolkit 13.0.2 optional-dependency marker normalizations. Those unrelated marker rewrites are excluded. Updating only the editable self-version passes uv lock --check, so the committed diff remains one deletion and one insertion.

core-operations remains 1.0.0 in both pyproject.toml and uv.lock and passes the same lock check because it is absent from the release extra-files list. That control pairing isolates the release configuration as the cause.

## Validation

- Exact uv 0.9.26: uv lock --check passes for core-worker; untouched core-operations also passes.
- Current CI install path, with UV_FROZEN=1: editable install of core-storage-api dev, core-api dev, core-operations dev, and core-worker dev succeeded.
- The current uv pip install path does not consume these independent locks. It validates installed compatibility; uv lock --check independently validates lock freshness.
- Full core-worker suite: 80 passed; required 50% coverage floor reached at 71.43%.
- Root/API suite: 5,832 passed, 4 skipped, 1 expected failure, 16 benchmark tests deselected.
- Ruff check and Ruff format --check: all exact CI scopes clean.
- Mypy: all six CI scopes clean.
- Exact uv 0.9.26 builds: all four packages succeeded.
- Legacy-name ratchet: No new lines.
- Do-not-touch sentinel: All 46 protected strings survive.

## Package AQ

This PR repairs one of three stale locks. It does not unblock AQ alone. The three lock PRs restore current locked-install viability; the separate release configuration PR prevents the next release from recreating the block. AQ is unblocked only after that set is merged.