### PR TITLE
feat(mcp): bill the batch write against the write counter, flag-gated

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -405,6 +405,22 @@ class Settings(BaseSettings):
     # for the first time, so enabling it is a deliberate billing decision,
     # not a deploy side effect. Off = the historical (miscounted) behavior.
     meter_recall_as_recall: bool = False
+    # Meter the MCP batch write (``caura_write(items=[...])``) against the
+    # write counter, one unit per item, as REST's ``POST /memories/bulk``
+    # already does. Off by default for the same reason as the D13 flag above,
+    # and the reason is stronger here: that path charges NOTHING today, so
+    # flipping this does not correct a miscount — it starts billing writes
+    # that have been free. Tenants that batch over MCP will consume quota they
+    # did not before, and some will cross their plan limit for the first time.
+    #
+    # Crossing it bites on REST FIRST. Over-plan mode is computed from these
+    # counters and stamped as ``x-org-read-only``, which core-api turns into a
+    # 403 on ~22 REST write routes — while the MCP surface only OBSERVES it
+    # (see ``_observe_plan_limit``). So enabling this can refuse a tenant's
+    # REST writes because of what it wrote over MCP. That is the intended end
+    # state, but it is not a deploy side effect. Off = the historical (unbilled)
+    # behavior. See caura-ai/caura#1220.
+    meter_mcp_bulk_writes: bool = False
     stm_backend: str = "memory"  # memory | redis
     stm_notes_ttl: int = 86400  # 24h
     stm_bulletin_ttl: int = 172800  # 48h

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -95,7 +95,9 @@ from core_api.services.trust_service import parse_trust_error
 from core_api.services.trust_service import require_trust as _require_trust
 from core_api.services.usage_service import (
     MutatingOp,
+    bulk_check_and_increment,
     charges_write_quota,
+    meters_mcp_bulk_write,
     plan_limit_gated,
     recall_operation,
 )
@@ -427,7 +429,8 @@ def _observe_plan_limit(op: MutatingOp, tenant_id: str) -> None:
     READ SILENCE CAREFULLY. Three different things produce no log, and only one
     of them is "nothing would be refused": the gateway may not stamp the header
     on this route at all (above), or the tenant may never have been marked over
