### PR TITLE
test: annotate the permanent tool/env alias literals in the compat-alias tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,15 +41,20 @@ for _k, _v in _TEST_DEFAULTS.items():
 
 # Defensively unset env vars that change auth shape and routinely leak in
 # from developers' shells (the OSS plugin onboarding writes
-# ``~/.config/caura-keys.env`` with ``MEMCLAW_API_KEY=...`` and many
+# ``~/.config/caura-keys.env`` with ``MEMCLAW_API_KEY=...`` and many  # legacy-name-ok: rule 3 env alias
 # rc files source it for the openclaw CLI). A leaked value flips
-# ``settings.memclaw_api_key`` to truthy, which makes ``get_auth_context``
+# ``settings.memclaw_api_key`` to truthy, which makes ``get_auth_context``  # legacy-name-ok: rule 3 dual-read field
 # enforce the gate at Path 2 with 401s before any standalone-mode
 # bypass — silently failing every test that doesn't sniff the env
 # itself (e.g. test_rate_limit's auth-gated burst test, which gets all
 # 401s instead of the expected 200/429 mix). Unset rather than
 # setdefault — setdefault doesn't override an existing env value.
-for _leaky in ("MEMCLAW_API_KEY", "MEMCLAW_KEY", "CAURA_API_KEY", "CAURA_KEY"):
+for _leaky in (
+    "MEMCLAW_API_KEY",  # legacy-name-ok: rule 3 env alias
+    "MEMCLAW_KEY",  # legacy-name-ok: rule 3 env alias
+    "CAURA_API_KEY",
+    "CAURA_KEY",
+):
     os.environ.pop(_leaky, None)
 
 # ruff: noqa: E402 — these imports MUST stay below the env defaults above;

