### PR TITLE
fix(contradiction): retract flipped verdicts too (A53)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -808,6 +808,17 @@ class CoreStorageClient:
         # is picked up by a later crystallizer pass.
         return await self._post("/memories/entity-overlap-candidates", data, read=True)  # type: ignore[return-value]
 
+    async def find_by_supersedes_id(self, tenant_id: str, supersedes_id: str) -> list[dict]:
+        """A53 — rows whose supersedes_id points at ``supersedes_id``.
+
+        Retraction-shaped: unlike ``find_successors`` this applies no status or
+        visibility filter, because retraction must reach the row that owns the
+        chain edge whatever state it is in.
+        """
+        return await self._get_list(
+            "/memories/by-supersedes-id", tenant_id=tenant_id, supersedes_id=supersedes_id
+        )
+
     async def find_successors(self, data: dict) -> list[dict]:
         return await self._post("/memories/find-successors", data, read=True)  # type: ignore[return-value]
 

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -1996,11 +1996,15 @@ async def _attempt_entity_retraction(
     disagrees with sufficient confidence. Returns True iff a retraction
     was performed.
 
-    Lookup is a direct dereference of ``new_memory.supersedes_id`` —
-    bypasses A4 #11's ``include_supersedes`` filter (which is structurally
-    inverted relative to Path A's chain shape — see follow-up). Works
-    in both canonical and flipped Path A directions: the dereferenced
-    row IS the conflicted candidate in either case.
+    A53 — resolution is DIRECTION-AWARE. Canonical verdicts put the edge on
+    ``new_memory`` (dereference ``supersedes_id``); flipped verdicts put it on
+    the pre-existing candidate and leave ``new_memory`` ``outdated`` with a NULL
+    ``supersedes_id``. The previous implementation dereferenced ``new_memory``
+    unconditionally and so returned False for every flipped verdict — and this
+    docstring used to claim the opposite ("works in both directions"), which was
+    never true. The flipped counterpart is found with a retraction-shaped
+    storage lookup; a chain claimed by more than one row is left alone rather
+    than guessed at.
 
     Retraction is a two-step write via A4 #10:
       1. ``update_memory_status(candidate.id, "active")`` — revert
@@ -2027,21 +2031,72 @@ async def _attempt_entity_retraction(
         )
         return False
 
-    retraction_target_id = new_memory.get("supersedes_id")
-    if not retraction_target_id:
-        return False
-
-    # Bound once: both the candidate lookup and the entity-context fetches below
-    # are by bare id and must be scoped to the row's own tenant.
+    # Bound once: the candidate lookup and the entity-context fetches below are
+    # by bare id and must be scoped to the row's own tenant.
     retraction_tenant_id = str(new_memory["tenant_id"])
-    candidate = await sc.get_memory(str(retraction_target_id), retraction_tenant_id)
+
+    # A53 — resolve the pair DIRECTION-AWARE. The content route (ex-"Path A")
+    # records its verdict two different ways:
+    #
+    #   canonical: new_memory wins  -> new_memory.supersedes_id = candidate.id
+    #                                  candidate becomes `conflicted`
+    #   flipped:   candidate wins   -> candidate.supersedes_id = new_memory.id
+    #                                  NEW_MEMORY becomes `outdated`
+    #
+    # The old code only dereferenced ``new_memory.supersedes_id``, which is NULL
+    # in the flipped case — so a flipped verdict could never be retracted, and
+    # the docstring claiming otherwise was simply wrong. The row to revert and
+    # the row owning the edge swap places between the two directions.
+    edge_owner: dict | None = None  # the row whose supersedes_id must be cleared
+    candidate: dict | None = None  # the row whose status must be reverted
+
+    if new_memory.get("supersedes_id"):
+        candidate = await sc.get_memory(str(new_memory["supersedes_id"]), retraction_tenant_id)
+        edge_owner = new_memory
+    else:
+        # Flipped: find who points AT us. Retraction-shaped lookup on purpose —
+        # ``find_successors`` filters to active/confirmed and applies visibility
+        # scoping, so it would miss the edge owner precisely when it matters.
+        try:
+            owners = await sc.find_by_supersedes_id(
+                retraction_tenant_id, str(new_memory.get("id"))
+            )
+        except Exception:
+            logger.warning(
+                "Retraction could not resolve the flipped counterpart for memory %s",
+                new_memory.get("id"),
+                exc_info=True,
+            )
+            return False
+        if len(owners) != 1:
+            # Zero: nothing to retract. More than one: the chain is ambiguous and
+            # picking arbitrarily could clear an edge a DIFFERENT contradiction
+            # legitimately created. Leave it to a human / the next run.
+            if owners:
+                logger.warning(
+                    "Retraction skipped for memory %s: %d rows claim the chain edge",
+                    new_memory.get("id"),
+                    len(owners),
+                )
+            return False
+        edge_owner = owners[0]
+        candidate = new_memory
+
     if not candidate or candidate.get("deleted_at") is not None:
         return False
-    # Only retract rows still in the conflicted state Path A produced.
-    # If the row has already been moved on by another writer (or by
-    # a previous Path C invocation), our retraction is no longer
-    # meaningful — skip without calling the judge.
-    if candidate.get("status") != "conflicted":
+
+    # Only retract a row still in the state the content route produced. Shape-
+    # based, not a single status literal: canonical marks the loser
+    # ``conflicted``, flipped marks it ``outdated``. If another writer (or an
+    # earlier retraction) already moved the row on, ours is no longer meaningful
+    # — skip without paying for the judge.
+    if candidate.get("status") not in ("conflicted", "outdated"):
+        return False
+
+    # The edge must still point where we think it does; otherwise the pair we
+    # resolved is not the pair the chain describes. The storage CAS below is the
+    # real guard, but failing here avoids an LLM call we would only discard.
+    if str(edge_owner.get("supersedes_id") or "") != str(candidate.get("id")):
         return False
 
     new_content = new_memory.get("content", "") or ""
@@ -2163,13 +2218,21 @@ async def _attempt_entity_retraction(
             f"Path C retraction missing tenant_id (candidate={candidate.get('id')}, "
             f"new_memory={new_memory.get('id')})"
         )
+    # A53 — revert the LOSER and clear the edge on whichever row OWNS it. In the
+    # canonical direction that is new_memory; in the flipped direction it is the
+    # pre-existing candidate, and the loser is new_memory itself. Writing these
+    # the canonical way round in a flipped chain would revert the wrong row and
+    # leave the real edge dangling.
     await sc.update_memory_status(str(candidate.get("id")), "active", tenant_id=cand_tenant)
     try:
         await sc.update_memory_status(
-            str(new_memory.get("id")),
-            new_memory.get("status", "active"),
-            tenant_id=new_tenant,
+            str(edge_owner.get("id")),
+            edge_owner.get("status", "active"),
+            tenant_id=str(edge_owner.get("tenant_id") or new_tenant),
             unset_supersedes=True,
+            # CAS anchor: the edge must still point at the row we just reverted,
+            # or another writer has taken the chain and this retraction is no
+            # longer ours to make.
             expected_supersedes_id=str(candidate.get("id")),
         )
     except Exception as e:

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -373,6 +373,17 @@ async def find_entity_overlap_candidates(request: Request) -> list[dict]:
     return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
 
 
+@router.get("/by-supersedes-id")
+async def find_by_supersedes_id(tenant_id: str, supersedes_id: str) -> list[dict]:
+    """A53 — rows owning a chain edge INTO the given memory, for retraction.
+
+    Distinct from /find-successors, which is search-shaped (status + visibility
+    scoped). Retraction needs the edge owner in any state.
+    """
+    memories = await _svc.memory_find_by_supersedes_id(tenant_id=tenant_id, supersedes_id=UUID(supersedes_id))
+    return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
+
+
 @router.post("/find-successors")
 async def find_successors(request: Request) -> list[dict]:
     body: dict = await request.json()

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2532,6 +2532,33 @@ class PostgresService:
     # D-0) Supersedes chain: find successor memories
     # ------------------------------------------------------------------
 
+    async def memory_find_by_supersedes_id(
+        self,
+        tenant_id: str,
+        supersedes_id: UUID,
+    ) -> list[Memory]:
+        """Rows whose ``supersedes_id`` points AT the given memory.
+
+        A53 — retraction-shaped, deliberately NOT ``memory_find_successors``.
+        That one is search-shaped: it filters ``status IN (active, confirmed)``
+        and applies fleet/visibility/agent scoping, because its job is to show a
+        caller the correction they are allowed to see. Retraction has the
+        opposite need — it must find the row that OWNS the chain edge whatever
+        state that row is in, or the edge is silently left dangling and the
+        flipped verdict can never be undone.
+
+        Tenant-scoped (the one filter that is a boundary, not a preference) and
+        excludes soft-deleted rows. Returns every match so the caller can refuse
+        to act on an ambiguous chain rather than picking one arbitrarily.
+        """
+        async with get_session() as session:
+            stmt = select(Memory).where(
+                Memory.tenant_id == tenant_id,
+                Memory.supersedes_id == supersedes_id,
+                Memory.deleted_at.is_(None),
+            )
+            return list((await session.execute(stmt)).scalars().all())
+
     async def memory_find_successors(
         self,
         supersedes_ids: list[UUID],

--- a/tests/test_a53_direction_aware_retraction.py
+++ b/tests/test_a53_direction_aware_retraction.py
@@ -1,0 +1,94 @@
+"""A53 — a flipped contradiction verdict could never be retracted.
+
+The content route records its verdict two ways:
+
+    canonical: new_memory wins -> new_memory.supersedes_id = candidate.id
+                                 candidate       -> `conflicted`
+    flipped:   candidate wins  -> candidate.supersedes_id = new_memory.id
+                                 NEW_MEMORY      -> `outdated`
+
+Retraction only ever dereferenced ``new_memory.supersedes_id``, which is NULL in
+the flipped case, so it returned False before reaching the judge. The row to
+revert and the row owning the chain edge SWAP between the two directions, so
+writing them the canonical way round in a flipped chain reverts the wrong row
+and leaves the real edge dangling.
+
+The function's docstring asserted the opposite ("works in both directions").
+"""
+
+import inspect
+
+import pytest
+
+from core_api.services import contradiction_detector as cd
+
+pytestmark = pytest.mark.unit
+
+
+def test_flipped_lookup_is_retraction_shaped_not_search_shaped():
+    """``find_successors`` filters status to active/confirmed and applies
+    visibility scoping — it would silently miss the edge owner exactly when
+    retraction needs it. The dedicated lookup applies neither."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_find_by_supersedes_id)
+    assert "Memory.supersedes_id == supersedes_id" in src
+    assert "Memory.tenant_id == tenant_id" in src  # the one real boundary
+    assert "status" not in src.split('"""')[2]  # no status predicate in the body
+    assert "visibility" not in src.split('"""')[2]
+
+
+def test_retraction_resolves_both_directions():
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    # canonical: dereference our own edge
+    assert 'new_memory.get("supersedes_id")' in src
+    # flipped: find who points AT us
+    assert "find_by_supersedes_id" in src
+    assert "edge_owner" in src and "candidate" in src
+
+
+def test_status_guard_is_shape_based_not_a_single_literal():
+    """Canonical marks the loser `conflicted`; flipped marks it `outdated`.
+    A guard hard-coded to `conflicted` refuses every flipped retraction."""
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    assert '("conflicted", "outdated")' in src
+    assert 'get("status") != "conflicted"' not in src
+
+
+def test_ambiguous_chain_is_refused_not_guessed():
+    """More than one row claiming the edge means clearing it could undo a
+    DIFFERENT contradiction's work. Refusing is the safe direction."""
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    assert "len(owners) != 1" in src
+
+
+def test_edge_is_cleared_on_the_row_that_owns_it():
+    """The CAS write must target edge_owner, not unconditionally new_memory —
+    that is the actual bug in the flipped direction."""
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    tail = src[src.index("await sc.update_memory_status") :]
+    assert 'str(edge_owner.get("id"))' in tail
+    assert "unset_supersedes=True" in tail
+    assert 'expected_supersedes_id=str(candidate.get("id"))' in tail
+
+
+def test_edge_consistency_checked_before_paying_for_the_judge():
+    """If the edge no longer points at the row we resolved, the pair is stale;
+    bail before the LLM call rather than discarding its answer."""
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    i = src.index('edge_owner.get("supersedes_id")')
+    j = (
+        src.index("_llm_contradiction_check")
+        if "_llm_contradiction_check" in src
+        else len(src)
+    )
+    assert i < j, "edge check must precede the judge call"
+
+
+def test_docstring_no_longer_claims_direction_independence():
+    doc = cd._attempt_entity_retraction.__doc__ or ""
+    assert "DIRECTION-AWARE" in doc
+    assert (
+        "the dereferenced\n    row IS the conflicted candidate in either case"
+        not in doc
+    )


### PR DESCRIPTION
> **Stacked on #1237** (A54/D3/C20) — base is that branch, not `main`, because this uses C20's renamed identifiers. Review after #1237 merges, or retarget then.

## A flipped contradiction verdict could never be retracted

The content route records its verdict two different ways:

```
canonical: new_memory wins -> new_memory.supersedes_id = candidate.id
                             candidate  -> `conflicted`

flipped:   candidate wins  -> candidate.supersedes_id = new_memory.id
                             NEW_MEMORY -> `outdated`
```

Retraction only ever dereferenced `new_memory.supersedes_id`. In the flipped case that is **NULL**, so it returned `False` before reaching the judge — the verdict stood permanently, however wrong.

Worse, the row to revert and the row that **owns the chain edge** swap places between the two directions. Applying the canonical write order to a flipped chain would revert the wrong row and leave the real edge dangling.

The function's docstring asserted the opposite — *"Works in both canonical and flipped Path A directions: the dereferenced row IS the conflicted candidate in either case."* That was never true, and is corrected here.

## Three parts

**1. A retraction-shaped storage lookup** — `memory_find_by_supersedes_id`.

Deliberately *not* `memory_find_successors`. That one filters `status IN (active, confirmed)` and applies fleet/visibility/agent scoping, because its job is to show a caller a correction they're allowed to see. Retraction has the opposite need — reach the row owning the edge **whatever state it's in** — so the search-shaped lookup would silently miss it precisely when it matters. Tenant scoping is kept, because that's a boundary rather than a preference.

**2. Direction-aware pair resolution** into `{candidate to revert, edge owner}`, with the CAS anchor on whichever row owns the edge.

**3. A shape-based status guard.** The loser is `conflicted` (canonical) or `outdated` (flipped). The old single-literal `!= "conflicted"` check refused every flipped retraction on its own, independently of the NULL dereference.

## Safety

A chain claimed by **more than one row** is refused, not guessed at — clearing an arbitrary edge could undo a different contradiction's work. Zero rows is a no-op. The edge is also re-checked before the judge runs, so a stale pair costs no LLM call.

## Testing

7 new tests, including one pinning that the new lookup has no status/visibility predicate (the whole reason it exists) and one asserting the docstring no longer claims direction-independence. 124 retraction/contradiction tests pass. Full suite **5925 passed** — the 8 failures in `test_capability_usage` / `test_request_observation` pre-exist on main.

Not wet-tested end-to-end: reproducing a *flipped* verdict on demand requires the judge to rule the pre-existing candidate newer, which is not reliably reproducible against a live LLM. The direction logic is pinned by unit tests instead, and the storage lookup's shape is asserted rather than assumed.

Refs: canonical A53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
