### PR TITLE
fix(storage): require a binding tenant on the usage query (contract step)

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/tenant_usage.py
+++ b/core-storage-api/src/core_storage_api/routers/tenant_usage.py
@@ -31,75 +31,44 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 from core_storage_api.services.postgres_service import PostgresService
 
 router = APIRouter(prefix="/tenant-usage", tags=["TenantUsage"])
 _svc = PostgresService()
 
-#: A list longer than this is a caller sending its whole tenant table by
-#: accident, not a large org. It does NOT bound the query's cost — that scales
-#: with how much history the named tenants have, which nothing here caps.
-MAX_TENANTS_PER_QUERY = 1000
-
 
 class TenantUsageQuery(BaseModel):
-    """Which tenant (or tenants), and which periods, to total.
+    """Which tenant, and which periods, to total.
 
-    A POST for a read: the tenant list is the org's whole tenant set, which has
-    no fixed bound, and a query string does. Validated by pydantic rather than
-    hand-parsed — the write endpoint below hand-parses because it coerces
-    per-row datetimes, and that is exactly where a missing key turned into a
-    500 in review.
+    A POST for a read rather than a GET: kept from the plural era because the
+    body already carries optional period parameters and the sibling endpoint
+    below is a POST, not because the scope needs the room.
 
-    EXPAND STEP OF #1095 (expand / migrate / contract). ``tenant_id`` is the
-    binding singular scope and is the one to use; ``tenant_ids`` is the legacy
-    plural that lets a caller name its own scope, which is the defect #1095
-    exists to close. Both are accepted here, exactly one is required, and
-    NOTHING IS FIXED YET — the plural path is still unbound until the contract
-    step deletes it. Do not read this step as closing #1095.
-
-    The two cannot be collapsed in one release because ``platform-admin-api``
-    and ``core-storage-api`` deploy separately, platform FIRST
-    (``deploy-to-staging.yml``: the ``oss`` job is ``needs: [guard-branch,
-    platform]``). So the new caller reaches the old storage before the new
-    storage exists, and storage has to accept the singular field before
-    anything sends it.
+    CONTRACT STEP OF #1095. ``tenant_ids`` (plural) is GONE. It let a caller
+    hand this service the list of tenants to total, which is the caller naming
+    its own scope -- and since #1066 the only credential here is a shared
+    secret carrying no tenant identity, so nothing could check the list against
+    who sent it. The org-level fan-out and summing now live in
+    ``platform-admin-api``, which resolves ``org_id -> tenant_ids`` against
+    ``platform-storage-api`` and is the only party that can say which tenants
+    an org owns. Do not reintroduce a plural field here; the check it would
+    need cannot be written on this side of the boundary.
     """
 
-    tenant_id: str | None = None
-    tenant_ids: list[str] | None = Field(default=None, min_length=1, max_length=MAX_TENANTS_PER_QUERY)
+    tenant_id: str = Field(min_length=1)
     period_start: datetime | None = None
     periods: int = Field(default=6, ge=1, le=24)
-
-    @model_validator(mode="after")
-    def _exactly_one_scope(self) -> TenantUsageQuery:
-        """Exactly one of ``tenant_id`` / ``tenant_ids``.
-
-        Neither is a caller that forgot its scope, and defaulting to "all
-        tenants" is the one answer this endpoint must never give. Both at once
-        is ambiguous rather than harmless: silently preferring the singular
-        would let a caller believe the wider list was honoured.
-        """
-        if (self.tenant_id is None) == (self.tenant_ids is None):
-            raise ValueError("exactly one of 'tenant_id' or 'tenant_ids' is required")
-        return self
 
 
 @router.post("/query")
 async def query_tenant_usage(body: TenantUsageQuery) -> dict:
-    """Total the counters for a set of tenants, per period, per operation.
+    """Total one tenant's counters, per period, per operation.
 
-    Body: ``{tenant_id | tenant_ids, period_start?, periods?}`` →
+    Body: ``{tenant_id, period_start?, periods?}`` →
     ``{"periods": [{"period_start": iso, "operations": {op: total}}, ...]}``,
     newest first.
-
-    The response shape is identical either way: a singular request is the
-    one-element case of the same aggregate, so the migrating caller sums N
-    responses instead of reading one. That is deliberate — a different shape
-    for the singular path would make the migrate step a rewrite rather than a
-    loop.
 
     The operation names are passed through as stored rather than mapped onto a
     fixed writes/searches/recalls triple. core-api also meters ``insights`` and
@@ -107,17 +76,9 @@ async def query_tenant_usage(body: TenantUsageQuery) -> dict:
     have no such column — mapping here would silently discard counts the write
     path is already paying for.
     """
