### PR TITLE
feat(mcp): report the writes a plan limit would have refused

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -93,7 +93,12 @@ from core_api.services.recall_service import summarize_memories
 # directly from ``core_api.services.trust_service``.
 from core_api.services.trust_service import parse_trust_error
 from core_api.services.trust_service import require_trust as _require_trust
-from core_api.services.usage_service import charges_write_quota, recall_operation
+from core_api.services.usage_service import (
+    MutatingOp,
+    charges_write_quota,
+    plan_limit_gated,
+    recall_operation,
+)
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
 from core_api.trust_utils import (
     effective_keystone_min_trust,
@@ -129,6 +134,15 @@ _credential_kind_var: contextvars.ContextVar[str | None] = contextvars.ContextVa
 _install_uuid_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "mcp_install_uuid", default=None
 )
+# Plan-limit read-only mode, computed by the platform from the persisted usage
+# counters and stamped as X-Org-Read-Only (see ``usage_service``'s module
+# docstring). REST reads it via ``AuthContext.is_read_only``; until now the MCP
+# middleware never read it at all, so no MCP tool could see plan-limit mode
+# (caura-ai/caura#1205).
+#
+# OBSERVED, NOT ENFORCED, for now. Nothing refuses on this yet — see
+# ``_observe_plan_limit`` below for why that sequencing is deliberate.
+_org_read_only_var: contextvars.ContextVar[bool] = contextvars.ContextVar("mcp_org_read_only", default=False)
 
 _UNAUTH = "__unauthenticated__"
 _ADMIN = "__admin__"
@@ -334,6 +348,22 @@ class MCPAuthMiddleware:
             _install_uuid_var.set(
                 (headers.get(b"x-install-uuid", b"").decode() or None) if via_gateway else None
             )
+            # Plan-limit read-only mode. Gateway-verified path only, for the
+            # same reason as the attributes above but with the direction of the
+            # risk reversed: for identity, self-assertion buys access the caller
+            # should not have; here, self-assertion the OTHER way — a direct
+            # caller simply omitting the header — would CLEAR its own read-only
+            # flag. Deriving it from ``via_gateway`` makes both impossible: off
+            # the verified path the value is not caller-influenced at all.
+            #
+            # Assigned on every request like its neighbours, never left unset.
+            # A stale True bleeding into the next request on a reused ASGI task
+            # would refuse a paying tenant; a stale False would be a billing
+            # bypass. Both are silent, so neither is allowed to depend on a
+            # header being present.
+            _org_read_only_var.set(
+                (headers.get(b"x-org-read-only", b"").decode().lower() == "true") if via_gateway else False
+            )
 
         await self.app(scope, receive, send)
 
@@ -366,6 +396,54 @@ def _is_install_credential() -> bool:
 def _get_install_uuid() -> str | None:
     """The broker's install UUID (X-Install-UUID), or None for non-broker calls."""
     return _install_uuid_var.get(None)
+
+
+def _is_org_read_only() -> bool:
+    """True when the platform stamped this org over its plan limit.
+
+    The MCP twin of ``AuthContext.is_read_only``. Read only by
+    ``_observe_plan_limit`` today — nothing refuses on it yet.
+    """
+    return _org_read_only_var.get(False)
+
+
+def _observe_plan_limit(op: MutatingOp, tenant_id: str) -> None:
+    """Record that ``op`` ran while the org was over its plan limit.
+
+    DELIBERATELY DOES NOT REFUSE. This is step one of caura-ai/caura#1205,
+    which closes a real divergence — an over-plan org is refused a write on
+    REST and allowed the same write on MCP — but closes it in a direction that
+    takes capability AWAY from tenants who have it today. Enforcing in the same
+    change that first plumbs the signal would mean discovering the blast radius
+    from the support queue.
+
+    So: emit what WOULD be refused, ship it, read the logs, then enforce with
+    the number in hand. The log also answers a question that cannot be answered
+    from this repo at all — whether the gateway stamps ``x-org-read-only`` on
+    the ``/mcp`` route or only on ``/api/v1``. The header has no producer in
+    OSS; if this line never fires in production, that is the first thing to
+    check.
+
+    READ SILENCE CAREFULLY. Three different things produce no log, and only one
+    of them is "nothing would be refused": the gateway may not stamp the header
+    on this route at all (above), or the tenant may never have been marked over
+    plan because the MCP batch path records no usage to compute that from
+    (caura-ai/caura#1220). Rule those out before reading a quiet log as a
+    green light to enforce.
+
+    Logged at WARNING rather than INFO because a firing line means real money:
+    a write that the plan says should not have happened.
+    """
+    if not _is_org_read_only() or not plan_limit_gated(op):
+        return
+    logger.warning(
+        "mcp_plan_limit_would_refuse",
+        extra={
+            "tenant_id": tenant_id,
+            "mcp_operation": op,
+            "enforced": False,
+        },
+    )
 
 
 def _is_write_allowed() -> bool:
