### PR TITLE
docs(outcome-inference): stop naming a table that was never built

### DIFF
--- a/core-api/src/core_api/services/outcome_inference/cross_agent_reuse.py
+++ b/core-api/src/core_api/services/outcome_inference/cross_agent_reuse.py
@@ -18,10 +18,34 @@ reuse via the recall_count threshold — it's an over-approximation
 but conservative on the firing side: ``recall_count >= 5`` typically
 means ≥3 distinct agents in practice.
 
-**Phase 2+ upgrade path**: a ``memory_recalls`` table keyed
-``(memory_id, agent_id, last_recalled_at)`` gives the exact distinct-
-agent count without inflation. The extractor signature stays the
-same; the SQL gets sharper. Tracked as OQ-future.
+**Phase 2+ upgrade path**: ``recall_event`` + ``recall_candidate``
+(migration 027) already shipped, and ``recall_event`` carries
+``agent_id`` — so joining the two gives the exact distinct-agent count
+without the self-recall inflation described above. The extractor
+signature stays the same; the SQL gets sharper.
+
+The ``memory_recalls`` table this file used to name as that path,
+keyed ``(memory_id, agent_id, last_recalled_at)``, was never built and
+is not what shipped — do not go looking for it, and do not carry it
+forward as OQ-future work. ``repeat_recall`` names the same
+non-existent table for the same reason and was corrected first.
+
+**READ THIS BEFORE WRITING THE PHASE 2 QUERY — the obvious join is
+cross-tenant.** ``recall_candidate`` has NO ``tenant_id`` of its own
+and NO foreign key on ``memory_id``; it is scoped only by the ``ON
+DELETE CASCADE`` from ``recall_event``, and ``POST
+/memories/recall-log`` does not validate the candidate ids it is
+handed — core-storage-api constructs each row verbatim. So a
+``recall_candidate`` row CAN name a memory belonging to another
+tenant.
+
+That matters more for THIS signal than for ``repeat_recall``, because
+this one counts DISTINCT ``agent_id`` per memory: an unconstrained
+join would count another tenant's agents toward a memory's reuse
+score, which both inflates the count and makes "some other tenant
+recalled this too" observable in this tenant's signal. Constrain on
+``recall_event.tenant_id`` explicitly; the cascade is not a tenant
+predicate.
 """
 
 from __future__ import annotations

--- a/tests/test_outcome_inference_signals.py
+++ b/tests/test_outcome_inference_signals.py
@@ -747,6 +747,32 @@ class TestSignalRegistry:
         kinds = [mod.kind for mod in self.ALL_MODULES]
         assert len(kinds) == len(set(kinds)), "duplicate signal kinds across modules"
 
+    def test_memory_recalls_is_never_named_as_a_live_path(self):
+        # ``memory_recalls`` was never built. Two docstrings named it as the
+        # Phase 2 deliverable and sent operators looking for a table that does
+        # not exist; both were corrected (#1232, and the cross-agent-reuse one
+        # after it). What shipped instead is ``recall_event`` +
+        # ``recall_candidate`` (migration 027).
+        #
+        # This is the ENFORCING half of those two corrections. Prose saying
+        # "do not go looking for it" cannot stop the name being reintroduced as
+        # an upgrade path by the next author, who has no reason to know it is
+        # fictional — the name reads like a table that ought to exist. So the
+        # rule is mechanical: mention it if you like, but only while saying it
+        # was never built.
+        for mod in self.ALL_MODULES:
+            doc = mod.__doc__ or ""
+            if "memory_recalls" not in doc:
+                continue
+            assert "never built" in doc, (
+                f"{mod.__name__} names ``memory_recalls`` without stating it "
+                "was never built. That table does not exist; the shipped "
+                "recall log is ``recall_event`` + ``recall_candidate`` "
+                "(migration 027). Either point at those, or keep the "
+                "'was never built' disclaimer so the next reader is not sent "
+                "looking for it."
+            )
+
     def test_each_module_documents_its_data_source(self):
         # Every signal module's docstring must reference its data
         # source ("memories.", "track_recalls", "recall_event", or


### PR DESCRIPTION
## The false claim

`cross_agent_reuse` named a `memory_recalls` table, keyed `(memory_id, agent_id, last_recalled_at)`, as its **"Phase 2+ upgrade path … Tracked as OQ-future"**.

That table was never built. The identical claim was corrected in `repeat_recall` by #1232 — which states plainly that it "was never built and is not what shipped — do not go looking for it". This is the other half of that correction.

The cost of leaving it was not cosmetic: it names a non-existent table as tracked future work, so an operator or the next implementer goes looking for a schema that does not exist, and a backlog item points at nothing.

## What it points at now

`recall_event` + `recall_candidate` (migration 027) shipped, and **`recall_event` carries `agent_id`** — so the exact distinct-agent count this module says it wants is available today by joining the two, rather than being blocked on a table that will never arrive.

## The part that is more than a docs fix

I carried #1232's cross-tenant warning across, because **this module would hit it harder than the one it was written for.**

`recall_candidate` has no `tenant_id` of its own and no foreign key on `memory_id`; it is scoped only by the `ON DELETE CASCADE` from `recall_event`, and `POST /memories/recall-log` does not validate the candidate ids it is handed — core-storage-api constructs each row verbatim. So a row *can* name a memory belonging to another tenant.

`repeat_recall` counts recalls of a query. **This signal counts DISTINCT `agent_id` per memory** — so an unconstrained join would:

1. count another tenant's agents toward a memory's reuse score, inflating it, and
2. make "some other tenant recalled this too" observable in *this* tenant's signal.

The docstring now says to constrain on `recall_event.tenant_id`, and states explicitly that the cascade is not a tenant predicate. Worth having in place *before* someone writes the Phase 2 query, rather than as a review comment afterwards.

## The enforcing half

Prose saying "do not go looking for it" cannot stop the name being reintroduced. `memory_recalls` *reads* like a table that ought to exist, the next author has no reason to know it is fictional, and until now nothing in the repo contradicted it — which is exactly how it survived in two files.

`test_memory_recalls_is_never_named_as_a_live_path` makes the rule mechanical: a signal docstring may mention the name, but only while stating it was never built.

**Confirmed load-bearing** rather than assumed: reverting the docstring to its pre-change text turns it red —

```
AssertionError: cross_agent_reuse names ``memory_recalls`` without stating it
was never built. That table does not exist; the shipped recall log is
``recall_event`` + ``recall_candidate`` (migration 027).
```

## Deliberately not done

`test_each_module_documents_its_data_source` still accepts `memory_recalls` as a data-source breadcrumb token. Left alone: both docstrings using the name now do so only to deny it, so the token is vestigial rather than incorrect, and narrowing that test is a separate change from correcting these two files.

## Checks

54 tests pass. `ruff check` and `ruff format --check` clean at CI's exact scopes (`core-api/src/`, `tests/`). Docs-only in `src/`; no behaviour change — `extract()` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
