### PR TITLE
feat(gate): a third marker for deferred work that stays counted

### DIFF
--- a/docs/plans/legacy-name-ratchet-engine.md
+++ b/docs/plans/legacy-name-ratchet-engine.md
@@ -69,7 +69,7 @@ is exactly these five fields:
 | `marker_inventory_meta_paths` | list of root-relative paths | Paths omitted only from marker analytics. |
 
 No sixth field is part of this port. Engine-wide rules, including marker-system
-code/test exclusions and the meaning of the two markers, remain in the engine.
+code/test exclusions and marker semantics, remain in the engine.
 A declared manifest must be a readable JSON object whose keys are valid
 repository-relative paths. Missing or malformed manifests fail closed rather
 than silently moving their mirrors into the fleet-summable headline.
@@ -100,6 +100,43 @@ line in each path whose basename starts with `CHANGELOG` (case-insensitive). It
 does not identify individual generated lines. No path outside that basename
 predicate is exempt.
 
+## Deferred work is an attribute, not an exemption
+
+`legacy-name-deferred: <reason> (<doc path or issue URL>)` records work that a
+decision explicitly postpones. It is deliberately outside the permanent-marker
+table and regular expression. The scan stores it as an attribute of a counted
+line, so a newly written deferred line fails exactly as the same unmarked line
+would. Adding the annotation to an already-counted line is text-neutral for the
+ratchet; it cannot provide headroom or turn a red build green.
+
+The reference is mandatory and is checked in the exact tree being scanned.
+Working-tree document references must be regular repository files that are
+already committed or fully staged; intent-to-add entries, symlinks, and
+submodules do not qualify. HTTPS issue references are syntax-checked without
+making gate availability depend on a remote service. Malformed syntax, a
+missing document, or a local-only document fails the gate.
+
+A line carrying both deferred and a permanent `legacy-name-ok` or
+`legacy-name-floor` marker is a hard error. The permanent marker still wins the
+classification, because `_kind()` remains the only exemption decision, but the
+gate then fails the contradiction instead of silently publishing a deferred
+line outside the headline. This differs from the measured alias-plus-floor
+population: those are two compatible permanent claims, while permanent and
+deferred are mutually exclusive lifecycle states. There is no deferred
+population to preserve, so choosing a hard error now has no migration cost.
+
+The only sanctioned count increase is a same-path `legacy-name-floor` to
+`legacy-name-deferred` replacement. It must preserve the exact text before the
+marker, including comment introducer and internal whitespace, and the exact
+syntactic closer after it. As everywhere else in this engine, outer indentation
+is normalized before text comparison, so reindentation alone is not treated as
+a new branded line. A surviving floor or alias occurrence consumes the base
+floor before transition matching, so one old floor cannot authorize both a
+permanent successor and a deferred duplicate. Each net-new deferred occurrence
+is allocated once: an old counted line in the same path claims it before the
+count-increasing floor transition is considered. The exception is derived from
+the base line; a line that had no base floor marker cannot use it.
+
 ## Report contract
 
 A bare `--report` is current inventory only. It does not resolve a base and
@@ -118,14 +155,23 @@ labels it “never sum,” and discloses any excluded mirror inventory.
 `--report --json` makes the boundary structural:
 
 - `headline.name` is `gated`; it contains numeric `lines` and `files` plus
-  `aggregation: {"allowed": true, "operation": "sum"}`.
+  `aggregation: {"allowed": true, "operation": "sum"}`. Its additive
+  `deferred` member partitions out valid deferred lines by file and decision
+  reference without removing them from `headline.lines`.
 - `diagnostics.present` contains an explicit denied aggregation contract and a
   display string. It deliberately has no numeric `lines` or `files` fields, so
   a generic caller cannot select a `present` number and silently sum it.
 - Mirror details remain auditable under `diagnostics.mirrors`, also tagged with
   denied aggregation.
-- `scope`, marker inventory, and an optional explicit-base change object carry
-  the remaining bounded diagnostics.
+- `marker_inventory.counts` includes the deferred token separately, including a
+  recognized marker whose syntax or reference is invalid.
+- `deferred_validation` exposes whether every recognized deferred marker is
+  valid and lists bounded path/line diagnostics when one is not.
+- `scope` and an optional explicit-base change object carry the remaining
+  bounded diagnostics. When present, `change.deferred` distinguishes
+  count-neutral annotations from narrowly excused floor-to-deferred increases.
+  These additions are backward-compatible fields in the existing
+  `legacy-name-ratchet-report/v1` object; existing field meanings do not change.
 
 ## Gate invariants and tests
 

--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -43,6 +43,19 @@ compat alias, a redirect, a test pinning the old wire format.
 reach, and cannot be correct without the literal: a pasteable command, an on-disk
 path, a served mirror path. Nothing is declared and the footprint does not grow.
 
+``legacy-name-deferred`` is deliberately not a third escape hatch. It records a
+rename that a decision document or issue postpones, while the line remains in the
+gated headline. Its mandatory ``(<doc path or issue URL>)`` keeps the claim
+falsifiable. A new line carrying it still fails exactly as the unmarked line
+would; adding it to an existing counted line changes no count.
+
+A permanent marker combined with ``legacy-name-deferred`` is a hard error. The
+alias/floor pair can both be true of one permanent line, which is why
+:func:`_kind` has a measured precedence rule. Permanent and deferred are
+mutually exclusive states: letting the permanent marker win silently would
+exempt the line and make the deferred annotation — and its headline count — a
+lie. There is no existing population, so failing the contradiction is free now.
+
 Why a second marker rather than a convention inside the reason text. Audited at
 full coverage across the seven repos: 622 markers — **340 aliases, 274 floor
 mentions**, and 8 on lines that should have been reworded rather than marked at
@@ -116,6 +129,7 @@ import sys
 from collections import Counter
 from pathlib import Path, PurePosixPath
 from typing import NamedTuple, overload
+from urllib.parse import urlsplit
 
 # The legacy brand. Matched case-insensitively, so every casing in the tree
 # counts — prose, identifiers and SCREAMING_SNAKE env names alike. This is the
@@ -128,6 +142,8 @@ LEGACY_NAME = "memclaw"  # legacy-name-ok: the pattern this gate searches for
 # decision rather than a formatting artifact.
 EXEMPT_MARKER = "legacy-name-ok"
 FLOOR_MARKER = "legacy-name-floor"
+DEFERRED_MARKER = "legacy-name-deferred"
+_DEFERRED_LABEL = "deferred line(s)"
 
 _CONFIG_PATH = "scripts/legacy_name_ratchet.json"
 _RELEASE_PLEASE_AUTHOR_ID = 265395343
@@ -247,6 +263,177 @@ EXEMPT_RE = re.compile(
     rf"(?<![\w-])(?P<marker>{'|'.join(re.escape(m) for m in _KINDS)})(?=[\s:]|$)",
     re.IGNORECASE,
 )