-    tenants = [body.tenant_id] if body.tenant_id is not None else body.tenant_ids
-    if tenants is None:
-        # Unreachable while ``_exactly_one_scope`` stands, and deliberately not
-        # an ``assert``: this is the one endpoint where an unscoped query must
-        # never become "every tenant", so the guard fails closed on its own
-        # rather than trusting a validator a later edit could drop. It also
-        # narrows the type for mypy without a cast.
-        raise HTTPException(status_code=422, detail="a tenant scope is required")
     return {
         "periods": await _svc.tenant_usage_query(
-            tenants,
+            body.tenant_id,
             period_start=body.period_start,
             periods=body.periods,
         )

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -3996,15 +3996,20 @@ class PostgresService:
 
     async def tenant_usage_query(
         self,
-        tenant_ids: list[str],
+        tenant_id: str,
         *,
         period_start: datetime | None = None,
         periods: int = 6,
     ) -> list[dict]:
-        """Per-period, per-operation totals summed across ``tenant_ids``.
+        """Per-period, per-operation totals for ONE tenant.
 
-        Summed across tenants because the consumer bills an ORGANISATION and an
-        org owns several tenants; the meter only ever knows the tenant. Returns
+        Takes a binding singular ``tenant_id`` (#1095, contract step). It used
+        to take a ``tenant_ids`` LIST and sum across it, because the consumer
+        bills an ORGANISATION and an org owns several tenants. That summing now
+        happens in ``platform-admin-api``, which owns the org->tenant mapping;
+        this service does not, so a list arriving here could never be checked
+        against the caller and was simply the caller naming its own scope.
+        Returns
         ``[{"period_start": iso-string, "operations": {op: total}}, ...]``,
         newest period first.
 
@@ -4018,8 +4023,6 @@ class PostgresService:
         core-api currently emits; the table keys the operation as data
         deliberately, so a new one needs no migration.
         """
-        if not tenant_ids:
-            return []
 
         # No ORDER BY on the aggregate: the newest-first contract is met by
         # sorting the reshaped result below, which is at most ``periods``
@@ -4030,7 +4033,7 @@ class PostgresService:
                 TenantUsageCounter.operation,
                 func.sum(TenantUsageCounter.count).label("total"),
             )
-            .where(TenantUsageCounter.tenant_id.in_(tenant_ids))
+            .where(TenantUsageCounter.tenant_id == tenant_id)
             .group_by(TenantUsageCounter.period_start, TenantUsageCounter.operation)
         )
         if period_start is not None:

--- a/core-storage-api/tenant_scope_allowlist.json
+++ b/core-storage-api/tenant_scope_allowlist.json
@@ -172,13 +172,6 @@
       "note": "Verified: every row carries tenant_id, which is stored and participates in the usage-counter conflict key."
     },
     {
-      "id": "method:tenant_usage_query",
-      "verdict": "NONE",
-      "evidence": "no binding tenant parameter",
-      "category": "grant-in-lieu-of-tenant",
-      "note": "Takes tenant_ids (plural) and no binding tenant. The one caller, POST /tenant-usage/query, passes body.tenant_ids verbatim, so the caller names the tenants it totals. Was classified REQUIRED until tenant_ids was removed from BINDING_SCOPE; a singular tenant_id the org is checked against would resolve it. Tracked in #1095."
-    },
-    {
       "id": "method:tenants_list_active",
       "verdict": "NONE",
       "evidence": "no binding tenant parameter",
@@ -422,8 +415,8 @@
       "id": "route:POST /api/v1/storage/tenant-usage/query",
       "verdict": "NONE",
       "evidence": "no binding tenant read from the request",
-      "category": "grant-in-lieu-of-tenant",
-      "note": "Reclassified from opaque-body-write, which describes an insert whose tenant rides in the payload; this is a POST-for-read and inserts nothing. Its only scope is the caller-supplied tenant_ids list it forwards to tenant_usage_query. Tracked in #1095."
+      "category": "blind-spot",
+      "note": "#1095 is FIXED here: tenant_ids (plural) is gone and the route now requires a binding singular tenant_id. It stays listed only because the guard is a pydantic field on TenantUsageQuery -- `tenant_id: str = Field(min_length=1)` -- and the AST pass reads dict-style access (`body[...]`, `body.get(...)`, `_require(body, ...)`), not model attribute access, so it cannot see it. A request omitting tenant_id 422s; test_no_scope_is_422 and test_the_plural_field_is_gone pin that. DO NOT hand-parse the body to satisfy the gate: this router chose pydantic deliberately (see its docstring -- the hand-parsed sibling below is where a missing key became a 500), and trading real validation for static visibility would be backwards. The durable fix is teaching the gate to read a required pydantic field; this is the only allowlisted route shaped that way today, which is why it has not been worth doing yet."
     }
   ]
 }

--- a/core-storage-api/tests/test_tenant_usage.py
+++ b/core-storage-api/tests/test_tenant_usage.py
@@ -87,7 +87,7 @@ class TestIncrementRequiresATenantPerRow:
         assert "tenant_id" in r.text
         # The whole batch is refused, so the well-formed row in it did not land
         # either: the guard runs over every row before any write is attempted.
-        assert await _query(client, tenant_ids=[tenant], period_start=AUGUST) == {"periods": []}
+        assert await _query(client, tenant_id=tenant, period_start=AUGUST) == {"periods": []}
 
     async def test_a_row_without_an_operation_is_refused(self, client: AsyncClient):
         tenant = f"t-{_uid()}"
@@ -99,25 +99,16 @@ class TestIncrementRequiresATenantPerRow:
 
         assert r.status_code == 422, r.text
         assert "row 0" in r.text
-        assert await _query(client, tenant_ids=[tenant], period_start=AUGUST) == {"periods": []}
+        assert await _query(client, tenant_id=tenant, period_start=AUGUST) == {"periods": []}
 
 
-async def test_counts_sum_across_the_orgs_tenants(client: AsyncClient):
-    """An org owns several tenants and is billed as one. Reporting a single
-    tenant's counts would under-bill by however many tenants it has."""
-    a, b = f"t-{_uid()}", f"t-{_uid()}"
-    await _increment(
-        client,
-        [
-            _row(a, "write", AUGUST, 5),
-            _row(b, "write", AUGUST, 7),
-            _row(b, "search", AUGUST, 2),
-        ],
-    )
-
-    got = await _query(client, tenant_ids=[a, b], period_start=AUGUST)
-
-    assert got["periods"] == [{"period_start": AUGUST, "operations": {"write": 12, "search": 2}}]
+# ``test_counts_sum_across_the_orgs_tenants`` lived here and is deliberately
+# gone (#1095, contract step). Summing an ORG's tenants was the capability the
+# plural ``tenant_ids`` existed for, and it moved to ``platform-admin-api``,
+# which owns the org->tenant mapping this service cannot see. Its replacement is
+# ``test_totals_are_summed_across_tenants`` in
+# ``platform-admin-api/tests/test_core_storage_client_usage_fanout.py``. Storage
+# answers for one tenant now, and that is the point rather than a regression.
 
 
 async def test_a_tenant_outside_the_org_is_not_counted(client: AsyncClient):
@@ -127,7 +118,7 @@ async def test_a_tenant_outside_the_org_is_not_counted(client: AsyncClient):
         [_row(a, "write", AUGUST, 3), _row(outsider, "write", AUGUST, 100)],
     )
 
-    got = await _query(client, tenant_ids=[a], period_start=AUGUST)
+    got = await _query(client, tenant_id=a, period_start=AUGUST)
 
     assert got["periods"][0]["operations"] == {"write": 3}
 
@@ -146,7 +137,7 @@ async def test_operations_without_a_platform_column_survive(client: AsyncClient)
         ],
     )
 