--- a/tests/test_migration_012_safety_gate.py
+++ b/tests/test_migration_012_safety_gate.py
@@ -17,6 +17,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+LEGACY_ENV = "MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS"  # legacy-name-ok: rule 3 env alias
+
 
 def _load_migration():
     """Re-import the migration module fresh.
@@ -85,7 +87,7 @@ def test_gate_proceeds_on_empty_db_without_opt_in(
     """Fresh install: row count == 0, env unset → upgrade() runs to
     completion (no RuntimeError)."""
     monkeypatch.delenv("CAURA_RUN_DESTRUCTIVE_MIGRATIONS", raising=False)
-    monkeypatch.delenv("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", raising=False)
+    monkeypatch.delenv(LEGACY_ENV, raising=False)
     _patch_op(monkeypatch, existing_count=0)
     mig = _load_migration()
     mig.upgrade()  # must not raise
@@ -98,7 +100,7 @@ def test_gate_refuses_destructive_run_without_opt_in(
     """Populated DB, env unset → RuntimeError with the row count and
     the env var name in the message."""
     monkeypatch.delenv("CAURA_RUN_DESTRUCTIVE_MIGRATIONS", raising=False)
-    monkeypatch.delenv("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", raising=False)
+    monkeypatch.delenv(LEGACY_ENV, raising=False)
     _patch_op(monkeypatch, existing_count=42_000)
     mig = _load_migration()
     with pytest.raises(RuntimeError) as ei:
@@ -107,7 +109,7 @@ def test_gate_refuses_destructive_run_without_opt_in(
     # The refusal must teach the canonical name and still name the legacy
     # alias operators may have in runbooks.
     assert "CAURA_RUN_DESTRUCTIVE_MIGRATIONS" in str(ei.value)
-    assert "MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS" in str(ei.value)
+    assert LEGACY_ENV in str(ei.value)
 
 
 @pytest.mark.unit
@@ -130,7 +132,7 @@ def test_gate_treats_non_true_values_as_opt_out(
     """Anything other than (case-insensitive) ``"true"`` is treated as
     opt-out, so an operator's typo doesn't accidentally green-light
     data destruction."""
-    monkeypatch.setenv("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", val)
+    monkeypatch.setenv(LEGACY_ENV, val)
     _patch_op(monkeypatch, existing_count=10)
     mig = _load_migration()
     with pytest.raises(RuntimeError):
@@ -145,7 +147,7 @@ def test_gate_accepts_case_insensitive_true(
 ) -> None:
     """``MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS=TRUE`` (or ``True``) opts
     in. Operators commonly capitalize bool envs."""
-    monkeypatch.setenv("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", val)
+    monkeypatch.setenv(LEGACY_ENV, val)
     _patch_op(monkeypatch, existing_count=10)
     mig = _load_migration()
     mig.upgrade()  # must not raise
@@ -157,7 +159,7 @@ def test_gate_accepts_legacy_env_alias(
 ) -> None:
     """The legacy opt-in spelling keeps working forever (rule 3)."""
     monkeypatch.delenv("CAURA_RUN_DESTRUCTIVE_MIGRATIONS", raising=False)
-    monkeypatch.setenv("MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS", "true")
+    monkeypatch.setenv(LEGACY_ENV, "true")
     _patch_op(monkeypatch, existing_count=10)
     mig = _load_migration()
     mig.upgrade()  # must not raise

--- a/tests/test_tool_rename_aliases.py
+++ b/tests/test_tool_rename_aliases.py
@@ -43,12 +43,13 @@ async def _outcome(name: str) -> tuple[str, str]:
     # error text mentions the canonical name under either spelling; what
     # matters is the error class (validation vs unknown-tool), not which
     # spelling was used.
-    suffix = name.removeprefix("caura_").removeprefix("memclaw_")
+    suffix = name.removeprefix("caura_")
+    suffix = suffix.removeprefix("memclaw_")  # legacy-name-ok: rule 3 dispatch alias
 
     def _normalize(text: str) -> str:
-        return text.replace(f"caura_{suffix}", "<tool>").replace(
-            f"memclaw_{suffix}", "<tool>"
-        )
+        text = text.replace(f"caura_{suffix}", "<tool>")
+        legacy_marker = f"memclaw_{suffix}"  # legacy-name-ok: rule 3 dispatch alias
+        return text.replace(legacy_marker, "<tool>")
 
     try:
         result = await mcp_server.mcp.call_tool(name, {})
@@ -64,7 +65,7 @@ async def test_listing_exposes_only_caura_names():
     offenders = [n for n in names if not n.startswith("caura_")]
     assert not offenders, (
         f"tools/list must advertise only caura_* names, got {offenders}. "
-        "Legacy memclaw_* names are dispatch aliases, never listed — "
+        "Legacy memclaw_* names are dispatch aliases, never listed — "  # legacy-name-ok: rule 3
         "dual-listing doubles every client's tool-schema token budget."
     )
 
@@ -75,7 +76,8 @@ async def test_every_tool_dispatches_under_its_legacy_name():
     registered tool — including tools that did not exist at rename time.
     """
     for name in await _listed_tool_names():
