### PR TITLE
feat(storage): accept a binding tenant_id on the usage query (expand step)

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/tenant_usage.py
+++ b/core-storage-api/src/core_storage_api/routers/tenant_usage.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from core_storage_api.services.postgres_service import PostgresService
 
@@ -45,27 +45,61 @@ MAX_TENANTS_PER_QUERY = 1000
 
 
 class TenantUsageQuery(BaseModel):
-    """Which tenants, and which periods, to total.
+    """Which tenant (or tenants), and which periods, to total.
 
     A POST for a read: the tenant list is the org's whole tenant set, which has
     no fixed bound, and a query string does. Validated by pydantic rather than
     hand-parsed — the write endpoint below hand-parses because it coerces
     per-row datetimes, and that is exactly where a missing key turned into a
     500 in review.
+
+    EXPAND STEP OF #1095 (expand / migrate / contract). ``tenant_id`` is the
+    binding singular scope and is the one to use; ``tenant_ids`` is the legacy
+    plural that lets a caller name its own scope, which is the defect #1095
+    exists to close. Both are accepted here, exactly one is required, and
+    NOTHING IS FIXED YET — the plural path is still unbound until the contract
+    step deletes it. Do not read this step as closing #1095.
+
+    The two cannot be collapsed in one release because ``platform-admin-api``
+    and ``core-storage-api`` deploy separately, platform FIRST
+    (``deploy-to-staging.yml``: the ``oss`` job is ``needs: [guard-branch,
+    platform]``). So the new caller reaches the old storage before the new
+    storage exists, and storage has to accept the singular field before
+    anything sends it.
     """
 
-    tenant_ids: list[str] = Field(min_length=1, max_length=MAX_TENANTS_PER_QUERY)
+    tenant_id: str | None = None
+    tenant_ids: list[str] | None = Field(default=None, min_length=1, max_length=MAX_TENANTS_PER_QUERY)
     period_start: datetime | None = None
     periods: int = Field(default=6, ge=1, le=24)
+
+    @model_validator(mode="after")
+    def _exactly_one_scope(self) -> TenantUsageQuery:
+        """Exactly one of ``tenant_id`` / ``tenant_ids``.
+
+        Neither is a caller that forgot its scope, and defaulting to "all
+        tenants" is the one answer this endpoint must never give. Both at once
+        is ambiguous rather than harmless: silently preferring the singular
+        would let a caller believe the wider list was honoured.
+        """
+        if (self.tenant_id is None) == (self.tenant_ids is None):
+            raise ValueError("exactly one of 'tenant_id' or 'tenant_ids' is required")
+        return self
 
 
 @router.post("/query")
 async def query_tenant_usage(body: TenantUsageQuery) -> dict:
     """Total the counters for a set of tenants, per period, per operation.
 
-    Body: ``{tenant_ids, period_start?, periods?}`` →
+    Body: ``{tenant_id | tenant_ids, period_start?, periods?}`` →
     ``{"periods": [{"period_start": iso, "operations": {op: total}}, ...]}``,
     newest first.
+
+    The response shape is identical either way: a singular request is the
+    one-element case of the same aggregate, so the migrating caller sums N
+    responses instead of reading one. That is deliberate — a different shape
+    for the singular path would make the migrate step a rewrite rather than a
+    loop.
 
     The operation names are passed through as stored rather than mapped onto a
     fixed writes/searches/recalls triple. core-api also meters ``insights`` and
