### PR TITLE
feat(search): let a caller assert an identity without filtering to it

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -1574,6 +1574,18 @@
       },
       "SearchRequest": {
         "properties": {
+          "caller_agent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Assert the agent identity this search runs as, WITHOUT filtering results to that agent's own memories (use filter_agent_id for that). Determines which scope_agent memories are visible and whose trust/fleet level the read is gated against. Ignored when the credential already carries an agent identity, which wins. An agent-scoped credential may only name itself.",
+            "title": "Caller Agent Id"
+          },
           "diagnostic": {
             "default": false,
             "title": "Diagnostic",

--- a/core-api/src/core_api/pipeline/steps/search/track_recalls.py
+++ b/core-api/src/core_api/pipeline/steps/search/track_recalls.py
@@ -46,10 +46,12 @@ class TrackRecalls:
         # that hit the endpoint with no agent — is not an agent using memory;
         # counting it inflates ``recall_count`` (and thus ``recall_boost``) with
         # non-agent noise and can pin a single memory under a repeating probe.
-        # ``caller_agent_id`` is the authenticated identity (``filter_agent_id``
-        # or ``auth.agent_id``), so genuine agent recalls — including cross-agent
-        # ones that omit ``filter_agent_id`` — still count. Results are returned
-        # unchanged either way; only the counter bump is skipped. (Gap A26.)
+        # ``caller_agent_id`` is the caller's effective identity — the
+        # authenticated agent, else one asserted via ``caller_agent_id``, else
+        # the legacy derivation from ``filter_agent_id`` — so genuine agent
+        # recalls, including cross-agent ones that omit ``filter_agent_id``,
+        # still count. Results are returned unchanged either way; only the
+        # counter bump is skipped. (Gap A26.)
         #
         # ``recall_tracked`` is set on every path below so the surfaces can
         # report what this search actually did rather than re-deriving the
@@ -58,6 +60,17 @@ class TrackRecalls:
         # and the "no rows" case below is invisible from the caller's inputs.
         ctx.data["recall_tracked"] = False
         if not ctx.data.get("caller_agent_id"):
+            return None
+        # #1197 — an identity the caller ASSERTED (a tenant-scoped key naming an
+        # agent via ``caller_agent_id``) does not move the counter unless the
+        # tenant opted in, because moving it reshuffles ranking for every other
+        # caller in that tenant, not just the one that sent the field.
+        #
+        # The route resolves this to a single boolean; the step does not know
+        # (or need to know) whether the identity was asserted or authenticated.
+        # Defaults True on the ``.get``, so every caller that never passes it —
+        # MCP recall, the internal search paths — behaves exactly as before.
+        if not ctx.data.get("allow_recall_bump", True):
             return None
         # D12 — a diagnostic call is inspection, not use: the caller is asking
         # "why does ranking look like this", and letting that bump

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1753,7 +1753,27 @@ async def _search_inner(
                 f"authenticated agent identity '{auth.agent_id}'."
             ),
         )
-    eff_agent_id = body.filter_agent_id or auth.agent_id
+    # Same rule for the identity knob. ``caller_agent_id`` feeds exactly the two
+    # things ``filter_agent_id`` used to smuggle in — the visibility identity and
+    # the subject of the trust<2 fleet forcing below — so leaving it unguarded
+    # would reopen the escalation the check above closes, by a new spelling.
+    if auth.agent_id and body.caller_agent_id and body.caller_agent_id != auth.agent_id:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"caller_agent_id '{body.caller_agent_id}' does not match the "
+                f"authenticated agent identity '{auth.agent_id}'."
+            ),
+        )
+    # Identity, in precedence order: an authenticated agent always wins, then an
+    # explicit assertion, then the legacy derivation from the filter so existing
+    # callers are untouched. The filter itself is passed separately below and is
+    # unchanged — it was already a distinct parameter all the way down to the
+    # storage predicate; only the identity was derived from it.
+    eff_agent_id = auth.agent_id or body.caller_agent_id or body.filter_agent_id
+    # True when the identity was ASSERTED by a tenant-scoped caller rather than
+    # authenticated. Gates the recall_count bump below — see the note there.
+    identity_asserted = bool(not auth.agent_id and body.caller_agent_id)
     if auth.tenant_id:  # skip for admin
         if eff_agent_id:
             fleet_id_hint = body.fleet_ids[0] if body.fleet_ids and len(body.fleet_ids) == 1 else None