+
+# Deliberately outside :data:`_KINDS` and :data:`EXEMPT_RE`. The gate decides
+# exemption solely through :func:`_kind`, so putting the deferred marker in
+# either place would make postponed work disappear from the gated headline.
+# Reuse the permanent markers' two-sided token construction exactly: a near
+# miss must neither exempt nor be reported as a real deferral.
+DEFERRED_RE = re.compile(
+    rf"(?<![\w-])(?P<marker>{re.escape(DEFERRED_MARKER)})(?=[\s:]|$)",
+    re.IGNORECASE,
+)
+
+
+class _Deferred(NamedTuple):
+    """One deferred annotation resolved from a counted line.
+
+    ``canonical`` is the counted line with only this annotation removed. That
+    makes adding the marker to an existing counted line text-neutral without
+    making a newly written line disappear. ``frame`` retains the exact text on
+    either side of the annotation for the narrower floor-to-deferred transition.
+
+    An invalid marker is still returned: silently treating malformed syntax as
+    ordinary prose would leave the promised hard failure unenforced on a line
+    whose count did not change.
+    """
+
+    reference: str
+    canonical: str
+    frame: tuple[str, str]
+    error: str | None
+
+
+class _DeferredLine(NamedTuple):
+    """A validated deferred attribute attached to one counted line."""
+
+    canonical: str
+    reference: str
+    frame: tuple[str, str]
+
+
+class _DeferredProblem(NamedTuple):
+    path: str
+    lineno: str
+    text: str
+    message: str
+
+
+_COMMENT_PREFIXES = ("<!--", "//", "/*", "--", "#", ";")
+# ``--!>`` closes an HTML comment as surely as ``-->`` does, so both spellings
+# have to be recognised here. Nothing security-critical rests on it — a suffix
+# this does not recognise makes an annotation invalid or a frame not match,
+# which fails the gate rather than exempting anything — but recognising only one
+# spelling is simply wrong about the markup, and CodeQL's py/bad-tag-filter is
+# right to say so.
+_ANNOTATION_SUFFIX = r"(?:--!?>|\*/|[\"'`](?:\s*[,;)\]}])*|[)\]}]+(?:\s*[,;])?)"
+_DEFERRED_SUFFIX_RE = re.compile(rf"\s*{_ANNOTATION_SUFFIX}?\s*\Z")
+_TERMINAL_SUFFIX_RE = re.compile(rf"(?P<suffix>\s*{_ANNOTATION_SUFFIX}\s*)\Z")
+
+
+def _invalid_deferred(
+    text: str,
+    message: str,
+    *,
+    reference: str = "",
+) -> _Deferred:
+    return _Deferred(
+        reference,
+        text,
+        (text, ""),
+        message,
+    )
+
+
+def _comment_introducer(prefix: str) -> str | None:
+    """The comment delimiter this annotation hangs off, if it hangs off one."""
+    stripped = prefix.rstrip()
+    return next(
+        (c for c in _COMMENT_PREFIXES if stripped.endswith(c)),
+        None,
+    )
+
+
+def _annotation_frame(prefix: str, suffix: str) -> tuple[str, tuple[str, str]]:
+    """Canonical text and exact syntactic frame for one annotated line.
+
+    The single implementation both marker kinds resolve through, and it has to
+    stay single. :func:`_floor_transitions` pairs a floor line with its deferred
+    successor by comparing the frames the two resolvers produce, so a second
+    copy of this that drifted from the first would stop pairing legitimate
+    transitions — charging them as mints — and no test would name the
+    divergence, because each half would still be self-consistent.
+    """
+    canonical_prefix = prefix.rstrip()
+    comment_prefix = _comment_introducer(prefix)
+    if comment_prefix is not None:
+        canonical_prefix = canonical_prefix[: -len(comment_prefix)].rstrip()
+
+    # Comment delimiters belong to the annotation. String/expression closers do
+    # not: retain those so canonical text cannot match a differently shaped line.
+    canonical_suffix = "" if comment_prefix is not None else suffix
+    return f"{canonical_prefix}{canonical_suffix}", (prefix, suffix)
+
+
+def _annotation_canonical(
+    text: str, marker_start: int, reference_end: int
+) -> tuple[str, tuple[str, str]] | None:
+    """Remove one trailing annotation and retain its exact syntactic frame.
+
+    The marker grammar ends at the reference. Anything after it must be only a
+    block-comment closer or the punctuation that closes a surrounding string or
+    expression. Rejecting arbitrary suffix text is what makes the transition's
+    "only its marker changed" claim mechanically true.
+    """
+    if _DEFERRED_SUFFIX_RE.fullmatch(text[reference_end:]) is None:
+        return None
+    return _annotation_frame(text[:marker_start], text[reference_end:])
+
+
+def _deferred(text: str) -> _Deferred | None:
+    """Resolve the non-exempting deferred marker and its decision reference."""
+    matches = list(DEFERRED_RE.finditer(text))
+    if not matches:
+        return None
+    if len(matches) != 1:
+        return _invalid_deferred(
+            text,
+            "the marker must appear exactly once on a line",
+        )
+
+    marker = matches[0]
+    tail = text[marker.end() :]
+    separator = re.match(r"\s*:\s*", tail)
+    if separator is None:
+        return _invalid_deferred(
+            text,
+            "use 'legacy-name-deferred: <reason> (<doc path or issue URL>)'",
+        )
+
+    payload_start = marker.end() + separator.end()
+    payload = text[payload_start:]
+    references = list(re.finditer(r"\((?P<reference>[^()\s]+)\)", payload))
+    if not references:
+        return _invalid_deferred(
+            text,
+            "a decision reference is required in parentheses",
+        )
+
+    reference_match = references[-1]
+    reason = payload[: reference_match.start()].strip()
+    reference = reference_match.group("reference")
+    reference_end = payload_start + reference_match.end()
+    if not reason:
+        return _invalid_deferred(
+            text,
+            "a reason is required before the decision reference",
+            reference=reference,
+        )
+
+    annotation = _annotation_canonical(text, marker.start(), reference_end)
+    if annotation is None:
+        return _invalid_deferred(
+            text,
+            "the decision reference must end the annotation",
+            reference=reference,
+        )
+    canonical, frame = annotation
+    return _Deferred(
+        reference,
+        canonical,
+        frame,
+        None,
+    )
 
 
 def _kind(text: str) -> str | None:
@@ -397,6 +584,104 @@ def _repo_path(value: object, field: str) -> str:
     return value
 
 
+_REGULAR_GIT_MODES = frozenset({"100644", "100755"})
+
+
+def _index_mode(path: str) -> str | None:
+    """Mode of one unconflicted index entry, or ``None`` when absent/unsafe."""
+    out = _git(["git", "ls-files", "--stage", "-z", "--", f":(top,literal){path}"])
+    records = [record for record in out.split("\0") if record]
+    if len(records) != 1:
+        return None
+    fields = records[0].partition("\t")[0].split()
+    if len(fields) != 3 or fields[2] != "0":
+        return None
+    return fields[0]
+
+
+def _tree_mode(tree: str, path: str) -> str | None:
+    """Git mode of ``path`` in ``tree``, without following symlinks."""
+    out = _git(["git", "ls-tree", "-z", tree, "--", f":(top,literal){path}"])
+    records = [record for record in out.split("\0") if record]
+    if len(records) != 1:
+        return None
+    fields = records[0].partition("\t")[0].split()
+    return fields[0] if len(fields) == 3 else None
+
+
+@functools.cache
+def _decision_reference_error(reference: str, tree: str | None) -> str | None:
+    """Return why a deferred decision reference cannot be opened, if anything.
+
+    Repository documents are verified in the exact tree being scanned. HTTPS
+    references are syntax-checked only: CI must not turn an issue tracker's
+    availability into the rename gate's availability.
+    """
+    # Any scheme at all means a URL was intended, so the answer has to be about
+    # the URL. Testing the literal ``https://`` instead sent ``HTTPS://...`` and
+    # ``http://...`` down the path branch, where they failed as a
+    # repository-relative path — naming a problem the author did not have.
+    # ``urlsplit`` normalises the scheme's case, so this covers every spelling.
+    parsed = urlsplit(reference)
+    if parsed.scheme:
+        # A bare domain locates nothing, so it cannot be opened to check the
+        # claim and is not a decision reference. A query-only URL does locate
+        # something; requiring a non-empty path rejected it for a reason the
+        # message did not give and the author did not have.
+        if parsed.scheme != "https" or not parsed.netloc:
+            return "decision issue URL must be an absolute HTTPS URL"
+        if not (parsed.path.strip("/") or parsed.query):
+            return (
+                "decision issue URL must name a specific issue or document, "
+                "not a bare domain"
+            )
+        return None
+
+    path_value = reference.split("#", 1)[0]
+    try:
+        path = _repo_path(path_value, "deferred decision reference")
+    except (TypeError, ValueError) as exc:
+        return str(exc)
+
+    if tree is None:
+        working_path = _repo_root() / path
+        if working_path.is_symlink():
+            return f"decision document must be a regular repository file: {path}"
+        if not working_path.is_file():
+            return f"decision document does not exist: {path}"
+        index_mode = _index_mode(path)
+        if index_mode is None:
+            return f"decision document is not tracked: {path}"
+        if index_mode not in _REGULAR_GIT_MODES:
+            return f"decision document must be a regular repository file: {path}"
+        staged = _git(
+            [
+                "git",
+                "diff",
+                "--cached",
+                "-M",
+                "--name-status",
+                "-z",
+                "--",
+                f":(top,literal){path}",
+            ]
+        )
+        if staged.startswith("D\0"):
+            return f"decision document is staged for deletion: {path}"
+        if _tree_mode("HEAD", path) in _REGULAR_GIT_MODES:
+            return None
+        if not staged:
+            return f"decision document is not committed or staged: {path}"
+        return None
+
+    mode = _tree_mode(tree, path)
+    if mode is None:
+        return f"decision document does not exist in {tree}: {path}"
+    if mode not in _REGULAR_GIT_MODES:
+        return f"decision document must be a regular file in {tree}: {path}"
+    return None
+
+
 def _base_ref(value: object, field: str) -> str:
     """Validate a ref before placing it in git's option-bearing argument area."""
     if not isinstance(value, str):
@@ -507,8 +792,8 @@ def _grep(
     pathspec: str | list[str] = ":/",
     *,
     exclusions: bool = True,
-) -> list[tuple[str, str, str, str | None]]:
-    """``(path, lineno, text, kind)`` for every matching line.
+) -> list[tuple[str, str, str, str | None, _Deferred | None]]:
+    """``(path, lineno, text, kind, deferred)`` for every matching line.
 
     ``kind`` is the marker literal exempting the line, or ``None`` for a line
     that carries none — see :func:`_kind`. A kind rather than a bool because the