@@ -73,9 +107,17 @@ async def query_tenant_usage(body: TenantUsageQuery) -> dict:
     have no such column — mapping here would silently discard counts the write
     path is already paying for.
     """
+    tenants = [body.tenant_id] if body.tenant_id is not None else body.tenant_ids
+    if tenants is None:
+        # Unreachable while ``_exactly_one_scope`` stands, and deliberately not
+        # an ``assert``: this is the one endpoint where an unscoped query must
+        # never become "every tenant", so the guard fails closed on its own
+        # rather than trusting a validator a later edit could drop. It also
+        # narrows the type for mypy without a cast.
+        raise HTTPException(status_code=422, detail="a tenant scope is required")
     return {
         "periods": await _svc.tenant_usage_query(
-            body.tenant_ids,
+            tenants,
             period_start=body.period_start,
             periods=body.periods,
         )

--- a/core-storage-api/tests/test_tenant_usage_binding_scope.py
+++ b/core-storage-api/tests/test_tenant_usage_binding_scope.py
@@ -1,0 +1,141 @@
+"""Expand step of #1095: ``POST /tenant-usage/query`` accepts a binding
+singular ``tenant_id`` alongside the legacy ``tenant_ids``.
+
+NOTHING IS FIXED YET. The plural still lets a caller name its own scope; it
+is deleted in the contract step, after ``platform-admin-api`` has been
+deployed on the singular field. These tests pin the expand contract only:
+both spellings work, exactly one is required, and the two agree.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_integration import PREFIX
+
+pytestmark = pytest.mark.asyncio
+
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _period() -> str:
+    now = datetime.now(UTC)
+    return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0).isoformat()
+
+
+async def _increment(client: AsyncClient, rows: list[dict]) -> None:
+    response = await client.post(f"{PREFIX}/tenant-usage/increment", json={"rows": rows})
+    assert response.status_code == 200, response.text
+
+
+async def test_singular_tenant_id_is_accepted(client: AsyncClient) -> None:
+    """The binding singular field the contract step will make mandatory."""
+    tenant, period = f"t-{_uid()}", _period()
+    await _increment(
+        client, [{"tenant_id": tenant, "operation": "write", "period_start": period, "count": 3}]
+    )
+
+    response = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_id": tenant})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["periods"][0]["operations"]["write"] == 3
+
+
+async def test_singular_and_plural_agree_for_one_tenant(client: AsyncClient) -> None:
+    """A singular request is the one-element case of the same aggregate, so the
+    migrating caller can sum N responses rather than reshape them."""
+    tenant, period = f"t-{_uid()}", _period()
+    await _increment(
+        client, [{"tenant_id": tenant, "operation": "search", "period_start": period, "count": 7}]
+    )
+
+    singular = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_id": tenant})
+    plural = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_ids": [tenant]})
+
+    assert singular.status_code == plural.status_code == 200
+    assert singular.json() == plural.json()
+
+
+async def test_plural_still_works_unchanged(client: AsyncClient) -> None:
+    """Expand must not break the caller that has not migrated yet."""
+    a, b, period = f"t-{_uid()}", f"t-{_uid()}", _period()
+    await _increment(
+        client,
+        [
+            {"tenant_id": a, "operation": "write", "period_start": period, "count": 2},
+            {"tenant_id": b, "operation": "write", "period_start": period, "count": 5},
+        ],
+    )
+
+    response = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_ids": [a, b]})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["periods"][0]["operations"]["write"] == 7
+
+
+async def test_neither_scope_is_422(client: AsyncClient) -> None:
+    """A caller that names no scope must never be read as 'every tenant'."""
+    response = await client.post(f"{PREFIX}/tenant-usage/query", json={"periods": 3})
+
+    assert response.status_code == 422, response.text
+
+
+async def test_both_scopes_is_422(client: AsyncClient) -> None:
+    """Ambiguous rather than harmless: silently preferring one would let a
+    caller believe the other was honoured."""
+    tenant = f"t-{_uid()}"
+    response = await client.post(
+        f"{PREFIX}/tenant-usage/query",
+        json={"tenant_id": tenant, "tenant_ids": [tenant]},
+    )
+
+    assert response.status_code == 422, response.text
+
+
+async def test_singular_scope_is_binding(client: AsyncClient) -> None:
+    """The point of the singular field: it totals ONLY the tenant named, so a
+    second tenant's counters cannot reach the response."""
+    mine, theirs, period = f"t-{_uid()}", f"t-{_uid()}", _period()
+    await _increment(
+        client,
+        [
+            {"tenant_id": mine, "operation": "write", "period_start": period, "count": 1},
+            {"tenant_id": theirs, "operation": "write", "period_start": period, "count": 99},
+        ],
+    )
+
+    response = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_id": mine})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["periods"][0]["operations"]["write"] == 1
+
+
+async def test_period_filters_still_apply_to_the_singular_path(client: AsyncClient) -> None:
+    """``period_start`` / ``periods`` are orthogonal to which scope field was
+    used — the singular path must not quietly drop them."""
+    tenant = f"t-{_uid()}"
+    now = datetime.now(UTC).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    older = (now - timedelta(days=60)).replace(day=1).isoformat()
+    await _increment(
+        client,
+        [
+            {"tenant_id": tenant, "operation": "write", "period_start": now.isoformat(), "count": 4},
+            {"tenant_id": tenant, "operation": "write", "period_start": older, "count": 8},
+        ],
+    )
+
+    response = await client.post(
+        f"{PREFIX}/tenant-usage/query",
+        json={"tenant_id": tenant, "period_start": older},
+    )
+
+    assert response.status_code == 200, response.text
+    periods = response.json()["periods"]
+    assert len(periods) == 1
+    assert periods[0]["operations"]["write"] == 8


