### PR TITLE
docs(outcome-inference): correct the recall-log gap and pin the Phase 2 tenant predicate

### DIFF
--- a/core-api/src/core_api/services/outcome_inference/repeat_recall.py
+++ b/core-api/src/core_api/services/outcome_inference/repeat_recall.py
@@ -4,24 +4,39 @@ When an agent issues the same (or near-same) recall query multiple
 times within a session, the first answer didn't land. Plan §6
 signal #3.
 
-**Data source gap (acknowledged)**: Caura does not currently
-persist a per-recall log keyed by (session, agent, query, ts) with
-the query string preserved. Two reasonable proxies are available
-today:
+**Data source — the gap this module was written against is CLOSED.**
+It previously said Caura does not persist a per-recall log with the
+query string preserved. That is no longer true: ``recall_event`` +
+``recall_candidate`` (migration 027) shipped, and ``recall_event``
+carries ``tenant_id``, ``agent_id``, ``ts``, ``source`` and
+``query_text``. They are written opt-in per tenant by
+``core_api.pipeline.steps.search.log_recall_event``.
 
-  (a) The agent's own memory stream — if the same trace produced
-      multiple recalls *and* multiple writes about the same entity,
-      the entity sequence within a single run_id reveals the
-      pattern.
-  (b) The audit log (op='recall') — but does not carry the query
-      string.
+The ``memory_recalls`` table this file used to name as the Phase 2
+deliverable was never built and is not what shipped — do not go
+looking for it. The old proxies (the agent's own memory stream; the
+audit log at op='recall', which does not carry the query string) are
+therefore no longer the only options.
 
-**Phase 1 MVP**: ship the extractor with the contract finalised but
-the body conservative — return [] unless the explicit recall log
-(``memory_recalls`` table, Phase 2 deliverable) is in place. This
-prevents false positives from the proxy approach while keeping the
-extractor wired into the dispatcher so Phase 2's swap-in is body-
-only.
+**Phase 1 MVP**: the body still returns []. The contract is
+finalised; the read is not written. Returning [] is the safe default
+per plan §6 / §17 — false positives are worse than false negatives
+here — and the extractor stays wired into the dispatcher so Phase
+2's swap-in is body-only.
+
+**READ THIS BEFORE WRITING THE PHASE 2 QUERY.** ``recall_candidate``
+has NO ``tenant_id`` of its own and NO foreign key on ``memory_id``;
+it is scoped only by the ``ON DELETE CASCADE`` from ``recall_event``.
+``POST /memories/recall-log`` does not validate the candidate ids it
+is handed — core-storage-api constructs each row verbatim — so a row
+CAN name a memory belonging to another tenant. That is inert today
+only because nothing reads the table, which stops being true the
+moment this extractor does. **Any JOIN from ``recall_candidate`` to
+``memories`` must carry a tenant predicate.** Joining on
+``memory_id`` alone converts an unvalidated write into a cross-tenant
+content read. Traced in #1180; the allowlist note on
+``method:recall_log_write`` records the same requirement from the
+storage side.
 
 The extractor logs at INFO level on every invocation so operators
 running Phase 1 forge dry-runs can see the gap explicitly in the
@@ -51,10 +66,17 @@ async def extract(query: SignalQuery) -> list[SignalEvidence]:
     table — false positives are worse than false negatives for
     outcome inference (they'd label good traces as failures and
     push Forge to NOT propose what was actually a fine procedure).
