### PR TITLE
feat(gate): report the AST half without an installed tree

### DIFF
--- a/scripts/tenant_scope_gate.py
+++ b/scripts/tenant_scope_gate.py
@@ -89,6 +89,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 ALLOWLIST_PATH = REPO_ROOT / "core-storage-api" / "tenant_scope_allowlist.json"
 ROUTERS_DIR = REPO_ROOT / "core-storage-api" / "src" / "core_storage_api" / "routers"
 
+INSTALL_HINT = 'uv pip install -e "core-storage-api/[dev]"'
+
 # Resolve imports from the repo layout rather than from the caller's
 # environment. ``common`` is a plain directory at the repo root and is on no
 # installed path even in CI, where the services are installed editable — so
@@ -1870,6 +1872,130 @@ def ratchet(
     return errors
 
 
+# ---------------------------------------------------------------------------
+# Running without an installed tree
+#
+# The gate needed a full dev environment to say anything at all: no ``pgvector``
+# and it exited 2 having printed one line. That is not a small inconvenience.
+# The rebranding series published the ratchet's numbers in twelve revisions and
+# this gate's in almost none, and an instrument that only runs in a full dev
+# environment is an instrument that goes unread.
+#
+# The two halves are not equally dependent, and measuring which is which is the
+# whole of this. ``_classify_handlers`` parses ``routers/*.py`` with ``ast`` and
+# imports nothing: 187 handlers classified on a bare interpreter. The service
+# methods, the widening grants and the identity-writability check all reach for
+# ``PostgresService`` through ``inspect``, which means importing
+# ``core_storage_api`` and everything under it. So does the ROUTE LIST, which
+# comes from the live app on purpose — a router registered in a loop is still
+# counted, and the walk is cross-checked against ``app.openapi()``.
+#
+# WHAT THIS DELIBERATELY DOES NOT DO. It does not reconstruct route paths from
+# decorators to replace the live walk. That would be a second enumeration of
+# the same surface, weaker than the one it stands in for, and its failure mode
+# is a route it did not find — a false negative, the one direction this gate
+# must never be wrong in. Without paths there are no ``route:<VERB> <path>``
+# idents, so the degraded run cannot join the allowlist and CANNOT enforce it.
+#
+# Which is why this is a REPORT and not a gate, says so in those words, and
+# still exits 2. A version that ran everywhere by checking less and exited 0
+# would be worse than one that refuses: it would read as a pass.
+# ---------------------------------------------------------------------------
+
+# Named in the skip notice, so what is missing is a list a reader can check
+# rather than "some checks". Each is a check the full run performs and this one
+# cannot, with the reason it cannot.
+SKIPPED_WITHOUT_IMPORTS: tuple[tuple[str, str], ...] = (
+    ("service-method signatures", "inspect.signature on PostgresService"),
+    ("widening-grant findings", "inspect.signature on PostgresService"),
+    ("identity-writability findings", "SQLAlchemy model column types"),
+    ("the live route list and its OpenAPI cross-check", "core_storage_api.app"),
+    ("the allowlist comparison", "needs route idents, which need the route list"),
+    ("the --base ratchet", "needs the full entry set"),
+)
+
+
+def report_degraded(exc: ImportError, allowlist_path: Path) -> int:
+    """Print everything decidable without imports, then refuse to call it a pass.
+
+    Ordered diagnosis-first: what could not be imported, then what DID run,
+    then — last, where it is read rather than scrolled past — the itemised list
+    of what did not. The skip notice is the part that keeps this honest, so it
+    is not a footnote.
+    """
+    print("tenant-scope gate: DEGRADED RUN — a REPORT, not a gate.")
+    print(f"  cannot import core-storage-api ({exc}).")
+    print(f"  Install it for a full run: {INSTALL_HINT}")
+    print()
+
+    handlers = _classify_handlers()
+    counts: dict[str, int] = {}
+    for verdict, _ in handlers.values():
+        counts[verdict] = counts.get(verdict, 0) + 1
+    print(
+        f"AST pass over {ROUTERS_DIR.relative_to(REPO_ROOT)}: "
+        f"{len(handlers)} route handlers classified, "
+        f"{counts.get('REQUIRED', 0)} requiring a binding tenant."
+    )
+
+    # Grouped by module. 33 undifferentiated lines is the wall this file's own
+    # CATEGORIES comment argues against, and the module is the axis a reader
+    # navigates by — it is the file they would open.
+    flagged: dict[str, list[str]] = {}
+    for (module, function), (verdict, detail) in sorted(handlers.items()):
+        if verdict == "REQUIRED":
+            continue
+        flagged.setdefault(module, []).append(f"{function}  [{verdict}] {detail}")
+    if flagged:
+        total = sum(len(v) for v in flagged.values())
+        print(
+            f"  {total} handler(s) the AST pass reads as taking no binding tenant. "
+            "Whether each is a known exception is exactly what this run cannot "
+            "tell you — see the skip notice."
+        )
+        for module in sorted(flagged):
+            print(f"    {module}.py")
+            for line in flagged[module]:
+                print(f"      {line}")
+    print()
+
+    # Two real checks that need no imports. Reported as pass/fail rather than
+    # folded into the skip list, because they genuinely ran.
+    errors: list[str] = []
+    try:
+        allowlist = load_allowlist(allowlist_path)
+    except AllowlistError as exc_allow:
+        errors.append(str(exc_allow))
+    else:
+        print(
+            f"Allowlist integrity: {allowlist_path.name} parses, "
+            f"{len(allowlist)} entries, no duplicate ids."
+        )
+    errors.extend(check_category_doc(allowlist_path))
+    if not errors:
+        print(f"Category documentation: {allowlist_path.name} matches CATEGORIES.")
+    print()
+
+    print("SKIPPED — these checks did not run, and this report does not cover them:")
+    for what, why in SKIPPED_WITHOUT_IMPORTS:
+        print(f"  - {what} ({why})")
+    print()
+    print(
+        "--write and --base are refused in a degraded run: reseeding the "
+        "allowlist or ratcheting it from a partial enumeration would delete "
+        "entries whose paths were never enumerated."
+    )
+
+    if errors:
+        print()
+        for err in errors:
+            print(f"::error::{_as_annotation(err)}" if _in_github_actions() else f"error: {err}")
+
+    # 2, not 0, and not 1. The run was INCOMPLETE, which is what 2 has always
+    # meant here, and it stays 2 whether or not the import-free checks found
+    # something: nothing that reads an exit code should be able to mistake this
+    # for a full green gate.
+    return 2
 
 
 def main() -> int:
@@ -1883,9 +2009,10 @@ def main() -> int:
         routes = enumerate_routes()
         grants = _widening_grant_findings()
     except ImportError as exc:
-        print(f"error: cannot import core-storage-api ({exc}).", file=sys.stderr)
-        print("Install it first: uv pip install -e core-storage-api/[dev]", file=sys.stderr)
-        return 2
+        # Report what the AST pass can decide instead of exiting having printed
+        # nothing — see the section header above for what that is and what it
+        # is not. Still exit 2, and never reach --write or --base from here.
+        return report_degraded(exc, ALLOWLIST_PATH)
 
     entries = methods + routes
     try:

--- a/tests/test_tenant_scope_gate.py
+++ b/tests/test_tenant_scope_gate.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import ast
 import json
+import re
 import subprocess
 import sys
 import textwrap
@@ -1971,3 +1972,162 @@ def test_a_qualified_reference_counts_as_mentioning_the_name() -> None:
 
     assert "Entity" in referenced["m"]
     assert "_ENTITY_UPDATABLE_FIELDS" in referenced["m"]
+
+
+# ── running without an installed tree ────────────────────────────────────────
+#
+# The gate used to exit 2 having printed two lines when core-storage-api was not
+# importable, which is why its numbers reached almost none of the rebranding
+# revisions while the ratchet's reached twelve. These cases hold the line on
+# both halves of the fix: the AST findings DO come out, and nothing about the
+# run can be mistaken for a pass or allowed to rewrite the allowlist.
+
+
+def _degraded(*args: str) -> subprocess.CompletedProcess:
+    """The script on a bare interpreter — no site-packages, so no imports work.
+
+    ``-S`` rather than ``-I``: ``-I`` only drops the USER site directory, so
+    inside a venv (which is how CI runs) every dependency is still importable
+    and the degraded path would never be reached. ``-S`` adds no site directory
+    at all, which is the same position as a fresh clone.
+    """
+    return subprocess.run(
+        [sys.executable, "-S", str(SCRIPT), *args],
+        check=False,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_a_bare_interpreter_reports_the_ast_findings() -> None:
+    """The whole point: findings, not a bare refusal."""
+    result = _degraded()
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "DEGRADED RUN" in result.stdout
+    # A count of handlers and a count of scoped ones — the numbers that were
+    # unpublishable before. Asserted as "a number appeared", not as a literal,
+    # so the case does not need editing every time a route lands.
+    assert re.search(r"\d+ route handlers classified", result.stdout), result.stdout
+    assert "requiring a binding tenant" in result.stdout
+
+
+def test_a_bare_interpreter_names_a_real_unscoped_handler() -> None:
+    """Findings, not just totals.
+
+    ``memories.bulk_get`` is the handler behind GHSA-wgvw-28pq-jc36's exploit
+    primitive, and ``admin_list`` is one the AST pass reads as OPTIONAL. If the
+    report only printed counts it would be a statistic, not an instrument.
+    """
+    result = _degraded()
+
+    assert "memories.py" in result.stdout
+    assert "admin_list" in result.stdout
+
+
+def test_a_bare_interpreter_says_what_it_skipped() -> None:
+    """Whatever it skips, it must say it skipped — every item, not "some checks".
+
+    Asserted against the script's own list rather than a copy of it, so adding
+    an import-dependent check without naming it here fails.
+    """
+    result = _degraded()
+
+    assert "SKIPPED" in result.stdout
+    for what, _why in gate.SKIPPED_WITHOUT_IMPORTS:
+        assert what in result.stdout, what
+    assert "service-method signatures" in result.stdout
+
+
+def test_a_bare_interpreter_does_not_claim_to_be_a_gate() -> None:
+    """Exit 2 and the words. A green-looking partial run is worse than a refusal.
+
+    Exit code AND text, because either alone is insufficient: a human reads the
+    text and a CI step reads the code, and this run must be unusable as a pass
+    to both.
+    """
+    result = _degraded()
+
+    assert result.returncode == 2
+    assert "REPORT, not a gate" in result.stdout
+
+
+def test_a_bare_interpreter_refuses_to_reseed_the_allowlist() -> None:
+    """``--write`` from a partial enumeration would DELETE reviewed entries.
+
+    ``render_allowlist`` writes the entries it was given, so seeding it from an
+    enumeration missing all 186 service methods would drop every method entry
+    and every category on them — silently, and with a green-looking "wrote"
+    line. This is the one failure in the degraded path that damages the
+    repository rather than merely under-reporting.
+    """
+    before = ALLOWLIST.read_bytes()
+
+    result = _degraded("--write")
+
+    assert result.returncode == 2
+    assert "refused in a degraded run" in result.stdout
+    assert "wrote" not in result.stdout
+    assert ALLOWLIST.read_bytes() == before
+
+
+def test_a_bare_interpreter_refuses_to_ratchet() -> None:
+    """``--base`` compares allowlists; a partial entry set makes the answer wrong.
+
+    Every method entry would read as "removed", which the ratchet reports as
+    progress — the direction it exists to distinguish from regression.
+    """
+    result = _degraded("--base", "origin/main")
+
+    assert result.returncode == 2
+    assert "refused in a degraded run" in result.stdout
+    assert "Allowlist comparison against" not in result.stdout
+
+
+def test_the_import_free_checks_actually_run_when_degraded(tmp_path: Path) -> None:
+    """The report is not only prose: two real checks run and can fail.
+
+    Driven through ``report_degraded`` with a deliberately broken allowlist,
+    since the committed one is (and must stay) valid.
+    """
+    broken = tmp_path / "tenant_scope_allowlist.json"
+    broken.write_text(
+        json.dumps(
+            {
+                "_categories": gate.CATEGORIES,
+                "exceptions": [
+                    {"id": "route:GET /x", "category": "no-tenant-data"},
+                    {"id": "route:GET /x", "category": "admin-unscoped"},
+                ],
+            }
+        )
+    )
+
+    code = gate.report_degraded(ImportError("No module named 'pgvector'"), broken)
+
+    assert code == 2
+
+
+def test_a_degraded_run_still_passes_its_own_integrity_checks() -> None:
+    """And on the committed allowlist, those checks report clean.
+
+    Paired with the case above so "the checks ran" is not satisfied by a check
+    that fails either way.
+    """
+    result = _degraded()
+
+    assert "no duplicate ids" in result.stdout
+    assert "matches CATEGORIES" in result.stdout
+
+
+def test_an_installed_tree_is_unaffected() -> None:
+    """The full run is the gate, and this change must not have touched it.
+
+    Verified against the real environment rather than a mock: if the tests can
+    import the service, so can the script, and it must take the full path.
+    """
+    result = _run()
+
+    assert "DEGRADED" not in result.stdout
+    assert "service methods" in result.stdout


### PR DESCRIPTION
`scripts/tenant_scope_gate.py` could not run without an installed environment: a bare run exited **2** having printed two lines.

```
error: cannot import core-storage-api (No module named 'pgvector').
Install it first: uv pip install -e core-storage-api/[dev]
```

`--help` worked and that message is a clean actionable line rather than a traceback — **better diagnosis, not better runnability.** Carried on the board for three consecutive revisions, and the cost is measurable: the rebranding series has published the ratchet's numbers in twelve revisions and this gate's in almost none. **An instrument that only runs in a full dev environment is an instrument that goes unread.**

## How much can run without imports — measured, not estimated

| half | imports? | evidence |
|---|---|---|
| `_classify_handlers` — AST over `routers/*.py` | **none** | **187 handlers classified on a bare interpreter** |
| `load_allowlist` | **none** | parses, 64 entries, duplicate detection live |
| `check_category_doc` | **none** | runs, compares against `CATEGORIES` |
| `enumerate_methods` | **yes** | `inspect.signature` on `PostgresService` |
| `_widening_grant_findings` | **yes** | same |
| `_identity_writability_findings` | **yes** | SQLAlchemy model column types |
| **the route list** | **yes** | `core_storage_api.app` — deliberately live |

The route list is the one that may surprise: `enumerate_routes` is *not* purely AST. `_classify_handlers` (AST) says what each handler does; the **list of routes** comes from the live app on purpose, so a router registered in a loop or behind a conditional is still counted, cross-checked against `app.openapi()`.

## What now happens on an ImportError

```
tenant-scope gate: DEGRADED RUN — a REPORT, not a gate.
  cannot import core-storage-api (No module named 'sqlalchemy').
  Install it for a full run: uv pip install -e "core-storage-api/[dev]"

AST pass over core-storage-api/src/core_storage_api/routers: 187 route handlers
classified, 155 requiring a binding tenant.
  32 handler(s) the AST pass reads as taking no binding tenant. Whether each is a
  known exception is exactly what this run cannot tell you — see the skip notice.
    memories.py
      admin_list  [OPTIONAL] reads tenant_id with .get() and never rejects a missing one
      bulk_get    [NONE] no binding tenant read from the request
      ...
Allowlist integrity: tenant_scope_allowlist.json parses, 64 entries, no duplicate ids.
Category documentation: tenant_scope_allowlist.json matches CATEGORIES.

SKIPPED — these checks did not run, and this report does not cover them:
  - service-method signatures (inspect.signature on PostgresService)
  - widening-grant findings (inspect.signature on PostgresService)
  - identity-writability findings (SQLAlchemy model column types)
  - the live route list and its OpenAPI cross-check (core_storage_api.app)
  - the allowlist comparison (needs route idents, which need the route list)
  - the --base ratchet (needs the full entry set)

--write and --base are refused in a degraded run: reseeding the allowlist or
ratcheting it from a partial enumeration would delete entries whose paths were
never enumerated.
exit: 2
```

Findings, not just totals — the 32 flagged handlers by name, grouped by module, because a count is a statistic and a name is an instrument.

## The gate is not weakened

**It still exits 2, and it calls itself a REPORT in those words.** A version that ran everywhere by checking less and exited 0 would be worse than one that refuses, because it would read as a pass. Exit code *and* text, since a human reads one and a CI step reads the other.

**`--write` and `--base` are refused.** `render_allowlist` writes the entries it is given, so reseeding from an enumeration missing all 186 service methods would delete every method entry **and every reviewed category on them** — silently, under a green-looking `wrote` line. That is the one degraded-path failure that damages the repository rather than merely under-reporting.

**No route-path reconstruction.** Deriving paths from decorators to stand in for the live walk would be a second, weaker enumeration of the same surface, and its failure mode is a route it did not find — a **false negative**, the one direction this gate must never be wrong in. Without paths there are no `route:<VERB> <path>` idents, so the degraded run cannot join the allowlist and **cannot enforce it**. That is why it is a report, and why the skip notice names it.

**Whatever it skips, it says it skipped** — and `test_a_bare_interpreter_says_what_it_skipped` asserts against the script's own `SKIPPED_WITHOUT_IMPORTS` list, so adding an import-dependent check without naming it there fails.

## The full path is untouched

A/B in-tree against `HEAD`'s script on the same interpreter, with and without `--base`: **identical stdout, stderr and exit code.** The change is confined to the `ImportError` branch.

## Tests, confirmed failing without the fix

8 of the 9 new cases fail against `HEAD`'s script. The pre-fix run produces empty stdout and `error: cannot import core-storage-api (No module named 'sqlalchemy')`:

```
FAILED test_a_bare_interpreter_reports_the_ast_findings
FAILED test_a_bare_interpreter_names_a_real_unscoped_handler
FAILED test_a_bare_interpreter_says_what_it_skipped
FAILED test_a_bare_interpreter_does_not_claim_to_be_a_gate
FAILED test_a_bare_interpreter_refuses_to_reseed_the_allowlist
FAILED test_a_bare_interpreter_refuses_to_ratchet
FAILED test_the_import_free_checks_actually_run_when_degraded
FAILED test_a_degraded_run_still_passes_its_own_integrity_checks
8 failed, 1 passed
```

**The ninth passes both ways, by design, and I am flagging it rather than counting it.** `test_an_installed_tree_is_unaffected` is a regression guard on the full path, not a new-behaviour test — it is the case that would catch the A/B above regressing. 122 pass with the change.

The harness uses `python -S`, not `-I`: `-I` only drops the *user* site directory, so inside a venv (which is how CI runs) every dependency is still importable and the degraded path would never be reached. `-S` adds no site directory at all — the same position as a fresh clone. Verified working on both a framework python and a venv python.

## Verified

- `ruff check` then `ruff format --check`, run separately, at all 6 caura CI scopes: clean
- mypy at all 5 CI scopes: clean (`core-api` 203, `core-storage-api` 85, `core-operations` 5, `core-worker` 11, `common/` 99 files)
- full gate: `189 routes + 186 service methods, 311 bound to a tenant, 64 allowlisted`, exit 0; with `--base origin/main`, `added (0)`, exit 0
- ratchet `No new lines.` exit 0; sentinel `All 46 protected strings survive.` exit 0
- `uv.lock` untouched (this repo has none); installed with the four editable `[dev]` extras

## Flagged, not fixed

**Neither changed file is in any caura CI ruff or mypy scope.** `scripts/` and the root `tests/` are linted by nothing here. Consequence, measured at `HEAD` on code I did not touch: `scripts/tenant_scope_gate.py` has **56 lines over 88 chars** (longest 119), and `ruff check` reports a pre-existing `ISC004` at line 1508 in `check_category_doc`. I have deliberately **not** reformatted — a wholesale reformat of a security gate is unrelated churn — and my one over-88 line is a verbatim copy of the file's own `print(f"::error::..." if _in_github_actions() else ...)` idiom, whose twin sits ~90 lines below in `main()`; wrapping mine alone would make two copies of one idiom look different.

`caura-enterprise` closed exactly this gap for its own `scripts/` (its ci.yml: *"scripts/ was linted by NOTHING until now"*). Worth the same here, as its own PR.