### PR TITLE
fix(storage): scope the conflict record's memory refs to the owning tenant

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1092,6 +1092,31 @@ async def record_memory_conflict(request: Request) -> dict:
     """A55 — persist a memory_conflicts classification record (additive; the
     memory-row status/supersedes effect is applied separately)."""
     body: dict = await request.json()
+    # Both referenced memories must belong to the tenant the record is filed
+    # under. ``memory_conflicts.{new,old}_memory_id`` have FKs to ``memories.id``
+    # but there is NO cross-column tenant constraint, so an insert naming
+    # another tenant's memory UUID satisfies the FK and lands. Worse, the
+    # unguarded route also answered "does this id exist?" for any id in the
+    # system: a real UUID returned 200 while an unknown one raised
+    # ForeignKeyViolationError, which no handler catches, so it came back as a
+    # 500. Identical defect and identical fix to ``POST /fleet/commands``.
+    #
+    # ``_require`` rather than ``body.get``: a missing tenant would otherwise
+    # skip the check entirely, and it is what makes this binding legible to the
+    # tenant-scope gate's AST pass.
+    tenant_id = _require(body, "tenant_id")
+    for key in ("new_memory_id", "old_memory_id"):
+        raw = _require(body, key)
+        try:
+            memory = await _svc.memory_get_by_id_for_tenant(UUID(str(raw)), tenant_id)
+        except (ValueError, TypeError):
+            # Not a UUID at all. Same answer as "not yours" — see below.
+            memory = None
+        if memory is None:
+            # 404 for "no such memory" and "not your memory" alike, so the
+            # route cannot be used to test whether a UUID exists. Mirrors the
+            # fleet-command guard and audit finding #22.
+            raise HTTPException(status_code=404, detail="Memory not found")
     try:
         row = await _svc.memory_conflict_record(body)
     except ValueError as exc:

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -111,7 +111,7 @@
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
       "category": "opaque-body-write",
