### PR TITLE
fix(contradiction): stop candidate queries reaching into another agent's private memories (A54, D3)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -825,6 +825,8 @@ class CoreStorageClient:
         exclude_id: str | None = None,
         fleet_id: str | None = None,
         object_value: str | None = None,
+        visibility: str | None = None,
+        agent_id: str | None = None,
     ) -> list[dict]:
         params: dict[str, Any] = {
             "tenant_id": tenant_id,
@@ -837,6 +839,11 @@ class CoreStorageClient:
             params["fleet_id"] = fleet_id
         if object_value is not None:
             params["object_value"] = object_value
+        # A54 — scope RDF candidates the same way the semantic path is scoped.
+        if visibility is not None:
+            params["visibility"] = visibility
+        if agent_id is not None:
+            params["agent_id"] = agent_id
         return await self._get_list("/memories/rdf-conflicts", **params)
 
     async def scored_search(self, data: dict) -> list[dict]:

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -808,6 +808,17 @@ class CoreStorageClient:
         # is picked up by a later crystallizer pass.
         return await self._post("/memories/entity-overlap-candidates", data, read=True)  # type: ignore[return-value]
 
+    async def find_by_supersedes_id(self, tenant_id: str, supersedes_id: str) -> list[dict]:
+        """A53 — rows whose supersedes_id points at ``supersedes_id``.
+
+        Retraction-shaped: unlike ``find_successors`` this applies no status or
+        visibility filter, because retraction must reach the row that owns the
+        chain edge whatever state it is in.
+        """
+        return await self._get_list(
+            "/memories/by-supersedes-id", tenant_id=tenant_id, supersedes_id=supersedes_id
+        )
+
     async def find_successors(self, data: dict) -> list[dict]:
         return await self._post("/memories/find-successors", data, read=True)  # type: ignore[return-value]
 

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -296,12 +296,22 @@ async def detect_contradictions_async(
         concluded = True
         n_conflicts = len(contradictions) if contradictions else 0
 
-        if contradictions:
-            logger.info(
-                "Async contradiction detection found %d conflict(s) for memory %s",
-                len(contradictions),
-                memory_id,
-            )
+        # D3 — log EVERY concluded run, not only the ones that found something.
+        # Before this, a run that found nothing was indistinguishable in the logs
+        # from a run that never happened (lock contention, an early return, a
+        # crashed worker), so "did detection run for this memory?" was
+        # unanswerable — and the answer matters most exactly when a contradiction
+        # was expected and none appeared.
+        logger.info(
+            "Async contradiction detection completed for memory %s: %d conflict(s)",
+            memory_id,
+            n_conflicts,
+            extra={
+                "path": "contradiction-detection",
+                "memory_id": str(memory_id),
+                "conflicts_found": n_conflicts,
+            },
+        )
 
     except Exception:
         logger.exception("Async contradiction detection failed for memory %s", memory_id)
@@ -412,6 +422,15 @@ async def _detect(
             # excludes same-value rows. Otherwise two writes of the
             # same fact trigger a false conflict on themselves.
             object_value=object_value,
+            # A54 — scope by the writer's visibility tier, exactly as the
+            # semantic path does below. Without it the RDF path could select
+            # another agent's ``scope_agent`` row as a candidate and then mark
+            # it outdated/conflicted: a status write into a row this writer
+            # cannot read. ``agent_id`` pins the owner for the agent-private
+            # tier, where the visibility value alone says only "private to SOME
+            # agent" and so still matches a different agent's private rows.
+            visibility=new_memory.get("visibility", "scope_team"),
+            agent_id=new_memory.get("agent_id"),
         )
         # CAURA-125 — state-corruption guard. When ``rdf_conflicts``
         # mixes older and newer candidates relative to ``new_memory``,
@@ -564,6 +583,10 @@ async def _detect(
                 # scope_org/scope_agent writes from being marked as superseding
                 # scope_team memories (cross-scope chain pollution).
                 "visibility": new_memory.get("visibility", "scope_team"),
+                # A54 — pins the OWNER for the scope_agent tier. The tier alone
+                # matches any agent's private rows, so without this a writer can
+                # mark another agent's private memory conflicted.
+                "agent_id": new_memory.get("agent_id"),
             }
         )
         # CAURA-132 diag — Path A semantic invocation + candidate count.
@@ -2254,6 +2277,10 @@ async def detect_contradictions_by_entities_async(
                 "fleet_id": fleet_id,
                 # Same visibility scoping as the semantic path above.
                 "visibility": new_memory.get("visibility", "scope_team"),
+                # A54 — pins the OWNER for the scope_agent tier. The tier alone
+                # matches any agent's private rows, so without this a writer can
+                # mark another agent's private memory conflicted.
+                "agent_id": new_memory.get("agent_id"),
             }
         )
         n_candidates = len(candidates) if candidates else 0

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -59,11 +59,11 @@ def _content_fingerprint(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8")).hexdigest()[:32]
 
 
-def _path_a_lock_key(memory_id, content: str) -> str:
+def _content_lock_key(memory_id, content: str) -> str:
     return f"contradiction:path_a:{memory_id}:{_content_fingerprint(content)}"
 
 
-def _path_c_lock_key(memory_id, content: str) -> str:
+def _entity_lock_key(memory_id, content: str) -> str:
     return f"contradiction:path_c:{memory_id}:{_content_fingerprint(content)}"
 
 
@@ -72,7 +72,7 @@ def _lock_token() -> str:
     return _uuid.uuid4().hex
 
 
-async def _acquire_path_a_lock(memory_id, content: str, token: str) -> bool:
+async def _acquire_content_lock(memory_id, content: str, token: str) -> bool:
     """Try to acquire the Path A (semantic + RDF) idempotency lock for
     ``memory_id`` at this ``content``. Returns True iff this caller owns the
     lock and should proceed; False if another caller already holds it and we
@@ -83,15 +83,15 @@ async def _acquire_path_a_lock(memory_id, content: str, token: str) -> bool:
     run that checked the previous text. ``token`` identifies THIS acquisition
     so the release can tell its own lock from a successor's.
     """
-    return await cache_set_nx(_path_a_lock_key(memory_id, content), token, _DETECTION_LOCK_TTL_SECONDS)
+    return await cache_set_nx(_content_lock_key(memory_id, content), token, _DETECTION_LOCK_TTL_SECONDS)
 
 
-async def _acquire_path_c_lock(memory_id, content: str, token: str) -> bool:
+async def _acquire_entity_lock(memory_id, content: str, token: str) -> bool:
     """Try to acquire the Path C (entity-overlap) idempotency lock for
     ``memory_id`` at this ``content``. Returns True iff this caller owns the
     lock; False means another caller already ran detection for this memory at
     this content."""
-    return await cache_set_nx(_path_c_lock_key(memory_id, content), token, _DETECTION_LOCK_TTL_SECONDS)
+    return await cache_set_nx(_entity_lock_key(memory_id, content), token, _DETECTION_LOCK_TTL_SECONDS)
 
 
 async def _release_lock(key: str, token: str) -> None:
@@ -260,7 +260,7 @@ async def detect_contradictions_async(
         # EMBEDDED handlers fire ``detect_contradictions_async`` for
         # the same memory; whichever arrives first owns the lock and
         # runs detection, the other skips. Fail-open: if Redis is
-        # unavailable, ``_acquire_path_a_lock`` returns True and we
+        # unavailable, ``_acquire_content_lock`` returns True and we
         # fall back to the prior double-detection behaviour (storage
         # CAS still keeps writes idempotent).
         # H-06: keyed on the CONTENT as well as the memory, so an edit
@@ -284,9 +284,9 @@ async def detect_contradictions_async(
         # and silently costs that memory its detection.
         raw_content = new_memory.get("content")
         examined = raw_content if raw_content is not None else (content or "")
-        lock_key = _path_a_lock_key(memory_id, examined)
+        lock_key = _content_lock_key(memory_id, examined)
         lock_token = _lock_token()
-        if not await _acquire_path_a_lock(memory_id, examined, lock_token):
+        if not await _acquire_content_lock(memory_id, examined, lock_token):
             skipped = True
             return
         lock_held = True
@@ -1412,7 +1412,7 @@ def _skip_contradiction_pairwise() -> tuple[bool, float]:
       out of non-exact-match recall. So the damage is to semantic/vector recall,
       which is the path that matters for a memory product, not to lookup-by-phrasing.
     * Recovery exists but is narrow. No sweep re-checks the status, and Path C's
-      retraction judge (:func:`_attempt_path_c_retraction`) only restores the
+      retraction judge (:func:`_attempt_entity_retraction`) only restores the
       canonical direction, needs resolved entities on both sides, needs confidence
       ≥ ``RETRACTION_CONFIDENCE_THRESHOLD`` (0.90), and is tenant kill-switchable.
       A flipped-direction mark is never revisited.
@@ -1793,7 +1793,7 @@ async def _llm_entity_aware_contradiction_check(
     parser; differs only in the prompt template (which receives resolved
     entity context as ``{new_entities}`` / ``{old_entities}``). Callers
     MUST have verified both ``new_entities`` and ``old_entities`` are
-    non-empty before invoking — see ``_attempt_path_c_retraction`` for
+    non-empty before invoking — see ``_attempt_entity_retraction`` for
     the guard.
     """
     provider_name = _judge_provider(tenant_config)
@@ -1958,7 +1958,7 @@ async def _llm_entity_aware_contradiction_check_batch(
 # entity context"; the comment block at A4 #13's introduction promised
 # the judge would see the resolved entity_links and answer a different,
 # entity-aware question than Path A's semantic similarity check. In
-# practice ``_attempt_path_c_retraction`` calls ``_llm_contradiction_check
+# practice ``_attempt_entity_retraction`` calls ``_llm_contradiction_check
 # (new_content, old_content, ...)`` with the SAME prompt and SAME inputs
 # as Path A's semantic judge. There is no entity context in the request
 # — it is the same LLM call rolled twice.
@@ -1987,7 +1987,7 @@ async def _llm_entity_aware_contradiction_check_batch(
 RETRACTION_CONFIDENCE_THRESHOLD = _CONF_CLEAN
 
 
-async def _attempt_path_c_retraction(
+async def _attempt_entity_retraction(
     sc,
     new_memory: dict,
     tenant_config,
@@ -2246,9 +2246,9 @@ async def detect_contradictions_by_entities_async(
         # H-06: per-content, so entity re-extraction after a content edit is
         # not deduped against the run that examined the previous text.
         content = new_memory.get("content") or ""
-        lock_key = _path_c_lock_key(memory_id, content)
+        lock_key = _entity_lock_key(memory_id, content)
         lock_token = _lock_token()
-        if not await _acquire_path_c_lock(memory_id, content, lock_token):
+        if not await _acquire_entity_lock(memory_id, content, lock_token):
             skipped = True
             return
         lock_held = True
@@ -2262,7 +2262,7 @@ async def detect_contradictions_by_entities_async(
         # entities with new_memory. A retraction in this phase doesn't
         # short-circuit the detection phase — Path C may still find a
         # different (genuine) contradiction below.
-        if await _attempt_path_c_retraction(sc, new_memory, tenant_config):
+        if await _attempt_entity_retraction(sc, new_memory, tenant_config):
             n_retractions = 1
             # The new memory's ``supersedes_id`` was just cleared.
             # Re-fetch so the detection phase below sees the fresh state.
@@ -2721,16 +2721,16 @@ async def detect_contradictions_by_entities_async(
                 )
 
         if updates:
-            path_c_result = await sc.batch_update_status(
+            entity_result = await sc.batch_update_status(
                 {"updates": list(updates.values())}, tenant_id=tenant_id
             )
-            if path_c_result.get("skipped"):
+            if entity_result.get("skipped"):
                 # See RDF path in ``_detect`` for the ``skipped`` semantics.
                 logger.warning(
                     "batch_update_status (Path C entity-overlap) skipped %d row(s) (trigger memory %s): %s",
-                    len(path_c_result["skipped"]),
+                    len(entity_result["skipped"]),
                     memory_id,
-                    path_c_result["skipped"],
+                    entity_result["skipped"],
                 )
         concluded = True
 

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -2058,9 +2058,7 @@ async def _attempt_entity_retraction(
         # ``find_successors`` filters to active/confirmed and applies visibility
         # scoping, so it would miss the edge owner precisely when it matters.
         try:
-            owners = await sc.find_by_supersedes_id(
-                retraction_tenant_id, str(new_memory.get("id"))
-            )
+            owners = await sc.find_by_supersedes_id(retraction_tenant_id, str(new_memory.get("id")))
         except Exception:
             logger.warning(
                 "Retraction could not resolve the flipped counterpart for memory %s",

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1996,11 +1996,15 @@ async def _attempt_entity_retraction(
     disagrees with sufficient confidence. Returns True iff a retraction
     was performed.
 
-    Lookup is a direct dereference of ``new_memory.supersedes_id`` —
-    bypasses A4 #11's ``include_supersedes`` filter (which is structurally
-    inverted relative to Path A's chain shape — see follow-up). Works
-    in both canonical and flipped Path A directions: the dereferenced
-    row IS the conflicted candidate in either case.
+    A53 — resolution is DIRECTION-AWARE. Canonical verdicts put the edge on
+    ``new_memory`` (dereference ``supersedes_id``); flipped verdicts put it on
+    the pre-existing candidate and leave ``new_memory`` ``outdated`` with a NULL
+    ``supersedes_id``. The previous implementation dereferenced ``new_memory``
+    unconditionally and so returned False for every flipped verdict — and this
+    docstring used to claim the opposite ("works in both directions"), which was
+    never true. The flipped counterpart is found with a retraction-shaped
+    storage lookup; a chain claimed by more than one row is left alone rather
+    than guessed at.
 
     Retraction is a two-step write via A4 #10:
       1. ``update_memory_status(candidate.id, "active")`` — revert
@@ -2027,21 +2031,72 @@ async def _attempt_entity_retraction(
         )
         return False
 
-    retraction_target_id = new_memory.get("supersedes_id")
-    if not retraction_target_id:
-        return False
-
-    # Bound once: both the candidate lookup and the entity-context fetches below
-    # are by bare id and must be scoped to the row's own tenant.
+    # Bound once: the candidate lookup and the entity-context fetches below are
+    # by bare id and must be scoped to the row's own tenant.
     retraction_tenant_id = str(new_memory["tenant_id"])
-    candidate = await sc.get_memory(str(retraction_target_id), retraction_tenant_id)
+
+    # A53 — resolve the pair DIRECTION-AWARE. The content route (ex-"Path A")
+    # records its verdict two different ways:
+    #
+    #   canonical: new_memory wins  -> new_memory.supersedes_id = candidate.id
+    #                                  candidate becomes `conflicted`
+    #   flipped:   candidate wins   -> candidate.supersedes_id = new_memory.id
+    #                                  NEW_MEMORY becomes `outdated`
+    #
+    # The old code only dereferenced ``new_memory.supersedes_id``, which is NULL
+    # in the flipped case — so a flipped verdict could never be retracted, and
+    # the docstring claiming otherwise was simply wrong. The row to revert and
+    # the row owning the edge swap places between the two directions.
+    edge_owner: dict | None = None  # the row whose supersedes_id must be cleared
+    candidate: dict | None = None  # the row whose status must be reverted
+
+    if new_memory.get("supersedes_id"):
+        candidate = await sc.get_memory(str(new_memory["supersedes_id"]), retraction_tenant_id)
+        edge_owner = new_memory
+    else:
+        # Flipped: find who points AT us. Retraction-shaped lookup on purpose —
+        # ``find_successors`` filters to active/confirmed and applies visibility
+        # scoping, so it would miss the edge owner precisely when it matters.
+        try:
+            owners = await sc.find_by_supersedes_id(
+                retraction_tenant_id, str(new_memory.get("id"))
+            )
+        except Exception:
+            logger.warning(
+                "Retraction could not resolve the flipped counterpart for memory %s",
+                new_memory.get("id"),
+                exc_info=True,
+            )
+            return False
+        if len(owners) != 1:
+            # Zero: nothing to retract. More than one: the chain is ambiguous and
+            # picking arbitrarily could clear an edge a DIFFERENT contradiction
+            # legitimately created. Leave it to a human / the next run.
+            if owners:
+                logger.warning(
+                    "Retraction skipped for memory %s: %d rows claim the chain edge",
+                    new_memory.get("id"),
+                    len(owners),
+                )
+            return False
+        edge_owner = owners[0]
+        candidate = new_memory
+
     if not candidate or candidate.get("deleted_at") is not None:
         return False
-    # Only retract rows still in the conflicted state Path A produced.
-    # If the row has already been moved on by another writer (or by
-    # a previous Path C invocation), our retraction is no longer
-    # meaningful — skip without calling the judge.
-    if candidate.get("status") != "conflicted":
+
+    # Only retract a row still in the state the content route produced. Shape-
+    # based, not a single status literal: canonical marks the loser
+    # ``conflicted``, flipped marks it ``outdated``. If another writer (or an
+    # earlier retraction) already moved the row on, ours is no longer meaningful
+    # — skip without paying for the judge.
+    if candidate.get("status") not in ("conflicted", "outdated"):
+        return False
+
+    # The edge must still point where we think it does; otherwise the pair we
+    # resolved is not the pair the chain describes. The storage CAS below is the
+    # real guard, but failing here avoids an LLM call we would only discard.
+    if str(edge_owner.get("supersedes_id") or "") != str(candidate.get("id")):
         return False
 
     new_content = new_memory.get("content", "") or ""
@@ -2163,13 +2218,21 @@ async def _attempt_entity_retraction(
             f"Path C retraction missing tenant_id (candidate={candidate.get('id')}, "
             f"new_memory={new_memory.get('id')})"
         )
+    # A53 — revert the LOSER and clear the edge on whichever row OWNS it. In the
+    # canonical direction that is new_memory; in the flipped direction it is the
+    # pre-existing candidate, and the loser is new_memory itself. Writing these
+    # the canonical way round in a flipped chain would revert the wrong row and
+    # leave the real edge dangling.
     await sc.update_memory_status(str(candidate.get("id")), "active", tenant_id=cand_tenant)
     try:
         await sc.update_memory_status(
-            str(new_memory.get("id")),
-            new_memory.get("status", "active"),
-            tenant_id=new_tenant,
+            str(edge_owner.get("id")),
+            edge_owner.get("status", "active"),
+            tenant_id=str(edge_owner.get("tenant_id") or new_tenant),
             unset_supersedes=True,
+            # CAS anchor: the edge must still point at the row we just reverted,
+            # or another writer has taken the chain and this retraction is no
+            # longer ours to make.
             expected_supersedes_id=str(candidate.get("id")),
         )
     except Exception as e:

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -199,7 +199,7 @@ DEFAULT_SETTINGS: dict = {
         # the global default (true).
         "triple_emission_enabled": None,
         # CAURA-130 (L3.8) — Path C retraction kill-switch. When true
-        # (the default), Path C's ``_attempt_path_c_retraction`` runs
+        # (the default), Path C's ``_attempt_entity_retraction`` runs
         # the entity-aware judge and may revert a Path A verdict. When
         # false, Path C skips retraction entirely and Path A's verdict
         # stands. Ops escape valve for tenants whose retraction

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -367,6 +367,8 @@ async def find_entity_overlap_candidates(request: Request) -> list[dict]:
         visibility=body.get("visibility", "scope_team"),
         limit=body.get("limit", 8),
         include_supersedes=bool(body.get("include_supersedes", False)),
+        # A54 — owner identity, applied only for the scope_agent tier.
+        agent_id=body.get("agent_id"),
     )
     return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
 
@@ -410,6 +412,8 @@ async def find_similar_candidates(request: Request) -> list[dict]:
         # through the constant.
         threshold=body.get("threshold", CONTRADICTION_SIMILARITY_THRESHOLD),
         limit=body.get("limit", CONTRADICTION_CANDIDATE_WINDOW),
+        # A54 — owner identity, applied only for the scope_agent tier.
+        agent_id=body.get("agent_id"),
     )
     return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
 
@@ -549,6 +553,11 @@ async def find_rdf_conflicts(
     exclude_id: str | None = None,
     fleet_id: str | None = None,
     object_value: str | None = None,
+    # A54 — the writer's visibility tier (and owning agent when the tier is
+    # agent-private). Optional on the wire so a storage instance deployed ahead
+    # of core-api keeps serving; core-api always sends them.
+    visibility: str | None = None,
+    agent_id: str | None = None,
 ) -> list[dict]:
     # CAURA-123 — forward ``fleet_id`` and ``object_value`` to the
     # service. Without ``object_value`` the previous default of ``""``
@@ -564,6 +573,8 @@ async def find_rdf_conflicts(
         object_value=object_value or "",
         memory_id=UUID(exclude_id) if exclude_id else UUID(int=0),
         fleet_id=fleet_id,
+        visibility=visibility,
+        agent_id=agent_id,
     )
     return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -373,6 +373,17 @@ async def find_entity_overlap_candidates(request: Request) -> list[dict]:
     return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
 
 
+@router.get("/by-supersedes-id")
+async def find_by_supersedes_id(tenant_id: str, supersedes_id: str) -> list[dict]:
+    """A53 — rows owning a chain edge INTO the given memory, for retraction.
+
+    Distinct from /find-successors, which is search-shaped (status + visibility
+    scoped). Retraction needs the edge owner in any state.
+    """
+    memories = await _svc.memory_find_by_supersedes_id(tenant_id=tenant_id, supersedes_id=UUID(supersedes_id))
+    return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
+
+
 @router.post("/find-successors")
 async def find_successors(request: Request) -> list[dict]:
     body: dict = await request.json()

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2532,6 +2532,33 @@ class PostgresService:
     # D-0) Supersedes chain: find successor memories
     # ------------------------------------------------------------------
 
+    async def memory_find_by_supersedes_id(
+        self,
+        tenant_id: str,
+        supersedes_id: UUID,
+    ) -> list[Memory]:
+        """Rows whose ``supersedes_id`` points AT the given memory.
+
+        A53 — retraction-shaped, deliberately NOT ``memory_find_successors``.
+        That one is search-shaped: it filters ``status IN (active, confirmed)``
+        and applies fleet/visibility/agent scoping, because its job is to show a
+        caller the correction they are allowed to see. Retraction has the
+        opposite need — it must find the row that OWNS the chain edge whatever
+        state that row is in, or the edge is silently left dangling and the
+        flipped verdict can never be undone.
+
+        Tenant-scoped (the one filter that is a boundary, not a preference) and
+        excludes soft-deleted rows. Returns every match so the caller can refuse
+        to act on an ambiguous chain rather than picking one arbitrarily.
+        """
+        async with get_session() as session:
+            stmt = select(Memory).where(
+                Memory.tenant_id == tenant_id,
+                Memory.supersedes_id == supersedes_id,
+                Memory.deleted_at.is_(None),
+            )
+            return list((await session.execute(stmt)).scalars().all())
+
     async def memory_find_successors(
         self,
         supersedes_ids: list[UUID],

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2606,6 +2606,7 @@ class PostgresService:
         visibility: str = "scope_team",
         limit: int = CONTRADICTION_CANDIDATE_MAX,
         include_supersedes: bool = False,
+        agent_id: str | None = None,
     ) -> list[Memory]:
         """Find active memories sharing entities with the given memory by entity name.
 
@@ -2686,6 +2687,13 @@ class PostgresService:
                     Memory.deleted_at.is_(None),
                     status_filter,
                     Memory.visibility == visibility,
+                    # A54 — ``scope_agent`` means "private to SOME agent", not
+                    # "private to THIS agent": the tier predicate alone still
+                    # matches a DIFFERENT agent's private rows, which
+                    # contradiction then marks outdated/conflicted — a status
+                    # write into a row the writer cannot read. Wet-proven, not
+                    # theoretical. Pin the owner for that tier.
+                    *([Memory.agent_id == agent_id] if visibility == "scope_agent" and agent_id else []),
                     *([Memory.fleet_id == fleet_id] if fleet_id else []),
                 )
                 .group_by(Memory.id)
@@ -2704,6 +2712,8 @@ class PostgresService:
         object_value: str,
         memory_id: UUID,
         fleet_id: str | None = None,
+        visibility: str | None = None,
+        agent_id: str | None = None,
     ) -> list[Memory]:
         async with get_session() as session:
             stmt = select(Memory).where(
@@ -2719,6 +2729,20 @@ class PostgresService:
                 stmt = stmt.where(Memory.fleet_id == fleet_id)
             else:
                 stmt = stmt.where(Memory.fleet_id.is_(None))
+            # A54 — scope candidates to the writer's visibility tier, mirroring
+            # ``memory_find_similar_candidates``. Without this the RDF path could
+            # select another agent's ``scope_agent`` row as a conflict candidate
+            # and then mark it outdated/conflicted — a write into a row the
+            # writer cannot even read, and an inference channel about its
+            # contents. Optional so a storage instance running ahead of core-api
+            # keeps working; core-api always sends it.
+            if visibility:
+                stmt = stmt.where(Memory.visibility == visibility)
+                # ``visibility == 'scope_agent'`` alone does NOT isolate agents:
+                # it only says "private to SOME agent", so two different agents'
+                # private rows still match each other. Pin the owner too.
+                if visibility == "scope_agent" and agent_id:
+                    stmt = stmt.where(Memory.agent_id == agent_id)
 
             result = await session.execute(stmt)
             return list(result.scalars().all())
@@ -2732,6 +2756,7 @@ class PostgresService:
         visibility: str = "scope_team",
         threshold: float = CONTRADICTION_SIMILARITY_THRESHOLD,
         limit: int = CONTRADICTION_CANDIDATE_MAX,
+        agent_id: str | None = None,
     ) -> list[Memory]:
         async with get_session() as session:
             distance = Memory.embedding.cosine_distance(embedding)
@@ -2757,6 +2782,13 @@ class PostgresService:
                 stmt = stmt.where(Memory.fleet_id.is_(None))
 
             stmt = stmt.where(Memory.visibility == visibility)
+            # A54 — ``scope_agent`` means "private to SOME agent", not "private
+            # to THIS agent": the tier predicate alone still matches a DIFFERENT
+            # agent's private rows, which contradiction then marks
+            # outdated/conflicted — a status write into a row the writer cannot
+            # read. Wet-proven, not theoretical. Pin the owner for that tier.
+            if visibility == "scope_agent" and agent_id:
+                stmt = stmt.where(Memory.agent_id == agent_id)
 
             result = await session.execute(stmt)
             return [row.Memory for row in result.all()]

--- a/tests/test_a1_17_subject_entity_preflight.py
+++ b/tests/test_a1_17_subject_entity_preflight.py
@@ -345,11 +345,11 @@ async def test_path_c_filters_candidates_with_distinct_subject():
             new=judge,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new=AsyncMock(return_value=True),
         ),
         patch(
-            "core_api.services.contradiction_detector._attempt_path_c_retraction",
+            "core_api.services.contradiction_detector._attempt_entity_retraction",
             new=AsyncMock(return_value=False),
         ),
         patch(
@@ -418,11 +418,11 @@ async def test_path_c_calls_judge_when_subjects_match():
             new=judge,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new=AsyncMock(return_value=True),
         ),
         patch(
-            "core_api.services.contradiction_detector._attempt_path_c_retraction",
+            "core_api.services.contradiction_detector._attempt_entity_retraction",
             new=AsyncMock(return_value=False),
         ),
         patch(
@@ -484,11 +484,11 @@ async def test_path_c_falls_through_when_new_memory_has_no_subject():
             new=judge,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new=AsyncMock(return_value=True),
         ),
         patch(
-            "core_api.services.contradiction_detector._attempt_path_c_retraction",
+            "core_api.services.contradiction_detector._attempt_entity_retraction",
             new=AsyncMock(return_value=False),
         ),
         patch(

--- a/tests/test_a4_13_path_c_retraction.py
+++ b/tests/test_a4_13_path_c_retraction.py
@@ -702,7 +702,7 @@ async def test_retraction_context_fetch_failure_logs_exc_type(caplog):
 
     # Patch ``_fetch_entity_context`` directly so the TimeoutError
     # surfaces at the OUTER ``asyncio.wait_for`` boundary in
-    # ``_attempt_path_c_retraction``. The inner helper swallows
+    # ``_attempt_entity_retraction``. The inner helper swallows
     # storage failures and returns ``[]``; patching it is the only
     # way to exercise the outer ``except Exception`` where the
     # CAURA-134 WARNING + symmetric INFO logs live.

--- a/tests/test_a4_14_back_channel_idempotency.py
+++ b/tests/test_a4_14_back_channel_idempotency.py
@@ -89,7 +89,7 @@ async def test_path_a_second_call_skips_when_lock_already_held():
     # would see.
     with (
         patch(
-            "core_api.services.contradiction_detector._acquire_path_a_lock",
+            "core_api.services.contradiction_detector._acquire_content_lock",
             new_callable=AsyncMock,
             return_value=False,
             create=True,
@@ -117,7 +117,7 @@ async def test_path_a_first_call_runs_when_lock_acquired():
 
     with (
         patch(
-            "core_api.services.contradiction_detector._acquire_path_a_lock",
+            "core_api.services.contradiction_detector._acquire_content_lock",
             new_callable=AsyncMock,
             return_value=True,
             create=True,
@@ -162,7 +162,7 @@ async def test_path_c_second_call_skips_when_lock_already_held():
 
     with (
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=False,
             create=True,
@@ -194,7 +194,7 @@ async def test_path_c_first_call_runs_when_lock_acquired():
 
     with (
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
             create=True,
@@ -231,8 +231,8 @@ async def test_path_a_and_path_c_use_independent_locks():
     SETNX calls, no shared state.
     """
     from core_api.services.contradiction_detector import (
-        _acquire_path_a_lock,
-        _acquire_path_c_lock,
+        _acquire_content_lock,
+        _acquire_entity_lock,
     )
 
     # Both helpers exist and are callable. Pin the key separation by
@@ -249,8 +249,8 @@ async def test_path_a_and_path_c_use_independent_locks():
         new=fake_set_nx,
         create=True,
     ):
-        await _acquire_path_a_lock(mid, "memory content", "tok")
-        await _acquire_path_c_lock(mid, "memory content", "tok")
+        await _acquire_content_lock(mid, "memory content", "tok")
+        await _acquire_entity_lock(mid, "memory content", "tok")
 
     assert len(captured) == 2
     assert captured[0] != captured[1], (
@@ -273,7 +273,7 @@ async def test_path_a_runs_when_redis_unavailable():
     so the FIRST detection still runs. Subsequent duplicates also
     run — that's the current behavior. The idempotency is best-effort,
     not load-bearing for correctness (storage CAS still guards)."""
-    from core_api.services.contradiction_detector import _acquire_path_a_lock
+    from core_api.services.contradiction_detector import _acquire_content_lock
 
     async def redis_down(key, value, ttl):
         return True  # fail-open
@@ -283,7 +283,7 @@ async def test_path_a_runs_when_redis_unavailable():
         new=redis_down,
         create=True,
     ):
-        assert await _acquire_path_a_lock(uuid4(), "memory content", "tok") is True
+        assert await _acquire_content_lock(uuid4(), "memory content", "tok") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_a53_direction_aware_retraction.py
+++ b/tests/test_a53_direction_aware_retraction.py
@@ -1,0 +1,94 @@
+"""A53 — a flipped contradiction verdict could never be retracted.
+
+The content route records its verdict two ways:
+
+    canonical: new_memory wins -> new_memory.supersedes_id = candidate.id
+                                 candidate       -> `conflicted`
+    flipped:   candidate wins  -> candidate.supersedes_id = new_memory.id
+                                 NEW_MEMORY      -> `outdated`
+
+Retraction only ever dereferenced ``new_memory.supersedes_id``, which is NULL in
+the flipped case, so it returned False before reaching the judge. The row to
+revert and the row owning the chain edge SWAP between the two directions, so
+writing them the canonical way round in a flipped chain reverts the wrong row
+and leaves the real edge dangling.
+
+The function's docstring asserted the opposite ("works in both directions").
+"""
+
+import inspect
+
+import pytest
+
+from core_api.services import contradiction_detector as cd
+
+pytestmark = pytest.mark.unit
+
+
+def test_flipped_lookup_is_retraction_shaped_not_search_shaped():
+    """``find_successors`` filters status to active/confirmed and applies
+    visibility scoping — it would silently miss the edge owner exactly when
+    retraction needs it. The dedicated lookup applies neither."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_find_by_supersedes_id)
+    assert "Memory.supersedes_id == supersedes_id" in src
+    assert "Memory.tenant_id == tenant_id" in src  # the one real boundary
+    assert "status" not in src.split('"""')[2]  # no status predicate in the body
+    assert "visibility" not in src.split('"""')[2]
+
+
+def test_retraction_resolves_both_directions():
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    # canonical: dereference our own edge
+    assert 'new_memory.get("supersedes_id")' in src
+    # flipped: find who points AT us
+    assert "find_by_supersedes_id" in src
+    assert "edge_owner" in src and "candidate" in src
+
+
+def test_status_guard_is_shape_based_not_a_single_literal():
+    """Canonical marks the loser `conflicted`; flipped marks it `outdated`.
+    A guard hard-coded to `conflicted` refuses every flipped retraction."""
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    assert '("conflicted", "outdated")' in src
+    assert 'get("status") != "conflicted"' not in src
+
+
+def test_ambiguous_chain_is_refused_not_guessed():
+    """More than one row claiming the edge means clearing it could undo a
+    DIFFERENT contradiction's work. Refusing is the safe direction."""
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    assert "len(owners) != 1" in src
+
+
+def test_edge_is_cleared_on_the_row_that_owns_it():
+    """The CAS write must target edge_owner, not unconditionally new_memory —
+    that is the actual bug in the flipped direction."""
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    tail = src[src.index("await sc.update_memory_status") :]
+    assert 'str(edge_owner.get("id"))' in tail
+    assert "unset_supersedes=True" in tail
+    assert 'expected_supersedes_id=str(candidate.get("id"))' in tail
+
+
+def test_edge_consistency_checked_before_paying_for_the_judge():
+    """If the edge no longer points at the row we resolved, the pair is stale;
+    bail before the LLM call rather than discarding its answer."""
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    i = src.index('edge_owner.get("supersedes_id")')
+    j = (
+        src.index("_llm_contradiction_check")
+        if "_llm_contradiction_check" in src
+        else len(src)
+    )
+    assert i < j, "edge check must precede the judge call"
+
+
+def test_docstring_no_longer_claims_direction_independence():
+    doc = cd._attempt_entity_retraction.__doc__ or ""
+    assert "DIRECTION-AWARE" in doc
+    assert (
+        "the dereferenced\n    row IS the conflicted candidate in either case"
+        not in doc
+    )

--- a/tests/test_a54_d3_rdf_visibility_and_logging.py
+++ b/tests/test_a54_d3_rdf_visibility_and_logging.py
@@ -1,0 +1,132 @@
+"""A54 / D3 — the RDF contradiction path could reach across a privacy boundary,
+and detection was invisible unless it found something.
+
+A54: ``memory_find_rdf_conflicts`` had no visibility predicate while its sibling
+     ``memory_find_similar_candidates`` did, so the RDF route could select
+     another agent's ``scope_agent`` row as a conflict candidate and then mark
+     it outdated/conflicted — a status write into a row the writer cannot read.
+D3:  the completion log fired only when conflicts were found, so "detection ran
+     and found nothing" and "detection never ran" looked identical.
+
+The A54 leak was REPRODUCED live before the fix (agent B's write turned agent
+A's private row ``conflicted``) and is gone after it, with a positive control
+proving same-owner detection still fires:
+
+    2) agent B private write (contradicts A) -> A: active   sup=None   [untouched]
+    3) agent A contradicts ITSELF            -> A: conflicted
+                                                C: active   sup=<A.id>
+
+Note the task filed only the RDF query. The live leak actually came through the
+SEMANTIC query, so the fix covers all three contradiction candidate paths.
+"""
+
+import inspect
+
+import pytest
+from core_api.services import contradiction_detector as cd
+
+pytestmark = pytest.mark.unit
+
+
+# ── A54 ───────────────────────────────────────────────────────────────────
+
+
+def test_storage_query_filters_on_visibility():
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_find_rdf_conflicts)
+    assert (
+        "visibility"
+        in inspect.signature(PostgresService.memory_find_rdf_conflicts).parameters
+    )
+    assert "Memory.visibility == visibility" in src
+
+
+def test_scope_agent_also_pins_the_owning_agent():
+    """``visibility == 'scope_agent'`` means "private to SOME agent", not "private
+    to THIS agent" — so filtering on the tier alone still matches a different
+    agent's private rows. The owner predicate is the part that actually isolates."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_find_rdf_conflicts)
+    assert 'visibility == "scope_agent"' in src
+    assert "Memory.agent_id == agent_id" in src
+
+
+def test_visibility_is_optional_at_the_storage_boundary():
+    """core-api and core-storage-api deploy independently. A storage instance
+    running ahead of core-api must keep serving callers that don't send the new
+    params rather than 422-ing every RDF lookup."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    sig = inspect.signature(PostgresService.memory_find_rdf_conflicts)
+    assert sig.parameters["visibility"].default is None
+    assert sig.parameters["agent_id"].default is None
+
+
+def test_client_forwards_visibility_and_agent():
+    from core_api.clients.storage_client import CoreStorageClient
+
+    src = inspect.getsource(CoreStorageClient.find_rdf_conflicts)
+    assert 'params["visibility"] = visibility' in src
+    assert 'params["agent_id"] = agent_id' in src
+
+
+def test_detector_always_sends_the_writers_scope():
+    """The whole fix is defeated if the one caller forgets to pass it, so pin
+    the call site — not just the plumbing underneath it."""
+    src = inspect.getsource(cd)
+    call = src[src.index("rdf_conflicts = await sc.find_rdf_conflicts(") :][:2200]
+    assert 'visibility=new_memory.get("visibility", "scope_team")' in call
+    assert 'agent_id=new_memory.get("agent_id")' in call
+
+
+def test_every_contradiction_candidate_query_pins_the_owner():
+    """The leak reproduced through the SEMANTIC path even after the RDF path was
+    fixed — scoping one query is not scoping the boundary. All three candidate
+    routes must carry the owner predicate or the hole simply moves."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    for fn in (
+        "memory_find_rdf_conflicts",
+        "memory_find_similar_candidates",
+        "memory_find_entity_overlap_candidates",
+    ):
+        src = inspect.getsource(getattr(PostgresService, fn))
+        assert "Memory.agent_id == agent_id" in src, f"{fn} does not pin the owner"
+        assert 'visibility == "scope_agent"' in src, (
+            f"{fn} pins the owner unconditionally"
+        )
+
+
+def test_rdf_scoping_matches_the_semantic_path():
+    """The two candidate routes must agree on the privacy boundary. A54 existed
+    precisely because they diverged; this fails if they diverge again."""
+    src = inspect.getsource(cd)
+    sem = src.count('"visibility": new_memory.get("visibility", "scope_team")')
+    rdf = src.count('visibility=new_memory.get("visibility", "scope_team")')
+    assert sem >= 1 and rdf >= 1
+
+
+# ── D3 ────────────────────────────────────────────────────────────────────
+
+
+def test_completion_is_logged_even_when_nothing_is_found():
+    src = inspect.getsource(cd)
+    i = src.index("Async contradiction detection completed for memory")
+    # Walk back to the nearest enclosing statement: it must NOT be guarded by
+    # `if contradictions:` — that guard is exactly the bug.
+    preceding = src[:i]
+    last_if = preceding.rfind("if contradictions:")
+    last_log_block = preceding.rfind("logger.info(")
+    assert last_if < last_log_block, (
+        "completion log is still inside `if contradictions:`"
+    )
+
+
+def test_completion_log_carries_the_conflict_count():
+    src = inspect.getsource(cd)
+    block = src[src.index("Async contradiction detection completed for memory") :][:600]
+    assert "n_conflicts" in block
+    assert '"conflicts_found"' in block  # structured, greppable in log search
+    assert '"memory_id"' in block

--- a/tests/test_a54_d3_rdf_visibility_and_logging.py
+++ b/tests/test_a54_d3_rdf_visibility_and_logging.py
@@ -23,6 +23,7 @@ SEMANTIC query, so the fix covers all three contradiction candidate paths.
 import inspect
 
 import pytest
+
 from core_api.services import contradiction_detector as cd
 
 pytestmark = pytest.mark.unit

--- a/tests/test_c20_contradiction_path_naming.py
+++ b/tests/test_c20_contradiction_path_naming.py
@@ -1,0 +1,77 @@
+"""C20 — "Path A" / "Path C" were opaque (and there is no Path B).
+
+Code identifiers now say what the route actually does:
+
+    Path A -> content   (semantic + RDF similarity)
+    Path C -> entity    (entity-overlap, after extraction resolves subjects)
+
+Two families of names deliberately KEEP the old spelling, because they are
+observed from outside this process:
+
+  * Redis lock keys ``contradiction:path_a:`` / ``contradiction:path_c:`` are
+    live runtime state. Renaming them orphans every in-flight lock for its
+    remaining TTL, so during a deploy the old and new key spaces coexist and the
+    same memory can be processed twice. A cosmetic rename is not worth a
+    double-detection window.
+  * ``path_a_completed`` / ``path_c_completed`` are log EVENT names that saved
+    log searches and the contradiction-quality dashboards match on (see D4).
+
+This test pins both, so a later "finish the rename" pass has to make that
+call deliberately rather than by tidy-up.
+"""
+
+import inspect
+
+import pytest
+
+from core_api.services import contradiction_detector as cd
+
+pytestmark = pytest.mark.unit
+
+
+def test_code_identifiers_use_the_meaningful_names():
+    for name in (
+        "_attempt_entity_retraction",
+        "_acquire_content_lock",
+        "_acquire_entity_lock",
+        "_content_lock_key",
+        "_entity_lock_key",
+    ):
+        assert hasattr(cd, name), f"{name} missing — rename incomplete"
+
+
+def test_no_path_a_or_path_c_identifiers_remain():
+    src = inspect.getsource(cd)
+    leftovers = [
+        ln
+        for ln in src.splitlines()
+        if ("path_a" in ln or "path_c" in ln)
+        # the deliberate exceptions: lock-key literals, log event names, prose
+        and "contradiction:path_" not in ln
+        and "_completed" not in ln
+        and not ln.strip().startswith("#")
+    ]
+    assert not leftovers, f"unrenamed identifiers: {leftovers}"
+
+
+def test_redis_lock_keys_are_unchanged():
+    """Runtime state — see the module docstring. If this ever changes, it must
+    be a deliberate migration, not a rename."""
+    src = inspect.getsource(cd)
+    assert 'f"contradiction:path_a:' in src
+    assert 'f"contradiction:path_c:' in src
+
+
+def test_log_event_names_are_unchanged():
+    """Dashboards and saved searches match these strings."""
+    src = inspect.getsource(cd)
+    assert '"path_a_completed for memory' in src
+    assert '"path_c_completed for memory' in src
+
+
+def test_the_two_lock_keys_stay_distinct():
+    """The routes must never share a lock: one taking the other's key would
+    suppress a whole detection route for the TTL."""
+    a = cd._content_lock_key("m1", "content")
+    c = cd._entity_lock_key("m1", "content")
+    assert a != c and a.startswith("contradiction:") and c.startswith("contradiction:")

--- a/tests/test_caura_130_path_c_safety.py
+++ b/tests/test_caura_130_path_c_safety.py
@@ -11,7 +11,7 @@
   * ``ResolvedConfig.retraction_enabled`` resolver (L3.8): JSONB
     absence → True; explicit False → False; explicit True → True.
 
-The kill-switch behaviour in ``_attempt_path_c_retraction`` itself
+The kill-switch behaviour in ``_attempt_entity_retraction`` itself
 is locked in by tests in ``tests/test_a4_13_path_c_retraction.py``.
 """
 
@@ -317,7 +317,7 @@ async def test_forward_preflight_drops_collision_when_subject_entity_id_null():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -376,7 +376,7 @@ async def test_forward_preflight_keeps_candidate_when_subjects_truly_match():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -441,7 +441,7 @@ async def test_l34_preflight_skips_drop_check_when_both_subject_ids_nonnull():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -489,7 +489,7 @@ async def test_forward_preflight_fails_open_on_storage_error():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -539,7 +539,7 @@ async def test_forward_preflight_caps_fallthrough_set_at_max():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -586,7 +586,7 @@ def _wt3_patches(sc, base_judge, entity_aware_judge):
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),

--- a/tests/test_caura_131_entity_aware_path_c_detection.py
+++ b/tests/test_caura_131_entity_aware_path_c_detection.py
@@ -163,7 +163,7 @@ async def test_entity_aware_judge_used_when_both_contexts_present():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -227,7 +227,7 @@ async def test_fallback_to_base_judge_when_new_memory_has_empty_context():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -277,7 +277,7 @@ async def test_fallback_to_base_judge_when_candidate_has_empty_context():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -351,7 +351,7 @@ async def test_fallback_to_base_judge_when_context_fetch_fails(caplog):
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -451,7 +451,7 @@ async def test_fallback_to_base_judge_logs_timeouterror_explicitly(caplog):
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -528,7 +528,7 @@ async def test_fallback_to_base_judge_when_candidate_set_exceeds_cap():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -607,7 +607,7 @@ async def test_a1_17_matched_candidates_do_not_count_toward_cap():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -696,7 +696,7 @@ async def test_detection_fetch_skipped_when_total_exceeds_detection_cap():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -772,7 +772,7 @@ async def test_a61_multi_candidate_entity_aware_batches_once_and_flags():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -853,7 +853,7 @@ async def test_l34_preflight_still_drops_collision_after_refactor():
             create=True,
         ),
         patch(
-            "core_api.services.contradiction_detector._acquire_path_c_lock",
+            "core_api.services.contradiction_detector._acquire_entity_lock",
             new_callable=AsyncMock,
             return_value=True,
         ),

--- a/tests/test_contradiction_engine_golden.py
+++ b/tests/test_contradiction_engine_golden.py
@@ -210,7 +210,7 @@ async def _run_path_c(*, verdict: bool, retraction: bool) -> list[list]:
     # retraction scenario: new already supersedes cand (a prior Path-A verdict),
     # cand is outdated, no fresh overlap — only the retraction re-judge runs.
     # Retraction only fires on a candidate still in the ``conflicted`` state
-    # Path A produced (see _attempt_path_c_retraction guard).
+    # Path A produced (see _attempt_entity_retraction guard).
     sc = _sc_for_path_c(
         cand_status="conflicted" if retraction else "active",
         overlap=not retraction,

--- a/tests/test_h06_contradiction_lock.py
+++ b/tests/test_h06_contradiction_lock.py
@@ -369,7 +369,7 @@ async def test_path_a_keys_on_the_row_that_will_be_examined_not_the_caller_copy(
     caller that lets the two drift apart.
     """
     from core_api.services.contradiction_detector import (
-        _path_a_lock_key,
+        _content_lock_key,
         detect_contradictions_async,
     )
 
@@ -391,7 +391,7 @@ async def test_path_a_keys_on_the_row_that_will_be_examined_not_the_caller_copy(
             mid, "t1", "f1", stale, [0.1] * 10, new_memory=_memory(mid, content=current)
         )
 
-    assert fake.acquired == [_path_a_lock_key(mid, current)]
+    assert fake.acquired == [_content_lock_key(mid, current)]
 
 
 # ---------------------------------------------------------------------------
@@ -455,7 +455,7 @@ async def test_a_late_release_cannot_take_a_successor_s_lock():
     before the first one's ``finally`` fires.
     """
     from core_api.services.contradiction_detector import (
-        _path_a_lock_key,
+        _content_lock_key,
         detect_contradictions_async,
     )
 
@@ -463,7 +463,7 @@ async def test_a_late_release_cannot_take_a_successor_s_lock():
     fake = _FakeLocks()
     content = "the sky is blue"
     mem = _memory(mid, content=content)
-    key = _path_a_lock_key(mid, content)
+    key = _content_lock_key(mid, content)
 
     async def _detect_then_lose_the_lock(*_a, **_kw):
         # The TTL lapses while this run is still working, and a fresh run
@@ -530,7 +530,7 @@ async def test_an_empty_row_content_is_a_real_value_not_a_missing_one():
     never looks at, undoing the guarantee two tests above.
     """
     from core_api.services.contradiction_detector import (
-        _path_a_lock_key,
+        _content_lock_key,
         detect_contradictions_async,
     )
 
@@ -552,23 +552,23 @@ async def test_an_empty_row_content_is_a_real_value_not_a_missing_one():
             mid, "t1", "f1", "a stale caller copy", [0.1] * 10, new_memory=mem
         )
 
-    assert fake.acquired == [_path_a_lock_key(mid, "")]
+    assert fake.acquired == [_content_lock_key(mid, "")]
 
 
 @pytest.mark.asyncio
 async def test_paths_keep_independent_locks_per_content():
     """Path A and Path C must still not block each other, now per content."""
     from core_api.services.contradiction_detector import (
-        _path_a_lock_key,
-        _path_c_lock_key,
+        _content_lock_key,
+        _entity_lock_key,
     )
 
     mid = uuid4()
-    assert _path_a_lock_key(mid, "x") != _path_c_lock_key(mid, "x")
-    assert _path_a_lock_key(mid, "x") != _path_a_lock_key(mid, "y")
+    assert _content_lock_key(mid, "x") != _entity_lock_key(mid, "x")
+    assert _content_lock_key(mid, "x") != _content_lock_key(mid, "y")
     # Same inputs must be stable across calls, or the dedup never fires at all.
-    assert _path_a_lock_key(mid, "x") == _path_a_lock_key(mid, "x")
-    assert str(mid) in _path_a_lock_key(mid, "x")
+    assert _content_lock_key(mid, "x") == _content_lock_key(mid, "x")
+    assert str(mid) in _content_lock_key(mid, "x")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## A54 — a writer could mark **another agent's private memory** outdated/conflicted

The task filed one query: the RDF candidate lookup had no visibility predicate, while its sibling `memory_find_similar_candidates` had one.

**Fixing that alone did not close the hole.** The wet test reproduced the leak anyway — through the *semantic* path — because:

> `visibility == "scope_agent"` means **"private to SOME agent"**, not "private to THIS agent".

Filtering on the tier still matches every *other* agent's private rows. So the real defect is broader than filed, and all three contradiction candidate routes had it:

| query | before | now |
|---|---|---|
| `memory_find_rdf_conflicts` | no visibility filter at all | tier + owner |
| `memory_find_similar_candidates` | tier only — **the live leak** | tier + owner |
| `memory_find_entity_overlap_candidates` | tier only | tier + owner |

The owner predicate applies **only** to `scope_agent`, so `scope_team` / `scope_org` behaviour is unchanged. Both new storage params are optional, so a storage instance deployed ahead of core-api keeps serving; core-api always sends them.

### Why this matters

A contradiction verdict is a **write**. Selecting another agent's private row as a candidate meant marking it `outdated`/`conflicted` — a status write into a row the writer cannot read, plus an inference channel about its contents.

## D3 — detection was invisible unless it found something

The completion log lived inside `if contradictions:`, so "ran and found nothing" and "never ran" (lock contention, early return, crashed worker) were indistinguishable — precisely when you most need to know, i.e. a contradiction was expected and none appeared. Every concluded run now logs, with structured `conflicts_found` / `memory_id`.

## Testing

9 unit tests, including one that asserts **all three** queries pin the owner — the hole moved once already, and that test is what stops it moving again. 297 contradiction tests pass. Full suite **5912 passed** (the 8 failures in `test_capability_usage` / `test_request_observation` pre-exist on main; verified by stashing).

**Wet-tested on a live stack, both directions:**

```
BEFORE the fix
  agent B writes a contradicting fact -> agent A's private row becomes `conflicted`   <-- leak

AFTER the fix
  2) agent B private write (contradicts A) -> A: active      sup=None    [untouched]
  3) agent A contradicts ITSELF            -> A: conflicted
                                              C: active      sup=<A.id>  [positive control]

  D3, observed on a zero-conflict run:
  "Async contradiction detection completed for memory ...: 0 conflict(s)"
     conflicts_found=0 memory_id=... path=contradiction-detection
```

The positive control matters as much as the negative one: scoping too tightly would silently disable contradiction detection, which no unit test would catch.

## Not in this PR

`memory_find_semantic_duplicate` has the same tier-only filter. It's the **dedup** path, not contradiction — it could return a 409 naming another agent's private memory id (existence disclosure). Filed separately rather than widening this change.

Refs: canonical A54, D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