@@ -540,7 +825,7 @@ def _grep(
 
     prefix = f"{tree}:" if tree is not None else ""
 
-    out: list[tuple[str, str, str, str | None]] = []
+    out: list[tuple[str, str, str, str | None, _Deferred | None]] = []
     # Records are newline-terminated (a matched line cannot contain one) and
     # their three fields are NUL-separated.
     for record in _git(args).split("\n"):
@@ -554,7 +839,7 @@ def _grep(
             if not path.startswith(prefix):
                 continue
             path = path[len(prefix) :]
-        out.append((path, lineno, text, _kind(text)))
+        out.append((path, lineno, text, _kind(text), _deferred(text.strip())))
     return out
 
 
@@ -717,6 +1002,8 @@ class Scan(NamedTuple):
     by_file: dict[str, Counter[str]]
     total: Counter[str]
     exempt_by_file: dict[str, Counter[str]]
+    deferred_by_file: dict[str, Counter[_DeferredLine]]
+    deferred_problems: tuple[_DeferredProblem, ...]
 
     def counts(self) -> Counter[str]:
         """Non-exempt lines per file — what the ratchet holds flat."""
@@ -727,6 +1014,16 @@ class Scan(NamedTuple):
         return Counter(
             {path: sum(c.values()) for path, c in self.exempt_by_file.items()}
         )
+
+    def deferred(self) -> Counter[str]:
+        """Valid deferred annotations per file, all inside the gated tally."""
+        return Counter(
+            {path: sum(c.values()) for path, c in self.deferred_by_file.items()}
+        )
+
+    def deferred_references(self) -> Counter[str]:
+        """Valid deferred annotations grouped by their decision reference."""
+        return _deferred_references(self.deferred_by_file)
 
 
 def scan(
@@ -744,14 +1041,58 @@ def scan(
     # so the kind is recoverable from the key. Splitting would be a second
     # definition of the same fact.
     exempt_by_file: dict[str, Counter[str]] = {}
-    for path, _, text, kind in _grep(tree, pathspec, exclusions=exclusions):
+    deferred_by_file: dict[str, Counter[_DeferredLine]] = {}
+    deferred_problems: list[_DeferredProblem] = []
+    for path, lineno, text, kind, deferred in _grep(
+        tree, pathspec, exclusions=exclusions
+    ):
         stripped = text.strip()
+        if deferred is not None:
+            if kind is not None:
+                deferred_problems.append(
+                    _DeferredProblem(
+                        path,
+                        lineno,
+                        stripped,
+                        f"{DEFERRED_MARKER} cannot be combined with {kind}; "
+                        "the permanent marker wins exemption, making the "
+                        "deferred annotation meaningless",
+                    )
+                )
+            elif deferred.error is not None:
+                deferred_problems.append(
+                    _DeferredProblem(path, lineno, stripped, deferred.error)
+                )
+            else:
+                reference_error = _decision_reference_error(deferred.reference, tree)
+                if reference_error is not None:
+                    deferred_problems.append(
+                        _DeferredProblem(path, lineno, stripped, reference_error)
+                    )
+                else:
+                    line = _DeferredLine(
+                        deferred.canonical,
+                        deferred.reference,
+                        deferred.frame,
+                    )
+                    deferred_by_file.setdefault(path, Counter())[line] += 1
         if kind is not None:
             exempt_by_file.setdefault(path, Counter())[stripped] += 1
             continue
-        by_file.setdefault(path, Counter())[stripped] += 1
-        total[stripped] += 1
-    return Scan(by_file, total, exempt_by_file)
+        counted = (
+            deferred.canonical
+            if deferred is not None and deferred.error is None
+            else stripped
+        )
+        by_file.setdefault(path, Counter())[counted] += 1
+        total[counted] += 1
+    return Scan(
+        by_file,
+        total,
+        exempt_by_file,
+        deferred_by_file,
+        tuple(deferred_problems),
+    )
 
 
 def _excluded_inventory() -> Counter[str]:
@@ -773,6 +1114,12 @@ def _marker_inventory(head: Scan, config: Config) -> Counter[str]:
             kind = _kind(text)
             if kind is not None:
                 inventory[kind] += count
+    for path, deferred_lines in head.deferred_by_file.items():
+        if path not in excluded:
+            inventory[DEFERRED_MARKER] += sum(deferred_lines.values())
+    inventory[DEFERRED_MARKER] += sum(
+        problem.path not in excluded for problem in head.deferred_problems
+    )
     return inventory
 
 
@@ -805,16 +1152,29 @@ def _updated_scan(before: Scan, tree: str, paths: list[str]) -> Scan:
 
     by_file = before.by_file.copy()
     exempt_by_file = before.exempt_by_file.copy()
+    deferred_by_file = before.deferred_by_file.copy()
+    deferred_problems = [
+        problem for problem in before.deferred_problems if problem.path not in paths
+    ]
     total = before.total.copy()
     for path in paths:
         total.subtract(by_file.pop(path, Counter()))
         exempt_by_file.pop(path, None)
+        deferred_by_file.pop(path, None)
 
     changed = scan(tree, [_literal(path) for path in paths])
     by_file.update(changed.by_file)
     exempt_by_file.update(changed.exempt_by_file)
+    deferred_by_file.update(changed.deferred_by_file)
+    deferred_problems.extend(changed.deferred_problems)
     total.update(changed.total)
-    return Scan(by_file, +total, exempt_by_file)
+    return Scan(
+        by_file,
+        +total,
+        exempt_by_file,
+        deferred_by_file,
+        tuple(deferred_problems),
+    )
 
 
 def _transition_paths(before: str, after: str | None = None) -> list[str]:
@@ -880,6 +1240,204 @@ def _transition_delta(
         for text, n in (lines - base.exempt_by_file.get(path, Counter())).items()
     }
     return lost, gained, gained_exempt
+
+
+class _FloorTransition(NamedTuple):
+    """One mechanically exact floor-to-deferred replacement."""
+
+    path: str
+    before: str
+    after: _DeferredLine
+    occurrences: int
+
+
+def _new_deferred(base: Scan, head: Scan) -> dict[str, Counter[_DeferredLine]]:
+    """Net-new deferred occurrences, ignoring metadata edits and moves."""
+    remaining = {path: lines.copy() for path, lines in head.deferred_by_file.items()}
+    base_pool: Counter[str] = Counter()
+
+    # Same-path predecessors get first claim. This keeps ordinary metadata edits
+    # local while still treating a cross-file relocation as an existing
+    # occurrence rather than a floor transition at its destination.
+    for path, base_lines in base.deferred_by_file.items():
+        local: Counter[str] = Counter()
+        for line, count in base_lines.items():
+            local[line.canonical] += count
+        for line, count in sorted(remaining.get(path, Counter()).items()):
+            consumed = min(count, local[line.canonical])
+            remaining[path][line] -= consumed
+            local[line.canonical] -= consumed
+        base_pool.update(local)
+
+    # A line whose OWN path held a floor marker in the exact same frame is that
+    # path's own transition, not the far end of somebody else's relocation. The
+    # pool claiming it first is what the comment above means to exclude: the
+    # relocation rule is about a line that ARRIVES somewhere new, and this line
+    # did not arrive, it changed marker in place. Letting the pool win reported
+    # the floor line as deleted and charged its successor as a mint — a red
+    # build on a change that minted nothing.
+    local_floor_frames = {
+        path: {
+            _permanent_annotation(text)[1]
+            for text in lines
+            if _kind(text) == FLOOR_MARKER
+        }
+        for path, lines in base.exempt_by_file.items()
+    }
+
+    for path in sorted(remaining):
+        own_floor: set[tuple[str, str]] = local_floor_frames.get(path, set())
+        for line, count in sorted(remaining[path].items()):
+            if line.frame in own_floor:
+                continue
+            consumed = min(count, base_pool[line.canonical])
+            remaining[path][line] -= consumed
+            base_pool[line.canonical] -= consumed
+
+    return {path: +lines for path, lines in remaining.items() if +lines}
+
+
+def _deferred_annotations(
+    base: Scan,
+    head: Scan,
+    gained_by_path: dict[str, Counter[_DeferredLine]],
+) -> tuple[dict[str, Counter[_DeferredLine]], dict[str, Counter[_DeferredLine]]]:
+    """Allocate new attributes to old counted lines, returning unspent ones."""
+    result: dict[str, Counter[_DeferredLine]] = {}
+    remaining = {path: lines.copy() for path, lines in gained_by_path.items()}
+    for path, gained in remaining.items():
+        already_deferred: Counter[str] = Counter()
+        for line, count in base.deferred_by_file.get(path, Counter()).items():
+            already_deferred[line.canonical] += count
+        base_plain = base.by_file.get(path, Counter()) - already_deferred
+        head_deferred: Counter[str] = Counter()
+        for line, count in head.deferred_by_file.get(path, Counter()).items():
+            head_deferred[line.canonical] += count
+        head_plain = head.by_file.get(path, Counter()) - head_deferred
+        available = base_plain - head_plain
+        for line, count in sorted(gained.items()):
+            matched = min(count, available[line.canonical])
+            if matched:
+                result.setdefault(path, Counter())[line] += matched
+                gained[line] -= matched
+                available[line.canonical] -= matched
+    return result, {path: +lines for path, lines in remaining.items() if +lines}
+
+
+def _permanent_annotation(text: str) -> tuple[str, tuple[str, str]]:
+    """Canonical content and syntax frame for one permanently marked line."""
+    match = EXEMPT_RE.search(text)
+    if match is None:
+        return text, (text, "")
+    prefix = text[: match.start()]
+    comment_prefix = _comment_introducer(prefix)
+
+    if comment_prefix == "<!--":
+        suffix_match = re.search(r"\s*--!?>\Z", text)
+    elif comment_prefix == "/*":
+        suffix_match = re.search(r"\s*\*/\Z", text)
+    elif comment_prefix is not None:
+        suffix_match = None
+    else:
+        suffix_match = _TERMINAL_SUFFIX_RE.search(text)
+    suffix = suffix_match.group() if suffix_match is not None else ""
+    return _annotation_frame(prefix, suffix)
+
+
+def _floor_transitions(
+    base: Scan,
+    head: Scan,
+    gained_by_path: dict[str, Counter[_DeferredLine]],
+) -> tuple[_FloorTransition, ...]:
+    """Pair only same-path lines whose floor annotation alone was replaced.
+
+    Existing permanent successors consume base floor occurrences first. A base
+    floor therefore cannot authorize a deferred duplicate while surviving as a
+    floor or alias. The remaining pair must preserve the exact prefix — including
+    comment introducer and whitespace — and the exact syntactic closer.
+    """
+    transitions: list[_FloorTransition] = []
+    for path, gained in gained_by_path.items():
+        candidates: dict[tuple[str, str], Counter[str]] = {}
+        canonical_by_frame: dict[tuple[str, str], str] = {}
+        for text, count in base.exempt_by_file.get(path, Counter()).items():
+            if _kind(text) != FLOOR_MARKER:
+                continue
+            canonical, frame = _permanent_annotation(text)
+            candidates.setdefault(frame, Counter())[text] += count
+            canonical_by_frame[frame] = canonical
+
+        # Consume exact-frame permanent survivors first. Only then use the
+        # conservative canonical fallback that prevents a restyled alias/floor
+        # from leaving the old floor available to authorize a deferred duplicate.
+        permanent_by_frame: Counter[tuple[str, str]] = Counter()
+        permanent_canonical: dict[tuple[str, str], str] = {}
+        for text, count in head.exempt_by_file.get(path, Counter()).items():
+            canonical, frame = _permanent_annotation(text)
+            permanent_by_frame[frame] += count
+            permanent_canonical[frame] = canonical
+        for frame in sorted(candidates):
+            available = permanent_by_frame[frame]
+            if not available:
+                continue
+            for text, count in sorted(candidates[frame].items()):
+                consumed = min(available, count)
+                candidates[frame][text] -= consumed
+                available -= consumed
+                if not available:
+                    break
+            permanent_by_frame[frame] = available
+
+        permanent: Counter[str] = Counter()
+        for frame, count in permanent_by_frame.items():
+            permanent[permanent_canonical[frame]] += count
+        for frame in sorted(candidates):
+            available = permanent[canonical_by_frame[frame]]
+            if not available:
+                continue
+            for text, count in sorted(candidates[frame].items()):
+                consumed = min(available, count)
+                candidates[frame][text] -= consumed
+                available -= consumed
+                if not available:
+                    break
+            permanent[canonical_by_frame[frame]] = available
+
+        for line, available in sorted(gained.items()):
+            if LEGACY_NAME.lower() not in line.canonical.lower():
+                continue
+            floor = candidates.get(line.frame, Counter())
+            for text, count in sorted(floor.items()):
+                if not available:
+                    break
+                matched = min(available, count)
+                if matched:
+                    transitions.append(_FloorTransition(path, text, line, matched))
+                    floor[text] -= matched
+                    available -= matched
+    return tuple(transitions)
+
+
+def _floor_excused(
+    transitions: tuple[_FloorTransition, ...],
+) -> dict[str, Counter[str]]:
+    result: dict[str, Counter[str]] = {}
+    for transition in transitions:
+        result.setdefault(transition.path, Counter())[transition.after.canonical] += (
+            transition.occurrences
+        )
+    return result
+
+
+def _floor_sources(
+    transitions: tuple[_FloorTransition, ...],
+) -> dict[str, Counter[str]]:
+    result: dict[str, Counter[str]] = {}
+    for transition in transitions:
+        result.setdefault(transition.path, Counter())[transition.before] += (
+            transition.occurrences
+        )
+    return result
 
 
 def _match_annotations(lost: _LineCounts, gained_exempt: _LineCounts) -> int:
@@ -1076,6 +1634,7 @@ def _minted(
     head_by_file: dict[str, Counter[str]],
     base_by_file: dict[str, Counter[str]],
     budget: Counter[str],
+    transition: Counter[str] | None = None,
 ) -> tuple[Counter[str], Counter[str]]:
     """``(minted, moved)`` for ``path``: text the repo did not have, and text it did.
 
@@ -1123,6 +1682,20 @@ def _minted(
     most a text comparison can honestly offer.
     """
     new_here = head_by_file.get(path, Counter()) - base_by_file.get(path, Counter())
+    if transition:
+        # An excused occurrence still SPENDS its unit of the shared budget. The
+        # repo really did gain that text — the transition is why it is not
+        # charged here, not evidence that the gain never happened. Dropping it
+        # from ``new_here`` without spending would leave the unit available to
+        # an unrelated file, where the next occurrence of the same text is
+        # charged as minted instead of recognised as a move: a red build on a
+        # change that minted nothing, in a file with no part in the transition.
+        for text, excused in transition.items():
+            spent = min(excused, new_here[text], budget[text])
+            if spent:
+                budget[text] -= spent
+        new_here.subtract(transition)
+        new_here = +new_here
 
     minted: Counter[str] = Counter()
     moved: Counter[str] = Counter()
@@ -1197,7 +1770,9 @@ def _truncated(paths: list[str]) -> str:
 
 
 def _report_removed_exemptions(
-    base_by_file: dict[str, Counter[str]], head_by_file: dict[str, Counter[str]]
+    base_by_file: dict[str, Counter[str]],
+    head_by_file: dict[str, Counter[str]],
+    ignored: dict[str, Counter[str]] | None = None,
 ) -> None:
     """Name every exempt line this change removed. Reports; never fails.
 
@@ -1260,7 +1835,9 @@ def _report_removed_exemptions(
     for path, counts in base_by_file.items():
         head_counts = head_by_file.get(path, Counter())
         for text, n_base in counts.items():
-            lost = n_base - head_counts[text]
+            lost = (
+                n_base - head_counts[text] - (ignored or {}).get(path, Counter())[text]
+            )
             if lost > 0:
                 drops.setdefault(text, Counter())[path] = lost
     if not drops:
@@ -1380,7 +1957,7 @@ def _report_new_exemptions(
     for path in sorted(paths):
         here = [
             (lineno, text.strip(), kind)
-            for _, lineno, text, kind in _grep(None, pathspec=_literal(path))
+            for _, lineno, text, kind, _ in _grep(None, pathspec=_literal(path))
             if kind is not None
         ]
         if not here:
@@ -1480,6 +2057,59 @@ def _report_new_exemptions(
     print()
 
 
+def _deferred_references(
+    lines: dict[str, Counter[_DeferredLine]],
+) -> Counter[str]:
+    references: Counter[str] = Counter()
+    for per_file in lines.values():
+        for line, count in per_file.items():
+            references[line.reference] += count
+    return references
+
+
+def _report_deferred_problems(problems: tuple[_DeferredProblem, ...]) -> None:
+    if not problems:
+        return
+    print(f"Invalid {DEFERRED_MARKER} marker(s):")
+    for problem in problems:
+        print(f"  {problem.path}:{problem.lineno}: {problem.message}")
+        print(f"      {problem.text[:100]}")
+    print(
+        "Deferred work stays in the gated count. Use "
+        f"'{DEFERRED_MARKER}: <reason> (<doc path or issue URL>)'; it cannot "
+        "be combined with a permanent marker."
+    )
+
+
+def _report_deferred_transitions(
+    annotations: dict[str, Counter[_DeferredLine]],
+    floor_transitions: tuple[_FloorTransition, ...],
+) -> None:
+    annotated = sum(sum(lines.values()) for lines in annotations.values())
+    if annotated:
+        print(
+            f"{annotated} existing counted line(s) annotated as deferred; "
+            "they remain counted."
+        )
+        for reference, count in sorted(_deferred_references(annotations).items()):
+            print(f"  {count} deferred by {reference}.")
+
+    floor = sum(transition.occurrences for transition in floor_transitions)
+    if floor:
+        print(
+            f"{floor} floor-to-deferred transition(s) excused. Each base line "
+            "carried a floor marker in the same file and its exact annotation "
+            "frame now carries deferred; the gated headline rises by this amount."
+        )
+        references: Counter[str] = Counter()
+        for transition in floor_transitions:
+            references[transition.after.reference] += transition.occurrences
+        for reference, count in sorted(references.items()):
+            print(f"  {count} deferred by {reference}.")
+    if annotated or floor:
+        print()
+
+
 def _present_display(head: Counter[str], mirrors: Counter[str]) -> str:
     """Human-only representation: JSON deliberately exposes no numeric column."""
     return (
@@ -1503,6 +2133,7 @@ def _report_payload(
     for audit and debugging.
     """
     head = head_scan.counts()
+    deferred = head_scan.deferred()
     no_sum = {
         "allowed": False,
         "error": "per-repository diagnostic may overlap authored content in other repositories",
@@ -1515,6 +2146,11 @@ def _report_payload(
             "lines": sum(head.values()),
             "files": len(head),
             "by_file": dict(sorted(head.items())),
+            "deferred": {
+                "lines": sum(deferred.values()),
+                "by_file": dict(sorted(deferred.items())),
+                "by_reference": dict(sorted(head_scan.deferred_references().items())),
+            },
         },
         "diagnostics": {
             "present": {
@@ -1529,9 +2165,23 @@ def _report_payload(
             },
         },
         "marker_inventory": {
-            "counts": {marker: markers[marker] for marker in _KINDS},
+            "counts": {
+                **{marker: markers[marker] for marker in _KINDS},
+                DEFERRED_MARKER: markers[DEFERRED_MARKER],
+            },
             "excluded_meta_paths": list(_config().marker_inventory_meta_paths),
             "system_paths_excluded": sorted(_MARKER_SYSTEM_PATHS),
+        },
+        "deferred_validation": {
+            "valid": not head_scan.deferred_problems,
+            "problems": [
+                {
+                    "path": problem.path,
+                    "line": int(problem.lineno),
+                    "message": problem.message,
+                }
+                for problem in head_scan.deferred_problems
+            ],
         },
         "scope": {
             "tracked_files_only": True,
@@ -1556,6 +2206,9 @@ def _print_inventory(
     for path, count in sorted(head.items(), key=lambda item: (-item[1], item[0])):
         print(f"  {count:>4}  {path}")
 
+    for reference, count in sorted(head_scan.deferred_references().items()):
+        print(f"Of which {count} deferred by {reference}.")
+
     if mirrors:
         print(
             f"Excluded from the count above: {sum(mirrors.values())} "
@@ -1573,10 +2226,12 @@ def _print_inventory(
     marker_summary = ", ".join(
         f"{markers[marker]} {_KINDS[marker].label}" for marker in _KINDS
     )
+    marker_summary += f", {markers[DEFERRED_MARKER]} {_DEFERRED_LABEL}"
     print(
         f"Marker inventory: {marker_summary}. Excludes gate code/tests and "
         f"{len(_config().marker_inventory_meta_paths)} declared meta path(s)."
     )
+    _report_deferred_problems(head_scan.deferred_problems)
     print(f"Scope: tracked files only; {untracked} untracked file(s) omitted.")
 
 
@@ -1648,6 +2303,17 @@ def main() -> int:
         return 2
 
     base = base_scan.counts()
+    new_deferred = _new_deferred(base_scan, head_scan)
+    deferred_annotations, unallocated_deferred = _deferred_annotations(
+        base_scan, head_scan, new_deferred
+    )
+    floor_transitions = _floor_transitions(base_scan, head_scan, unallocated_deferred)
+    deferred_annotation_count = sum(
+        sum(lines.values()) for lines in deferred_annotations.values()
+    )
+    floor_transition_count = sum(
+        transition.occurrences for transition in floor_transitions
+    )
 
     if args.report:
         assert payload is not None
@@ -1673,6 +2339,10 @@ def main() -> int:
             "removed": report_summary.removed,
             "moved": report_summary.moved,
             "net": report_summary.net,
+            "deferred": {
+                "annotated": deferred_annotation_count,
+                "floor_to_deferred": floor_transition_count,
+            },
         }
         if args.json:
             print(json.dumps(payload, indent=2, sort_keys=True))
@@ -1684,7 +2354,26 @@ def main() -> int:
                 f"{report_summary.moved} {_move_label(report_summary.moved)} "
                 f"({report_summary.net:+d} net)."
             )
+            if deferred_annotation_count or floor_transition_count:
+                print(
+                    "Deferred transitions: "
+                    f"{deferred_annotation_count} existing counted annotation(s), "
+                    f"{floor_transition_count} floor-to-deferred excusal(s)."
+                )
         return 0
+
+    # Printed here rather than returning the moment a bad marker is found, so one
+    # run surfaces every violation. A malformed marker and a genuinely minted line
+    # are independent failures, and failing on the first hid the second entirely:
+    # the author fixed the marker, pushed, and only then learned about the mint.
+    # Both still fail — no exit path below can reach 0 while a problem stands.
+    #
+    # Before the empty-tree check and not after it, because a line carrying a
+    # permanent marker AND a deferred one is exempt, so it is absent from both
+    # counted sets. In a tree whose only branded line is that one, both sets are
+    # empty and the check below would answer a contradictory marker with a note
+    # about a broken pathspec.
+    _report_deferred_problems(head_scan.deferred_problems)
 
     if not head and not base:
         # A pathspec that matches nothing exits 1 with an empty stderr, exactly
@@ -1692,16 +2381,22 @@ def main() -> int:
         # the gate passes every PR from then on, silently, for the rest of the
         # programme. Both trees empty is either that or a finished migration,
         # and both want a human.
-        print(
-            f"Found no '{LEGACY_NAME}' lines in either tree.\n"
-            "Either the pattern or the pathspec is broken — in which case this gate has\n"
-            "been passing without checking anything — or the migration is complete and\n"
-            "this gate should be deleted along with the last of the old names."
-        )
+        #
+        # Unless a marker report above already named the precise problem, in
+        # which case this would talk the reader out of the accurate diagnosis
+        # they have just been given.
+        if not head_scan.deferred_problems:
+            print(
+                f"Found no '{LEGACY_NAME}' lines in either tree.\n"
+                "Either the pattern or the pathspec is broken — in which case this gate has\n"
+                "been passing without checking anything — or the migration is complete and\n"
+                "this gate should be deleted along with the last of the old names."
+            )
         return 1
 
     head_by_file, base_by_file = head_scan.by_file, base_scan.by_file
     budget = _mint_budget(head_scan.total, base_scan.total)
+    floor_excused = _floor_excused(floor_transitions)
 
     grown = {}
     excused: dict[str, Counter[str]] = {}
@@ -1726,14 +2421,25 @@ def main() -> int:
         # text — so the new name is never surfaced and the gate reports "No new
         # lines." Comparing the text is what catches it; the count was only ever
         # a cheap proxy for "worth looking at", and it is the wrong one.
-        minted, moved = _minted(path, head_by_file, base_by_file, budget)
+        minted, moved = _minted(
+            path,
+            head_by_file,
+            base_by_file,
+            budget,
+            floor_excused.get(path),
+        )
         if moved:
             excused[path] = moved
         if minted:
             grown[path] = (before, n, minted)
 
     _report_new_exemptions(base_scan.exempt(), head_scan.exempt(), base_ref)
-    _report_removed_exemptions(base_scan.exempt_by_file, head_scan.exempt_by_file)
+    _report_removed_exemptions(
+        base_scan.exempt_by_file,
+        head_scan.exempt_by_file,
+        _floor_sources(floor_transitions),
+    )
+    _report_deferred_transitions(deferred_annotations, floor_transitions)
     _report_excused_moves(excused, base_by_file, head_by_file)
 
     if exempt_changelogs:
@@ -1745,6 +2451,16 @@ def main() -> int:
             print(f"  {path}")
 
     if not grown:
+        # An invalid marker fails on its own, with nothing minted anywhere. Said
+        # separately from the mint report because every summary below this point
+        # opens with "no new lines" or "gate passes", and printing either one
+        # under a failing exit code would contradict the marker report above.
+        if head_scan.deferred_problems:
+            print(
+                "No new lines fail the gate; the invalid "
+                f"{DEFERRED_MARKER} marker(s) above do."
+            )
+            return 1
         try:
             gate_summary = _change_summary(
                 base_ref,
@@ -1807,15 +2523,20 @@ def main() -> int:
         # holding the text, which in a file that already had one is a line
         # nobody touched.
         added = _added_lines(base_ref, path)
-        candidates = [
-            (lineno, text.strip())
-            for _, lineno, text, kind in _grep(None, pathspec=_literal(path))
-            if kind is None and text.strip() in minted
-        ]
+        candidates = []
+        for _, lineno, text, kind, deferred in _grep(None, pathspec=_literal(path)):
+            stripped = text.strip()
+            counted = (
+                deferred.canonical
+                if deferred is not None and deferred.error is None
+                else stripped
+            )
+            if kind is None and counted in minted:
+                candidates.append((lineno, stripped, counted))
         shown = (
             candidates
             if added is None
-            else [(n, t) for n, t in candidates if int(n) in added]
+            else [(n, raw, key) for n, raw, key in candidates if int(n) in added]
         )
         # Falling back to every occurrence rather than to silence: if the diff
         # could not be read, too many lines is a nuisance and none is a dead end.
@@ -1826,7 +2547,7 @@ def main() -> int:
         # and an empty intersection means the two disagree. Naming every
         # occurrence keeps a real offender on screen.
         shown = shown or candidates
-        for lineno, stripped in shown:
+        for lineno, stripped, _ in shown:
             print(f"      {lineno}: {stripped[:110]}")
 
         # When a change adds several identical lines and only some are minted,
@@ -1834,7 +2555,7 @@ def main() -> int:
         # apart — that is what identical means. Naming one would be a guess
         # dressed as a finding, so all are printed and the split is stated.
         for text, new in sorted(minted.items()):
-            here = sum(1 for _, t in shown if t == text)
+            here = sum(1 for _, _, key in shown if key == text)
             if here > new:
                 print(
                     f"      ^ {here} added lines share this text; {new} new, "
@@ -1855,7 +2576,11 @@ def main() -> int:
         f"mirror path — append '{FLOOR_MARKER}: <reason>' instead. Identical exemption,\n"
         "different claim: nothing is declared there, so it is counted apart and the\n"
         "aliases stay readable. Check the claim before you make it — if rewording the\n"
-        "line would leave it correct, reword it rather than marking it."
+        "line would leave it correct, reword it rather than marking it.\n\n"
+        "If the rename is deliberately postponed rather than permanent, append\n"
+        f"'{DEFERRED_MARKER}: <reason> (<doc path or issue URL>)'. This marker stays\n"
+        "inside the gated count: it annotates deferred work and does not make this build green.\n"
+        "The reference is mandatory, and combining deferred with either permanent marker fails."
     )
     return 1
 

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import os
 import runpy
+import shutil
 import subprocess
 import sys
 from collections import Counter
@@ -270,6 +271,22 @@ _EACH = pytest.mark.parametrize("m", _MARKERS, ids=lambda m: m.marker)
 # identical reasons is collapsed to a "Nx <reason>" header rather than printed
 # line by line.
 _GROUPED = 6
+
+_DEFERRED_MARKER = "legacy-name-deferred"
+_DECISION_DOC = "docs/rebrand-decision.md"
+
+
+def _write_decision(repo: Path) -> None:
+    path = repo / _DECISION_DOC
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "# Rebrand decision\n\nThe remaining rename is deliberately postponed.\n"
+    )
+    _git(repo, "add", _DECISION_DOC)
+
+
+def _deferred(reason: str = "the rename is deliberately postponed") -> str:
+    return f"{_DEFERRED_MARKER}: {reason} ({_DECISION_DOC})"
 
 
 @_EACH
@@ -546,6 +563,653 @@ def test_a_removed_floor_mention_is_still_reported(repo: Path) -> None:
     assert "the command name" in result.stdout
 
 
+# ── deferred work: counted, visible, and never an exemption ─────────────────
+
+
+def test_a_new_deferred_line_is_still_counted_and_still_fails(repo: Path) -> None:
+    """Recognition must not become exemption.
+
+    The inventory assertion makes this fail on the pre-feature engine, where the
+    unknown token happens to stay counted. The exit-code assertion makes it fail
+    on the dangerous implementation that recognises the token by adding it to
+    the exempt-marker table.
+    """
+    _write_decision(repo)
+    _stage(
+        repo,
+        "new.py",
+        f'IMPORT = "{LEGACY}/pkg"  # {_deferred()}\n',
+    )
+
+    gate = _run(repo)
+    report = json.loads(_run(repo, "--report", "--json", base=None).stdout)
+
+    assert gate.returncode == 1
+    assert "does not make this build green" in gate.stdout
+    assert report["headline"]["lines"] == 2
+    assert report["headline"]["deferred"]["lines"] == 1
+    assert report["marker_inventory"]["counts"][_DEFERRED_MARKER] == 1
+
+
+def test_annotating_an_existing_counted_line_as_deferred_is_count_neutral(
+    repo: Path,
+) -> None:
+    _write_decision(repo)
+    _git(repo, "commit", "-qm", "record the decision")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "1 existing counted line(s) annotated as deferred" in result.stdout
+    assert "No new lines" in result.stdout
+
+
+def test_report_ties_deferred_lines_to_the_gated_headline_and_decision(
+    repo: Path,
+) -> None:
+    _write_decision(repo)
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    human = _run(repo, "--report", base=None).stdout
+    payload = json.loads(_run(repo, "--report", "--json", base=None).stdout)
+
+    assert f"Of which 1 deferred by {_DECISION_DOC}." in human
+    assert payload["headline"]["deferred"] == {
+        "lines": 1,
+        "by_file": {"existing.py": 1},
+        "by_reference": {_DECISION_DOC: 1},
+    }
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "legacy-name-deferredly: later (docs/rebrand-decision.md)",
+        "somelegacy-name-deferred: later (docs/rebrand-decision.md)",
+    ],
+    ids=["right-bound", "left-bound"],
+)
+def test_deferred_marker_is_bounded_on_both_sides(repo: Path, suffix: str) -> None:
+    _write_decision(repo)
+    _stage(repo, "new.py", f'KEY = "{LEGACY}"  # {suffix}\n')
+
+    gate = _run(repo)
+    report = json.loads(_run(repo, "--report", "--json", base=None).stdout)
+
+    assert gate.returncode == 1
+    assert report["marker_inventory"]["counts"][_DEFERRED_MARKER] == 0
+
+
+def test_deferred_marker_is_recognised_case_insensitively(repo: Path) -> None:
+    _write_decision(repo)
+    _stage(
+        repo,
+        "new.py",
+        f'KEY = "{LEGACY}"  # {_DEFERRED_MARKER.upper()}: later ({_DECISION_DOC})\n',
+    )
+
+    gate = _run(repo)
+    report = json.loads(_run(repo, "--report", "--json", base=None).stdout)
+
+    assert gate.returncode == 1
+    assert report["marker_inventory"]["counts"][_DEFERRED_MARKER] == 1
+
+
+def test_a_deferred_marker_without_a_reference_fails_even_when_preexisting(
+    repo: Path,
+) -> None:
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # {_DEFERRED_MARKER}: later\n'
+    )
+    _git(repo, "add", "existing.py")
+    _git(repo, "commit", "-qm", "commit an invalid deferred marker")
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "Invalid legacy-name-deferred marker" in result.stdout
+    assert "decision reference is required" in result.stdout
+
+
+def test_a_deferred_marker_with_a_missing_decision_document_fails(
+    repo: Path,
+) -> None:
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # {_DEFERRED_MARKER}: later (docs/missing.md)\n'
+    )
+    _git(repo, "add", "existing.py")
+    _git(repo, "commit", "-qm", "commit a dangling deferred marker")
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "decision document does not exist: docs/missing.md" in result.stdout
+
+
+def test_an_issue_url_is_a_valid_deferred_decision_reference(repo: Path) -> None:
+    reference = "https://github.com/caura-ai/caura/issues/1234"
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # {_DEFERRED_MARKER}: later ({reference})\n'
+    )
+    _git(repo, "add", "existing.py")
+    _git(repo, "commit", "-qm", "commit a referenced deferral")
+
+    gate = _run(repo)
+    report = json.loads(_run(repo, "--report", "--json", base=None).stdout)
+
+    assert gate.returncode == 0, gate.stdout
+    assert report["headline"]["deferred"]["by_reference"] == {reference: 1}
+
+
+def test_a_document_fragment_is_a_valid_deferred_decision_reference(
+    repo: Path,
+) -> None:
+    _write_decision(repo)
+    reference = f"{_DECISION_DOC}#remaining-module-path"
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # {_DEFERRED_MARKER}: later ({reference})\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "commit a referenced deferral")
+
+    gate = _run(repo)
+    report = json.loads(_run(repo, "--report", "--json", base=None).stdout)
+
+    assert gate.returncode == 0, gate.stdout
+    assert report["headline"]["deferred"]["by_reference"] == {reference: 1}
+
+
+@pytest.mark.parametrize(
+    ("annotation", "message"),
+    [
+        (
+            f"{_DEFERRED_MARKER} later ({_DECISION_DOC})",
+            "use 'legacy-name-deferred:",
+        ),
+        (
+            f"{_DEFERRED_MARKER}: ({_DECISION_DOC})",
+            "a reason is required",
+        ),
+        (
+            f"{_deferred()}  {_deferred()}",
+            "marker must appear exactly once",
+        ),
+        (
+            f"{_DEFERRED_MARKER}: later (../outside.md)",
+            "repository-relative",
+        ),
+        # The two URL rejections are separate messages on purpose: one says the
+        # scheme is wrong, the other that the URL locates nothing. Pinned apart
+        # because a single message covering both named a problem the author did
+        # not have, whichever of the two they actually made.
+        (
+            f"{_DEFERRED_MARKER}: later (https://github.com)",
+            "not a bare domain",
+        ),
+        (
+            f"{_DEFERRED_MARKER}: later (http://github.com/o/p/issues/1)",
+            "absolute HTTPS URL",
+        ),
+    ],
+    ids=[
+        "missing-colon",
+        "empty-reason",
+        "duplicate",
+        "unsafe-path",
+        "bare-domain",
+        "wrong-scheme",
+    ],
+)
+def test_malformed_deferred_syntax_fails_when_preexisting(
+    repo: Path, annotation: str, message: str
+) -> None:
+    _write_decision(repo)
+    (repo / "existing.py").write_text(f'URL = "https://{LEGACY}.net"  # {annotation}\n')
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "commit an invalid deferral")
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert message in result.stdout
+
+
+def test_report_exposes_invalid_deferred_markers_without_exempting_them(
+    repo: Path,
+) -> None:
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # {_DEFERRED_MARKER}: later\n'
+    )
+    _git(repo, "add", "existing.py")
+
+    payload = json.loads(_run(repo, "--report", "--json", base=None).stdout)
+
+    assert payload["headline"]["lines"] == 1
+    assert payload["headline"]["deferred"]["lines"] == 0
+    assert payload["marker_inventory"]["counts"][_DEFERRED_MARKER] == 1
+    assert payload["deferred_validation"] == {
+        "valid": False,
+        "problems": [
+            {
+                "path": "existing.py",
+                "line": 1,
+                "message": "a decision reference is required in parentheses",
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize("permanent", ["legacy-name-ok", "legacy-name-floor"])
+def test_deferred_cannot_be_combined_with_a_permanent_marker(
+    repo: Path, permanent: str
+) -> None:
+    _write_decision(repo)
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # {permanent}: permanent  {_deferred()}\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "commit contradictory markers")
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "cannot be combined" in result.stdout
+    assert permanent in result.stdout
+
+
+def test_floor_to_deferred_is_a_narrow_excused_transition(repo: Path) -> None:
+    _write_decision(repo)
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: permanent path\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "classify the line as floor")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "1 floor-to-deferred transition(s) excused" in result.stdout
+    assert "+1 net" in result.stdout
+
+
+def test_floor_to_deferred_supports_a_marker_inside_a_quoted_value(
+    repo: Path,
+) -> None:
+    _write_decision(repo)
+    (repo / "existing.py").write_text(
+        f'VALUE = "{LEGACY} legacy-name-floor: frozen value"\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "classify the quoted value as floor")
+    _stage(
+        repo,
+        "existing.py",
+        f'VALUE = "{LEGACY} {_deferred()}"\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "1 floor-to-deferred transition(s) excused" in result.stdout
+
+
+def test_floor_to_deferred_does_not_treat_reason_punctuation_as_syntax(
+    repo: Path,
+) -> None:
+    _write_decision(repo)
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: frozen path (documented)\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "classify the documented path as floor")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "1 floor-to-deferred transition(s) excused" in result.stdout
+
+
+def test_floor_to_deferred_pairs_a_surviving_floor_by_exact_frame(
+    repo: Path,
+) -> None:
+    _write_decision(repo)
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: hash comment\n'
+        f'URL = "https://{LEGACY}.net"  // legacy-name-floor: slash comment\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "classify two syntax frames as floor")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n'
+        f'URL = "https://{LEGACY}.net"  // legacy-name-floor: slash comment\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "1 floor-to-deferred transition(s) excused" in result.stdout
+
+
+def test_one_deferred_occurrence_is_allocated_to_only_one_transition(
+    repo: Path,
+) -> None:
+    _write_decision(repo)
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"\n'
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: permanent path\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "record counted and floor occurrences")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    gate = _run(repo)
+    payload = json.loads(_run(repo, "--report", "--json").stdout)
+
+    assert gate.returncode == 0, gate.stdout
+    assert "1 existing counted line(s) annotated as deferred" in gate.stdout
+    assert "floor-to-deferred transition(s) excused" not in gate.stdout
+    assert payload["change"]["deferred"] == {
+        "annotated": 1,
+        "floor_to_deferred": 0,
+    }
+
+
+def test_floor_to_deferred_rejects_content_after_the_decision_reference(
+    repo: Path,
+) -> None:
+    """The transition may replace an annotation, never hide another edit."""
+    _write_decision(repo)
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: permanent path\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "classify the line as floor")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()} AND_NEW_CONTENT\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "floor-to-deferred transition(s) excused" not in result.stdout
+
+
+def test_floor_to_deferred_preserves_the_comment_introducer(repo: Path) -> None:
+    """Changing ``#`` to ``//`` is more than changing the marker annotation."""
+    _write_decision(repo)
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: permanent path\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "classify the line as floor")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  // {_deferred()}\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "floor-to-deferred transition(s) excused" not in result.stdout
+
+
+def test_floor_to_deferred_cannot_reuse_a_floor_reclassified_as_an_alias(
+    repo: Path,
+) -> None:
+    """One base floor occurrence can fund one successor, not two."""
+    _write_decision(repo)
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: permanent path\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "classify the line as floor")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # legacy-name-ok: compatibility alias\n'
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "floor-to-deferred transition(s) excused" not in result.stdout
+
+
+def test_floor_to_deferred_cannot_reuse_a_deferred_metadata_edit(
+    repo: Path,
+) -> None:
+    """Changing a decision reference does not create another deferred line."""
+    first = "docs/first-decision.md"
+    second = "docs/second-decision.md"
+    for reference in (first, second):
+        path = repo / reference
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"# {reference}\n")
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: permanent path\n'
+        f'URL = "https://{LEGACY}.net" # '
+        f"{_DEFERRED_MARKER}: first decision ({first})\n"
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "record floor and deferred occurrences")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # '
+        f"{_DEFERRED_MARKER}: revised decision ({second})\n"
+        f'URL = "https://{LEGACY}.net"\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "floor-to-deferred transition(s) excused" not in result.stdout
+
+
+def test_deferred_canonicalization_preserves_syntactic_suffix_whitespace(
+    repo: Path,
+) -> None:
+    _write_decision(repo)
+    _git(repo, "commit", "-qm", "record the decision")
+    (repo / "existing.py").write_text(f'KEY = ("{LEGACY}" );\n')
+    _git(repo, "add", "existing.py")
+    _git(repo, "commit", "-qm", "use a spaced expression")
+    _stage(
+        repo,
+        "existing.py",
+        f'KEY = ("{LEGACY} {_deferred()}" );\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "No new lines" in result.stdout
+
+
+def test_a_deferred_duplicate_is_not_reported_as_an_existing_annotation(
+    repo: Path,
+) -> None:
+    _write_decision(repo)
+    _git(repo, "commit", "-qm", "record the decision")
+    plain = f'URL = "https://{LEGACY}.net"\n'
+    _stage(
+        repo,
+        "existing.py",
+        plain + f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "existing counted line(s) annotated as deferred" not in result.stdout
+
+
+def test_an_untracked_decision_document_cannot_validate_a_deferral(repo: Path) -> None:
+    path = repo / _DECISION_DOC
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# Local-only decision\n")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "decision document is not tracked" in result.stdout
+
+
+def test_an_intent_to_add_document_cannot_validate_a_deferral(repo: Path) -> None:
+    path = repo / _DECISION_DOC
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# Not staged yet\n")
+    _git(repo, "add", "-N", _DECISION_DOC)
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "decision document is not committed or staged" in result.stdout
+
+
+def test_intent_to_add_cannot_hide_a_staged_document_deletion(repo: Path) -> None:
+    _write_decision(repo)
+    _git(repo, "commit", "-qm", "record the decision")
+    _git(repo, "rm", "--cached", _DECISION_DOC)
+    _git(repo, "add", "-N", _DECISION_DOC)
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "decision document is staged for deletion" in result.stdout
+
+
+def test_a_fully_staged_document_rename_can_validate_a_deferral(repo: Path) -> None:
+    old = "docs/old-decision.md"
+    path = repo / old
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# Rebrand decision\n")
+    _git(repo, "add", old)
+    _git(repo, "commit", "-qm", "record the old decision path")
+    _git(repo, "mv", old, _DECISION_DOC)
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+
+
+def test_a_symlink_cannot_validate_a_deferred_document_reference(
+    repo: Path,
+) -> None:
+    path = repo / _DECISION_DOC
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.symlink_to("/etc/passwd")
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "commit an external decision symlink")
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "decision document must be a regular repository file" in result.stdout
+
+
+def test_explicit_base_report_treats_a_deferred_annotation_as_count_neutral(
+    repo: Path,
+) -> None:
+    _write_decision(repo)
+    _git(repo, "commit", "-qm", "record the decision")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    payload = json.loads(_run(repo, "--report", "--json").stdout)
+
+    assert payload["change"] == {
+        "available": True,
+        "base": "HEAD",
+        "added": 0,
+        "annotated": 0,
+        "removed": 0,
+        "moved": 0,
+        "net": 0,
+        "deferred": {"annotated": 1, "floor_to_deferred": 0},
+    }
+
+
+def test_explicit_base_report_names_a_floor_to_deferred_excusal(repo: Path) -> None:
+    _write_decision(repo)
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # legacy-name-floor: permanent path\n'
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "classify the line as floor")
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_deferred()}\n',
+    )
+
+    human = _run(repo, "--report").stdout
+    payload = json.loads(_run(repo, "--report", "--json").stdout)
+
+    assert payload["change"]["added"] == 1
+    assert payload["change"]["net"] == 1
+    assert payload["change"]["deferred"] == {
+        "annotated": 0,
+        "floor_to_deferred": 1,
+    }
+    assert "1 floor-to-deferred excusal(s)" in human
+
+
 # ── what must NOT fail ───────────────────────────────────────────────────────
 
 