-    got = await _query(client, tenant_ids=[t], period_start=AUGUST)
+    got = await _query(client, tenant_id=t, period_start=AUGUST)
 
     assert got["periods"][0]["operations"] == {"write": 1, "insights": 4, "evolve": 2}
 
@@ -171,7 +162,7 @@ async def test_periods_means_periods_not_rows(client: AsyncClient):
         ],
     )
 
-    got = await _query(client, tenant_ids=[t], periods=2)
+    got = await _query(client, tenant_id=t, periods=2)
 
     assert [p["period_start"] for p in got["periods"]] == [AUGUST, JULY]
     assert got["periods"][1]["operations"] == {"write": 9}
@@ -183,7 +174,7 @@ async def test_quiet_periods_do_not_consume_the_window(client: AsyncClient):
     t = f"t-{_uid()}"
     await _increment(client, [_row(t, "write", AUGUST, 1), _row(t, "write", JUNE, 2)])
 
-    got = await _query(client, tenant_ids=[t], periods=2)
+    got = await _query(client, tenant_id=t, periods=2)
 
     assert [p["period_start"] for p in got["periods"]] == [AUGUST, JUNE]
 
@@ -191,10 +182,28 @@ async def test_quiet_periods_do_not_consume_the_window(client: AsyncClient):
 async def test_an_unknown_tenant_reads_empty_rather_than_404(client: AsyncClient):
     """A brand-new org has no counters yet, and that is not an error — the
     dashboard shows zeros. The legacy endpoint 404'd on this."""
