### PR TITLE
docs(env): document JWT_SECRET and SETTINGS_ENCRYPTION_KEY in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,12 @@ CAURA_API_KEY=
 # random value in a private volume; non-Compose deployments must set the same
 # non-empty value on every storage caller and storage instance.
 # CORE_STORAGE_SHARED_SECRET=
+# JWT signing secret — signs auth tokens. REQUIRED in production: use a random
+# 32+ byte value; defaults to the insecure placeholder "change-me-in-production".
+JWT_SECRET=
+# Fernet key used to encrypt stored settings. REQUIRED in production: defaults
+# to empty, which leaves encryption disabled.
+SETTINGS_ENCRYPTION_KEY=
 
 # -- Embedding provider -----------------------------------------------------
 # Options: openai | local | fake


### PR DESCRIPTION
## Summary

Adds `JWT_SECRET` and `SETTINGS_ENCRYPTION_KEY` to `.env.example`, in the existing `-- Auth --` section, so the example config documents the two settings that `core-api` marks as required in production.

## Related Issue

Closes #717

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

(The issue is labelled `kind/bug`: the current example config silently implies no auth secret and no encryption are needed. The fix itself is a docs/config change.)

## How Has This Been Tested?

Docs/config only, so there is no runtime behaviour to exercise. Verification was by inspection against the source of truth:

- Confirmed both defaults in `core-api/src/core_api/config.py` (lines 391-392): `jwt_secret = "change-me-in-production"`, `settings_encryption_key = ""`.
- Confirmed the config declares no `env_prefix`, so the bare names `JWT_SECRET` / `SETTINGS_ENCRYPTION_KEY` are the correct variable names.
- Confirmed both names were absent from `.env.example` before the change (the insertion script asserts on this before writing).
- Confirmed the diff is `+6 / -0` in `.env.example` and nothing else.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes (or explained why none are needed)
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] `pytest` passes locally
- [x] I have updated relevant documentation (README, docs, etc.)
- [x] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

Notes on the last four:

- **Tests / ruff / mypy / pytest:** no Python is touched — the change is six added comment-and-assignment lines in `.env.example` — so there is nothing for those tools to act on. Adding a test that asserts on the contents of an example file would be testing the docs, not the code.
- **CHANGELOG:** `CHANGELOG.md` carries no `Unreleased` section; it is generated by release-please from Conventional Commits (stated in the file header). This commit uses the `docs(env):` prefix, so it will be picked up automatically on release.

## Additional Notes

Wording follows the convention already used elsewhere in this file (`ADMIN_API_KEY`, `POSTGRES_PASSWORD`): an inline `REQUIRED in production` note that also names the insecure default, so a reader sees both the requirement and the consequence of skipping it.

```diff
 # CORE_STORAGE_SHARED_SECRET=
+# JWT signing secret — signs auth tokens. REQUIRED in production: use a random
+# 32+ byte value; defaults to the insecure placeholder "change-me-in-production".
+JWT_SECRET=
+# Fernet key used to encrypt stored settings. REQUIRED in production: defaults
+# to empty, which leaves encryption disabled.
+SETTINGS_ENCRYPTION_KEY=
```

Related prior art: #511 covered the same category of gap for the `TESTING` env var, in the opposite direction of risk (a dangerous-to-set flag left undocumented, versus these dangerous-to-leave-unset ones).
