### PR TITLE
perf(llm): warm the Vertex genai client at startup, not in the first request

### DIFF
--- a/common/llm/_platform.py
+++ b/common/llm/_platform.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 
 from common.embedding import (
     get_platform_embedding,
@@ -40,6 +41,41 @@ from common.provider_names import ProviderName
 logger = logging.getLogger(__name__)
 
 _platform_llm: LLMProvider | None = None
+# Handle for the background client warm-up (see _start_warmup_thread).
+# Module-level so tests can join it for deterministic assertions.
+_warmup_thread: threading.Thread | None = None
+
+
+def _start_warmup_thread(provider: LLMProvider) -> None:
+    """Kick off the provider's client warm-up on a daemon thread.
+
+    Never raises: a warm-up failure is logged and the provider falls
+    back to building its client lazily on first call (the pre-warm-up
+    behavior). Daemon so a hung credential fetch can never block
+    process shutdown.
+    """
+    global _warmup_thread
+
+    # Duck-typed: ``warm_up`` is provider-specific (not part of the
+    # ``LLMProvider`` Protocol) — providers without one need no warming.
+    warm_up = getattr(provider, "warm_up", None)
+    if warm_up is None:
+        return
+
+    def _warm() -> None:
+        try:
+            warm_up()
+        except Exception:
+            logger.warning(
+                "Platform Vertex client warm-up failed; the client "
+                "will be built lazily on first call instead",
+                exc_info=True,
+            )
+
+    _warmup_thread = threading.Thread(
+        target=_warm, name="platform-llm-client-warmup", daemon=True
+    )
+    _warmup_thread.start()
 _platform_init_errors: list[str] = []
 
 __all__ = [
@@ -86,6 +122,27 @@ def init_platform_providers() -> None:
                     project_id,
                     resolved_location,
                 )
+                # Warm the genai client in the BACKGROUND at startup
+                # instead of letting the first request pay for it: the
+                # lazy build (SDK import + ADC discovery + HTTP pool)
+                # measured ~13s per cold instance on staging
+                # (2026-09-01) — enough to trip recall's 15s
+                # per-attempt cap once per instance.
+                #
+                # A daemon thread rather than an inline (or awaited
+                # to_thread) call, deliberately: this function runs
+                # inside the services' async lifespans, so an inline
+                # build would block the event loop, and awaiting it
+                # would add the full ~13s to readiness — i.e. to every
+                # Cloud Run scale-up cold start. The thread does
+                # neither. The race is safe: a request that lands
+                # before warm-up completes blocks on the provider's
+                # ``_client_lock`` inside its own to_thread worker —
+                # the pre-warm-up first-call behavior, at worst once.
+                # Non-fatal by design: environments without ADC
+                # (tests, misconfigured installs) log a warning and
+                # fall back to the lazy build on first call.
+                _start_warmup_thread(_platform_llm)
             except Exception:
                 logger.exception("Failed to initialize platform Vertex LLM provider")
                 _platform_init_errors.append("vertex-llm")

--- a/common/llm/providers/vertex.py
+++ b/common/llm/providers/vertex.py
@@ -102,6 +102,19 @@ class VertexLLMProvider:
     def model(self) -> str:
         return self._model
 
+    def warm_up(self) -> None:
+        """Build the genai client now instead of on the first completion.
+
+        Called from ``init_platform_providers`` at lifespan startup — on
+        a background thread, so the one-time client cost (SDK import +
+        ADC discovery + HTTP pool, ~13s measured on a cold Cloud Run
+        instance) never lands inside a latency-capped request, never
+        blocks the event loop, and never delays readiness. Safe to skip:
+        any failure leaves the provider intact and the client is built
+        lazily on first call.
+        """
+        self._get_client()
+
     def _get_client(self):
         # Double-checked locking: the unlocked read keeps the steady
         # state lock-free; the locked re-check makes concurrent first

--- a/tests/test_platform_providers.py
+++ b/tests/test_platform_providers.py
@@ -263,6 +263,80 @@ class TestInitPlatformProviders:
 
         monkeypatch.setattr(cfg, "settings", cfg.Settings())
 
+    @staticmethod
+    def _join_warmup():
+        """Wait for the background warm-up thread (deterministic asserts)."""
+        import common.llm._platform as plat
+
+        assert plat._warmup_thread is not None, "warm-up thread never started"
+        plat._warmup_thread.join(timeout=10)
+        assert not plat._warmup_thread.is_alive(), "warm-up thread hung"
+
+    def test_init_vertex_warms_client_eagerly(self, monkeypatch):
+        # The one-time client build (~13s on a cold Cloud Run instance)
+        # must be kicked off here, at startup, on a BACKGROUND thread —
+        # not inside the first latency-capped request (staging
+        # 2026-09-01: first-call builds tripped recall's 15s cap once
+        # per instance) and not inline (init runs inside the services'
+        # async lifespans; an inline build would block the event loop
+        # and an awaited one would add ~13s to every cold start).
+        monkeypatch.setenv("PLATFORM_LLM_PROVIDER", "vertex")
+        monkeypatch.setenv("PLATFORM_LLM_GCP_PROJECT_ID", "test-proj")
+        monkeypatch.setenv("PLATFORM_LLM_GCP_LOCATION", "us-central1")
+        monkeypatch.setenv("PLATFORM_LLM_MODEL", "gemini-2.5-flash-lite")
+        self._reinit_settings(monkeypatch)
+
+        calls = []
+
+        class _FakeClient:
+            def __init__(self, **kwargs):
+                calls.append(kwargs)
+
+        import google.genai as genai_mod
+
+        monkeypatch.setattr(genai_mod, "Client", _FakeClient)
+
+        from core_api.providers._platform import (
+            get_platform_llm,
+            init_platform_providers,
+        )
+
+        init_platform_providers()
+        self._join_warmup()
+        assert len(calls) == 1  # built by startup warm-up, not deferred
+        assert isinstance(get_platform_llm()._client, _FakeClient)
+
+    def test_init_vertex_warmup_failure_is_nonfatal(self, monkeypatch):
+        # No ADC (tests, misconfigured installs): the warm-up may fail,
+        # but the provider must survive with a lazy retry on first call
+        # — and the failure must NOT count as a vertex-llm init error.
+        monkeypatch.setenv("PLATFORM_LLM_PROVIDER", "vertex")
+        monkeypatch.setenv("PLATFORM_LLM_GCP_PROJECT_ID", "test-proj")
+        monkeypatch.setenv("PLATFORM_LLM_GCP_LOCATION", "us-central1")
+        monkeypatch.setenv("PLATFORM_LLM_MODEL", "gemini-2.5-flash-lite")
+        self._reinit_settings(monkeypatch)
+
+        class _ExplodingClient:
+            def __init__(self, **kwargs):
+                raise RuntimeError("no ADC here")
+
+        import google.genai as genai_mod
+
+        monkeypatch.setattr(genai_mod, "Client", _ExplodingClient)
+
+        from core_api.providers._platform import (
+            get_platform_init_errors,
+            get_platform_llm,
+            init_platform_providers,
+        )
+
+        init_platform_providers()
+        self._join_warmup()
+        llm = get_platform_llm()
+        assert llm is not None  # provider survived the failed warm-up
+        assert llm._client is None  # will retry lazily on first call
+        assert "vertex-llm" not in get_platform_init_errors()
+
 
 # ---------------------------------------------------------------------------
 # Group 2: LLM tier resolution


### PR DESCRIPTION
## Problem

The migrated `VertexLLMProvider` (#1209) builds its google-genai client lazily on first call. On a cold Cloud Run instance that build (SDK import + ADC discovery + HTTP pool) measured **~13s** during the 2026-09-01 staging rehearsal — enough to trip recall's 15s per-attempt cap **once per instance**, surfacing as a sporadic first-request fake-fallback after every autoscaling event. (Warm-instance calls were 0.9–2.3s throughout.)

## Fix

`init_platform_providers()` kicks the new `VertexLLMProvider.warm_up()` onto a **daemon background thread** right after constructing the platform singleton.

Why a thread, not inline and not `await asyncio.to_thread(...)` (review round 2): `init_platform_providers()` runs inside both services' async lifespans, so an inline build would block the event loop for the full build — and an *awaited* offload keeps the ~13s as added readiness delay, i.e. every Cloud Run scale-up cold start gets 13s slower (and the deploy smoke's readiness budget gets 13s tighter). The background thread blocks nothing and delays nothing. The race is safe by construction: a request landing before warm-up completes blocks on the provider's `_client_lock` inside its own `to_thread` worker — the pre-warm-up first-call behavior, at worst once per instance.

Failure-tolerant: no ADC (tests, misconfigured installs) → warning, provider kept, lazy build on first call — exactly the pre-existing behavior. A failed warm-up is deliberately **not** recorded as a `vertex-llm` init error, since the provider remains fully functional. The warm-up call is duck-typed (`getattr`) — providers without a `warm_up` need no warming, and the `LLMProvider` Protocol stays untouched.

## Testing

- Eager path: fake `genai.Client` constructed exactly once by the startup thread (tests join the exposed module-level thread handle for deterministic asserts) and attached to the singleton.
- Failure path: exploding client → provider survives with `_client=None` (lazy retry) and no init error recorded.
- Full affected set green: 133 passed. Ruff clean; mypy clean with CI's invocation.

Pairs with [caura-enterprise#1463](https://github.com/caura-ai/caura-enterprise/pull/1463) (flip staging/prod to `gemini-3.1-flash-lite` @ `us`) — recommended merge order: this first, so the model switch never exposes the cold-instance gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)