-    assert await _query(client, tenant_ids=[f"t-{_uid()}"]) == {"periods": []}
+    assert await _query(client, tenant_id=f"t-{_uid()}") == {"periods": []}
 
 
-async def test_an_empty_tenant_list_is_rejected(client: AsyncClient):
-    """An org with no tenants must not read as 'total every tenant'."""
-    r = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_ids": []})
-    assert r.status_code == 422
+async def test_a_missing_tenant_id_is_rejected(client: AsyncClient):
+    """Was ``test_an_empty_tenant_list_is_rejected``. The plural is gone, so
+    the shape of "named no scope" changed from ``[]`` to an absent field — but
+    the requirement is the same one, and it is the requirement that matters:
+    an unscoped query must never be read as "every tenant"."""
+    r = await client.post(f"{PREFIX}/tenant-usage/query", json={})
+    assert r.status_code == 422, r.text
+
+
+async def test_an_empty_tenant_id_is_rejected(client: AsyncClient):
+    """``min_length=1`` — an empty string is a caller that lost its scope, not
+    a caller asking about a tenant named ""."""
+    r = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_id": ""})
+    assert r.status_code == 422, r.text
+
+
+async def test_the_plural_field_is_gone(client: AsyncClient):
+    """The defect #1095 closes: a caller can no longer hand this service the
+    list of tenants to total. Sending only the old field is now an unscoped
+    request and must be refused, not silently honoured."""
+    r = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_ids": [f"t-{_uid()}"]})
+    assert r.status_code == 422, r.text