@@ -725,7 +1389,7 @@ def test_a_move_does_not_launder_an_addition_beside_it(repo: Path) -> None:
     assert "SNUCK" in offenders
     # The moved line is not why this failed, and pointing at it there sends the
     # reader to "fix" a line that was already in the tree.
-    assert "URL" not in offenders
+    assert "URL =" not in offenders
 
 
 def test_identical_added_lines_are_all_named_with_the_split_stated(repo: Path) -> None:
@@ -1600,8 +2264,10 @@ def test_change_summary_falls_back_when_replay_cannot_spawn_git(
         {"existing.py": Counter({"legacy text": 1})},
         Counter({"legacy text": 1}),
         {},
+        {},
+        (),
     )
-    head = scan_type({}, Counter(), {})
+    head = scan_type({}, Counter(), {}, {}, ())
 
     def cannot_spawn(_: list[str]) -> str:
         raise OSError("argument list too long")
@@ -2312,6 +2978,11 @@ def test_json_exposes_only_the_gated_metric_as_aggregatable(repo: Path) -> None:
         "allowed": True,
         "operation": "sum",
     }
+    assert payload["headline"]["deferred"] == {
+        "lines": 0,
+        "by_file": {},
+        "by_reference": {},
+    }
     present = payload["diagnostics"]["present"]
     assert present["aggregation"]["allowed"] is False
     assert set(present) == {"aggregation", "display"}
