### PR TITLE
fix(gate): stop a floor-to-deferred transition charging an unrelated move

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -1683,17 +1683,11 @@ def _minted(
     """
     new_here = head_by_file.get(path, Counter()) - base_by_file.get(path, Counter())
     if transition:
-        # An excused occurrence still SPENDS its unit of the shared budget. The
-        # repo really did gain that text — the transition is why it is not
-        # charged here, not evidence that the gain never happened. Dropping it
-        # from ``new_here`` without spending would leave the unit available to
-        # an unrelated file, where the next occurrence of the same text is
-        # charged as minted instead of recognised as a move: a red build on a
-        # change that minted nothing, in a file with no part in the transition.
-        for text, excused in transition.items():
-            spent = min(excused, new_here[text], budget[text])
-            if spent:
-                budget[text] -= spent
+        # Only the local tally is adjusted here. The excused occurrence is kept
+        # out of the shared budget by :func:`_mint_budget`'s caller instead,
+        # before any file is visited — spending it here would work only when the
+        # transitioned file happens to sort before the file that would otherwise
+        # claim the same text, which is a coin toss on filenames.
         new_here.subtract(transition)
         new_here = +new_here
 
@@ -2395,8 +2389,23 @@ def main() -> int:
         return 1
 
     head_by_file, base_by_file = head_scan.by_file, base_scan.by_file
-    budget = _mint_budget(head_scan.total, base_scan.total)
     floor_excused = _floor_excused(floor_transitions)
+    # A floor-to-deferred transition raises the repo-wide count of its text: the
+    # base occurrence was exempt and uncounted, the deferred one is counted. That
+    # gain is sanctioned, so it must not also become budget for charging some
+    # other file — an unrelated legitimate move of the same text would be
+    # reported as minted, in a file with no part in the transition.
+    #
+    # Neutralised HERE, once, before any file is visited, rather than spent as
+    # each transitioned file is reached: the loop below runs in sorted path
+    # order, so spending it late works only when the transitioned file happens
+    # to sort before the file that would otherwise claim the text. That is a
+    # coin toss on filenames, and it passes a test whose files happen to sort
+    # the lucky way while the bug is still there for every other pair.
+    excused_total: Counter[str] = Counter()
+    for counts in floor_excused.values():
+        excused_total.update(counts)
+    budget = _mint_budget(head_scan.total, base_scan.total + excused_total)
 
     grown = {}
     excused: dict[str, Counter[str]] = {}

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -3307,37 +3307,49 @@ def test_the_engine_stays_formatter_stable() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("transitioned", "destination"),
+    [("a_transition.py", "z_move.py"), ("z_transition.py", "a_move.py")],
+    ids=["transition-sorts-first", "transition-sorts-last"],
+)
 def test_a_floor_transition_survives_a_same_text_relocation_elsewhere(
-    repo: Path,
+    repo: Path, transitioned: str, destination: str
 ) -> None:
-    """Two independent bugs met here, and the second was hidden by the first.
+    """Three bugs met here, each hidden by the one before it.
 
     The change is: one file's floor marker becomes deferred in place, while a
     byte-identical deferred line is deleted from a second file and re-added to a
     third. Nothing is minted — the repo gains exactly the one occurrence the
     transition sanctions, and the other is a move.
 
-    The relocation rule used to claim the transitioned line first, because the
-    identical text existed in the base tree; the transition then went
-    unrecognised, its floor line was reported as deleted, and its successor was
-    charged as a mint. Fixing that exposed the second bug: the excused
-    occurrence was dropped from the file's tally without spending its unit of
-    the shared repo-wide budget, so the unit stayed available and the genuine
-    move at the far end was charged instead. Either one alone fails this.
+    First, the relocation rule claimed the transitioned line, because the
+    identical text existed in the base tree; the transition went unrecognised,
+    its floor line was reported as deleted, and its successor was charged as a
+    mint. Fixing that exposed the second: the sanctioned gain still counted
+    towards the shared repo-wide mint budget, so that unit was spent charging
+    the genuine move at the far end.
+
+    **Both orderings, and that is the point.** The first attempt at the second
+    fix spent the budget as each transitioned file was reached. The files are
+    visited in sorted path order, so it worked whenever the transitioned file
+    sorted before the file that would otherwise claim the text, and not
+    otherwise — and the single test written for it happened to use the lucky
+    names. The budget is now made transition-neutral once, before any file is
+    visited; these two cases are what tell the difference.
     """
     _write_decision(repo)
     body = f'URL = "https://{LEGACY}.net"'
     floor = f"{body}  # legacy-name-floor: frozen path\n"
     deferred = f"{body}  # {_deferred()}\n"
 
-    (repo / "a.py").write_text(floor)
-    (repo / "c.py").write_text(deferred)
+    (repo / transitioned).write_text(floor)
+    (repo / "source.py").write_text(deferred)
     _git(repo, "add", "-A")
     _git(repo, "commit", "-qm", "a floor line, and the same text deferred elsewhere")
 
-    _stage(repo, "a.py", deferred)  # floor -> deferred, in place
-    _stage(repo, "c.py", "PLACEHOLDER = 1\n")  # the other copy leaves here
-    _stage(repo, "b.py", deferred)  # ...and arrives here: a move
+    _stage(repo, transitioned, deferred)  # floor -> deferred, in place
+    _stage(repo, "source.py", "PLACEHOLDER = 1\n")  # the other copy leaves here
+    _stage(repo, destination, deferred)  # ...and arrives here: a move
 
     result = _run(repo)
 


### PR DESCRIPTION
> **DO NOT MERGE UNTIL THE SEVEN PORTS OF caura#1234 HAVE LANDED.** This changes
> `scripts/legacy_name_ratchet.py`, which the `Legacy-name engine parity` org ruleset
> compares byte-for-byte against `caura/main`. Those seven PRs are green **right now**
> because they match `main`. Merging this first turns all seven red again and re-opens
> the estate-wide window they exist to close. Land them, then this, then re-port.
>
> The seven: caura-ai/caura-ops#353 · caura-ai/caura-onprem-installer#48 ·
> caura-ai/caura-daemon#170 · caura-ai/caura-onprem#69 ·
> caura-ai/caura-test-automation#305 · caura-ai/openclaw-fleet-tester#39 ·
> caura-ai/caura-enterprise#1468

Follows caura#1234. A reviewer on two of the port PRs found this, it is real, and the
fix that shipped in #1234 only worked for half the inputs.

## What is wrong

A floor-to-deferred transition raises the repo-wide count of its text — the base
occurrence carried a floor marker and was uncounted, the deferred one is counted. That
gain is sanctioned by the transition, and #1234 correctly kept it out of the
transitioned file's own tally.

It did **not** keep it out of the shared mint budget. That budget is spent across files
in sorted path order, so the sanctioned gain stayed available, and the next file to add
the same text had it charged as **minted** rather than recognised as a **move** — a red
build on a change that minted nothing, in a file with no part in the transition.

## Why #1234's version of the fix was not enough

#1234 spent the budget as each transitioned file was reached. That works only when the
transitioned file sorts **before** the file that would otherwise claim the text. The
regression test written for it used `a.py` for the transition and `b.py` for the
destination — the lucky order — so it passed while the bug remained for every pair that
sorted the other way.

The budget is now made transition-neutral **once, before any file is visited**, so path
order cannot decide the verdict. That is the shape the reviewer proposed, and it is the
right one.

## Verified

- **The regression test runs both orderings.** Against the engine currently on `main`,
  `transition-sorts-last` **fails** and `transition-sorts-first` **passes** — the exact
  distinction a single-ordering test cannot draw. Both pass here.
- 191 tests pass (190 before this branch; the added case is the second ordering).
- Ratchet `No new lines.` (exit 0); sentinel `All 46 protected strings survive.` (exit 0).
- All eight `ruff check` scopes, all seven `ruff format --check` scopes including the two
  `scripts/` and `tests/` steps added by #1231, the isolated three-file step, and
  `mypy scripts/` all pass. `ruff format` was not run on either protected script.
- The non-exemption property is unaffected and re-proven end-to-end: a line carrying only
  `legacy-name-deferred` is still counted and still fails; `legacy-name-ok` on the same
  line still passes; a missing reference still fails; deferred combined with a permanent
  marker still fails.

## Bearing on the caura-daemon reclassification

That change turns 315 floor lines into deferred ones in a single PR. Every one of them is
a sanctioned gain, so it would have contributed 315 units of spurious budget under the
merged engine. Any same-text move anywhere in that PR could then have been charged as a
mint. This wants to be in the engine before that reclassification is attempted.