--- a/core-storage-api/tests/test_tenant_usage_binding_scope.py
+++ b/core-storage-api/tests/test_tenant_usage_binding_scope.py
@@ -1,10 +1,14 @@
-"""Expand step of #1095: ``POST /tenant-usage/query`` accepts a binding
-singular ``tenant_id`` alongside the legacy ``tenant_ids``.
+"""``POST /tenant-usage/query`` binds to one tenant (#1095).
 
-NOTHING IS FIXED YET. The plural still lets a caller name its own scope; it
-is deleted in the contract step, after ``platform-admin-api`` has been
-deployed on the singular field. These tests pin the expand contract only:
-both spellings work, exactly one is required, and the two agree.
+The plural ``tenant_ids`` is gone as of the contract step: it let a caller hand
+this service the list of tenants to total, and since #1066 the only credential
+here is a shared secret carrying no tenant identity, so nothing could check
+that list against who sent it. What remains is pinned here — the singular field
+is required, non-empty, and genuinely confines the query.
+
+The expand-era cases that asserted the two spellings coexisted (``…agree for
+one tenant``, ``plural still works unchanged``, ``both scopes is 422``) are
+deliberately gone with the field they tested.
 """
 
 from __future__ import annotations
@@ -35,7 +39,7 @@ async def _increment(client: AsyncClient, rows: list[dict]) -> None:
 
 
 async def test_singular_tenant_id_is_accepted(client: AsyncClient) -> None:
-    """The binding singular field the contract step will make mandatory."""
+    """The binding field, and now the only one."""
     tenant, period = f"t-{_uid()}", _period()
     await _increment(
         client, [{"tenant_id": tenant, "operation": "write", "period_start": period, "count": 3}]
@@ -47,60 +51,16 @@ async def test_singular_tenant_id_is_accepted(client: AsyncClient) -> None:
     assert response.json()["periods"][0]["operations"]["write"] == 3
 
 
-async def test_singular_and_plural_agree_for_one_tenant(client: AsyncClient) -> None:
-    """A singular request is the one-element case of the same aggregate, so the
-    migrating caller can sum N responses rather than reshape them."""
-    tenant, period = f"t-{_uid()}", _period()
-    await _increment(
-        client, [{"tenant_id": tenant, "operation": "search", "period_start": period, "count": 7}]
-    )
-
-    singular = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_id": tenant})
-    plural = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_ids": [tenant]})
-
-    assert singular.status_code == plural.status_code == 200
-    assert singular.json() == plural.json()
-
-
-async def test_plural_still_works_unchanged(client: AsyncClient) -> None:
-    """Expand must not break the caller that has not migrated yet."""
-    a, b, period = f"t-{_uid()}", f"t-{_uid()}", _period()
-    await _increment(
-        client,
-        [
-            {"tenant_id": a, "operation": "write", "period_start": period, "count": 2},
-            {"tenant_id": b, "operation": "write", "period_start": period, "count": 5},
-        ],
-    )
-
-    response = await client.post(f"{PREFIX}/tenant-usage/query", json={"tenant_ids": [a, b]})
-
-    assert response.status_code == 200, response.text
-    assert response.json()["periods"][0]["operations"]["write"] == 7
-
-
-async def test_neither_scope_is_422(client: AsyncClient) -> None:
+async def test_no_scope_is_422(client: AsyncClient) -> None:
     """A caller that names no scope must never be read as 'every tenant'."""
     response = await client.post(f"{PREFIX}/tenant-usage/query", json={"periods": 3})
 
     assert response.status_code == 422, response.text
 
 
-async def test_both_scopes_is_422(client: AsyncClient) -> None:
-    """Ambiguous rather than harmless: silently preferring one would let a
-    caller believe the other was honoured."""
-    tenant = f"t-{_uid()}"
-    response = await client.post(
-        f"{PREFIX}/tenant-usage/query",
-        json={"tenant_id": tenant, "tenant_ids": [tenant]},
-    )
-
-    assert response.status_code == 422, response.text
-
-
 async def test_singular_scope_is_binding(client: AsyncClient) -> None:
-    """The point of the singular field: it totals ONLY the tenant named, so a
-    second tenant's counters cannot reach the response."""
+    """The whole point: the query totals ONLY the tenant named, so a second
+    tenant's counters cannot reach the response."""
     mine, theirs, period = f"t-{_uid()}", f"t-{_uid()}", _period()
     await _increment(
         client,
@@ -116,9 +76,9 @@ async def test_singular_scope_is_binding(client: AsyncClient) -> None:
     assert response.json()["periods"][0]["operations"]["write"] == 1
 
 
-async def test_period_filters_still_apply_to_the_singular_path(client: AsyncClient) -> None:
-    """``period_start`` / ``periods`` are orthogonal to which scope field was
-    used — the singular path must not quietly drop them."""
+async def test_period_filters_still_apply(client: AsyncClient) -> None:
+    """``period_start`` / ``periods`` are orthogonal to the scope field and
+    must not have been dropped when the plural went."""
     tenant = f"t-{_uid()}"
     now = datetime.now(UTC).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     older = (now - timedelta(days=60)).replace(day=1).isoformat()

--- a/tests/test_tenant_scope_gate.py
+++ b/tests/test_tenant_scope_gate.py
@@ -131,26 +131,30 @@ def test_a_plural_tenant_list_is_not_a_binding_scope() -> None:
     """``tenant_ids`` names which tenants to span; it does not confine to one.
 
     The gate cannot see whether such a list was derived from a verified
-    caller-tenant relationship or taken verbatim from the body, and the live
-    instance is the unsafe one: ``POST /tenant-usage/query`` forwards
-    ``body.tenant_ids`` straight through to the query. Crediting it is a false
-    REQUIRED, the direction the gate must never be wrong in.
+    caller-tenant relationship or taken verbatim from the body, so crediting it
+    would be a false REQUIRED — the direction this gate must never be wrong in.
 
-    Asserted through the real enumeration against the real service, not a
-    synthetic class — classifying a stand-in here would mean reimplementing the
-    rule under test and asserting the copy agrees with itself.
+    THIS TEST USED TO PIN A LIVE INSTANCE. ``POST /tenant-usage/query``
+    forwarded ``body.tenant_ids`` straight through, and the assertions here
+    named it by id. #1095 removed the plural field, so the example is gone and
+    ``tenant_usage_query`` now scores REQUIRED on a binding singular
+    ``tenant_id``. What survives is the rule, which is the part that has to
+    hold whether or not anything currently breaks it: the key stays out of
+    ``BINDING_SCOPE``, and no live method may be credited on a plural list.
     """
     assert "tenant_ids" not in gate.BINDING_SCOPE
 
+    # The former offender is fixed, and stays fixed: it is now bound.
     entries = {e.key: e for e in gate.enumerate_methods()}
-    assert entries["tenant_usage_query"].verdict == "NONE"
+    assert entries["tenant_usage_query"].verdict == "REQUIRED"
 
-    listed = {e["id"]: e for e in json.loads(ALLOWLIST.read_text())["exceptions"]}
-    assert listed["method:tenant_usage_query"]["category"] == "grant-in-lieu-of-tenant"
-    assert (
-        listed["route:POST /api/v1/storage/tenant-usage/query"]["category"]
-        == "grant-in-lieu-of-tenant"
-    )
+    # The category outlives its last occupant. Nothing is filed under it now,
+    # and it stays DEFINED so a future offender has somewhere to land and the
+    # gate keeps flagging it as backlog rather than silently accepting it.
+    listed = json.loads(ALLOWLIST.read_text())["exceptions"]
+    assert not [e for e in listed if e["category"] == "grant-in-lieu-of-tenant"]
+    assert "grant-in-lieu-of-tenant" in gate.CATEGORIES
+    assert "grant-in-lieu-of-tenant" in gate.BACKLOG_CATEGORIES
 
 
 def test_the_id_addressed_backlog_is_split_by_blast_radius() -> None:
@@ -266,7 +270,12 @@ def test_every_owned_entry_carries_a_tracked_issue() -> None:
     """
     listed = json.loads(ALLOWLIST.read_text())["exceptions"]
     owned = [e for e in listed if e["category"] in gate.TRACKED_CATEGORIES]
-    assert owned, "expected a non-empty owned backlog"
+    # No floor on the count. This asserted ``owned`` was non-empty, which was
+    # true while the owned backlog had entries and became a FAILURE the moment
+    # it was emptied — #1095 cleared the last ``grant-in-lieu-of-tenant`` and
+    # ``id-addressed-write`` has been empty since #1082. An empty owned backlog
+    # is the goal state, so the property here is "whatever is owned carries a
+    # reference", which is vacuously true at zero and still bites at one.
     untracked = [
         e["id"] for e in owned if not gate.ISSUE_REF.search(e.get("note") or "")
     ]


### PR DESCRIPTION
**PR 3 of 3 — DRAFT. Do not merge until caura-ai/caura-enterprise#1473 is DEPLOYED, not merely merged.**

`deploy-to-staging.yml` runs the `oss` job as `needs: [guard-branch, platform]`, so platform deploys first. Landing this before the migrate step is live 422s the usage dashboard — and `get_org_usage(strict=True)` gates a read-only lock, so that is not cosmetic. Draft until the running artifact is verified, not until a pipeline event is green.

## What

Closes #1095. `tenant_ids` (plural) is gone from `POST /tenant-usage/query`, along with `MAX_TENANTS_PER_QUERY`. The service method takes a binding singular `tenant_id` and filters on equality instead of `IN`.

The plural let a caller hand this service the list of tenants to total. Since #1066 the only credential here is a shared secret carrying no tenant identity, so nothing could check that list against who sent it — the caller named its own scope. The fan-out and summing now live in `platform-admin-api` (#1473), which resolves `org_id → tenant_ids` against `platform-storage-api` and is the only party that can say which tenants an org owns.

## Gate movement — measured, not predicted

```
  removed — fixed (1):
      - method:tenant_usage_query [grant-in-lieu-of-tenant]
  recategorised (1):
      ~ route:POST /api/v1/storage/tenant-usage/query [grant-in-lieu-of-tenant -> blind-spot]
  grant-in-lieu-of-tenant: 2 -> 0        blind-spot: 0 -> 1
tenant-scope gate: 189 routes + 186 service methods, 312 bound to a tenant, 63 allowlisted.
```

**The category #1095 was filed under is now empty.**

**Only one entry deletes, not two.** I had expected both. The route genuinely requires a binding `tenant_id` now — but the guard is a **pydantic field** on `TenantUsageQuery`, and the AST pass reads dict-style access (`body[...]`, `body.get(...)`, `_require(body, ...)`), not model attribute access. It cannot see a binding that is really there, which is the `blind-spot` definition exactly, so the entry is recategorised rather than deleted and its note says why.

**I did not hand-parse the body to make the gate see it.** This router chose pydantic deliberately — its own docstring notes the hand-parsed sibling below is where a missing key became a 500 in review. Trading real validation for static visibility would be the same mistake as casting away a mypy error: it removes the signal without removing the risk. The durable fix is teaching the gate to read a required pydantic field, and this is the **only** allowlisted route shaped that way today, which is why it has not been worth doing yet.

## Two gate tests updated, because the fix invalidated them

Both keep the rule and drop the now-fixed instance:

- **`test_a_plural_tenant_list_is_not_a_binding_scope`** pinned the live offender by id (`entries["tenant_usage_query"].verdict == "NONE"`). It now asserts the rule (`tenant_ids` stays out of `BINDING_SCOPE`), that the former offender scores `REQUIRED`, and that the category stays **defined** so a future offender has somewhere to land. **Confirmed load-bearing**: adding `tenant_ids` to `BINDING_SCOPE` turns it red. (My first attempt at this replacement was vacuous — it looped over `entry.scope_params`, an attribute `Entry` does not have, so it asserted nothing. Caught before commit.)
- **`test_every_owned_entry_carries_a_tracked_issue`** asserted the owned backlog was non-empty. That became a **failure the moment the backlog was emptied** — `id-addressed-write` has been empty since #1082 and this clears the last `grant-in-lieu-of-tenant`. An empty owned backlog is the goal state, so the floor is gone; the property that matters ("whatever is owned carries a reference") is vacuously true at zero and still bites at one.

## Tests

`test_counts_sum_across_the_orgs_tenants` is **deliberately deleted** — summing an org's tenants was the capability the plural existed for, and it moved to `platform-admin-api`, where `test_totals_are_summed_across_tenants` replaces it. A comment at the old site says so, so the next reader does not read it as a dropped check.

`test_an_empty_tenant_list_is_rejected` becomes `test_a_missing_tenant_id_is_rejected` — the shape of "named no scope" changed from `[]` to an absent field, but the requirement is the same one. Added `test_an_empty_tenant_id_is_rejected` (`min_length=1`) and **`test_the_plural_field_is_gone`**, which pins the actual defect: sending only `tenant_ids` is now an unscoped request and is refused rather than silently honoured.

- `pytest core-storage-api/tests/` — **320 passed**
- `pytest tests/test_tenant_scope_gate.py` — **122 passed**

## Gates

- `python scripts/tenant_scope_gate.py --write` — regenerated, not hand-edited; re-running after the note edit is byte-identical (`shasum` matched)
- `mypy src/` in `core-storage-api` — no issues in 85 source files
- `ruff check` / `ruff format --check` separately at CI's exact scopes — **including the new `scripts/` and root `tests/` scopes added by #1231** — all clean
- `legacy_name_ratchet.py --base origin/main` — `No new lines.`
- `do_not_touch_sentinel.py` — all 46 protected strings survive
- `uv.lock` / `plugin/package-lock.json` untouched

One signed-off commit, rebased onto `origin/main` immediately before push with the gate and both suites re-run after.
