### PR TITLE
fix(api): stop /whoami claiming a gateway identity it never verified

### DIFF
--- a/core-api/src/core_api/routes/health.py
+++ b/core-api/src/core_api/routes/health.py
@@ -1,4 +1,5 @@
 import asyncio
+import hmac
 import logging
 from typing import Any
 
@@ -35,6 +36,20 @@ async def version():
     return {"version": VERSION}
 
 
+def _gateway_verified(request: Request) -> bool:
+    """True when the caller proved this request came through the gateway.
+
+    Mirrors ``MCPAuthMiddleware``: the identity headers carry no credential
+    of their own, so when a shared secret is configured the request must
+    present it. When none is configured (OSS self-hosted, and the test
+    suite) the header path is trusted exactly as before.
+    """
+    gw_secret = settings.gateway_shared_secret
+    if not gw_secret:
+        return True
+    return hmac.compare_digest(request.headers.get("x-gateway-secret", ""), gw_secret)
+
+
 @router.get("/whoami")
 async def whoami(request: Request) -> dict:
     """Identity probe — returns the caller's resolved (tenant_id, agent_id)
@@ -44,13 +59,29 @@ async def whoami(request: Request) -> dict:
 
     Resolution priority mirrors MCPAuthMiddleware:
       gateway-header — X-Tenant-ID (and optionally X-Agent-ID) injected
-                       by the enterprise gateway after auth_request
+                       by the enterprise gateway after auth_request, and
+                       only when the gateway secret verifies (below)
       standalone     — settings.is_standalone fixed tenant
       anonymous      — no auth resolved (caller will hit 401 on first
                        write; this endpoint stays open as a probe)
     """
     tenant_id = request.headers.get("x-tenant-id")
     agent_id = request.headers.get("x-agent-id")
+    if tenant_id and not _gateway_verified(request):
+        # Unverified identity headers make every field derived from them
+        # unverified too — including ``via_gateway``, which unlike the fields
+        # beside it is NOT an echo but core-api's own assertion about how the
+        # request arrived. Claiming ``via_gateway: true`` on the strength of a
+        # header the caller set themselves states as fact something never
+        # checked, on the one endpoint whose whole job is telling an
+        # integrator how their request actually resolves.
+        #
+        # Degrade rather than 401: a probe is most useful when it reports the
+        # real resolution, and "your headers are not being trusted here" is
+        # precisely the diagnosis a misconfigured integration needs. The
+        # request falls through to standalone/anonymous below, which is what
+        # a write on this same connection would resolve to.
+        tenant_id = None
     if tenant_id:
         # Surface the cross-tenant scope the gateway plumbed so callers
         # can verify what their credential authorizes WITHOUT having to
@@ -81,12 +112,17 @@ async def whoami(request: Request) -> dict:
             #
             # Echo, like ``capabilities`` and ``auth_mode`` beside it — this
             # endpoint reports what the gateway asserted about the caller and
-            # LOOKS NOTHING UP. That is what keeps it safe without a perimeter
-            # check: there is no auth dependency and no shared-secret
-            # verification here, so a field that resolved caller-supplied ids
-            # against storage would let anyone read another tenant's
-            # attributes. Keep additions to this handler echo-only until that
-            # check exists (issue: /whoami perimeter).
+            # LOOKS NOTHING UP.
+            #
+            # Keep it that way. The perimeter check above closes the identity
+            # spoof for deployments that CONFIGURE a gateway secret; it does
+            # not make a lookup safe everywhere, because with no secret set
+            # (OSS self-hosted) ``_gateway_verified`` trusts the header path
+            # by design. There is still no auth dependency on this route, so
+            # a field resolving caller-supplied ids against storage would let
+            # anyone on such a deployment read another tenant's attributes.
+            # A lookup-backed field (``trust_level``) needs that case
+            # answered first — see #1202.
             "key_kind": (request.headers.get("x-caura-credential-kind") or "").lower() or None,
         }
     if settings.is_standalone:

--- a/tests/test_api_whoami.py
+++ b/tests/test_api_whoami.py
@@ -50,10 +50,12 @@ async def test_whoami_standalone_or_anonymous(client):
 # differently from a plain agent key.
 #
 # ECHO ONLY, and that is load-bearing rather than lazy: ``/whoami`` has no auth
-# dependency and no gateway-shared-secret check, so it is safe precisely because
-# it looks nothing up. A field that resolved caller-supplied ids against storage
-# would let anyone read another tenant's attributes — which is why
-# ``trust_level`` is NOT here and is blocked on a perimeter fix.
+# dependency, so it is safe precisely because it looks nothing up. The gateway
+# perimeter check added below narrows who may claim a gateway identity, but it
+# does not lift this: with no shared secret configured (OSS self-hosted) the
+# header path is trusted by design, so a field resolving caller-supplied ids
+# against storage would still let anyone read another tenant's attributes.
+# ``trust_level`` therefore remains NOT here — see #1202.
 
 
 async def test_whoami_reports_key_kind_from_the_gateway(client):
@@ -101,3 +103,87 @@ async def test_whoami_still_looks_nothing_up(client):
     data = resp.json()
     assert data["tenant_id"] == "tenant-that-does-not-exist"
     assert data["agent_id"] == "agent-that-does-not-exist"