@@ -2321,6 +2992,7 @@ def test_json_exposes_only_the_gated_metric_as_aggregatable(repo: Path) -> None:
         "tracked_files_only": True,
         "untracked_files_omitted": 0,
     }
+    assert payload["deferred_validation"] == {"valid": True, "problems": []}
     assert payload["change"] is None
 
 
@@ -2337,6 +3009,7 @@ def test_json_includes_an_explicit_base_change_split(repo: Path) -> None:
         "removed": 0,
         "moved": 0,
         "net": 1,
+        "deferred": {"annotated": 0, "floor_to_deferred": 0},
     }
 
 
@@ -2514,3 +3187,179 @@ def test_a_declared_mirror_manifest_must_be_usable(
     assert result.returncode == 2
     assert message in result.stderr
     assert "Traceback" not in result.stderr
+
+
+def test_an_invalid_marker_and_a_minted_line_are_reported_in_one_run(
+    repo: Path,
+) -> None:
+    """Both failures print, because they are independent and both need fixing.
+
+    Failing on the first one found hid the second entirely: the author fixed the
+    marker, pushed, and only then learned a line had been minted — one wasted CI
+    round trip per occurrence, in eight repositories.
+    """
+    _stage(repo, "minted.py", f'KEY = "{LEGACY.upper()}_KEY"\n')
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_DEFERRED_MARKER}: later\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "Invalid legacy-name-deferred marker" in result.stdout
+    assert "minted.py" in result.stdout
+
+
+def test_an_invalid_marker_alone_never_reports_a_passing_gate(repo: Path) -> None:
+    """The marker is already in the base tree, so nothing is minted by this change.
+
+    That is the one shape where the mint check has nothing to say and the marker
+    is the only thing wrong, so it is the shape that decides whether reporting
+    every violation in one run cost the gate its teeth. It must not print any of
+    the passing summaries, and it must not exit 0.
+    """
+    (repo / "existing.py").write_text(
+        f'URL = "https://{LEGACY}.net"  # {_DEFERRED_MARKER}: later\n'
+    )
+    _git(repo, "add", "existing.py")
+    _git(repo, "commit", "-qm", "commit an invalid deferred marker")
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "Invalid legacy-name-deferred marker" in result.stdout
+    assert "Gate passes" not in result.stdout
+    assert result.stdout.rstrip().endswith("marker(s) above do.")
+
+
+@pytest.mark.parametrize(
+    "reference",
+    ["http://example.test/i/1", "HTTP://example.test/i/1", "ftp://example.test/i/1"],
+    ids=["http", "uppercase-http", "ftp"],
+)
+def test_a_non_https_reference_is_named_as_a_scheme_problem(
+    repo: Path, reference: str
+) -> None:
+    """A reference with any scheme is answered as a URL, not as a path.
+
+    Testing the literal ``https://`` sent every other spelling down the path
+    branch, where it failed as a repository-relative path — an error naming a
+    problem the author did not have.
+    """
+    _stage(
+        repo,
+        "new.py",
+        f'URL = "https://{LEGACY}.net"  # {_DEFERRED_MARKER}: later ({reference})\n',
+    )
+
+    result = _run(repo)
+
+    assert result.returncode == 1
+    assert "must be an absolute HTTPS URL" in result.stdout
+    assert "repository-relative" not in result.stdout
+
+
+@pytest.mark.parametrize("scheme", ["https", "HTTPS"], ids=["lower", "upper"])
+def test_an_https_reference_is_accepted_whatever_its_scheme_casing(
+    repo: Path, scheme: str
+) -> None:
+    """``HTTPS://`` is as absolute as ``https://``; only the casing differs."""
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_DEFERRED_MARKER}: later '
+        f"({scheme}://example.test/i/1)\n",
+    )
+
+    assert _run(repo).returncode == 0
+
+
+def test_the_engine_stays_formatter_stable() -> None:
+    """The eight-repo byte-parity guarantee rests on this and nothing asserted it.
+
+    One repository's pre-commit hooks format this file rather than excluding it,
+    so a construct the formatter would rewrite gets rewritten there on commit —
+    silently, at exactly the moment the copy is supposed to become byte-identical
+    to canonical. The parity check then fails on a file nobody knowingly edited.
+
+    Checked at the formatter's own defaults rather than any repository's config,
+    because this file is byte-identical across repositories whose configs are
+    not. Read-only: the writing form of ``ruff format`` must never be run on this
+    file. Skipped rather than failed where ruff is absent, so a repository that
+    does not ship it in its test environment is not held to a tool it lacks.
+    """
+    ruff = shutil.which("ruff")
+    if ruff is None:
+        pytest.skip("ruff is not installed in this environment")
+
+    result = subprocess.run(
+        [ruff, "format", "--check", "--isolated", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"{SCRIPT.name} is not formatter-stable, so a repository whose pre-commit "
+        f"hooks format it will rewrite it and break byte-parity:\n{result.stdout}"
+    )
+
+
+def test_a_floor_transition_survives_a_same_text_relocation_elsewhere(
+    repo: Path,
+) -> None:
+    """Two independent bugs met here, and the second was hidden by the first.
+
+    The change is: one file's floor marker becomes deferred in place, while a
+    byte-identical deferred line is deleted from a second file and re-added to a
+    third. Nothing is minted — the repo gains exactly the one occurrence the
+    transition sanctions, and the other is a move.
+
+    The relocation rule used to claim the transitioned line first, because the
+    identical text existed in the base tree; the transition then went
+    unrecognised, its floor line was reported as deleted, and its successor was
+    charged as a mint. Fixing that exposed the second bug: the excused
+    occurrence was dropped from the file's tally without spending its unit of
+    the shared repo-wide budget, so the unit stayed available and the genuine
+    move at the far end was charged instead. Either one alone fails this.
+    """
+    _write_decision(repo)
+    body = f'URL = "https://{LEGACY}.net"'
+    floor = f"{body}  # legacy-name-floor: frozen path\n"
+    deferred = f"{body}  # {_deferred()}\n"
+
+    (repo / "a.py").write_text(floor)
+    (repo / "c.py").write_text(deferred)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "a floor line, and the same text deferred elsewhere")
+
+    _stage(repo, "a.py", deferred)  # floor -> deferred, in place
+    _stage(repo, "c.py", "PLACEHOLDER = 1\n")  # the other copy leaves here
+    _stage(repo, "b.py", deferred)  # ...and arrives here: a move
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "floor-to-deferred transition(s) excused" in result.stdout
+    assert "treated as moved rather than added" in result.stdout
+
+
+def test_a_query_only_https_reference_is_accepted(repo: Path) -> None:
+    """A tracker that addresses an issue by query string still locates it.
+
+    No slash before the query, so ``urlsplit`` yields an empty path — the shape
+    the old non-empty-path requirement rejected, with a message about the scheme
+    rather than about the path it was really objecting to. With a slash it
+    passed either way, which is why this spells the URL out rather than reusing
+    a tidier one.
+    """
+    _stage(
+        repo,
+        "existing.py",
+        f'URL = "https://{LEGACY}.net"  # {_DEFERRED_MARKER}: later '
+        "(https://tracker.example?id=1234)\n",
+    )
+
+    assert _run(repo).returncode == 0