@@ -1792,6 +1812,15 @@ async def _search_inner(
             # explicit filter) so the caller sees its own scope_agent rows and
             # nobody else's, even when filter_agent_id is omitted.
             caller_agent_id=eff_agent_id,
+            # An identity the caller ASSERTED does not move recall_count unless
+            # the tenant opted in. Ranking is the reason: recall_boost defaults
+            # to True, so without this gate one integration adding
+            # caller_agent_id would reshuffle results for every other caller in
+            # the tenant. An authenticated agent identity is unaffected.
+            #
+            # Resolved here rather than in the step because the tenant config
+            # lives at the route; the pipeline gets the decision, not the inputs.
+            allow_recall_bump=(not identity_asserted) or config.recall_for_asserted_identity,
             memory_type_filter=body.memory_type_filter,
             status_filter=body.status_filter,
             valid_at=body.valid_at,

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -615,6 +615,30 @@ class SearchRequest(BaseModel):
     fleet_ids: list[str] | None = None
     query: str = Field(min_length=1, max_length=MAX_QUERY_LENGTH)
     filter_agent_id: str | None = None
+    # The identity knob, separate from the filter above. Before this, the two
+    # were one field: the visibility identity was DERIVED from
+    # ``filter_agent_id``, so a tenant-scoped key (``auth.agent_id`` is None)
+    # could only present an identity by also narrowing results to that agent's
+    # authored rows. ``GET /memories`` has drawn the same distinction in
+    # production for a while; /search was the odd one out.
+    #
+    # Grants no new visibility. ``scope_agent`` rows are admitted by
+    # ``visibility == "scope_agent" AND agent_id == caller_agent_id`` — keyed
+    # on the author column, the same one the filter matches — so naming X here
+    # admits exactly X's own scope_agent rows plus the shared rows, both
+    # already reachable today. The restriction that an AGENT credential may
+    # only name itself carries over unchanged.
+    caller_agent_id: str | None = Field(
+        default=None,
+        description=(
+            "Assert the agent identity this search runs as, WITHOUT filtering "
+            "results to that agent's own memories (use filter_agent_id for "
+            "that). Determines which scope_agent memories are visible and "
+            "whose trust/fleet level the read is gated against. Ignored when "
+            "the credential already carries an agent identity, which wins. An "
+            "agent-scoped credential may only name itself."
+        ),
+    )
     # C31/D2 — the short names are canonical (the spellings the MCP tools use);
     # the historical `*_filter` forms stay accepted forever as aliases. Before
     # this, `memory_type=fact` (the MCP spelling) was silently DROPPED by the

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -4502,7 +4502,13 @@ async def search_memories(
     source: str = "search",
     min_similarity: float | None = None,
     recall_ctx: dict | None = None,
+    allow_recall_bump: bool = True,
 ) -> list[MemoryOut]:
+    # ``allow_recall_bump`` defaults True so every existing caller — MCP
+    # ``caura_recall``, the internal search paths — keeps bumping exactly as
+    # before. Only ``POST /search`` passes False, and only for an identity the
+    # caller asserted rather than authenticated (#1197).
+    #
     # Diagnostic mode requires the pipeline path for score introspection
     if _USE_PIPELINE_SEARCH or diagnostic:
         return await _search_memories_pipeline(
@@ -4511,6 +4517,7 @@ async def search_memories(
             fleet_ids=fleet_ids,
             filter_agent_id=filter_agent_id,
             caller_agent_id=caller_agent_id,
+            allow_recall_bump=allow_recall_bump,
             memory_type_filter=memory_type_filter,
             status_filter=status_filter,
             valid_at=valid_at,
@@ -4551,9 +4558,10 @@ async def search_memories(
         tenant_config=tenant_config,
         search_profile=search_profile,
         min_similarity=min_similarity,
+        allow_recall_bump=allow_recall_bump,
     )
     if recall_ctx is not None:
-        recall_ctx["recall_tracked"] = bool(legacy_results)
+        recall_ctx["recall_tracked"] = bool(legacy_results) and allow_recall_bump
     return legacy_results
 
 
@@ -4563,6 +4571,7 @@ async def _search_memories_pipeline(
     fleet_ids: list[str] | None = None,
     filter_agent_id: str | None = None,
     caller_agent_id: str | None = None,
+    allow_recall_bump: bool = True,
     memory_type_filter: str | None = None,
     status_filter: str | None = None,
     valid_at: datetime | None = None,
@@ -4590,6 +4599,7 @@ async def _search_memories_pipeline(
             "fleet_ids": fleet_ids,
             "filter_agent_id": filter_agent_id,
             "caller_agent_id": caller_agent_id,
+            "allow_recall_bump": allow_recall_bump,
             "memory_type_filter": memory_type_filter,
             "status_filter": status_filter,
             "valid_at": valid_at,
@@ -4677,6 +4687,7 @@ async def _search_memories_legacy(
     tenant_config=None,
     search_profile: dict | None = None,
     min_similarity: float | None = None,
+    allow_recall_bump: bool = True,
 ) -> list[MemoryOut]:
     """Legacy search -- uses scored_search storage API endpoint."""
     sc = get_storage_client()
@@ -4827,8 +4838,14 @@ async def _search_memories_legacy(
             )
         )
 
-    # Increment recall_count and update last_recalled_at for returned memories
-    if memory_ids:
+    # Increment recall_count and update last_recalled_at for returned memories.
+    #
+    # This path bumps unconditionally — it does not apply the A26 agentless rule
+    # or the D12 diagnostic rule the pipeline step does, which is one of the
+    # reasons it is deprecated. ``allow_recall_bump`` is honoured here anyway:
+    # the flag exists so an identity a caller merely ASSERTED cannot move
+    # ranking, and a rollback lever is not a reason for that to stop being true.
+    if memory_ids and allow_recall_bump:
         try:
             await get_storage_client().increment_recall(
                 [str(m) for m in memory_ids],

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -100,6 +100,14 @@ DEFAULT_SETTINGS: dict = {
     },
     "search": {
         "recall_boost": None,
+        # Whether a caller-ASSERTED identity (SearchRequest.caller_agent_id from
+        # a tenant-scoped key) may move recall_count, and so ranking. Off by
+        # default, and deliberately a tenant switch rather than a per-request
+        # one: the effect is tenant-wide — recall_boost defaults to True — so
+        # one integration adopting the field would otherwise reshuffle results
+        # for every other caller in the tenant that never asked. An
+        # AUTHENTICATED agent identity is unaffected and bumps as it always has.
+        "recall_for_asserted_identity": None,
         "graph_retrieval": None,
         # Master switch for query-time entity/graph retrieval. ``False`` blocks
         # BOTH read entry points: the ``ENTITY_LOOKUP`` short-circuit in
@@ -572,6 +580,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "security_audit.alert_critical_findings_min": int,
     "security_audit.alert_score_drop_delta": (int, float),
     "search.recall_boost": bool,
+    "search.recall_for_asserted_identity": bool,
     "search.graph_retrieval": bool,
     "search.entity_retrieval": bool,
     "crystallizer.auto_crystallize": bool,
@@ -895,6 +904,15 @@ class ResolvedConfig:
     def recall_boost(self) -> bool:
         val = self._ts.get("search", {}).get("recall_boost")
         return val if val is not None else True
+
+    @property
+    def recall_for_asserted_identity(self) -> bool:
+        # Defaults FALSE, unlike its neighbours here. Every other search knob
+        # defaults on because it improves results for everyone; this one changes
+        # whose recalls shape ranking, which is a decision a tenant makes rather
+        # than one inherited from a client adopting a request field.
+        val = self._ts.get("search", {}).get("recall_for_asserted_identity")
+        return val if val is not None else False
 
     @property
     def graph_expand(self) -> bool:

--- a/tests/test_search_caller_identity.py
+++ b/tests/test_search_caller_identity.py
@@ -1,0 +1,204 @@
+"""POST /search — asserting a caller identity without filtering to it (#1197).
+
+Baseline first. #1197 claimed ``recall_count`` was "permanently dead for
+tenant-key callers". That is not right, and the first two tests here pin the
+accurate version: a tenant key that sets ``filter_agent_id`` ALREADY moves the
+counter today, because the route derived the visibility identity from the
+filter. What was dead is the bump for a tenant key that does not filter — and
+the cost of the workaround was the filtering itself, not a dead counter.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+@pytest.fixture
+def as_auth(monkeypatch):
+    """Controlled AuthContext, mirroring the gateway header-trust path."""
+    from core_api.app import app
+    from core_api.auth import AuthContext, get_auth_context
+    from core_api.tenant_context import set_current_tenant
+
+    def _install(tenant_id: str, agent_id: str | None = None, **kwargs):
+        async def _dep():
+            set_current_tenant(tenant_id)
+            return AuthContext(
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                readable_tenant_ids=[tenant_id],
+                **kwargs,
+            )
+
+        app.dependency_overrides[get_auth_context] = _dep
+
+    yield _install
+    from core_api.app import app as _app
+    from core_api.auth import get_auth_context as _gac
+
+    _app.dependency_overrides.pop(_gac, None)
+
+
+async def _seed(client, tenant: str, agent: str, visibility: str = "scope_team") -> None:
+    resp = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant,
+            "agent_id": agent,
+            "memory_type": "fact",
+            "content": f"a recallable fact {_uid()}",
+            "visibility": visibility,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+
+async def _search(client, tenant: str, **body) -> dict:
+    resp = await client.post(
+        "/api/v1/search",
+        json={"tenant_id": tenant, "query": "recallable fact", "top_k": 5, **body},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# --- baseline: what the tenant key could already do --------------------------
+
+
+async def test_a_tenant_key_that_filters_already_tracks_recalls(client, as_auth):
+    """The correction to #1197: filtering already carries an identity."""
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant)  # tenant-scoped: auth.agent_id is None
+    await _seed(client, tenant, "agent-a")
+    data = await _search(client, tenant, filter_agent_id="agent-a")
+    assert data["recall_tracked"] is True
+
+
+async def test_a_tenant_key_that_does_not_filter_tracks_nothing(client, as_auth):
+    """...and this is the case that was actually dead."""
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant)
+    await _seed(client, tenant, "agent-a")
+    data = await _search(client, tenant)
+    assert data["recall_tracked"] is False
+
+
+# --- identity without filtering ---------------------------------------------
+
+
+async def test_caller_agent_id_grants_identity_without_filtering(client, as_auth):
+    """The whole point: assert an identity, keep seeing everyone's rows.
+
+    The seed is deliberate. A ``scope_agent`` row is visible ONLY to the agent
+    that wrote it, so it is the one thing a tenant key cannot see without
+    presenting an identity — which makes it the only assertion here that can
+    tell "the field worked" apart from "the field was silently ignored".
+    ``SearchRequest`` is ``extra="ignore"``, so a test that merely counted
+    unfiltered rows would pass just as happily against a build with no such
+    field at all.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant)
+    await _seed(client, tenant, "agent-a", visibility="scope_agent")
+    await _seed(client, tenant, "agent-b", visibility="scope_team")
+
+    bare = await _search(client, tenant)
+    asserted = await _search(client, tenant, caller_agent_id="agent-a")
+    filtered = await _search(client, tenant, filter_agent_id="agent-a")
+
+    # No identity: agent-a's private row is invisible.
+    assert len(bare["items"]) == 1
+    # Identity asserted: agent-a's private row PLUS the shared one.
+    assert len(asserted["items"]) == 2
+    # The old workaround buys the same visibility at the cost of the filter.
+    assert len(filtered["items"]) == 1
+
+
+async def test_an_authenticated_agent_identity_wins(client, as_auth):
+    """Precedence: a credential that carries an identity is not overridable."""
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, agent_id="agent-a")
+    await _seed(client, tenant, "agent-a")
+    # Naming ITSELF is allowed, so this exercises precedence rather than the
+    # 403 below — auth.agent_id is what reaches the pipeline either way.
+    data = await _search(client, tenant, caller_agent_id="agent-a")
+    assert data["recall_tracked"] is True
+
+
+async def test_an_agent_credential_may_not_assert_a_peer_identity(client, as_auth):
+    """The escalation this field must not reopen.
+
+    ``caller_agent_id`` feeds exactly what ``filter_agent_id`` used to smuggle
+    in — the visibility identity and the subject of the trust<2 fleet forcing —
+    so the existing 403 has to cover the new spelling too.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, agent_id="agent-a")
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "tenant_id": tenant,
+            "query": "anything",
+            "top_k": 5,
+            "caller_agent_id": "agent-b",
+        },
+    )
+    assert resp.status_code == 403, resp.text
+
+
+# --- ranking stays put unless the tenant says otherwise ----------------------
+
+
+async def test_an_asserted_identity_does_not_move_recall_count_by_default(client, as_auth):
+    """The reason this is not just a one-line field.
+
+    recall_boost defaults to True, so a bump reshuffles results for every
+    caller in the tenant — not only the one that sent the field.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant)
+    await _seed(client, tenant, "agent-a", visibility="scope_agent")
+    data = await _search(client, tenant, caller_agent_id="agent-a")
+    # The scope_agent row proves the identity actually took effect — without
+    # that, "no bump" would also be satisfied by the field being ignored.
+    assert len(data["items"]) == 1
+    assert data["recall_tracked"] is False
+
+
+async def test_a_tenant_can_opt_in_to_tracking_asserted_recalls(client, as_auth, monkeypatch):
+    """...and the capability #1197 asked for is still reachable."""
+    from core_api.services.organization_settings import ResolvedConfig
+
+    monkeypatch.setattr(
+        ResolvedConfig,
+        "recall_for_asserted_identity",
+        property(lambda self: True),
+    )
+
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant)
+    await _seed(client, tenant, "agent-a", visibility="scope_agent")
+    data = await _search(client, tenant, caller_agent_id="agent-a")
+    assert len(data["items"]) == 1
+    assert data["recall_tracked"] is True
+
+
+async def test_an_authenticated_identity_is_unaffected_by_the_setting(client, as_auth):
+    """The setting gates ASSERTED identities only — it must not gate real ones.
+
+    Without this, shipping the default-off switch would silently stop recall
+    tracking for every agent-credential caller in the system.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, agent_id="agent-a")
+    await _seed(client, tenant, "agent-a")
+    data = await _search(client, tenant)
+    assert data["recall_tracked"] is True


### PR DESCRIPTION
Closes #1197. Re-verifying that issue before writing code changed it twice — it
is both **smaller** than filed and **differently wrong** than filed.

## The defect

`POST /search` derived the visibility identity from the author filter:

```python
eff_agent_id = body.filter_agent_id or auth.agent_id
```

A tenant-scoped key has `auth.agent_id = None`, so its only way to present an
identity was `filter_agent_id` — which unavoidably also narrowed results to
that agent's own authored rows. There was no way to say *"I am agent X"*
without also saying *"and show me only X's rows"*.

## Correction 1 — this is much smaller than #1197 claimed

The issue described a change touching auth resolution, TrackRecalls and the
stats route. It doesn't.

**The storage layer already takes the two as independent parameters** and
applies them to different predicates:

```python
if caller_agent_id:                       # visibility
    ... or_(scope_org, scope_team, and_(scope_agent, agent_id == caller_agent_id))
if filter_agent_id:                       # author filter
    ... where(Memory.agent_id == filter_agent_id)
```

And `_search_inner` **already passes them separately** — `filter_agent_id` from
the body, `caller_agent_id` as the identity. `GET /memories` has drawn the same
distinction in production for a while.

So the only conflation left was that the identity was *derived* from the
filter. The fix is one new optional field and one line.

## Correction 2 — `recall_count` was never "permanently dead"

#1197 said the counter was *"permanently dead for tenant-key callers"*. That is
not right, and this PR's first two tests pin the accurate version **against
unmodified `main`**:

| tenant key | `recall_tracked` |
|---|---|
| sets `filter_agent_id` | **true** — already bumps today |
| sets nothing | false |

A tenant key that filters already carries an identity and already moves the
counter. What was dead is the bump for a tenant key that does *not* filter — and
the real cost of the workaround was the filtering, not a dead counter. The
`SearchResponse.recall_tracked` description shipped in #1189 already states it
correctly; the issue text was the sloppy one.

## The change

```python
eff_agent_id = auth.agent_id or body.caller_agent_id or body.filter_agent_id
```

Authenticated agent wins, then an explicit assertion, then the legacy
derivation so existing callers are untouched. The filter is unchanged.

**No new visibility.** `scope_agent` rows are admitted by
`visibility == "scope_agent" AND agent_id == caller_agent_id` — keyed on the
**author column**, the same one the filter matches. Naming X as the identity
admits exactly X's own `scope_agent` rows plus the shared rows, both already
reachable by a tenant key today. Verified at the predicate rather than asserted.

The existing 403 is extended to the new spelling. `caller_agent_id` feeds
exactly what `filter_agent_id` used to smuggle in — the visibility identity and
the subject of the trust<2 fleet forcing — so leaving it unguarded would reopen
that escalation under a new name.

## Ranking is deferred, deliberately

Per the decision on the issue: **identity now, the bump behind a switch.**

`recall_boost` defaults to **True**, so a bump reshuffles results for every
caller in the tenant — not only the integration that sent the new field. That
makes it the wrong thing for a per-request field to decide, so it sits behind
`search.recall_for_asserted_identity`, **defaulting off**.

An **authenticated** agent identity is completely unaffected and bumps exactly
as before. The gate applies only to an identity the caller *asserted*.

The route resolves this to a single boolean (`allow_recall_bump`); the pipeline
step gets the decision, not the inputs. Defaulted `True` at every layer, so MCP
recall and the internal search paths are untouched. The deprecated legacy search
path honours it too — a rollback lever is not a reason for the property to stop
holding.

## Verification

Four of the six new tests **fail without this change**: the visibility grant,
the peer-assertion 403, the default no-bump, and the tenant opt-in.

Two pass either way **on purpose** — `test_an_authenticated_agent_identity_wins`
and `test_an_authenticated_identity_is_unaffected_by_the_setting`. They bound
the change rather than demonstrate it; without the second, shipping a default-off
switch could silently stop recall tracking for every agent-credential caller and
nothing would notice.

**Two of these tests were initially tautological and are worth flagging.**
`SearchRequest` is `extra="ignore"`, so a test that just counted unfiltered rows
passed identically against a build with no such field — the field being *dropped*
produced the same numbers as the field *working*. Both now seed a `scope_agent`
row, which is the one thing a tenant key cannot see without presenting an
identity, and so is the only assertion that distinguishes the two.

Full suite green. `ruff check`, `ruff format --check`, `mypy` clean. The broker
OpenAPI baseline is regenerated — the diff is one optional nullable request
field, additive and non-breaking.
