### PR TITLE
fix(api): enforce the read-only capability gate on memory update

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1651,6 +1651,20 @@ async def update_memory_endpoint(
       request through this endpoint that removes one.
     """
     auth.enforce_tenant(tenant_id)
+    # The capability gate every other mutating memory route already applies.
+    # ``enforce_tenant`` above checks tenant binding and the admin bypass — it
+    # never looks at capabilities, so without this a credential minted
+    # read-only (capabilities={'read'}) could rewrite the content, title,
+    # metadata and weight of any memory in its tenant, while the DELETE
+    # sibling refused it. Same shape as the H-12/H-13/H-15 findings.
+    auth.enforce_read_only()
+    # Asked, not assumed, per the table added in #1196: ``update`` is not in
+    # ``PLAN_LIMIT_GATED_OPS`` (an update adds no row, so it does not grow the
+    # store), making this a no-op today. Written as a lookup rather than left
+    # absent because "free" expressed by omission is invisible in review — the
+    # missing gate above is exactly what that costs.
+    if plan_limit_gated("update"):
+        auth.enforce_usage_limits()
     # C3/C8: server-reserved types (outcome/rule/insight) are authored only by
     # internal flows — reject agent-supplied values on update too, mirroring the
     # create (POST /memories) and bulk-create handlers.

--- a/core-api/src/core_api/services/usage_service.py
+++ b/core-api/src/core_api/services/usage_service.py
@@ -105,13 +105,14 @@ OperationType = Literal["write", "search", "recall", "insights", "evolve"]
 # ``enforce_read_only()`` is NEITHER axis. That is the demo-mode gate, a
 # separate question, and it stays on the transition route.
 #
-# ``update`` is recorded as it BEHAVES, not as it arguably should: it charges
-# quota while skipping both ``enforce_usage_limits()`` and
-# ``enforce_read_only()``, which makes it the only mutating memory route gated
-# by neither (caura-ai/caura#1204 — the demo-mode half of that looks like an
-# oversight rather than a decision). Encoding it faithfully here keeps this
-# table a description of the system rather than an aspiration, so wiring a call
-# site through it cannot silently change behaviour.
+# ``update`` charges quota and is deliberately NOT plan-limit gated: an update
+# rewrites a row rather than adding one, so it does not grow the store, which
+# is the principle this table encodes. That omission is a decision, not the
+# oversight it once sat beside — ``update`` also skipped ``enforce_read_only()``
+# and so was gated by neither, which let a read-only credential rewrite any
+# memory in its tenant (caura-ai/caura#1204). That half is now closed: the route
+# calls ``enforce_read_only()`` like every other mutating memory route, which is
+# what makes the remaining omission legible as a choice.
 WRITE_QUOTA_OPS: frozenset[str] = frozenset({"create", "bulk_create", "update", "redistribute"})
 
 # Ops refused when the org is over its plan limit. A subset of the above minus

--- a/tests/test_route_authz_gaps.py
+++ b/tests/test_route_authz_gaps.py
@@ -543,6 +543,87 @@ async def test_settings_still_refuses_the_demo_sandbox(client, as_auth):
 
 
 # ---------------------------------------------------------------------------
+# PATCH /memories/{id} — the capability gate its own neighbours already apply
+#
+# Same shape as H-12/H-13/H-15 above: a mutating route that skipped a gate its
+# neighbours apply. The 2026-08-14 pass swept /fleet/commands,
+# /agents/{id}/trust and /settings; it did not reach this one.
+#
+# Every other mutating memory route calls ``enforce_read_only`` — POST
+# /memories, POST /memories/bulk, DELETE /memories/{id}, POST
+# /memories/bulk-delete, PATCH /memories/{id}/status, POST
+# /memories/redistribute. The route that rewrites content, title, metadata and
+# weight is the only one that does not, so a credential minted read-only could
+# overwrite any memory in its tenant. ``enforce_tenant`` does not cover this:
+# it checks tenant binding and the admin bypass, never capabilities.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_memory(client, tenant: str) -> str:
+    """Create one memory as a write-capable caller and return its id."""
+    resp = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant,
+            "memory_type": "fact",
+            "content": f"original content {_uid()}",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def test_update_memory_rejects_a_read_only_credential(client, as_auth):
+    """A read-only credential must not rewrite a memory's content.
+
+    ``enforce_read_only`` is the gate for BOTH the demo sandbox and a
+    credential minted without the ``write`` capability. Its own error text
+    calls that "a property of the CREDENTIAL, not of the endpoint" — which
+    only holds if every write-shaped endpoint asks.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant)
+    memory_id = await _seed_memory(client, tenant)
+
+    as_auth(tenant, capabilities=READ_ONLY)
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant}",
+        json={"content": "rewritten by a read-only key"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+async def test_update_memory_refuses_the_demo_sandbox(client, as_auth):
+    """The demo half of the same gate — the sandbox is read-only end to end."""
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant)
+    memory_id = await _seed_memory(client, tenant)
+
+    as_auth(tenant, is_demo=True)
+    resp = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant}",
+        json={"content": "rewritten from the demo sandbox"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+async def test_delete_memory_already_rejects_a_read_only_credential(client, as_auth):
+    """The neighbour that has always had the gate.
+
+    Kept alongside the two above so the asymmetry is visible in the suite
+    rather than only in review: removing a memory was refused while rewriting
+    its contents was not.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant)
+    memory_id = await _seed_memory(client, tenant)
+
+    as_auth(tenant, capabilities=READ_ONLY)
+    resp = await client.delete(f"/api/v1/memories/{memory_id}?tenant_id={tenant}")
+    assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
 # H-14 / H-16 — client-trusted identity on READ paths
 #
 # The 2026-06-11 pass fixed the identity precedence on WRITE paths (delete/update


### PR DESCRIPTION
Closes #1204, which I filed while verifying the write-quota parity work in
#1196 — and which understated the problem. I filed it as a demo-mode bypass
and a billing inconsistency. Re-verifying it before writing the fix showed the
demo half is the *less* serious half.

## The bug

`enforce_read_only()` guards **two** signals, not one. Its own docstring:

- `is_demo` → the demo sandbox is read-only
- `capabilities` is set and does **not** include `write` → the credential is
  read-only by construction (a viewer or reporting key)

`PATCH /memories/{memory_id}` never calls it. `enforce_tenant()` — the only
authorization it does call — checks tenant binding and the admin bypass, and
never looks at capabilities.

So a credential minted read-only could rewrite the content, title, metadata
and weight of any memory in its tenant. Not a 403:

```
PATCH /memories/{id}  →  200 OK
{"content": "rewritten by a read-only key", ...}
```

The error text that *should* have fired says the quiet part: read-only is
**"a property of the CREDENTIAL, not of the endpoint"**. That only holds if
every write-shaped endpoint asks, and this one did not.

### The asymmetry

| route | `enforce_read_only` |
|---|---|
| `POST /memories` | ✓ |
| `POST /memories/bulk` | ✓ |
| `DELETE /memories/{id}` | ✓ |
| `POST /memories/bulk-delete` | ✓ |
| `PATCH /memories/{id}/status` | ✓ |
| `POST /memories/redistribute` | ✓ |
| **`PATCH /memories/{id}`** | **✗** |

A read-only credential could not *delete* a memory but could *overwrite its
contents*. The route that rewrites content was the only one without the gate.

## Not a new class of bug

This is the same shape as **H-12 / H-13 / H-15** from the 2026-08-14 audit,
already recorded in `tests/test_route_authz_gaps.py`: *"a mutating route that
skipped a gate its own neighbours already applied."* That pass swept
`/fleet/commands`, `/agents/{id}/trust` and `/settings`. It did not reach this
one.

## The fix

One call, placed where its siblings place it. Plus the plan-limit half written
as an **explicit no-op lookup** rather than left absent:

```python
if plan_limit_gated("update"):
    auth.enforce_usage_limits()
```

`update` is not in `PLAN_LIMIT_GATED_OPS` — an update adds no row, so it does
not grow the store, which is the principle #1196 settled on — so **behaviour
here is unchanged**. It is written as a lookup because "free" expressed by
omission is invisible in review, and that is precisely what the missing
capability gate above cost.

## Verification

Three tests, in the conventions of the audit-gap file they join:

- `test_update_memory_rejects_a_read_only_credential` — **fails without this
  change** (200, content rewritten)
- `test_update_memory_refuses_the_demo_sandbox` — **fails without this change**
- `test_delete_memory_already_rejects_a_read_only_credential` — **passes
  before and after**, kept deliberately so the asymmetry stays visible in the
  suite rather than only in this description

Full suite green: 5,858 passed, 4 skipped, 1 xfailed. `ruff check`,
`ruff format --check`, `mypy` and the broker OpenAPI check are clean.

## Blast radius

Read-only credentials and demo tenants can no longer PATCH memories. That is
the intended semantics of both — but it is a live behaviour change, so it is
worth knowing rather than discovering. Nothing else changes: the plan-limit
lookup is a no-op, and write-capable credentials are unaffected.