### PR DESCRIPTION
The gate has two markers and both mean *permanent*. Work the rename deliberately
postpones has no way to say so, so it gets filed as `legacy-name-floor` and leaves
the only count that tracks it. That has now happened three times, most recently to
315 Go `import` lines in `caura-daemon` — whose module path rename `docs/rebrand-naming.md:299`
calls "a later decision", not something the rename will never reach.

`legacy-name-deferred` fills that gap. **It annotates; it does not exempt.**

## It stays counted — that is the whole point

A line carrying only this marker stays inside the gated headline and **still fails a
gate it would have failed unmarked**. It is not an escape hatch for a red build, and
the failure text says so in as many words. Adding it to an already-counted line
changes no count at all, so it is free to adopt going forward.

## Why it lives outside `_KINDS` and `EXEMPT_RE`

`_kind()` documents that "the gate's decision reads only whether this is `None`", and
the `_KINDS` comment documents that "the gate never reads this". **Anything added to
either place exempts automatically** — a third entry there would have been a third
permanent marker and would have reproduced the exact bug this closes.

So the marker gets its own constant, its own regex reusing the permanent markers'
two-sided bounded-token construction verbatim, and its own resolver. The scan carries
it as an attribute of a counted line. `_KINDS`, `EXEMPT_RE`, `_kind` and `_reason` are
untouched — every hunk before line 400 is a pure insertion.

