### PR TITLE
chore(clients): annotate the permanent class/exception alias lines

### DIFF
--- a/clients/python/src/caura_client/__init__.py
+++ b/clients/python/src/caura_client/__init__.py
@@ -10,26 +10,26 @@ package-forwarder distributions that once depended on this one were retired
 
 from __future__ import annotations
 
-from .client import DEFAULT_BASE_URL, Caura, MemClaw
+from .client import DEFAULT_BASE_URL, Caura, MemClaw  # legacy-name-ok: rule 3 permanent class alias
 from .exceptions import (
     AuthError,
     CauraAPIError,
     CauraError,
-    MemClawAPIError,
-    MemClawError,
+    MemClawAPIError,  # legacy-name-ok: rule 3 permanent exception alias
+    MemClawError,  # legacy-name-ok: rule 3 permanent exception alias
     NotFoundError,
 )
 from .models import Memory, RecallResult
 
 __all__ = [
     "Caura",
-    "MemClaw",
+    "MemClaw",  # legacy-name-ok: rule 3 permanent class alias
     "Memory",
     "RecallResult",
     "CauraError",
     "CauraAPIError",
-    "MemClawError",
-    "MemClawAPIError",
+    "MemClawError",  # legacy-name-ok: rule 3 permanent exception alias
+    "MemClawAPIError",  # legacy-name-ok: rule 3 permanent exception alias
     "AuthError",
     "NotFoundError",
     "DEFAULT_BASE_URL",

--- a/clients/python/src/caura_client/client.py
+++ b/clients/python/src/caura_client/client.py
@@ -221,4 +221,4 @@ class Caura:
 
 # Permanent legacy alias (2026-08 rename) — same class, not a subclass, so
 # isinstance checks and type() comparisons agree across old and new code.
-MemClaw = Caura
+MemClaw = Caura  # legacy-name-ok: rule 3 permanent class alias

--- a/clients/python/src/caura_client/exceptions.py
+++ b/clients/python/src/caura_client/exceptions.py
@@ -33,5 +33,5 @@ class NotFoundError(CauraAPIError):
 # Permanent legacy aliases (2026-08 rename): existing code catches these
 # names, and published 0.4.x examples teach them. Same objects, not copies —
 # ``except MemClawError`` keeps catching everything ``CauraError`` raises.  # legacy-name-ok: rule 3 permanent exception alias
-MemClawError = CauraError
-MemClawAPIError = CauraAPIError
+MemClawError = CauraError  # legacy-name-ok: rule 3 permanent exception alias
+MemClawAPIError = CauraAPIError  # legacy-name-ok: rule 3 permanent exception alias

--- a/clients/python/tests/test_legacy_alias.py
+++ b/clients/python/tests/test_legacy_alias.py
@@ -17,12 +17,12 @@ import caura_client
 
 
 def test_class_alias_is_identity_not_subclass():
-    assert caura_client.MemClaw is caura_client.Caura
+    assert caura_client.MemClaw is caura_client.Caura  # legacy-name-ok: rule 3 permanent class alias
 
 
 def test_legacy_exception_catches_new_raises():
     err = caura_client.CauraAPIError(500, "boom")
     try:
         raise err
-    except caura_client.MemClawAPIError as caught:
+    except caura_client.MemClawAPIError as caught:  # legacy-name-ok: rule 3 permanent exception alias
         assert caught.status_code == 500

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -217,10 +217,10 @@ async function raiseForStatus(res: Response): Promise<void> {
 
 // Permanent legacy aliases (2026-08 rename) — same classes/types, so
 // instanceof and catch clauses agree across old and new spellings.
-export const MemClaw = Caura;
-export type MemClaw = Caura;
-export const MemClawError = CauraError;
-export type MemClawError = CauraError;
-export const MemClawApiError = CauraApiError;
-export type MemClawApiError = CauraApiError;
-export type MemClawOptions = CauraOptions;
+export const MemClaw = Caura; // legacy-name-ok: rule 3 permanent class alias
+export type MemClaw = Caura; // legacy-name-ok: rule 3 permanent class alias
+export const MemClawError = CauraError; // legacy-name-ok: rule 3 permanent exception alias
+export type MemClawError = CauraError; // legacy-name-ok: rule 3 permanent exception alias
+export const MemClawApiError = CauraApiError; // legacy-name-ok: rule 3 permanent exception alias
+export type MemClawApiError = CauraApiError; // legacy-name-ok: rule 3 permanent exception alias
+export type MemClawOptions = CauraOptions; // legacy-name-ok: rule 3 permanent options-type alias


### PR DESCRIPTION
## Summary
Part of the wider repo sweep — auditing every unannotated `memclaw` line rather than only the items named in the original brief.

The `MemClaw`/`MemClawError`/`MemClawAPIError` class and exception aliases in both `clients/python` and `clients/typescript` are permanent by design (rule 3 — same pattern as the MCP tool rename) and already documented with a `legacy-name-ok` comment on the assignment's own explanatory comment line in most places. But `scripts/legacy_name_ratchet.py` only exempts the exact physical line a marker sits on, so the multi-line `from .exceptions import (...)` block, the `__all__` list, and the mirrored TypeScript `export const`/`export type` lines were still counted as unannotated debt — 18 lines across 5 files — even though nothing about them is actually unresolved.

Adds the same `legacy-name-ok: rule 3 permanent class/exception alias` marker directly to each of those lines. No behavior change; verified nothing needed a rename (all of it is the intentional, already-decided permanent alias surface).

## Gates
- `python3 scripts/legacy_name_ratchet.py --base origin/main` → `No new lines. 18 annotated, 0 removed, 0 excused moves (-18 net).`
- `python3 scripts/do_not_touch_sentinel.py` → `All 39 protected strings survive.`
- `ruff check src tests` (clients/python, with the pinned `ruff>=0.15.4,<0.16` from the `dev` extra) clean.
- `pytest` — 139 passed (clients/python, isolated venv).
- `npm test` (clients/typescript) — `tsc` compiles clean, 14/14 tests passed.

Measured against `origin/main` at `c0930483...` (post-#1247 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)