-    plan because the MCP batch path records no usage to compute that from
+    plan because the MCP batch path records no usage to compute that from —
+    which stays true while ``meters_mcp_bulk_write()`` is off, its default
     (caura-ai/caura#1220). Rule those out before reading a quiet log as a
     green light to enforce.
 
@@ -1211,19 +1214,25 @@ async def caura_write(
             # path where an over-plan tenant can add the most rows per call, so
             # leaving it out would have made the numbers read low in exactly
             # the direction that matters.
-            #
-            # NOTE while you are here: this path charges NO write quota at all
-            # — no ``check_and_increment``, no ``bulk_check_and_increment``,
-            # while REST's ``POST /memories/bulk`` charges one per item
-            # (caura-ai/caura#1220). Filed rather than fixed here: that one
-            # changes billing, this one only changes logging.
-            #
-            # It also bounds what the line below can tell you. The counters
-            # that never move here are the same counters ``x-org-read-only`` is
-            # computed from, so a batch-heavy tenant may never be marked over
-            # plan at all — meaning silence from this observation is not by
-            # itself evidence that nothing would be refused.
             _observe_plan_limit("bulk_create", tenant_id)
+            # One unit per item, mirroring REST's ``POST /memories/bulk``, which
+            # charges ``len(body.items)`` before the write. Before this the path
+            # charged nothing at all (caura-ai/caura#1220).
+            #
+            # Ordering is copied from REST deliberately rather than reasoned out
+            # afresh: the charge lands BEFORE the write, so a batch that fails
+            # partway still costs what it attempted. Two conventions for the
+            # same operation across two surfaces is the drift this whole area
+            # keeps producing.
+            #
+            # ``meters_mcp_bulk_write()`` is off by default. It is a billing
+            # switch, not a correctness one — see its docstring. While it is
+            # off, the caveat on ``_observe_plan_limit`` still stands: the
+            # counters this would move are the ones over-plan mode is computed
+            # from, so a quiet observation log is not evidence that nothing
+            # would be refused.
+            if charges_write_quota("bulk_create") and meters_mcp_bulk_write():
+                await bulk_check_and_increment(tenant_id, len(bulk_items))
             bulk_data = BulkMemoryCreate(
                 tenant_id=tenant_id,
                 fleet_id=fleet_id,

--- a/core-api/src/core_api/services/usage_service.py
+++ b/core-api/src/core_api/services/usage_service.py
@@ -248,6 +248,28 @@ def recall_operation() -> OperationType:
     return "recall" if settings.meter_recall_as_recall else "search"
 
 
+def meters_mcp_bulk_write() -> bool:
+    """Whether the MCP batch write bills the write counter (caura-ai/caura#1220).
+
+    ``caura_write(items=[...])`` reaches ``create_memories_bulk`` with no
+    metering call of any kind, while REST's ``POST /memories/bulk`` charges one
+    unit per item. Same tenant, same N memories, different bill.
+
+    Gated for the same reason as ``recall_operation`` above, and more sharply:
+    that one bills the wrong counter, this one bills nothing. Turning it on
+    starts charging for writes that have been free, so it is a billing decision
+    rather than a deploy side effect — see the setting's comment for why the
+    first refusal a tenant sees will come from REST.
+
+    ``charges_write_quota("bulk_create")`` is still consulted at the call site.
+    This flag is the deploy-time gate; that table remains the policy record, so
+    a future change to it reaches this path like any other.
+    """
+    from core_api.config import settings
+
+    return settings.meter_mcp_bulk_writes
+
+
 async def check_and_increment(
     tenant_id: str,
     operation: OperationType,

--- a/tests/test_mcp_bulk_write_metering.py
+++ b/tests/test_mcp_bulk_write_metering.py
@@ -1,0 +1,108 @@
+"""MCP batch write bills the write counter, flag-gated (caura-ai/caura#1220).
+
+``caura_write(items=[...])`` reached ``create_memories_bulk`` with no metering
+call of any kind, while REST's ``POST /memories/bulk`` charges one unit per
+item. Same tenant, same N memories, different bill — and the counters it missed
+are the ones over-plan mode is computed from, so a batch-heavy tenant could
+never trip its plan limit.
+
+Gated behind ``settings.meter_mcp_bulk_writes``, default OFF, mirroring the D13
+``meter_recall_as_recall`` precedent: this starts charging for writes that have
+been free, which is a billing decision rather than a deploy side effect.
+
+Both states are pinned below. The off case is not a placeholder — while it is
+the default it IS the shipped behaviour, and a silent flip would bill live
+tenants without anyone choosing to.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core_api import mcp_server
+from core_api.config import settings
+from tests._mcp_test_helpers import parse_envelope
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class _OutStub:
+    def model_dump(self, mode: str = "python"):  # noqa: ARG002
+        return {"id": "batch-1", "status": "created"}
+
+
+@pytest.fixture
+def bulk_meter(monkeypatch):
+    """Patch the bulk meter and hand back the mock for call assertions."""
+    meter = AsyncMock(return_value=None)
+    monkeypatch.setattr(mcp_server, "bulk_check_and_increment", meter)
+    return meter
+
+
+async def test_batch_write_is_not_billed_while_the_flag_is_off(mcp_env, bulk_meter, monkeypatch):
+    """The shipped default. Pins it deliberately rather than by omission."""
+    monkeypatch.setattr(settings, "meter_mcp_bulk_writes", False)
+    mcp_env["service"]("create_memories_bulk").return_value = _OutStub()
+
+    out = await mcp_server.caura_write(items=[{"content": "one"}, {"content": "two"}])
+
+    assert "error" not in parse_envelope(out)
+    bulk_meter.assert_not_awaited()
+
+
+async def test_batch_write_bills_one_unit_per_item_when_enabled(mcp_env, bulk_meter, monkeypatch):
+    """The fix: N items cost N, matching REST's POST /memories/bulk."""
+    monkeypatch.setattr(settings, "meter_mcp_bulk_writes", True)
+    mcp_env["service"]("create_memories_bulk").return_value = _OutStub()
+
+    out = await mcp_server.caura_write(
+        items=[{"content": "one"}, {"content": "two"}, {"content": "three"}]
+    )
+
+    assert "error" not in parse_envelope(out)
+    bulk_meter.assert_awaited_once()
+    tenant_id, count = bulk_meter.await_args.args
+    assert count == 3, "must charge per item, not once per call"
+    assert tenant_id == mcp_env["tenant"]
+
+
+async def test_billing_happens_before_the_write(mcp_env, bulk_meter, monkeypatch):
+    """REST charges before the write, so a batch that fails partway still costs
+    what it attempted. Two orderings for one operation across two surfaces is
+    the drift this area keeps producing, so the ordering is pinned, not assumed.
+    """
+    monkeypatch.setattr(settings, "meter_mcp_bulk_writes", True)
+    order: list[str] = []
+    bulk_meter.side_effect = lambda *a, **k: order.append("meter")
+
+    async def _write(*args, **kwargs):
+        order.append("write")
+        return _OutStub()
+
+    mcp_env["service"]("create_memories_bulk").side_effect = _write
+
+    await mcp_server.caura_write(items=[{"content": "one"}])
+
+    assert order == ["meter", "write"]
+
+
+async def test_the_single_write_path_is_untouched(mcp_env, bulk_meter, monkeypatch):
+    """Scope guard: this change is the batch path only.
+
+    The single-content path has always metered through ``check_and_increment``
+    and must not start double-charging through the bulk meter as well.
+    """
+    monkeypatch.setattr(settings, "meter_mcp_bulk_writes", True)
+    mcp_env["service"]("create_memory").return_value = _OutStub()
+
+    await mcp_server.caura_write(content="a single fact")
+
+    bulk_meter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_the_flag_defaults_off():
+    """A rebuilt image with no env change must bill exactly as before."""
+    assert settings.meter_mcp_bulk_writes is False


### PR DESCRIPTION
Closes #1220.

## The gap

`caura_write(items=[...])` reached `create_memories_bulk` with **no metering
call of any kind** — no `check_and_increment`, no `bulk_check_and_increment`.
The only metering inside `caura_write` sits on the single-content path, behind
`if content is not None`.

REST charges:

```python
# routes/memories.py — POST /memories/bulk
usage = await bulk_check_and_increment(body.tenant_id, len(body.items))
```

`bulk_check_and_increment` had **zero occurrences** in `mcp_server.py`.

| surface | call | write quota charged |
|---|---|---|
| REST | `POST /memories/bulk`, N items | N |
| MCP | `caura_write(items=[…])`, N items | **0** |

### The second-order effect is the worse one

Those are the counters the platform computes "over plan" from. A tenant writing
batches over MCP did not merely underpay — **it could never trip its plan limit
at all**, because the usage that would trip it was never recorded.

## Off by default, and why

Gated behind `settings.meter_mcp_bulk_writes`, **defaulting False**, mirroring
the D13 `meter_recall_as_recall` precedent in the same module — a metering
correction held behind a flag because *"enabling it is a deliberate billing
decision, not a deploy side effect."*

**The reason is stronger here than for D13.** That one bills the wrong counter;
this one bills nothing. Turning it on starts charging for writes that have been
free, so tenants batching over MCP will consume quota they did not before, and
some will cross their plan limit for the first time.

### Crossing it bites on REST first

This is the part worth reading twice. Over-plan mode is stamped as
`x-org-read-only`, and core-api turns that into a **403 on ~22 REST write
routes** — while the MCP surface only *observes* it (#1221, which deliberately
does not enforce yet).

So enabling this flag can **refuse a tenant's REST writes because of what it
wrote over MCP**. That is the intended end state, but it is not something to
discover from a deploy.

To enable: set `METER_MCP_BULK_WRITES=true`. Say the word if you would rather
the default were on — it is a one-line change plus one test assertion, and the
tests already cover both states.

## Ordering copied, not re-derived

The charge lands **before** the write, so a batch that fails partway still costs
what it attempted. That is REST's convention and it is copied rather than
reasoned out afresh — two conventions for one operation across two surfaces is
precisely the drift this area keeps producing (#1196, #1205, #1220 are all the
same shape).

`charges_write_quota("bulk_create")` is still consulted at the call site. The
flag is the deploy-time gate; the table stays the policy record, so a future
change to it reaches this path like any other.

## Verification

Five tests, and the two that matter were confirmed by **mutation** rather than
by passing:

- removing the flag guard (always meter) → `test_batch_write_is_not_billed_while_the_flag_is_off` **fails**
- charging `1` instead of `len(bulk_items)` → `test_batch_write_bills_one_unit_per_item_when_enabled` **fails**

So both the default-off behaviour and the per-item count are genuinely held by a
test, not merely asserted in a comment.

Also pinned: the meter-before-write ordering, that the single-content path does
not start double-charging through the bulk meter, and that the flag defaults
off. That last one is not a placeholder — while it is the default it **is** the
shipped behaviour, and a silent flip would bill live tenants without anyone
choosing to.

Full suite green. `ruff check`, `ruff format --check`, `mypy` and the broker
OpenAPI check are clean.

## Knock-on to #1205

`_observe_plan_limit`'s docstring warned that a quiet log is not evidence that
nothing would be refused, partly because this path recorded no usage. That
caveat now says it holds **while this flag is off** — which is its default, so
the warning still stands today.