## Two semantics, decided

**A decision reference is mandatory.** `legacy-name-deferred: <reason> (<doc path or issue URL>)`.
What separates a deferral from a TODO is that somebody wrote it down, so the marker is
falsifiable by opening the reference, and the reference must resolve to a tracked file
or a URL. A missing one fails the gate — including on a count-neutral line, where
nothing else could fail it. There is no existing population to break, so a hard
failure is free here and never will be again.

**A permanent marker combined with deferred is a hard error.** The alias/floor pair can
both be true of one line, which is why `_kind()` has a measured precedence rule over a
real 28-line population. Permanent and deferred are not both-true states: letting the
permanent marker win silently would exempt the line and make the deferred annotation —
and its place in the headline — a lie. Again, no existing population, so failing the
contradiction costs nothing now.

## The excused transition, and why it cannot excuse anything else

Reclassifying floors to deferred raises a repo's counted total, and the ratchet is
shrink-only. `floor -> deferred` on an otherwise-identical line is therefore an excused
transition. It is deliberately narrow: same path, the base line must have carried a
**floor** marker specifically, the exact prefix *and* syntactic closer must match,
permanent survivors consume base floors first, and the line must still contain the
legacy name. A line with no floor marker in the base cannot use it, so it cannot hide
new work. Excused moves were left alone — they are net-zero cross-file moves, not
sanctioned increases. **No blanket `--allow-increase` flag**: this file is byte-identical
across eight repositories, so a lingering override would be eight lingering overrides.