+
+    Phase 2 implementer: the tables are already here
+    (``recall_event`` / ``recall_candidate``, migration 027), so the
+    only missing piece is this body. The tenant-predicate requirement
+    in the module docstring is not optional — ``recall_candidate``
+    rows carry unvalidated ``memory_id`` values. See #1180.
     """
     logger.info(
-        "repeat_recall extractor: returning [] (Phase 1 MVP — recall log "
-        "table arrives in Phase 2; see module docstring). tenant=%s",
+        "repeat_recall extractor: returning [] (Phase 1 MVP — the recall log "
+        "tables exist, the Phase 2 read is not written; see module docstring). "
+        "tenant=%s",
         query.tenant_id,
     )
     return []

--- a/tests/test_outcome_inference_signals.py
+++ b/tests/test_outcome_inference_signals.py
@@ -666,13 +666,19 @@ class TestSignalRegistry:
 
     def test_each_module_documents_its_data_source(self):
         # Every signal module's docstring must reference its data
-        # source ("memories.", "track_recalls", "memory_recalls", or
+        # source ("memories.", "track_recalls", "recall_event", or
         # "external") so operators reading the code at 3 AM know
         # where to look. Catches accidentally undocumented stubs.
+        #
+        # ``recall_event`` is the real recall-log table (migration 027).
+        # ``memory_recalls`` stays accepted because it is still the name
+        # two docstrings use — but it was never built, so a module
+        # naming only it is pointing operators at nothing.
         for mod in self.ALL_MODULES:
             doc = (mod.__doc__ or "").lower()
             assert any(
                 token in doc
-                for token in ("memories.", "track_recalls", "memory_recalls", "external",
-                              "audit", "recall_count", "contradiction", "supersedes", "phase 2", "phase 5")
+                for token in ("memories.", "track_recalls", "recall_event", "memory_recalls",
+                              "external", "audit", "recall_count", "contradiction",
+                              "supersedes", "phase 2", "phase 5")
             ), f"{mod.__name__} docstring lacks data-source breadcrumb"


### PR DESCRIPTION
Closes the last loose end of #1180. Prose only — the extractor still returns `[]`, no behaviour change.

## Two things the file said that are no longer true

**It said the data source is missing.** The docstring claimed Caura *"does not currently persist a per-recall log keyed by (session, agent, query, ts) with the query string preserved."* `recall_event` / `recall_candidate` (migration 027) shipped and do exactly that — `recall_event` carries `tenant_id`, `agent_id`, `ts`, `source` and `query_text`, written opt-in per tenant by `pipeline.steps.search.log_recall_event`.

**It named a table that does not exist.** `memory_recalls` was called "the Phase 2 deliverable". It was never built: `git grep memory_recalls` returns two docstrings and one test token list, and no model, migration or query.

So the file points a Phase 2 implementer at nothing, while telling them the thing they need is absent when it is present. Phase 2 is closer than the file reads.

## The third thing, which it did not say at all

`recall_candidate` has **no `tenant_id` of its own and no foreign key on `memory_id`** — it is scoped only by the `ON DELETE CASCADE` from `recall_event` (deliberately; `postgres_service.py` documents that choice). And `POST /memories/recall-log` validates `event.tenant_id` and `event.source` but takes the candidate list verbatim — `RecallCandidate(**c)` is constructed from caller keys.

A row can therefore name a memory belonging to another tenant. **That is inert only while nothing reads the table — which stops being true the moment this extractor does.** Any JOIN from `recall_candidate` to `memories` must carry a tenant predicate; joining on `memory_id` alone converts an unvalidated write into a cross-tenant content read.

## Why here and not in the allowlist

#1180's trace already recorded this on `method:recall_log_write`'s allowlist note. That note is correct and it is in the wrong place: whoever writes the Phase 2 query will be reading `repeat_recall.py`, not `tenant_scope_allowlist.json`. A requirement filed only where the reader will not be is documented, not guarded.

There is no Phase 2 ticket to attach it to (`gh issue list --search` finds none), so the module docstring and the `extract()` stub are the artifacts that will actually be read.

## The test change

`test_each_module_documents_its_data_source` requires each signal module's docstring to name its data source from a fixed token list, and `memory_recalls` was the token this module satisfied it with — i.e. the check was accepting a table that does not exist as a valid breadcrumb.

Added `recall_event` to the list so a future author who drops the stale mention can name the real table instead of tripping the check. `memory_recalls` stays accepted, with a comment saying why it is still there and that a module naming only it is pointing operators at nothing.

**Widening a token list weakens a test, so I checked it still bites**: gutting this module's docstring to a one-liner with no breadcrumb turns `test_each_module_documents_its_data_source` red (`1 failed, 52 deselected`); restored, 53 pass. The check still catches an undocumented stub, which is what it is for.

## Gates

Venv on `PATH`, `UV_FROZEN=1`. `ruff check` and `ruff format --check` run separately at CI's exact scopes, discovery-based, no `--config`.

- `pytest tests/test_outcome_inference_signals.py` — **53 passed**
- `mypy src/` in `core-api` — no issues in 203 source files
- `ruff check` — `core-api/src/`, `core-storage-api/src/`, `core-storage-api/tests/`, `common/`, `core-operations/{src,tests}/`, `core-worker/{src,tests}/` — all clean
- `ruff format --check core-api/src/` — 203 files already formatted
- `python3 scripts/legacy_name_ratchet.py --base origin/main` — `No new lines.`
- `python3 scripts/do_not_touch_sentinel.py` — all 46 protected strings survive
- `uv.lock` / `plugin/package-lock.json` untouched

No new test: this changes prose, and the assertion that matters (the breadcrumb check) already exists and is verified above to still fail on a stub.

One signed-off commit, rebased onto `origin/main` immediately before push with the suite re-run after.

## Not in scope

`cross_agent_reuse.py:21` also names a hypothetical `memory_recalls` table as a "Phase 2+ upgrade path". It is a different signal with a different data need and its phrasing is conditional rather than a false statement of fact, so I left it — flagging it rather than widening this PR.