### PR DESCRIPTION
**PR 1 of 3** for #1095, branch A. **This does not fix #1095** — see "What is not fixed" below before reading it as closure.

## What

Adds an optional singular `tenant_id` to `POST /tenant-usage/query` beside the existing `tenant_ids`, with **exactly one** required. Purely additive: a caller sending the plural sees no change.

```python
tenant_id: str | None = None
tenant_ids: list[str] | None = Field(default=None, min_length=1, max_length=MAX_TENANTS_PER_QUERY)
```

Neither is rejected (a caller that named no scope must never be read as "every tenant"); both is rejected as ambiguous rather than silently preferring one, which would let a caller believe the wider list was honoured.

## What is NOT fixed

The plural still lets a caller name its own scope. The endpoint is still unbound, and **the gate confirms it** — I ran it rather than predicting the movement:

```
  added (0)  removed — fixed (0)  removed — gone (0)  removed — still unscoped (0)  recategorised (0)
tenant-scope gate: 189 routes + 186 service methods, 311 bound to a tenant, 64 allowlisted.
      grant-in-lieu-of-tenant: 2 -> 2
```

Both allowlist entries stay. **The security fix lands in PR 3**, when the plural is deleted.

## Why three PRs and not two

`platform-admin-api` and `core-storage-api` are separately deployed, and **platform goes first** — verified in `caura-enterprise` at `origin/dev`, `.github/workflows/deploy-to-staging.yml`:

```yaml
  oss:
    needs: [guard-branch, platform]
```

So a migrated caller reaches the *old* storage before the new storage exists. Ship the singular field and its consumer together and the usage dashboard 422s in production for the length of that window — and `get_org_usage(strict=True)` gates a read-only lock, so a 422 there is not cosmetic.

Hence expand / migrate / contract:

| | repo | what |
|---|---|---|
| 1 | `caura` | **this PR** — storage accepts the singular field |
| 2 | `caura-enterprise` | `core_storage_client.query_tenant_usage` loops on the singular field and merges |
| 3 | `caura` | delete `tenant_ids` + `MAX_TENANTS_PER_QUERY`, delete both allowlist entries |

**PR 3 must not merge until PR 2 is *deployed*, not merely merged.**

## Shape

The singular path returns the **same** response shape — a one-element case of the same aggregate. Deliberate: a different shape would make the migrate step a rewrite instead of a loop plus a sum. The caller already holds the tenant list five lines earlier (`usage_service.py:180` resolves `org_id → tenant_ids`, `:185` makes this call), so the loop goes where the list already is.

## The fail-closed guard

`tenants is None` is unreachable while the validator stands, and it is deliberately **not** an `assert` and not a `cast`:

```python
if tenants is None:
    raise HTTPException(status_code=422, detail="a tenant scope is required")
```

This is the one endpoint where an unscoped query must never widen to every tenant, so the guard fails closed on its own rather than trusting a validator a later edit could drop. It also narrows the type for mypy without a cast — mypy flagged the `list[str] | None` before this was added, and papering that over with `cast` would have removed the signal without removing the risk.

## Tests — confirmed failing without the fix

New `core-storage-api/tests/test_tenant_usage_binding_scope.py`, 7 tests. **Reverted the router to `origin/main` with the tests in place: 5 failed, 2 passed.**

The 2 that pass are `test_plural_still_works_unchanged` and `test_neither_scope_is_422` — correct, since both held before this change. They are regression guards, not guards on the new field.

Coverage: singular accepted · singular and plural agree for one tenant · plural unchanged · neither is 422 · both is 422 · **singular scope is binding** (a second tenant's counters cannot reach the response) · `period_start` still applies on the singular path.

## Gates

Venv on `PATH`, `UV_FROZEN=1`. `ruff check` and `ruff format --check` run separately at CI's exact scopes, discovery-based, no `--config`.

- `python scripts/tenant_scope_gate.py --base origin/main` — output above, zero movement
- `pytest core-storage-api/tests/` — **322 passed** (315 + 7 new)
- `mypy src/` in `core-storage-api` — no issues in 85 source files
- `ruff check` — all seven CI scopes clean
- `ruff format --check` — all scopes formatted
- `python3 scripts/legacy_name_ratchet.py --base origin/main` — `No new lines.`
- `python3 scripts/do_not_touch_sentinel.py` — all 46 protected strings survive
- `uv.lock` / `plugin/package-lock.json` untouched

One signed-off commit, rebased onto `origin/main` immediately before push with the gate and suite re-run after.

## No migration

Branch A needs none, and if this work starts wanting one that is branch B, which is not what was picked. Nothing here touches the schema.
