### PR TITLE
fix(release): keep service lock versions in sync

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,13 +25,28 @@
         },
         {
           "type": "toml",
+          "path": "core-api/uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='core-api')].version"
+        },
+        {
+          "type": "toml",
           "path": "core-worker/pyproject.toml",
           "jsonpath": "$.project.version"
         },
         {
           "type": "toml",
+          "path": "core-worker/uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='core-worker')].version"
+        },
+        {
+          "type": "toml",
           "path": "core-storage-api/pyproject.toml",
           "jsonpath": "$.project.version"
+        },
+        {
+          "type": "toml",
+          "path": "core-storage-api/uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='core-storage-api')].version"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Add each independently locked service uv.lock to the existing Release Please TOML extra-files list, targeted at only that service editable package version. This PR deliberately contains no lock refresh; those facts remain isolated in OSS PR 1210, OSS PR 1211, and OSS PR 1212.

## Root cause and recurrence evidence

Release Please already updates the core-api, core-worker, and core-storage-api project versions, but not their lock entries. OSS PR 1200 demonstrated the failure again while this work was in progress: it bumped all three pyproject versions from 2.41.0 to 2.41.1 and left all three locks at 2.27.0.

core-operations is the control: its project and editable lock versions are both 1.0.0, exact uv 0.9.26 accepts its lock, and it is the only service omitted from the release extra-files list. That measured pairing identifies version automation, rather than dependency resolution, as the cause.

## Recommendation and alternatives

Recommend the targeted Release Please TOML updaters in this PR.

- Managed lock entries: low cost. Fifteen static config lines cause each release PR to update exactly one editable version line per service alongside its pyproject version. No resolver or write-back job is introduced.
- Relock automation: materially higher cost. It needs an exact uv pin, write credentials, commit-back coordination, and a policy for dependency or marker churn. The core-worker diagnostic already shows why: a normal uv 0.9.26 relock also normalizes ten unrelated cuda-toolkit markers.
- Stop recording self-version: high and uncertain design cost. The field is generated editable-package metadata in four independent projects; removing it would require proving a supported uv mechanism or changing package or workspace topology.
- Accept recurring drift: zero implementation cost, but it deliberately recreates locked-install failures after every backend release and repeatedly blocks package AQ.

The targeted updater is the smallest durable change and keeps release diffs reviewable.

## Exact updater proof

A local simulation with the repository-pinned Release Please 17.6.0 and a hypothetical 2.41.2 release changed exactly six lines with unchanged line counts:

- three project.version lines, one in each managed pyproject.toml;
- three editable package version lines, one in each corresponding uv.lock;
- no dependency, marker, source, or artifact content.

## Validation

- Root/API suite: 5,832 passed, 4 skipped, 1 expected failure, 16 benchmark tests deselected.
- Full core-storage-api suite: 309 passed.
- Full core-worker suite: 80 passed; 71.43% coverage.
- Untouched core-operations control suite: 50 passed; 81.67% coverage.
- Coverage floors: core-api 85%; core-storage-api 67%.
- Ruff check and Ruff format --check: all exact CI scopes clean.
- Mypy: all six CI scopes clean.
- Exact uv 0.9.26 builds: all four packages succeeded.
- Legacy-name ratchet: No new lines.
- Do-not-touch sentinel: All 46 protected strings survive.

The current CI uv pip install path does not consume the independent service locks. It validates installed compatibility; exact uv lock --check on the lock PRs independently validates freshness.

## Package AQ

AQ remains blocked until OSS PR 1210, OSS PR 1211, OSS PR 1212, and this systemic PR land. The three lock PRs make the current locks viable; this PR prevents the next Release Please run from re-staling them. After that set is merged, the uv sync --locked CI conversion can proceed.