### PR TITLE
fix(search): stop withholding information the caller needs (A28, C6, D6)

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -1657,6 +1657,7 @@
                 "type": "null"
               }
             ],
+            "description": "Restrict results to one status. When omitted, superseded memories are hidden: 'outdated' rows are excluded, and 'conflicted' rows are excluded unless they exactly match the query text. Their replacements are injected in their place. Pass an explicit status to bypass this and read the superseded rows directly.",
             "title": "Status Filter"
           },
           "tenant_id": {
@@ -1716,12 +1717,53 @@
             "description": "Whether this search bumped recall_count for the memories it returned. False means they were not reinforced: the caller presented no agent identity (a tenant-scoped key that did not set filter_agent_id — recall_count stays 0 for that caller and recall_boost never engages), the call set diagnostic=true, or nothing matched.",
             "title": "Recall Tracked",
             "type": "boolean"
+          },
+          "warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SearchWarning"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warnings"
           }
         },
         "required": [
           "items"
         ],
         "title": "SearchResponse",
+        "type": "object"
+      },
+      "SearchWarning": {
+        "description": "A28 — a coded, non-fatal caveat about the result set.\n\nThe search succeeded, but something the caller would reasonably assume\nhappened did not. Distinct from ``SearchDiagnostic``: that is opt-in\nintrospection, this is unsolicited and only present when there is something\nto say.",
+        "properties": {
+          "code": {
+            "description": "Stable slug, e.g. 'successor_enrichment_incomplete'.",
+            "title": "Code",
+            "type": "string"
+          },
+          "details": {
+            "additionalProperties": true,
+            "description": "Machine-readable context.",
+            "title": "Details",
+            "type": "object"
+          },
+          "message": {
+            "description": "Human-readable summary of what is incomplete.",
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "title": "SearchWarning",
         "type": "object"
       },
       "UsageSummary": {

--- a/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
+++ b/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
@@ -13,7 +13,29 @@ from core_api.services.memory_service import _memory_to_out
 
 logger = logging.getLogger(__name__)
 
-MAX_SUCCESSOR_LOOKUPS = 10
+# A28 — defensive ceiling on the successor lookup's IN-list, NOT a cost control.
+#
+# This was 10, which truncated silently: a result set with more than ten
+# outdated/conflicted rows left the 11th onward with no successor loaded and no
+# signal to the caller, so a stale claim surfaced as if no correction existed —
+# the exact failure the A34 contract exists to prevent.
+#
+# The truncation bought nothing. ``find_successors`` is ONE storage call, and on
+# the storage side ONE indexed query (``supersedes_id IN (...)`` with no LIMIT),
+# so ten ids and a thousand cost the same round-trip. The bound survives only to
+# keep a pathological array parameter away from Postgres' bind limits, and is set
+# far above anything the public contract can produce: ``top_k`` is capped at
+# MAX_SEARCH_TOP_K (20), so ``outdated_ids`` cannot approach this from the API.
+# If it ever does engage, the caller is TOLD (see SUCCESSOR_ENRICHMENT_INCOMPLETE
+# below) rather than silently handed stale rows.
+MAX_SUCCESSOR_LOOKUPS = 1000
+
+# Coded warning surfaced on the search response when successor injection could
+# not be completed. Two causes, one signal: the bound above engaged, or the
+# storage call failed. Both previously produced nothing but a server-side log,
+# which meant the caller could not distinguish "no correction exists" from "we
+# did not look".
+SUCCESSOR_ENRICHMENT_INCOMPLETE = "successor_enrichment_incomplete"
 
 _SCORE_FACTORS = (
     "vec_sim",
@@ -33,6 +55,29 @@ def _mem_field(memory, key: str):
     if isinstance(memory, dict):
         return memory.get(key)
     return None
+
+
+def _warn(ctx: PipelineContext, *, reason: str, stale_result_count: int, enriched: int) -> None:
+    """Record a caller-visible warning that successor injection was incomplete.
+
+    Written into ``ctx.data["warnings"]``, which the search service hands back to
+    the route. Unlike the D12 diagnostic block this is NOT opt-in: a caller who
+    did not ask for diagnostics still needs to know the result set is missing
+    corrections it would otherwise have carried.
+    """
+    ctx.data.setdefault("warnings", []).append(
+        {
+            "code": SUCCESSOR_ENRICHMENT_INCOMPLETE,
+            "message": (
+                "Some outdated/conflicted results may be missing the newer memory that supersedes them."
+            ),
+            "details": {
+                "reason": reason,
+                "stale_result_count": stale_result_count,
+                "enriched": enriched,
+            },
+        }
+    )
 
 
 def _score_parts(row) -> ScoreParts | None:
@@ -64,13 +109,24 @@ class LoadAndSerialize:
             in ("outdated", "conflicted")
         ]
         if outdated_ids:
-            if len(outdated_ids) > MAX_SUCCESSOR_LOOKUPS:
+            stale_total = len(outdated_ids)
+            if stale_total > MAX_SUCCESSOR_LOOKUPS:
                 logger.warning(
                     "Capping successor lookups from %d to %d",
-                    len(outdated_ids),
+                    stale_total,
                     MAX_SUCCESSOR_LOOKUPS,
                 )
                 outdated_ids = outdated_ids[:MAX_SUCCESSOR_LOOKUPS]
+                # Partial enrichment beats none — the rows that DID get a
+                # successor keep the A34 guarantee — but the caller has to know
+                # the set is incomplete, or an unenriched stale row reads as
+                # "no correction exists".
+                _warn(
+                    ctx,
+                    reason="lookup_bound_exceeded",
+                    stale_result_count=stale_total,
+                    enriched=MAX_SUCCESSOR_LOOKUPS,
+                )
             existing_ids = {
                 str(row.Memory.id if hasattr(row.Memory, "id") else row.Memory.get("id")) for row in rows
             }
@@ -95,6 +151,11 @@ class LoadAndSerialize:
                     "find_successors failed; continuing without successor enrichment", exc_info=True
                 )
                 successors = []
+                # Same class of silence as the cap: the search still returns
+                # stale rows, but nothing looked for their corrections. Degrading
+                # to an un-enriched result set is the right behaviour; doing it
+                # invisibly is not.
+                _warn(ctx, reason="storage_error", stale_result_count=stale_total, enriched=0)
             for successor in successors:
                 sid = successor.get("id")
                 if sid not in existing_ids:

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -58,6 +58,7 @@ from core_api.schemas import (
     SearchDiagnostic,
     SearchRequest,
     SearchResponse,
+    SearchWarning,
     STMWriteResponse,
     UsageSummary,
 )
@@ -1798,6 +1799,9 @@ async def _search_inner(
     # Filled by TrackRecalls (via search_memories) with whether this search
     # dispatched a recall_count bump — reported to the caller below.
     recall_ctx: dict = {}
+    # A28 — always collected (no request flag gates it); only serialized below
+    # when a step actually put something in it.
+    search_warnings: list = []
     try:
         config = await resolve_config(body.tenant_id)
         # Widen the read predicate when the caller authenticated with
@@ -1833,6 +1837,7 @@ async def _search_inner(
             readable_tenant_ids=auth.readable_tenant_ids if auth.is_cross_tenant_read else None,
             diagnostic=body.diagnostic,
             diagnostic_ctx=diagnostic_ctx if body.diagnostic else None,
+            warnings_ctx=search_warnings,
             min_similarity=body.min_similarity,
             recall_ctx=recall_ctx,
         )
@@ -1857,12 +1862,15 @@ async def _search_inner(
                 },
             )
     recall_tracked = bool(recall_ctx.get("recall_tracked"))
+    # A28 — null when empty (matches ``diagnostic``); purely additive.
+    warn_out = [SearchWarning(**w) for w in search_warnings] or None
     if not body.diagnostic:
-        return SearchResponse(items=results, recall_tracked=recall_tracked)
+        return SearchResponse(items=results, recall_tracked=recall_tracked, warnings=warn_out)
     counts = diagnostic_ctx.get("counts", {}) or {}
     return SearchResponse(
         items=results,
         recall_tracked=recall_tracked,
+        warnings=warn_out,
         diagnostic=SearchDiagnostic(
             retrieval_strategy=diagnostic_ctx.get("retrieval_strategy"),
             top_k_requested=diagnostic_ctx.get("diagnostic_original_top_k"),

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -51,6 +51,13 @@ from core_api.constants import (
 # today; the alias-safety test pins that the search aliases still work.
 STRICT_WRITE_BODY = ConfigDict(extra="forbid")
 
+# C6 — fields the SERVER owns on a memory row. A caller may never supply these
+# on a write body; ``MemoryCreate._refuse_server_owned_fields`` turns them into
+# an explanatory 422 instead of the generic unknown-field one. Deliberately a
+# short explicit list rather than a pattern: everything not named here keeps the
+# ordinary ``extra="forbid"`` behaviour, so a typo is still just a typo.
+SERVER_OWNED_MEMORY_FIELDS = ("supersedes_id",)
+
 
 # --- Memory ---
 
@@ -110,6 +117,42 @@ class MemoryCreate(BaseModel):
             "it is a per-write choice rather than a default to flip."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _refuse_server_owned_fields(cls, data):
+        """C6 — refuse ``supersedes_id`` on create, and say why.
+
+        Supersession is established by the SERVER, never by the caller: the
+        contradiction detector decides that a new memory retires an older one
+        and writes the pointer through ``update_memory_status``, which is
+        CAS-guarded against NULL so two concurrent detections cannot both claim
+        the same predecessor. There is deliberately no public route that sets
+        ``supersedes_id`` directly.
+
+        Accepting it here would hand a caller a pointer at an arbitrary
+        predecessor with no check that the row exists, shares the tenant, or is
+        not already superseded — and would bypass the CAS entirely. So the
+        answer to C6's "intentional or oversight?" is *intentional*.
+
+        ``extra="forbid"`` already rejected this, but with pydantic's generic
+        "Extra inputs are not permitted", which cannot tell a caller whether the
+        field is misspelled, unsupported, or deliberately refused. This runs
+        BEFORE that check (mode="before" sees the raw payload) purely to replace
+        the message. Every other unknown field still falls through to the
+        existing unknown-field 422 — the denylist is named, not a category, so a
+        genuine typo keeps its old behaviour.
+        """
+        if isinstance(data, dict):
+            present = [f for f in SERVER_OWNED_MEMORY_FIELDS if f in data]
+            if present:
+                raise ValueError(
+                    f"{', '.join(present)} is set by the server, not by the caller, and cannot be "
+                    "supplied on create. Supersession is established by contradiction detection: "
+                    "write the corrected fact as an ordinary memory and the detector links it to "
+                    "the row it supersedes."
+                )
+        return data
 
 
 class BulkMemoryItem(BaseModel):
@@ -576,6 +619,20 @@ class SearchDiagnostic(BaseModel):
     all_candidates: list[dict] = []
 
 
+class SearchWarning(BaseModel):
+    """A28 — a coded, non-fatal caveat about the result set.
+
+    The search succeeded, but something the caller would reasonably assume
+    happened did not. Distinct from ``SearchDiagnostic``: that is opt-in
+    introspection, this is unsolicited and only present when there is something
+    to say.
+    """
+
+    code: str = Field(description="Stable slug, e.g. 'successor_enrichment_incomplete'.")
+    message: str = Field(description="Human-readable summary of what is incomplete.")
+    details: dict = Field(default_factory=dict, description="Machine-readable context.")
+
+
 class SearchResponse(BaseModel):
     """Envelope for search results — matches PaginatedMemoryResponse shape."""
 
@@ -602,6 +659,12 @@ class SearchResponse(BaseModel):
     )
     # D12 — present only when the request set ``diagnostic=true``.
     diagnostic: SearchDiagnostic | None = None
+    # A28 — ``null`` when there is nothing to warn about, exactly as
+    # ``diagnostic`` already behaves (FastAPI serializes None fields rather than
+    # dropping them). Deliberately NOT switched to exclude_none: that would also
+    # change ``diagnostic``'s existing serialization. Additive for integrators —
+    # a new nullable key alongside one they already tolerate.
+    warnings: list[SearchWarning] | None = None
 
 
 class SearchRequest(BaseModel):
@@ -653,6 +716,21 @@ class SearchRequest(BaseModel):
         default=None,
         pattern=MEMORY_STATUSES_PATTERN,
         validation_alias=AliasChoices("status_filter", "status"),
+        # D6 — the default is NOT "every status". With this unset, search
+        # excludes rows the contradiction detector has retired: ``outdated``
+        # always, and ``conflicted`` unless the row is an exact lexical match
+        # for the query. That is deliberate (a stale claim shouldn't dilute
+        # ranking) but it was undocumented, which is what made it feel silent:
+        # a caller could not tell "nothing matched" from "matches were withheld".
+        # Setting this to an explicit status turns the default policy off and
+        # returns that status verbatim.
+        description=(
+            "Restrict results to one status. When omitted, superseded memories are "
+            "hidden: 'outdated' rows are excluded, and 'conflicted' rows are excluded "
+            "unless they exactly match the query text. Their replacements are injected "
+            "in their place. Pass an explicit status to bypass this and read the "
+            "superseded rows directly."
+        ),
     )
     valid_at: datetime | None = None
     top_k: int = Field(

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -4498,6 +4498,9 @@ async def search_memories(
     search_profile: dict | None = None,
     diagnostic: bool = False,
     diagnostic_ctx: dict | None = None,
+    # A28 — always-on channel for caller-visible warnings (unlike
+    # diagnostic_ctx, which is opt-in). Filled by pipeline steps.
+    warnings_ctx: list | None = None,
     readable_tenant_ids: list[str] | None = None,
     source: str = "search",
     min_similarity: float | None = None,
@@ -4529,6 +4532,7 @@ async def search_memories(
             search_profile=search_profile,
             diagnostic=diagnostic,
             diagnostic_ctx=diagnostic_ctx,
+            warnings_ctx=warnings_ctx,
             readable_tenant_ids=readable_tenant_ids,
             source=source,
             min_similarity=min_similarity,
@@ -4583,6 +4587,9 @@ async def _search_memories_pipeline(
     search_profile: dict | None = None,
     diagnostic: bool = False,
     diagnostic_ctx: dict | None = None,
+    # A28 — always-on channel for caller-visible warnings (unlike
+    # diagnostic_ctx, which is opt-in). Filled by pipeline steps.
+    warnings_ctx: list | None = None,
     readable_tenant_ids: list[str] | None = None,
     source: str = "search",
     min_similarity: float | None = None,
@@ -4658,6 +4665,12 @@ async def _search_memories_pipeline(
         # pinned counter is fine — the exact silent-zero this field exists to
         # end.
         recall_ctx["recall_tracked"] = bool(ctx.data.get("recall_tracked"))
+
+    # A28 — hand any step-emitted warnings back to the caller. Unconditional:
+    # a caller that did not ask for diagnostics still needs to hear that the
+    # result set is missing successors it would normally carry.
+    if warnings_ctx is not None:
+        warnings_ctx.extend(ctx.data.get("warnings", []) or [])
 
     return ctx.data["results"]
 

--- a/tests/test_a28_c6_d6_contract.py
+++ b/tests/test_a28_c6_d6_contract.py
@@ -1,0 +1,159 @@
+"""A28 / C6 / D6 — three ways the API was quietly withholding information.
+
+A28: successor injection truncated at 10 with only a server-side log, so the
+     11th stale row surfaced as if no correction existed.
+C6:  ``supersedes_id`` on create was refused by ``extra="forbid"`` with a
+     generic message, so a caller could not tell refused-on-purpose from typo.
+D6:  the default status policy hides superseded rows and said so nowhere.
+"""
+
+import pytest
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search import load_and_serialize as las
+from core_api.schemas import (
+    SERVER_OWNED_MEMORY_FIELDS,
+    MemoryCreate,
+    SearchRequest,
+    SearchResponse,
+)
+from pydantic import ValidationError
+
+pytestmark = pytest.mark.unit
+
+
+# ── C6 ────────────────────────────────────────────────────────────────────
+
+
+def _body(**over):
+    return {"tenant_id": "t1", "agent_id": "a1", "content": "x", **over}
+
+
+def test_create_refuses_supersedes_id_with_an_explanatory_message():
+    with pytest.raises(ValidationError) as e:
+        MemoryCreate(**_body(supersedes_id="11111111-1111-1111-1111-111111111111"))
+    msg = str(e.value)
+    assert "supersedes_id" in msg
+    assert "set by the server" in msg
+    # It must point at the mechanism that DOES exist. There is no public route
+    # that sets supersedes_id, so naming one would send callers nowhere.
+    assert "contradiction detection" in msg
+    assert "/status" not in msg
+
+
+def test_unknown_fields_keep_the_ordinary_rejection():
+    """The denylist must not swallow the generic unknown-field path — a typo is
+    still a typo, and C26's behaviour has to survive."""
+    with pytest.raises(ValidationError) as e:
+        MemoryCreate(**_body(superseeds_id="oops"))
+    msg = str(e.value)
+    assert "set by the server" not in msg
+    assert "superseeds_id" in msg
+
+
+def test_a_valid_create_body_is_untouched():
+    m = MemoryCreate(**_body())
+    assert m.content == "x" and m.tenant_id == "t1"
+
+
+def test_server_owned_list_is_narrow():
+    """Widening this is a wire-contract decision, not a refactor: every name
+    here converts a generic 422 into a specific refusal."""
+    assert SERVER_OWNED_MEMORY_FIELDS == ("supersedes_id",)
+
+
+# ── D6 ────────────────────────────────────────────────────────────────────
+
+
+def test_status_filter_documents_the_default_exclusion():
+    """The row's complaint was 'silently excluded'. The override already
+    existed; what was missing was any statement that a default policy applies."""
+    desc = SearchRequest.model_fields["status_filter"].description or ""
+    assert "outdated" in desc and "conflicted" in desc
+    assert "exactly match" in desc  # the carve-out is stated, not just the rule
+
+
+# ── A28 ───────────────────────────────────────────────────────────────────
+
+
+def test_bound_cannot_engage_under_the_public_contract():
+    """top_k caps the result set, which caps the stale-id list. The bound is a
+    guard against a pathological array param, not a cost control — if it ever
+    drops below reachable, truncation becomes silent-by-default again."""
+    from core_api.constants import MAX_SEARCH_TOP_K
+
+    assert las.MAX_SUCCESSOR_LOOKUPS > MAX_SEARCH_TOP_K
+
+
+def _ctx():
+    return PipelineContext(data={})
+
+
+def test_warn_emits_a_coded_caller_visible_entry():
+    ctx = _ctx()
+    las._warn(
+        ctx, reason="lookup_bound_exceeded", stale_result_count=1200, enriched=1000
+    )
+    (w,) = ctx.data["warnings"]
+    assert w["code"] == las.SUCCESSOR_ENRICHMENT_INCOMPLETE
+    assert w["details"] == {
+        "reason": "lookup_bound_exceeded",
+        "stale_result_count": 1200,
+        "enriched": 1000,
+    }
+    # the message has to be readable by whoever gets the response, not a slug
+    assert "supersedes" in w["message"]
+
+
+def test_warn_accumulates_rather_than_overwrites():
+    ctx = _ctx()
+    las._warn(ctx, reason="lookup_bound_exceeded", stale_result_count=9, enriched=5)
+    las._warn(ctx, reason="storage_error", stale_result_count=9, enriched=0)
+    assert [w["details"]["reason"] for w in ctx.data["warnings"]] == [
+        "lookup_bound_exceeded",
+        "storage_error",
+    ]
+
+
+def test_warnings_is_null_when_there_is_nothing_to_say():
+    """Pins the WIRE behaviour, which is ``"warnings": null`` — not an absent
+    key. FastAPI serializes None fields, so the response carries the key with a
+    null value, exactly as the pre-existing ``diagnostic`` field already does.
+
+    Verified live against the deployed image, not just the model:
+        keys: ['diagnostic', 'items', 'warnings'] | warnings=None diagnostic=None
+
+    Asserted against ``diagnostic`` rather than hard-coded so the two can't
+    diverge: if anyone later adds exclude_none, both change together or this
+    fails.
+    """
+    r = SearchResponse(items=[])
+    assert r.warnings is None
+    dumped = r.model_dump()
+    assert dumped["warnings"] is None
+    assert ("warnings" in dumped) == ("diagnostic" in dumped)
+
+
+def test_response_carries_warnings_when_present():
+    r = SearchResponse(
+        items=[],
+        warnings=[
+            {
+                "code": "successor_enrichment_incomplete",
+                "message": "m",
+                "details": {"a": 1},
+            }
+        ],
+    )
+    dumped = r.model_dump(exclude_none=True)
+    assert dumped["warnings"][0]["code"] == "successor_enrichment_incomplete"
+
+
+def test_storage_failure_is_reported_not_swallowed():
+    """Before A28 a find_successors failure logged and returned an un-enriched
+    result set with no caller signal — the same silence as the cap."""
+    import inspect
+
+    src = inspect.getsource(las.LoadAndSerialize.execute)
+    fail_block = src[src.index("except Exception:") :]
+    assert "_warn(" in fail_block
+    assert 'reason="storage_error"' in fail_block


### PR DESCRIPTION
## Summary

Three canonical rows, one theme: the API knew something and didn't tell the caller.

### A28 — successor injection truncated silently

`MAX_SUCCESSOR_LOOKUPS = 10` sliced the stale-id list, so a result set with **more than ten** outdated/conflicted rows left the 11th onward with no successor loaded and **no signal**. A stale claim then surfaces as if no correction exists — the exact failure the A34 contract exists to prevent. Only a `logger.warning` recorded it.

The task text assumed the cap protected against per-ID round-trips and proposed "batch into one storage call". **That was already the case:** `find_successors` is one HTTP call, and on the storage side one indexed query (`supersedes_id IN (...)`, no `LIMIT`). Ten ids and a thousand cost the same round-trip, so the truncation bought nothing.

Raised to a defensive `1000` — unreachable from the public API, since `top_k` caps at `MAX_SEARCH_TOP_K` (20) — and if it ever *does* engage, the caller is told. A new coded warning also covers a `find_successors` failure, which was silent in exactly the same way.

### C6 — "intentional or oversight?" → intentional, now said out loud

`extra="forbid"` already rejected `supersedes_id`, but with `"Extra inputs are not permitted"`, so a caller couldn't tell a deliberate refusal from a misspelling.

It **stays refused.** Supersession is server-owned: the contradiction detector sets it through `update_memory_status`, which is CAS-guarded so two concurrent detections can't both claim the same predecessor. Accepting it on create would point a brand-new row at an arbitrary predecessor with no check that it exists, shares the tenant, or isn't already superseded — and bypass the CAS entirely.

A `model_validator(mode="before")` replaces only the *message*. Note the error deliberately does **not** name a route: there is no public endpoint that sets `supersedes_id`, so pointing at one would send callers nowhere. It names the mechanism instead — write the corrected fact, detection links it.

### D6 — the override already existed; the documentation didn't

Default search hides superseded rows (`outdated` always; `conflicted` unless an exact lexical match). The `status_filter` override this task proposed **is already implemented and plumbed**. What was missing was any statement that a default policy applies at all — which is what made it feel silent: a caller couldn't distinguish "nothing matched" from "matches were withheld".

I did **not** build the suggested `conflicted_suppressed_count`. The exclusion is a WHERE clause, so an honest count means re-running the scored query — a second full search on a hot read path — to report a number nobody has asked for. If a caller ever needs it, it should be opt-in.

## Wire impact

`SearchResponse.warnings` is additive and is `null` when empty — **not absent**. FastAPI serializes `None` fields, exactly as the existing `diagnostic` field already behaves. Deliberately not switched to `exclude_none`, which would change `diagnostic`'s serialization too. A test asserts the two stay consistent.

## Testing

11 unit tests. Full suite **5719 passed**; the 8 failures in `test_capability_usage` / `test_request_observation` **pre-exist on main** (verified by stashing and re-running). ruff + format clean on every touched file.

**Wet-tested** against the deployed image on real vectors:

```
1) create WITH supersedes_id -> 422  "...is set by the server, not by the caller...
                                      Supersession is established by contradiction detection"
2) create with a TYPO        -> 422  extra_forbidden (unchanged)
3) ordinary write            -> 201
4) search                    -> 200  warnings: None
5) three real supersession pairs:
     successor #1 -> supersedes #2 [conflicted]  OK
     successor #2 -> supersedes #3 [conflicted]  OK
     successor #3 -> supersedes #4 [conflicted]  OK
6) live OpenAPI status_filter documents the default exclusion
```

Refs: canonical A28, C6, D6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