+
+
+# --- gateway perimeter ------------------------------------------------------
+#
+# ``via_gateway`` is not an echo like the fields beside it. ``tenant_id`` /
+# ``capabilities`` / ``key_kind`` report what the caller sent; ``via_gateway``
+# is core-api's own claim about how the request arrived. Returning True on the
+# strength of a header the caller set themselves made the probe assert a
+# provenance it never verified — on the endpoint whose stated job is telling an
+# integrator how their request actually resolves.
+#
+# The check mirrors ``MCPAuthMiddleware``: required only when a shared secret
+# is configured, so OSS self-hosted deployments (and this suite's other tests)
+# are unaffected.
+
+
+async def test_whoami_does_not_claim_gateway_identity_without_the_secret(client, monkeypatch):
+    """The spoof: identity headers with no secret must not report a gateway."""
+    from core_api.config import settings
+
+    monkeypatch.setattr(settings, "gateway_shared_secret", "s3cret")
+    resp = await client.get(
+        "/api/v1/whoami",
+        headers={"X-Tenant-ID": "victim-tenant", "X-Agent-ID": "victim-agent"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["via_gateway"] is False
+    assert data["auth_source"] != "gateway-header"
+    # The unverified identity must not be reflected back either — echoing it
+    # under auth_source=anonymous would still tell a caller its spoof "took".
+    assert data["tenant_id"] != "victim-tenant"
+    assert data["agent_id"] is None
+
+
+async def test_whoami_does_not_claim_gateway_identity_with_a_wrong_secret(client, monkeypatch):
+    from core_api.config import settings
+
+    monkeypatch.setattr(settings, "gateway_shared_secret", "s3cret")
+    resp = await client.get(
+        "/api/v1/whoami",
+        headers={"X-Tenant-ID": "victim-tenant", "X-Gateway-Secret": "wrong"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["via_gateway"] is False
+
+
+async def test_whoami_honors_the_gateway_identity_with_the_correct_secret(client, monkeypatch):
+    """The real gateway path keeps working — this is a narrowing, not a block."""
+    from core_api.config import settings
+
+    monkeypatch.setattr(settings, "gateway_shared_secret", "s3cret")
+    resp = await client.get(
+        "/api/v1/whoami",
+        headers={
+            "X-Tenant-ID": "real-tenant",
+            "X-Agent-ID": "real-agent",
+            "X-Gateway-Secret": "s3cret",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["via_gateway"] is True
+    assert data["auth_source"] == "gateway-header"
+    assert data["tenant_id"] == "real-tenant"
+
+
+async def test_whoami_trusts_headers_when_no_secret_is_configured(client, monkeypatch):
+    """OSS self-hosted is untouched: no secret configured, no new check.
+
+    Pins the scope of this change. Without it a self-hosted deployment that
+    never sets a gateway secret would lose its identity probe entirely.
+    """
+    from core_api.config import settings
+
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    resp = await client.get(
+        "/api/v1/whoami",
+        headers={"X-Tenant-ID": "solo-tenant", "X-Agent-ID": "solo-agent"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["via_gateway"] is True
+    assert data["tenant_id"] == "solo-tenant"


### PR DESCRIPTION
Addresses the perimeter half of #1202. Re-verifying that issue before writing
code turned up something I had not filed: the endpoint is not merely *missing a
check that a future field would need* — it is **making an unverified claim
today**.

## The bug

`GET /api/v1/whoami` has no auth dependency and did no shared-secret check. Set
one header and it answers:

```
GET /api/v1/whoami   -H "X-Tenant-ID: any-tenant-you-like"

{"tenant_id": "any-tenant-you-like", "auth_source": "gateway-header",
 "via_gateway": true, ...}
```

**`via_gateway` is not an echo like the fields beside it.** `tenant_id`,
`capabilities`, `auth_mode` and `key_kind` all report *what the caller sent* —
"you told me X" is a true statement regardless of who is asking. `via_gateway`
is core-api's own assertion about **how the request arrived**, and it was
answered from a header the caller set themselves.

That matters most on this endpoint specifically. `/whoami` exists to answer
"is my integration wired correctly?" — and it was reporting the wiring
incorrectly, in the direction that hides the misconfiguration.

## The fix

`_gateway_verified()`, mirroring `MCPAuthMiddleware`: the identity headers
carry no credential of their own, so when a shared secret is configured the
request must present it.

**Scope is narrow by construction.** When no secret is configured — OSS
self-hosted, and this test suite — the header path is trusted exactly as
before. Self-hosted deployments keep their identity probe unchanged.

### Why degrade instead of 401

MCP rejects outright; this returns the resolution the caller actually has.
A probe's value is reporting what is true, and *"your headers are not being
trusted here"* is the diagnosis a misconfigured integration needs — a 401
tells them less. The request falls through to standalone/anonymous, which is
what a write on that same connection would resolve to.

The unverified tenant is not echoed back either. Returning it under
`auth_source: anonymous` would still tell a caller its spoof "took".

## What this does NOT do

**It does not unblock `trust_level`,** and #1202 stays open for that.

With no shared secret configured the header path is still trusted by design, so
a storage-backed field would remain a cross-tenant read on exactly those
deployments. The handler comment previously said additions must stay echo-only
"until that check exists" — that would now read as satisfied, which is why this
PR rewrites it to state the remaining condition rather than delete the warning.

## Verification

- `test_whoami_does_not_claim_gateway_identity_without_the_secret` — **fails
  without this change**
- `test_whoami_does_not_claim_gateway_identity_with_a_wrong_secret` — **fails
  without this change**
- `test_whoami_honors_the_gateway_identity_with_the_correct_secret` — passes
  before and after; the real gateway path is untouched
- `test_whoami_trusts_headers_when_no_secret_is_configured` — passes before and
  after, pinning that this is a narrowing and not a block. Without it, a
  regression here would silently cost self-hosted deployments their probe.

The last two pass either way on purpose: they bound the change rather than
demonstrate it.

`ruff check`, `ruff format --check`, `mypy` and the broker OpenAPI check are
clean.
