### PR TITLE
test(search): stop leaking the search-dispatch flag out of the equivalence test

### DIFF
--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -16,6 +16,45 @@ FLEET_ID = "test-fleet"
 AGENT_ID = "test-agent"
 
 
+@pytest.fixture(autouse=True)
+def _search_dispatch_flag_must_be_restored():
+    """Fail any test in this module that leaks ``_USE_PIPELINE_SEARCH``.
+
+    This is the file that manipulates the flag — four places, one of which
+    forgot to put it back and left it ``False`` for the remainder of the pytest
+    session, silently moving every later test onto the DEPRECATED
+    ``_search_memories_legacy`` path while CI believed it was covering the
+    production pipeline. Nothing failed, because almost nothing asserts which
+    path served a search; the coverage simply stopped being what it claimed.
+
+    It repairs AND reports, and the reporting half is the point. A fixture that
+    only restored would make the next leak invisible in exactly the way the
+    first one was — the suite would stay green and the offending test would
+    never say anything. Restoring first means one leak cannot cascade; asserting
+    after means it still gets attributed to the test that caused it.
+
+    Autouse so it does not depend on being remembered, and module-scoped rather
+    than in the root conftest because this is the only module that touches the
+    flag — elsewhere it would guard against nothing.
+    """
+    from core_api.services import memory_service
+
+    original = memory_service._USE_PIPELINE_SEARCH
+    try:
+        yield
+    finally:
+        leaked = memory_service._USE_PIPELINE_SEARCH
+        # Repair before asserting, so a failure here costs one test rather than
+        # every test that follows it.
+        memory_service._USE_PIPELINE_SEARCH = original
+        assert leaked == original, (
+            f"this test left memory_service._USE_PIPELINE_SEARCH={leaked} "
+            f"(expected {original}). Use monkeypatch.setattr or try/finally — "
+            "leaking it puts the rest of the session on the deprecated legacy "
+            "search path."
+        )
+
+
 _SEED_CONTENTS = [
     "The quick brown fox jumped over the lazy dog on a sunny afternoon in the park near downtown.",
     "Alice prefers dark roast coffee every morning before her standup meeting at nine o'clock sharp.",
@@ -578,7 +617,6 @@ async def test_legacy_search_returns_results():
 @pytest.mark.asyncio
 async def test_search_pipeline_equivalence():
     """Pipeline and legacy paths produce equivalent results (order, scores to 4 decimals, entity links)."""
-    from core_api.services import memory_service
     from core_api.services.memory_service import (
         _search_memories_legacy,
         _search_memories_pipeline,
@@ -598,12 +636,15 @@ async def test_search_pipeline_equivalence():
         "recall_boost": False,
     }
 
-    memory_service._USE_PIPELINE_SEARCH = False
+    # NO ``_USE_PIPELINE_SEARCH`` juggling here. The two paths are called
+    # DIRECTLY, and the flag is read in exactly one place — ``search_memories``
+    # (``memory_service.py``), the dispatcher neither of these calls goes
+    # through. So setting it around them never selected anything; it only
+    # leaked. The three assignments this replaces left the global ``False`` for
+    # the remainder of the session, which silently moved every later test onto
+    # the deprecated legacy path.
     legacy_results = await _search_memories_legacy(**kwargs)
-
-    memory_service._USE_PIPELINE_SEARCH = True
     pipeline_results = await _search_memories_pipeline(**kwargs)
-    memory_service._USE_PIPELINE_SEARCH = False
 
     assert len(legacy_results) == len(pipeline_results), (
         f"Result count mismatch: legacy={len(legacy_results)}, pipeline={len(pipeline_results)}"


### PR DESCRIPTION
Found while working the REST/MCP parity smoke queue: an item-1 test passed in
isolation and failed in a full run, because it was being served by a different
search path than the one it was written against.

## The bug

`test_search_pipeline_equivalence` set `memory_service._USE_PIPELINE_SEARCH =
False` and never put it back — no `try/finally`, no `monkeypatch`. Production
default is `True` (`memory_service.py:131`).

The global stayed `False` for the remainder of the pytest session, so every
test collected afterwards ran its searches through the **deprecated**
`_search_memories_legacy` path while CI believed it was covering the production
pipeline.

Nothing failed. Almost nothing asserts *which* path served a search, so the
suite stayed green and the coverage quietly stopped being what it claimed.

## Blast radius, measured

98.6% of the suite — 5,755 of 5,834 tests — is collected after this module.

Rather than infer from that, I counted actual dispatches inside
`search_memories` across a full run:

| | pipeline | legacy |
|---|---|---|
| **before** | 19 | **96** |
| **after** | 100 | 15 |

81 of 115 search dispatches were being served by the wrong path. The 15
remaining are the deliberately-legacy tests.

## The fix

**The three assignments were also dead.** `_USE_PIPELINE_SEARCH` is read in
exactly one place — the `search_memories` dispatcher — and this test calls
`_search_memories_legacy` and `_search_memories_pipeline` **directly**, so
setting the flag around them never selected anything. It only leaked.

So they are removed rather than wrapped in `try/finally`: there is nothing here
for a guard to protect, and keeping them would imply the flag governs these
calls when it does not.

**Plus an autouse fixture** as the backstop for the other three sites in this
file. Those save and restore correctly today, but they do it by each author
remembering — the property that already failed once here, and that fails
silently.

The fixture **repairs and then reports**, and the reporting half is the point.
It restores first so one leak cannot cascade, then fails the offending test by
name:

```
AssertionError: this test left memory_service._USE_PIPELINE_SEARCH=False
(expected True). Use monkeypatch.setattr or try/finally — leaking it puts the
rest of the session on the deprecated legacy search path.
```

A fixture that only restored would have been the wrong shape: it would make the
next leak invisible in exactly the way this one was.

## Verification

Both directions, both mechanisms:

- **Fix works** — a guard assertion placed immediately after the offending test
  fails before the change, passes after. (Not kept in the final diff: with the
  fixture present it can no longer fail, and a test that cannot fail is the
  same anti-pattern this PR is about.)
- **Fixture works** — reintroducing the leak with the fixture in place errors
  `test_search_pipeline_equivalence` with the message above.
- Each fix was also confirmed **independently sufficient**: fixture alone stops
  the leak, assignment-removal alone stops the leak.

## Triage

Full suite green: **5,847 passed**, 4 skipped, 1 xfailed. Nothing was passing
only because it ran on the legacy path.

That is worth stating plainly rather than treating as a clean bill of health:
this change alters **which code is covered**, not which tests pass. That is
exactly why it went unnoticed, and why the fixture now makes a recurrence
loud instead of silent.

`ruff check`, `ruff format --check`, `mypy`, and the broker OpenAPI check are
all clean.