## Rollout window — read before merging

The `Legacy-name engine parity` org ruleset (id `22008246`, active, **no bypass actors**)
runs a required workflow that fetches
`raw.githubusercontent.com/caura-ai/caura/main/scripts/legacy_name_ratchet.py` and compares
it **byte-for-byte** against each downstream copy, failing closed.

**The moment this merges, all seven downstream repos go red — on every unrelated PR —
until each port lands.** The order is forced: canonical must land first, because the
guard reads canonical to know what to expect.

Expected engine sha256 after this merges:

```
5fa1d5d5acd32dc4e7ecb867e6f333f7b709c357560c4d6f8b8fb4beee364968
```

**All seven port branches are already pushed and verified**, branch
`sync-deferred-legacy-name-marker` in each: `caura-ops`, `caura-onprem-installer`,
`caura-daemon`, `caura-onprem`, `caura-test-automation`, `openclaw-fleet-tester`,
`caura-enterprise` (base `dev`). Every one is byte-identical to the file in this PR.
The ruleset was not touched and no bypass was requested.

Note the ports carry `tests/test_legacy_name_ratchet.py` as well, and must: three of its
existing tests assert the exact shape of the JSON change split and construct the `Scan`
tuple positionally, and the engine adds a field to each. An engine-only port would have
traded a red parity check for a red test suite in all seven.

## Verified

- **179 tests pass** under the real root conftest, the way CI runs them (157 before).
- **The tests fail without the change**: pointing `LEGACY_NAME_RATCHET_SCRIPT` at the
  untouched `origin/main` engine gives **34 failed / 145 passed**. 31 of the 34 are newly
  added; the other 3 are pre-existing tests whose changes are purely additive assertions
  plus the `Scan` arity update — none was weakened.
- Ratchet `No new lines.` (exit 0) and sentinel `All 46 protected strings survive.` (exit 0).
- All six `ruff check` scopes, all five `ruff format --check` scopes and the isolated
  three-file step pass; all six `mypy` steps pass. `ruff format` was not run on
  `legacy_name_ratchet.py` or `do_not_touch_sentinel.py`.
- End-to-end at the CLI, on a scratch repo: a new branded line fails unmarked **and**
  fails carrying only a valid deferred marker; the same line with `legacy-name-ok`
  passes; a deferred marker with no reference fails; deferred combined with a permanent
  marker fails; annotating a pre-existing counted line is count-neutral and passes; and
  `legacy-name-deferredx` is not treated as a marker.
- Per-repo predicted-vs-actual for all seven ports: gate PASS, sentinel PASS,
  **zero added / annotated / removed / moved / net movement**, 179 tests passing.

## Could not establish

- Behaviour under the parity workflow itself is inferred from reading
  `check-legacy-name-engine-parity.sh` and the ruleset definition; it cannot be exercised
  until this merges, because the checker fetches canonical `main` at run time.
- The eventual `caura-daemon` reclassification is a separate PR and is **not** included
  here. This change is the capability; the decision about those 315 specific lines is not
  made by merging it.
- `caura-test-automation`'s suite was run isolated from its own `conftest.py`, which
  imports a package unrelated to the gate that is not installed locally. Every other repo
  ran with its conftest in place.

One behavioural note found while porting: `caura-enterprise` is the one repo whose
pre-commit hooks lint and format the engine rather than excluding it the way `caura-ops`
does. Its `ruff-format` hook rewrote the file on first attempt, which would have silently
broken byte-parity. The canonical file is now format-stable and free of the one new lint
finding, so it lands there unmodified with every hook passing and no bypass.

## The seven port PRs (open, verified, awaiting this merge)

| repo | PR | base |
|---|---|---|
| caura-ops | caura-ai/caura-ops#353 | main |
| caura-onprem-installer | caura-ai/caura-onprem-installer#48 | main |
| caura-daemon | caura-ai/caura-daemon#170 | main |
| caura-onprem | caura-ai/caura-onprem#69 | main |
| caura-test-automation | caura-ai/caura-test-automation#305 | main |
| openclaw-fleet-tester | caura-ai/openclaw-fleet-tester#39 | main |
| caura-enterprise | caura-ai/caura-enterprise#1468 | dev |

Each carries the identical engine and states that its parity check is expected red until
this merges. Their reviews can run during the window; only the parity check waits.


