### PR TITLE
docs(gate): say what the tenant-scope categories actually assert

### DIFF
--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -3,12 +3,12 @@
   "_categories": {
     "no-tenant-data": "Touches no tenant-scoped table at all \u2014 liveness probes, the pg_locks snapshot, idempotency keys. There is no tenant to bind to.",
     "cross-tenant-by-design": "Legitimately spans tenants and would be wrong if it did not: the capability-usage flush (one batch carries many tenants' counters, migration 023), the tenant-discovery lists that drive the lifecycle fanout, and global operational counts.",
-    "opaque-body-write": "An insert/upsert whose tenant travels as a field inside the payload dict rather than as a parameter, so no signature can carry it. The binding is real but lives in the row being written; the route above is responsible for having validated it.",
+    "opaque-body-write": "An insert/upsert whose tenant travels as a field inside the payload dict rather than as a parameter, so no signature can carry it. The binding is real but lives in the row being written, which settles which tenant OWNS the new row. WHAT IT DOES NOT SETTLE is whether that tenant is the right one. Since #1066 the only credential this service accepts is a shared secret carrying no tenant identity: it authenticates THAT a caller is internal, never WHICH tenant it speaks for. A foreign ``tenant_id`` in the body is written faithfully and nothing here can tell. The accepted control is that the caller was correct \u2014 say that plainly rather than deferring to an unnamed route. (This replaces ``the route above is responsible for having validated it``, which named no route and, for a caller reaching this service directly, referred to nothing.) A write that ALSO references other rows by bare id raises a separate question this category does not answer: that id needs its own tenant check, as ``POST /fleet/commands`` and ``POST /memories/conflicts`` do.",
     "admin-unscoped": "A deliberate operator-facing path that runs across tenants, reached only through an admin-gated route upstream.",
     "grant-in-lieu-of-tenant": "Scoped only by a caller-supplied list of tenants \u2014 a ``readable_tenant_ids`` grant, or a ``tenant_ids`` filter \u2014 with no binding tenant behind it. ALSO BACKLOG. Storage authenticates nothing and takes the list verbatim from the request body, so accepting it in place of a home tenant is strictly weaker than requiring one: the caller names its own scope. Where sibling routes DO require a binding tenant, the difference is an inconsistency to resolve rather than a design. Added as its own category because filing such a route under ``cross-tenant-by-design`` said the opposite of what its note said.",
     "id-addressed-write": "Addressed by a primary key the caller is assumed to already hold, with no tenant predicate, AND it mutates the row. THIS IS THE TOP OF THE BACKLOG. GHSA-wgvw-28pq-jc36 was the read form of this shape; these are the same defect where the consequence is a write, so knowing a UUID is enough to change or destroy another tenant's row, not merely to read it. Fix these before the read half. Shrink; never add.",
-    "id-addressed-read": "Addressed by a primary key the caller is assumed to already hold, with no tenant predicate, and it only reads. THIS IS THE BACKLOG. It is the shape of GHSA-wgvw-28pq-jc36 \u2014 knowing a UUID is not the same as being entitled to the row behind it \u2014 and every entry here is one an attacker who can reach storage directly can use. Shrink; never add.",
-    "blind-spot": "The path IS scoped, but by an idiom the AST pass cannot read \u2014 an inline ``if not isinstance(...): raise`` rather than the shared ``_require`` guard. The entry records that a human checked it. Prefer rewriting the guard to use ``_require`` and deleting the entry."
+    "id-addressed-read": "Addressed by a primary key the caller is assumed to already hold, with no tenant predicate, and it only reads. THIS IS THE BACKLOG. It is the shape of GHSA-wgvw-28pq-jc36 \u2014 knowing a UUID is not the same as being entitled to the row behind it \u2014 and every entry here is one that any caller reaching this service can use against any tenant. Until #1066 that meant anyone who could reach the port; it now means any holder of the shared secret. That is a narrower set, not a smaller consequence: the secret says nothing about which tenant its holder speaks for, so the reach of a single entry is unchanged. Shrink; never add.",
+    "blind-spot": "The path IS scoped, but by an idiom the AST pass cannot read \u2014 an inline ``if not isinstance(...): raise`` rather than the shared ``_require`` guard. The entry records that a human checked it. Prefer rewriting the guard to use ``_require`` and deleting the entry. THIS IS A BACKLOG CATEGORY, and filing here counts against the backlog exactly as the ``id-addressed-*`` pair does \u2014 it is not a tidier home for a path that is merely awkward to read. In particular, a ``_require`` this pass misses because it sits one frame down in a HELPER does not belong here: the pass reads each handler's own AST, so hoisting that call into the handler scores the route REQUIRED and the entry deletes outright rather than moving (#1199, which did that for six ``insights/*`` routes)."
   },
   "exceptions": [
     {
@@ -56,7 +56,7 @@
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
       "category": "opaque-body-write",
-      "note": "Verified: payload['tenant_id'] is assigned directly to the DedupReview row."
+      "note": "Verified: payload['tenant_id'] is assigned directly to the DedupReview row. new_memory_id and candidate_memory_id are caller-supplied and unvalidated, but inert: both are plain UUID columns with NO foreign key, so an unknown id cannot be told from a real one, and new_content/candidate_content are caller-supplied snapshots, so storage never joins back to the rows they name. Traced in #1180."
     },
     {
       "id": "method:entity_add",
@@ -148,7 +148,7 @@
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
       "category": "opaque-body-write",
-      "note": "Verified: event['tenant_id'] is stored on RecallEvent; candidate rows are attached to that new event."
+      "note": "Verified: event['tenant_id'] is stored on RecallEvent; candidate rows are attached to that new event. RecallCandidate has no tenant_id of its own and no FK -- it is scoped only by the ON DELETE CASCADE from recall_event -- so a caller-supplied candidate memory_id is unvalidated. Inert TODAY only because nothing reads the table: when repeat_recall's Phase 2 read lands, that JOIN must carry a tenant predicate or a foreign memory_id becomes a cross-tenant content read. Traced in #1180."
     },
     {
       "id": "method:relation_add",
@@ -395,7 +395,7 @@
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
       "category": "opaque-body-write",
-      "note": "Verified: body tenant_id is assigned directly to the DedupReview row by dedup_review_enqueue."
+      "note": "Verified: body tenant_id is assigned directly to the DedupReview row by dedup_review_enqueue. The two caller-supplied memory ids are unvalidated but inert -- no FK, and no join back to the rows they name. See method:dedup_review_enqueue; traced in #1180."
     },
     {
       "id": "route:POST /api/v1/storage/reports",

--- a/scripts/tenant_scope_gate.py
+++ b/scripts/tenant_scope_gate.py
@@ -252,14 +252,15 @@ TRACKED_CATEGORIES = DESTRUCTIVE_CATEGORIES | frozenset({"grant-in-lieu-of-tenan
 # sentences nobody reads, and ``legacy_name_ratchet.py`` already learned this
 # the expensive way: it carries two markers instead of one specifically because
 # "a reviewer facing eleven undifferentiated entries stops reading". At 150 the
-# argument is not close. Six categories get argued over once, properly, and then
-# each entry's claim is a single word a reviewer can check against the code.
+# argument is not close. Eight categories get argued over once, properly, and
+# then each entry's claim is a single word a reviewer can check against the code.
 #
 # These are not equally benign, and the point of separating them is that they
-# are not. Four describe paths that are correct as they stand. Two describe a
-# backlog: ID_ADDRESSED is the shape both advisories had, and BLIND_SPOT is this
-# gate failing to see a guard that is really there. Those two are what the
-# ratchet exists to drive down.
+# are not. Four describe paths that are correct as they stand. Four are a
+# backlog, and ``BACKLOG_CATEGORIES`` above is the authority on which: the
+# ``id-addressed-*`` pair is the shape both advisories had, BLIND_SPOT is this
+# gate failing to see a guard that is really there, and GRANT_IN_LIEU is a
+# caller naming its own scope. Those four are what the ratchet drives down.
 # ---------------------------------------------------------------------------
 CATEGORIES: dict[str, str] = {
     "no-tenant-data": (
@@ -275,8 +276,20 @@ CATEGORIES: dict[str, str] = {
     "opaque-body-write": (
         "An insert/upsert whose tenant travels as a field inside the payload "
         "dict rather than as a parameter, so no signature can carry it. The "
-        "binding is real but lives in the row being written; the route above is "
-        "responsible for having validated it."
+        "binding is real but lives in the row being written, which settles "
+        "which tenant OWNS the new row. WHAT IT DOES NOT SETTLE is whether "
+        "that tenant is the right one. Since #1066 the only credential this "
+        "service accepts is a shared secret carrying no tenant identity: it "
+        "authenticates THAT a caller is internal, never WHICH tenant it "
+        "speaks for. A foreign ``tenant_id`` in the body is written "
+        "faithfully and nothing here can tell. The accepted control is that "
+        "the caller was correct — say that plainly rather than deferring to "
+        "an unnamed route. (This replaces ``the route above is responsible "
+        "for having validated it``, which named no route and, for a caller "
+        "reaching this service directly, referred to nothing.) A write that "
+        "ALSO references other rows by bare id raises a separate question "
+        "this category does not answer: that id needs its own tenant check, "
+        "as ``POST /fleet/commands`` and ``POST /memories/conflicts`` do."
     ),
     "admin-unscoped": (
         "A deliberate operator-facing path that runs across tenants, reached "
@@ -306,14 +319,26 @@ CATEGORIES: dict[str, str] = {
         "Addressed by a primary key the caller is assumed to already hold, with "
         "no tenant predicate, and it only reads. THIS IS THE BACKLOG. It is the "
         "shape of GHSA-wgvw-28pq-jc36 — knowing a UUID is not the same as being "
-        "entitled to the row behind it — and every entry here is one an attacker "
-        "who can reach storage directly can use. Shrink; never add."
+        "entitled to the row behind it — and every entry here is one that any "
+        "caller reaching this service can use against any tenant. Until #1066 "
+        "that meant anyone who could reach the port; it now means any holder of "
+        "the shared secret. That is a narrower set, not a smaller consequence: "
+        "the secret says nothing about which tenant its holder speaks for, so "
+        "the reach of a single entry is unchanged. Shrink; never add."
     ),
     "blind-spot": (
         "The path IS scoped, but by an idiom the AST pass cannot read — an "
         "inline ``if not isinstance(...): raise`` rather than the shared "
         "``_require`` guard. The entry records that a human checked it. Prefer "
-        "rewriting the guard to use ``_require`` and deleting the entry."
+        "rewriting the guard to use ``_require`` and deleting the entry. "
+        "THIS IS A BACKLOG CATEGORY, and filing here counts against the "
+        "backlog exactly as the ``id-addressed-*`` pair does — it is not a "
+        "tidier home for a path that is merely awkward to read. In "
+        "particular, a ``_require`` this pass misses because it sits one "
+        "frame down in a HELPER does not belong here: the pass reads each "
+        "handler's own AST, so hoisting that call into the handler scores the "
+        "route REQUIRED and the entry deletes outright rather than moving "
+        "(#1199, which did that for six ``insights/*`` routes)."
     ),
 }
 


### PR DESCRIPTION
Closes the last item of the #1180 sizing. Four pieces of prose in the category block had drifted from the code they describe.

**Nothing moves.** The gate reports `added (0)  removed — fixed (0)  removed — gone (0)  removed — still unscoped (0)  recategorised (0)`, 64 allowlisted before and after. No classification logic changes.

## `opaque-body-write` — the load-bearing clause named nothing

It ended *"the route above is responsible for having validated it."* #1180 called that the load-bearing clause and asked **which route, and validated against what?** There is no answer: for a caller reaching this service directly there is no route above.

Since **#1066** the only credential this service accepts is a shared secret carrying no tenant identity — it authenticates *that* a caller is internal, never *which* tenant it speaks for. A foreign `tenant_id` in the body is written faithfully and nothing here can tell. That is true of **34 of the 36** entries this category held when #1180 was filed, so the definition should say it rather than defer to an unnamed party.

Now: the payload tenant settles which tenant **owns** the new row; it does not settle whether that tenant is the **right** one; the accepted control is that the caller was correct.

It also records that a write referencing **other** rows by bare id is a separate question the category does not answer — the id needs its own tenant check. That is precisely what #1215 had to add to `/memories/conflicts`, and what `POST /fleet/commands` already did.

## `id-addressed-read` — the premise was falsified

Still said every entry is one *"an attacker who can reach storage directly can use"* — the staleness #1180 flagged in passing. #1066 closed the port to unauthenticated callers.

Rewritten to say it is any caller that reaches this service: before #1066 anyone who could reach the port, now any holder of the shared secret. **A narrower set, not a smaller consequence** — the secret says nothing about which tenant its holder speaks for, so the reach of a single entry is unchanged. Worth stating that way round, because "we added auth" reads as mitigation and here it is not.

## `blind-spot` — it never said it was a backlog category

It is in `BACKLOG_CATEGORIES`, but nothing in its own text said so, and it reads as a tidy home for anything awkward to classify. Filing there grows the backlog exactly as `id-addressed-*` does.

**I got this wrong myself on #1180** — I recommended moving six `insights/*` routes here and called it the zero-risk option, which would have grown the backlog by six while looking like tidying. The definition now says it is backlog, and records the specific trap: a `_require` the pass misses because it sits one frame down in a **helper** does not belong here, because the pass reads each handler's own AST, so hoisting the call into the handler scores the route REQUIRED and the entry **deletes outright**. That is what #1199 did instead.

## The header count

Said *"Six categories"* and *"Two describe a backlog"*. There are **eight**, and `BACKLOG_CATEGORIES` holds **four**. Now points at that frozenset as the authority rather than restating the membership in prose that can drift again.

## Three entry notes — the bucket-E findings

From the #1180 trace, so the conclusions live where the next reader meets them:

- **`method:dedup_review_enqueue`** and **`route:POST /memories/dedup-reviews`** — the caller-supplied memory ids are unvalidated but **inert**: plain UUID columns with no FK (so no existence oracle) and caller-supplied content snapshots (so storage never joins back).
- **`method:recall_log_write`** — `RecallCandidate` has no tenant of its own and no FK, scoped only by the CASCADE from `recall_event`. Inert **today only because nothing reads the table**; when `repeat_recall`'s Phase 2 read lands, that JOIN must carry a tenant predicate or a foreign `memory_id` becomes a cross-tenant content read.

That last one is a constraint on unwritten code, so an allowlist note is not where it will be found. **It still wants to be on the Phase 2 ticket or at the `repeat_recall.extract()` stub** — flagging rather than doing, since that is not this PR's file.

## Gates

Venv on `PATH`, `UV_FROZEN=1`. `ruff check` and `ruff format --check` run **separately** at each of CI's exact scopes, discovery-based, no `--config`.

- `python scripts/tenant_scope_gate.py --base origin/main` — 0 added / 0 removed / 0 recategorised, 64 allowlisted
- `python scripts/tenant_scope_gate.py --write` — the `_categories` block is generated from `CATEGORIES`, so it was regenerated, not hand-edited; re-running after the three note edits is **byte-identical** (`shasum` matched), confirming the notes survive regeneration
- `pytest tests/test_tenant_scope_gate.py` — **122 passed** (includes `check_category_doc`, which fails if the JSON block and the script disagree)
- `pytest core-storage-api/tests/` — **315 passed**
- `mypy src/` in `core-storage-api` — no issues in 85 source files
- `ruff check` / `ruff format --check` — all seven CI scopes clean
- `python3 scripts/legacy_name_ratchet.py --base origin/main` — `No new lines.`
- `python3 scripts/do_not_touch_sentinel.py` — all 46 protected strings survive
- `uv.lock` / `plugin/package-lock.json` untouched

**One pre-existing lint left alone:** `ruff check scripts/tenant_scope_gate.py` reports one `ISC004`, identical on `origin/main` (line 1508 there, 1533 here — shifted by the added lines, not introduced). `scripts/` is in no CI ruff scope, so it gates nothing, and fixing it here would be an unrelated change in a docs PR.

No test is added: this changes prose only, and `check_category_doc` already fails if the generated block and the script disagree — which is the assertion that matters for this diff.

One signed-off commit, rebased onto `origin/main` immediately before push, with the gate and both suites re-run after.