-        legacy = "memclaw_" + name.removeprefix("caura_")
+        suffix = name.removeprefix("caura_")
+        legacy = "memclaw_" + suffix  # legacy-name-ok: rule 3 dispatch alias
         canonical_kind, canonical_detail = await _outcome(name)
         legacy_kind, legacy_detail = await _outcome(legacy)
         assert "unknown tool" not in legacy_detail.lower(), (
@@ -98,7 +100,7 @@ async def test_legacy_alias_reaches_the_handler_body(monkeypatch):
     monkeypatch.setattr(mcp_server, "_check_auth", lambda: mcp_server._AUTH_ERROR)
 
     result = await mcp_server.mcp.call_tool(
-        "memclaw_write",
+        "memclaw_write",  # legacy-name-ok: rule 3 dispatch alias
         {"content": "alias probe body", "agent_id": "claude-eldad"},
     )
     envelope = parse_envelope(result)
@@ -108,6 +110,9 @@ async def test_legacy_alias_reaches_the_handler_body(monkeypatch):
 @pytest.mark.asyncio
 async def test_unknown_names_still_fail_under_both_prefixes():
     """The shim must not turn nonexistent tools into false positives."""
-    for bogus in ("caura_nonexistent", "memclaw_nonexistent"):
+    for bogus in (
+        "caura_nonexistent",
+        "memclaw_nonexistent",  # legacy-name-ok: rule 3 dispatch alias
+    ):
         with pytest.raises(ToolError):
             await mcp_server.mcp.call_tool(bogus, {})


### PR DESCRIPTION
## What

Adds `legacy-name-ok: rule 3 ...` markers to the `memclaw` literals in
`tests/test_tool_rename_aliases.py`, `tests/test_migration_012_safety_gate.py`,
and `tests/conftest.py`. No renames — these three files exist specifically
to pin two permanent aliases forever:

- `tests/test_tool_rename_aliases.py` — the `memclaw_*` → `caura_*` MCP
  tool-dispatch shim (`core_api/mcp_server.py`'s `name.startswith("memclaw_")`,
  sentinel-protected).
- `tests/test_migration_012_safety_gate.py` — the
  `MEMCLAW_RUN_DESTRUCTIVE_MIGRATIONS` env-var alias for the vector-dim
  migration's destructive-run gate. Introduced a `LEGACY_ENV` module
  constant instead of repeating the literal in all 6 call sites — one
  annotated definition instead of six annotated call sites.
- `tests/conftest.py` — the defensive unset of a leaked `MEMCLAW_API_KEY`/
  `MEMCLAW_KEY` from developers' shells, and the comment documenting the
  `settings.memclaw_api_key` dual-read field it's guarding against.

Several of the original literal call sites, once a trailing marker was
added, no longer fit `ruff format`'s line-length limit — `ruff format`
would then wrap the call so the closing-paren line (carrying the marker)
no longer shared a physical line with the matched "memclaw" text, which
the ratchet requires. Restructured those (the `LEGACY_ENV` constant above;
a `suffix`/`legacy_marker` local in the alias test; the leaky-env tuple
split one-per-line) so the literal and its marker always share one short,
already-formatted line.

4 occurrences are left unannotated on purpose: the first line of a module
or function docstring in each file (`test_tool_rename_aliases.py:1,8,74`;
`test_migration_012_safety_gate.py:146`) — an inline `#` marker there
would leak into `__doc__`, and rewording to avoid the literal would blur
exactly which prefix/env-var name the guarantee covers. Same call made for
`clients/python/src/caura_client/__init__.py`'s docstring in #1249.

`tests/conftest.py:69`'s `postgresql+asyncpg://memclaw:changeme@.../memclaw`
default is untouched here — it's part of the wider Postgres role/db-name
question (also live in `docker-compose*.yml`, `.env.example`, CI, etc.)
that needs an infra-owner decision before anyone touches it, not a
sweep-scope annotation.

## Verification

- `python3 scripts/legacy_name_ratchet.py --base origin/main` → `No new
  lines. 4 annotated, 11 removed, 0 excused moves (-15 net).` EXIT 0
  (the 11 "removed" are literals now referenced via `LEGACY_ENV`/locals
  instead of repeated inline, so they no longer read as bare occurrences)
- `python3 scripts/do_not_touch_sentinel.py` → `All 39 protected strings
  survive.`
- `pytest tests/test_tool_rename_aliases.py tests/test_migration_012_safety_gate.py -v`
  → 17 passed (no DB required — both suites are `@pytest.mark.unit`)
- `ruff check tests/test_tool_rename_aliases.py tests/test_migration_012_safety_gate.py tests/conftest.py`
  → All checks passed
- `ruff format --check` on the same three files → all already formatted
  (fixes the CI failure from the first push, caused by an unformatted
  trailing marker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)