@@ -1071,6 +1149,11 @@ async def caura_write(
             if not fleet_id and agent.get("fleet_id"):
                 fleet_id = agent["fleet_id"]
             if content is not None:
+                # Observation only; the write proceeds. The batch path below
+                # carries the ``bulk_create`` twin — between them they cover
+                # every op on this surface that ``PLAN_LIMIT_GATED_OPS``
+                # names (MCP exposes no ``redistribute``).
+                _observe_plan_limit("create", tenant_id)
                 if charges_write_quota("create"):
                     await check_and_increment(tenant_id, "write")
                 result = await create_memory(
@@ -1124,6 +1207,23 @@ async def caura_write(
             for _idx, _item in enumerate(bulk_items):
                 if refuse := _refuse_reserved_memory_type(_item.memory_type, index=_idx):
                     return _with_latency(refuse, t0)
+            # The batch twin of the single-write observation above. This is the
+            # path where an over-plan tenant can add the most rows per call, so
+            # leaving it out would have made the numbers read low in exactly
+            # the direction that matters.
+            #
+            # NOTE while you are here: this path charges NO write quota at all
+            # — no ``check_and_increment``, no ``bulk_check_and_increment``,
+            # while REST's ``POST /memories/bulk`` charges one per item
+            # (caura-ai/caura#1220). Filed rather than fixed here: that one
+            # changes billing, this one only changes logging.
+            #
+            # It also bounds what the line below can tell you. The counters
+            # that never move here are the same counters ``x-org-read-only`` is
+            # computed from, so a batch-heavy tenant may never be marked over
+            # plan at all — meaning silence from this observation is not by
+            # itself evidence that nothing would be refused.
+            _observe_plan_limit("bulk_create", tenant_id)
             bulk_data = BulkMemoryCreate(
                 tenant_id=tenant_id,
                 fleet_id=fleet_id,

--- a/tests/test_mcp_gateway_secret.py
+++ b/tests/test_mcp_gateway_secret.py
@@ -39,6 +39,7 @@ def _reset_mcp_context_vars():
     mcp_server._readable_tenant_ids_var.set(None)
     mcp_server._scopes_var.set(None)
     mcp_server._via_gateway_var.set(False)
+    mcp_server._org_read_only_var.set(False)
 
 
 async def _call_middleware(headers: list[tuple[bytes, bytes]]):
@@ -197,3 +198,60 @@ async def test_identity_headers_ignored_without_tenant_header(monkeypatch):
     assert mcp_server._get_agent_id() is None
     assert mcp_server._get_readable_tenants() == []
     assert mcp_server._get_scopes() is None
+
+
+# ---------------------------------------------------------------------------
+# S2 — plan-limit read-only mode (X-Org-Read-Only)
+#
+# The gateway computes "over plan" from the persisted counters and stamps this
+# header; REST turns it into a 403 via ``AuthContext.is_read_only``. The MCP
+# middleware never read it, so no MCP tool could see plan-limit mode at all
+# (caura-ai/caura#1205).
+#
+# The risk here runs the OPPOSITE way to the identity headers above. There,
+# self-assertion buys access; here, a direct caller simply OMITTING the header
+# would clear its own read-only flag. Both are closed by the same rule: the
+# value is honoured only on the gateway-verified path.
+# ---------------------------------------------------------------------------
+
+
+async def test_org_read_only_is_honored_on_the_gateway_path(monkeypatch):
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    await _call_middleware(
+        [(b"x-tenant-id", b"tenant-A"), (b"x-org-read-only", b"true")]
+    )
+    assert mcp_server._is_org_read_only() is True
+
+
+async def test_org_read_only_is_ignored_off_the_gateway_path(monkeypatch):
+    """A direct caller must not be able to SET one either."""
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(settings, "is_standalone", False)
+    await _call_middleware(
+        [(b"x-api-key", b"some-key"), (b"x-org-read-only", b"true")]
+    )
+    assert mcp_server._is_org_read_only() is False
+
+
+async def test_org_read_only_does_not_bleed_between_requests(monkeypatch):
+    """The billing-bypass case: a stale False would let an over-plan tenant
+    through, a stale True would refuse a paying one. Both silent, so the var is
+    assigned on every request rather than only when the header is present."""
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    await _call_middleware(
+        [(b"x-tenant-id", b"tenant-A"), (b"x-org-read-only", b"true")]
+    )
+    assert mcp_server._is_org_read_only() is True
+
+    await _call_middleware([(b"x-tenant-id", b"tenant-A")])
+    assert mcp_server._is_org_read_only() is False
+
+
+async def test_org_read_only_requires_the_gateway_secret_when_configured(monkeypatch):
+    """Rejected before any context var is set — the perimeter runs first."""
+    monkeypatch.setattr(settings, "gateway_shared_secret", "s3cret")
+    app_called, _ = await _call_middleware(
+        [(b"x-tenant-id", b"tenant-A"), (b"x-org-read-only", b"true")]
+    )
+    assert app_called is False
+    assert mcp_server._is_org_read_only() is False

--- a/tests/test_mcp_plan_limit_observation.py
+++ b/tests/test_mcp_plan_limit_observation.py
@@ -1,0 +1,100 @@
+"""MCP plan-limit observation — step one of caura-ai/caura#1205.
+
+An org over its plan limit is refused a write on REST and allowed the same
+write on MCP, because the MCP middleware never read ``x-org-read-only``. This
+change plumbs the signal and reports what WOULD be refused; it deliberately
+does not refuse yet.
+
+The tests below pin both halves of that, and the second half is the one that
+matters most right now: **the write must still succeed**. A test suite that
+only proved the logging works would go green on an accidental enforcement,
+which is precisely the outcome the observe-first sequencing exists to avoid.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from core_api import mcp_server
+
+pytestmark = pytest.mark.unit
+
+
+class _OutStub:
+    """Minimal stand-in for what ``create_memory`` returns (see test_mcp_write)."""
+
+    def model_dump(self, mode: str = "python"):  # noqa: ARG002
+        return {"id": "m-over-plan", "status": "created"}
+
+
+@pytest.fixture(autouse=True)
+def _reset_org_read_only():
+    """Leave the flag clean — the session shares one context across tests."""
+    yield
+    mcp_server._org_read_only_var.set(False)
+
+
+def _warnings(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.message == "mcp_plan_limit_would_refuse"]
+
+
+# --- what gets observed -----------------------------------------------------
+
+
+@pytest.mark.parametrize("op", ["create", "bulk_create"])
+def test_a_gated_op_over_plan_is_reported(caplog, op):
+    mcp_server._org_read_only_var.set(True)
+    with caplog.at_level(logging.WARNING, logger="core_api.mcp_server"):
+        mcp_server._observe_plan_limit(op, "tenant-over-plan")
+    records = _warnings(caplog)
+    assert len(records) == 1
+    assert records[0].tenant_id == "tenant-over-plan"
+    assert records[0].mcp_operation == op
+    # Pinned so the log itself says which era it came from: a line without
+    # this is from a build that enforces, and means something different.
+    assert records[0].enforced is False
+
+
+def test_nothing_is_reported_when_the_org_is_within_plan(caplog):
+    mcp_server._org_read_only_var.set(False)
+    with caplog.at_level(logging.WARNING, logger="core_api.mcp_server"):
+        mcp_server._observe_plan_limit("create", "tenant-ok")
+    assert _warnings(caplog) == []
+
+
+@pytest.mark.parametrize("op", ["transition", "delete", "update", "bulk_delete"])
+def test_an_ungated_op_is_not_reported_even_over_plan(caplog, op):
+    """The observation reads the same table REST gates on, so it cannot report
+    a refusal REST would not make. ``transition`` and the deletes are free by
+    decision (an over-plan org must be able to delete its way back under), and
+    ``update`` rewrites a row rather than adding one."""
+    mcp_server._org_read_only_var.set(True)
+    with caplog.at_level(logging.WARNING, logger="core_api.mcp_server"):
+        mcp_server._observe_plan_limit(op, "tenant-over-plan")
+    assert _warnings(caplog) == []
+
+
+# --- and, critically, nothing is refused ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_over_plan_write_still_succeeds(mcp_env, caplog):
+    """Observe, do not enforce. This is the behavioural contract of this PR.
+
+    If someone later adds the refusal without meaning to, this fails — which
+    is the point. Flipping it is a deliberate act with a blast radius that
+    wants measuring first.
+    """
+    mcp_env["service"]("create_memory").return_value = _OutStub()
+    mcp_server._org_read_only_var.set(True)
+
+    with caplog.at_level(logging.WARNING, logger="core_api.mcp_server"):
+        out = await mcp_server.caura_write(content="written while over plan")
+
+    payload = json.loads(out)
+    assert "error" not in payload, payload
+    # The write happened AND was reported — both, not either.
+    assert len(_warnings(caplog)) == 1


### PR DESCRIPTION
Step one of #1205, taken deliberately short of the fix.

## The divergence

Plan-limit enforcement travels out-of-band. The platform computes "over plan"
from the persisted counters and stamps `x-org-read-only`; `AuthContext.is_read_only`
reads it and `enforce_usage_limits()` turns it into a 403 across ~22 REST write
routes.

`MCPAuthMiddleware` never read that header. `enforce_usage_limits` has **zero
code occurrences** in `mcp_server.py` — the one textual match is inside a
comment. There was no context var, no getter, and so nothing a handler could
consult even if it wanted to.

**Same tenant, same operation, different answer per transport:** an over-plan
org is refused a write on REST and allowed it on MCP.

## Why this PR does not fix that

Closing the divergence takes capability **away** from tenants who have it
today. Over-plan orgs writing successfully over MCP right now would start
getting refused — presumably the intent of plan limits, but it surfaces as an
incident for anyone relying on it.

So this plumbs the signal and **reports what would be refused, without
refusing**. Emit, ship, read the logs, then enforce with the number in hand.

It also answers a question that **cannot be answered from this repo at all**:
`x-org-read-only` has no producer in OSS — the gateway that stamps it lives
elsewhere — so whether it reaches `/mcp` or only `/api/v1` is not knowable
here. Silence from this log is the first symptom of it never arriving.

## The plumbing

Honoured **only on the gateway-verified path**, and the risk runs *opposite* to
the identity headers beside it:

- for `x-agent-id` / `x-capabilities`, self-assertion buys access the caller
  should not have
- for `x-org-read-only`, a direct caller simply **omitting** the header would
  clear its own read-only flag

Deriving from `via_gateway` closes both directions: off the verified path the
value is not caller-influenced at all.

The var is assigned on **every** request, never left unset. The middleware
already carries a comment about context vars surviving into the next request on
a reused ASGI task; here a stale `True` would refuse a paying tenant and a stale
`False` would be a billing bypass — both silent.

Covers `create` and `bulk_create`, which between them are every op on this
surface that `PLAN_LIMIT_GATED_OPS` names (MCP exposes no `redistribute`).

## Found while doing this — filed, not fixed

The MCP **batch write path charges no write quota at all** — no
`check_and_increment`, no `bulk_check_and_increment` — while REST's
`POST /memories/bulk` charges one per item. Filed as #1220 rather than folded
in here: that changes billing, this only changes logging.

It **bounds what this observation can tell you**, which is why the code says so
rather than leaving a future reader to trust a quiet log. The counters the batch
path never moves are the same counters `x-org-read-only` is computed from, so a
batch-heavy tenant may never be marked over plan in the first place. Three
different things produce silence here and only one of them is "nothing would be
refused".

## Verification

Middleware plumbing (`test_mcp_gateway_secret.py`, joining the existing
perimeter suite):

- honoured on the gateway path
- **ignored off it** — verified by mutation: dropping the `via_gateway` guard
  makes this test fail, so the security property is genuinely held by a test
  rather than merely asserted in a comment
- **does not bleed between requests** — a request carrying the header followed
  by one without
- rejected before any context var is set when a gateway secret is configured

Observation behaviour (`test_mcp_plan_limit_observation.py`):

- gated ops over plan are reported, with `enforced: False` pinned into the log
  record so the line says which era it came from
- ungated ops (`transition`, `delete`, `update`, `bulk_delete`) are **not**
  reported even over plan — the observation reads the same table REST gates on,
  so it cannot report a refusal REST would not make
- **an over-plan write still succeeds.** This is the behavioural contract of
  the PR. A suite that only proved the logging works would go green on an
  accidental enforcement, which is the exact outcome observe-first exists to
  avoid.

Full suite green. `ruff check`, `ruff format --check`, `mypy` and the broker
OpenAPI check are clean.

## What step two looks like

Add the refusal envelope (`_error_response` — MCP tools return envelopes, not
`HTTPException`s, so `AuthContext.enforce_usage_limits` cannot be reused
as-is) and gate on the same helper. The call sites are already in place; only
the body of `_observe_plan_limit` and the handling at each site change.