-      "note": "Verified: payload['tenant_id'] is assigned directly to the MemoryConflict row."
+      "note": "Verified: payload['tenant_id'] is assigned directly to the MemoryConflict row, after the route confirms BOTH new_memory_id and old_memory_id belong to that tenant. The FKs to memories.id carry no cross-column tenant constraint, so that route guard is the whole of the binding for the referenced rows -- same shape as method:fleet_add_command."
     },
     {
       "id": "method:memory_count_all",
@@ -389,13 +389,6 @@
       "evidence": "no binding tenant read from the request",
       "category": "opaque-body-write",
       "note": "Verified: every body item carries tenant_id; memory_add_all rejects mixed-tenant batches and scopes recovery."
-    },
-    {
-      "id": "route:POST /api/v1/storage/memories/conflicts",
-      "verdict": "NONE",
-      "evidence": "no binding tenant read from the request",
-      "category": "opaque-body-write",
-      "note": "Verified: body tenant_id is assigned directly to the MemoryConflict row by memory_conflict_record."
     },
     {
       "id": "route:POST /api/v1/storage/memories/dedup-reviews",

--- a/core-storage-api/tests/test_memory_conflict_tenant_scope.py
+++ b/core-storage-api/tests/test_memory_conflict_tenant_scope.py
@@ -1,0 +1,137 @@
+"""Tenant binding for ``POST /memories/conflicts``.
+
+``memory_conflicts.{new,old}_memory_id`` are FKs to ``memories.id`` with no
+cross-column tenant constraint, so before the route guard an insert naming
+another tenant's memory satisfied the FK and landed — and an unknown UUID
+raised ForeignKeyViolationError as an unhandled 500 while a real one returned
+200, which made the route an existence oracle for memory ids.
+
+Both cases must now be an indistinguishable 404, the same way
+``POST /fleet/commands`` treats a foreign node id.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX, _memory_payload
+
+pytestmark = pytest.mark.asyncio
+
+
+def _conflict_payload(tenant_id: str, new_memory_id: str, old_memory_id: str) -> dict:
+    return {
+        "tenant_id": tenant_id,
+        "new_memory_id": new_memory_id,
+        "old_memory_id": old_memory_id,
+        "relationship": "exact_value",
+        "diagnosis": "temporal_change",
+        "evidence_strength": "explicit",
+        "action": "supersede",
+    }
+
+
+async def _make_memory(client: AsyncClient, tenant_id: str, fleet_id: str | None) -> str:
+    response = await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+async def test_foreign_memory_id_is_404_not_a_recorded_conflict(
+    client: AsyncClient, tenant_id: str, fleet_id: str
+) -> None:
+    """A memory owned by another tenant must not be referenceable."""
+    mine = await _make_memory(client, tenant_id, fleet_id)
+    theirs = await _make_memory(client, f"other-{uuid.uuid4()}", None)
+
+    response = await client.post(
+        f"{PREFIX}/memories/conflicts",
+        json=_conflict_payload(tenant_id, mine, theirs),
+    )
+
+    assert response.status_code == 404, response.text
+
+
+async def test_foreign_memory_id_in_the_new_slot_is_also_404(
+    client: AsyncClient, tenant_id: str, fleet_id: str
+) -> None:
+    """Both id slots are checked, not just ``old_memory_id``."""
+    mine = await _make_memory(client, tenant_id, fleet_id)
+    theirs = await _make_memory(client, f"other-{uuid.uuid4()}", None)
+
+    response = await client.post(
+        f"{PREFIX}/memories/conflicts",
+        json=_conflict_payload(tenant_id, theirs, mine),
+    )
+
+    assert response.status_code == 404, response.text
+
+
+async def test_unknown_memory_id_is_404_not_a_500(client: AsyncClient, tenant_id: str, fleet_id: str) -> None:
+    """An id that exists nowhere must not be distinguishable from one that
+    exists in another tenant — before the guard this was an unhandled 500 from
+    the FK violation, which is what made the route an existence oracle."""
+    mine = await _make_memory(client, tenant_id, fleet_id)
+
+    response = await client.post(
+        f"{PREFIX}/memories/conflicts",
+        json=_conflict_payload(tenant_id, mine, str(uuid.uuid4())),
+    )
+
+    assert response.status_code == 404, response.text
+
+
+async def test_unknown_and_foreign_are_indistinguishable(
+    client: AsyncClient, tenant_id: str, fleet_id: str
+) -> None:
+    """The oracle is closed only if the two answers are byte-identical."""
+    mine = await _make_memory(client, tenant_id, fleet_id)
+    theirs = await _make_memory(client, f"other-{uuid.uuid4()}", None)
+
+    foreign = await client.post(
+        f"{PREFIX}/memories/conflicts",
+        json=_conflict_payload(tenant_id, mine, theirs),
+    )
+    unknown = await client.post(
+        f"{PREFIX}/memories/conflicts",
+        json=_conflict_payload(tenant_id, mine, str(uuid.uuid4())),
+    )
+
+    assert foreign.status_code == unknown.status_code == 404
+    assert foreign.json() == unknown.json()
+
+
+async def test_same_tenant_pair_still_records(client: AsyncClient, tenant_id: str, fleet_id: str) -> None:
+    """The guard must not break the legitimate path."""
+    a = await _make_memory(client, tenant_id, fleet_id)
+    b = await _make_memory(client, tenant_id, fleet_id)
+
+    response = await client.post(
+        f"{PREFIX}/memories/conflicts",
+        json=_conflict_payload(tenant_id, a, b),
+    )
+
+    assert response.status_code == 200, response.text
+    row = response.json()
+    assert row["new_memory_id"] == a
+    assert row["old_memory_id"] == b
+
+
+async def test_missing_memory_id_is_422_not_a_500(client: AsyncClient, tenant_id: str, fleet_id: str) -> None:
+    """A missing id used to reach ``payload["new_memory_id"]`` and raise
+    KeyError as an unhandled 500; the fail-closed guard makes it a 422."""
+    mine = await _make_memory(client, tenant_id, fleet_id)
+
+    response = await client.post(
+        f"{PREFIX}/memories/conflicts",
+        json={
+            "tenant_id": tenant_id,
+            "old_memory_id": mine,
+            "relationship": "exact_value",
+        },
+    )
+
+    assert response.status_code == 422, response.text


### PR DESCRIPTION
## The defect

`POST /memories/conflicts` took `new_memory_id` and `old_memory_id` straight from the body with no check. Both are `ForeignKey("memories.id", ondelete="CASCADE")` with **no cross-column tenant constraint** (`common/models/memory_conflict.py:73-80`), and two things followed from that.

**1. A record filed under tenant A could reference tenant B's memory.** The FK is satisfied, so the insert lands. Measured before the fix, posting a foreign `old_memory_id`:

```
assert 200 == 404
{"id":"4f6dce2c-…","tenant_id":"test-tenant-55725c84",
 "new_memory_id":"ce537d44-…","old_memory_id":"2b869593-…",   ← another tenant's memory
 "relationship":"exact_value","action":"supersede", …}
```

**2. It was an existence oracle for memory ids.** No handler in this service catches `IntegrityError` (`app.py` registers only `DuplicateContentHashError` and `JSONDecodeError`), so an unknown UUID came back as an unhandled 500 while a real one returned 200:

```
asyncpg.exceptions.ForeignKeyViolationError: insert or update on table "memory_conflicts"
violates foreign key constraint "memory_conflicts_old_memory_id_fkey"
DETAIL:  Key (old_memory_id)=(162b30de-…) is not present in table "memories".
```

200 vs 500 is the oracle: any holder of the shared secret could test whether a memory id exists anywhere in the system, regardless of tenant.

## The fix is one this repo has already made once

`POST /fleet/commands` carries the same FK-without-tenant-constraint shape and closes it, with a comment that describes this defect exactly:

> 404 for "no such node" and "not your node" alike. Splitting them would make this route an existence oracle for node UUIDs — and an unguarded insert of an unknown UUID raises `ForeignKeyViolationError`, which is an unhandled 500 rather than an answer.

So this applies the identical guard: resolve both ids with `memory_get_by_id_for_tenant` against the body's tenant, and 404 uniformly on either miss. That method is the right primitive by construction — its own docstring records that the unscoped sibling `memory_get_by_id` "is gone: it was the single-row form of GHSA-wgvw-28pq-jc36's primitive", and it keeps the predicate in the statement so no row crosses the DB boundary first.

`_require` on the two ids (rather than `body.get`) does double duty: it is what makes the binding legible to the tenant-scope gate's AST pass, and it turns a missing id from `payload["new_memory_id"]` → KeyError → **500** into a clean **422**, matching the fail-closed convention in the sibling routers.

## Blast radius: none for correct callers

Traced for #1180 before writing this. The only writer is `record_detected_conflicts` (`contradiction_detector.py:726`), and both ids come from tenant-bound searches run under the same `tenant_id` that gets written:

- RDF path → `memory_find_rdf_conflicts(tenant_id, …)`
- semantic path → `memory_find_similar_candidates({tenant_id, …})`

Neither is allowlisted, so the gate already scores both REQUIRED. The live path was already correct; what was missing was anything *making* it correct.

## Tests — confirmed failing without the fix

New: `core-storage-api/tests/test_memory_conflict_tenant_scope.py`, 6 tests.

**Reverted the router to `origin/main` with the test file in place: 5 failed, 1 passed.** The one that passes is `test_same_tenant_pair_still_records` — correctly, since the legitimate path worked before too; it is the regression guard, not a guard on the fix. The other five fail exactly as the defect predicts (the 200-with-row and the `ForeignKeyViolationError` quoted above). Restored: **6 passed**.

Coverage: foreign id in the `old` slot, foreign id in the `new` slot, unknown id, **the two answers being byte-identical** (the oracle is only closed if they are), the legitimate path still recording, and missing-id → 422.

## Gate movement

```
  removed — fixed (1):
      - route:POST /api/v1/storage/memories/conflicts [opaque-body-write]
  added (0)  removed — gone (0)  removed — still unscoped (0)  recategorised (0)
      opaque-body-write: 29 -> 28
tenant-scope gate: 189 routes + 186 service methods, 311 bound to a tenant, 64 allowlisted.
```

**Allowlist 65 → 64**, `opaque-body-write` **29 → 28**.

`method:memory_conflict_record` **stays** — its tenant still rides in the payload dict, which is the category's definition. Its note is rewritten to record that the route guard is now the whole of the binding for the referenced rows, which is the same arrangement `method:fleet_add_command` already documents. I corrected an estimate here: on #1180 I said fixing this would remove **two** entries. It removes one — the method entry is `fleet_add_command`-shaped and correctly remains.

## Gates

Venv on `PATH`, `UV_FROZEN=1`. `ruff check` and `ruff format --check` run **separately** at each of CI's exact scopes, discovery-based, no `--config`.

- `python scripts/tenant_scope_gate.py --base origin/main` — output above
- `python scripts/tenant_scope_gate.py --write` — regenerated, not hand-edited; re-running it after the note edit is **byte-identical** (`shasum` matched), so the note survives regeneration
- `pytest core-storage-api/tests/` — **315 passed** (309 + the 6 new)
- `pytest tests/test_tenant_scope_gate.py` — **113 passed**
- `mypy src/` in `core-storage-api` — no issues in 85 source files
- `ruff check` — `core-api/src/`, `core-storage-api/src/`, `core-storage-api/tests/`, `common/`, `core-operations/{src,tests}/`, `core-worker/{src,tests}/` — all clean
- `ruff format --check` — same scopes plus isolated `common/__init__.py common/structlog_config.py common/serve.py` — all formatted
- `python3 scripts/legacy_name_ratchet.py --base origin/main` — `No new lines.`
- `python3 scripts/do_not_touch_sentinel.py` — all 46 protected strings survive
- `uv.lock` / `plugin/package-lock.json` untouched

One signed-off commit, rebased onto `origin/main` immediately before push, with the gate and both suites re-run after the rebase.

## Scope

This fixes one of the three findings from the #1180 bucket-E trace. The other two are deliberately **not** in here:

- **`recall_log_write`** — latent, not live. `RecallCandidate.memory_id` has no FK and no tenant column, so there is no oracle, and nothing reads the table yet. It becomes a cross-tenant read only when `repeat_recall.py`'s Phase 2 JOIN lands, so the fix belongs on that work as a tenant-predicate requirement, not here.
- **`dedup_review_enqueue`** — no FKs (so no oracle) and its stored content is caller-supplied, so storage never joins back. Wants a sharper note, nothing more.
