### PR TITLE
chore: floor-mark sentinel-protected memclaw literals in core-api and plugin

### DIFF
--- a/core-api/src/core_api/agent_ids.py
+++ b/core-api/src/core_api/agent_ids.py
@@ -20,7 +20,7 @@ DEFAULT_AGENT_ID = "mcp-agent"
 # collapsing onto the anonymous default (which is unregistered, so its writes
 # never surface in Prism or the per-agent report). Registered per-tenant with
 # ``belonging_type='service'`` the first time the job runs for that tenant.
-INSIGHTER_AGENT_ID = "memclaw-insighter"
+INSIGHTER_AGENT_ID = "memclaw-insighter"  # legacy-name-floor: floor
 
 # Trust tier the insighter self-registers at: service level, granting cross-fleet
 # read (>=2, needed for scope='all') and write (>=3, it persists scope_org
@@ -39,7 +39,7 @@ INSIGHTER_TRUST_LEVEL = 3
 # cosmetic here: ``caura_insights`` defaults to ``scope="agent"``, which filters
 # ``Memory.agent_id == agent_id``, so rows attributed to this service identity are
 # invisible to every real agent's default insights run.
-DOC_INDEXER_AGENT_ID = "memclaw-doc-indexer"
+DOC_INDEXER_AGENT_ID = "memclaw-doc-indexer"  # legacy-name-floor: floor
 
 # Bare ``"main"`` is the OpenClaw plugin's *unset* default agent_id: when an
 # operator never sets ``CAURA_AGENT_ID`` every install collapses onto this one

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -969,7 +969,11 @@ app.include_router(keystones_router, prefix="/api/v1")
 # shipped as /api/v1/memclaw/keystones and customer scripts call it. The
 # canonical path is now the brand-neutral /api/v1/keystones (matching every
 # other route); the old prefix keeps serving forever, hidden from the schema.
-app.include_router(keystones_router, prefix="/api/v1/memclaw", include_in_schema=False)
+app.include_router(
+    keystones_router,
+    prefix="/api/v1/memclaw",  # legacy-name-floor: floor
+    include_in_schema=False,
+)
 app.include_router(crystallizer_router, prefix="/api/v1")
 app.include_router(plugin_router, prefix="/api/v1")
 # Bootstrap aliases — see plugin.py:plugin_bootstrap_router for rationale.

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -675,8 +675,8 @@ class _InstrumentedFastMCP(FastMCP):
         # them is the one thing the rebrand promised never to do. Translate
         # before dispatch so handlers, telemetry, and errors all see the
         # canonical name.
-        if isinstance(name, str) and name.startswith("memclaw_"):
-            name = "caura_" + name.removeprefix("memclaw_")
+        if isinstance(name, str) and name.startswith("memclaw_"):  # legacy-name-floor: floor
+            name = "caura_" + name.removeprefix("memclaw_")  # legacy-name-floor: floor
         t0 = time.perf_counter()
         status = "ok"
         try:

--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -428,7 +428,7 @@ async def _auto_upgrade_enabled_for_tenant(tenant_id: str) -> bool:
     """
     try:
         raw = await get_raw_settings(tenant_id)
-        flag = raw.get("memclaw", {}).get("auto_upgrade_enabled")
+        flag = raw.get("memclaw", {}).get("auto_upgrade_enabled")  # legacy-name-floor: floor
         # None (no override) → use the global default (true).
         return flag is not False
     except Exception:

--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -318,7 +318,7 @@ else
 fi
 echo ""
 
-PLUGIN_DIR="$HOME/.openclaw/plugins/memclaw"
+PLUGIN_DIR="$HOME/.openclaw/plugins/memclaw"  # legacy-name-floor: floor
 CONFIG_PATH="$HOME/.openclaw/openclaw.json"
 
 # When the on-prem uses self-signed TLS, the bootstrap fetches below
@@ -575,7 +575,7 @@ SDEOF
       # The systemd drop-in only covers the openclaw-gateway *service*, not
       # the customer's terminal sessions. Idempotent — guarded by a marker
       # comment so re-running install-plugin doesn't append duplicates.
-      _RC_MARKER="# memclaw-onprem CA - managed by install-plugin"
+      _RC_MARKER="# memclaw-onprem CA - managed by install-plugin"  # legacy-name-floor: pinned floor string
       _RC_LINE='[ -r "'"$PLUGIN_DIR"'/onprem-ca.pem" ] && export NODE_EXTRA_CA_CERTS="'"$PLUGIN_DIR"'/onprem-ca.pem"'
       for _RC in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
         [ -f "$_RC" ] || continue

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -219,7 +219,7 @@ DEFAULT_SETTINGS: dict = {
     # is a separate global guard that prevents auto-deploy specifically
     # for plugin versions whose deploy machinery is itself broken
     # (currently: 2.3.0 — drift in srcFiles + missing version-stamp).
-    "memclaw": {
+    "memclaw": {  # legacy-name-floor: floor
         "auto_upgrade_enabled": None,  # None = use global default (true)
     },
     "security_audit": {
@@ -595,7 +595,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "chunking.auto_chunk_enabled": bool,
     "agents.require_agent_approval": bool,
     "entity_blocklist": list,
-    "memclaw.auto_upgrade_enabled": bool,
+    "memclaw.auto_upgrade_enabled": bool,  # legacy-name-floor: floor
     "write.triple_emission_enabled": bool,
     "write.retraction_enabled": bool,
     # Skill Factory SF-006 — type validators for the skills_factory namespace.

--- a/core-api/src/core_api/services/report_corpus.py
+++ b/core-api/src/core_api/services/report_corpus.py
@@ -45,7 +45,7 @@ NON_COHESIVE_TITLE_REGEX = (
     r"(heartbeat|health[- ]?check|healthz|healthy|watchdog|gpu.?health|no.?change|"
     r"auth error|zero auth|0 auth|encrypted|unreadable|no readable|no actionable|"
     r"no usable|no_reply|polled|quickcheck|app-fleet|discovery script|"
-    r"gateway (active|reachable)|cache refresh|memclaw-smoke)"
+    r"gateway (active|reachable)|cache refresh|memclaw-smoke)"  # legacy-name-floor: floor
 )
 _NON_COHESIVE_TITLE_RE = re.compile(NON_COHESIVE_TITLE_REGEX, re.IGNORECASE)
 

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -561,7 +561,7 @@ export class CauraContextEngine {
         `config keys=${Object.keys(this.config || {}).join(",") || "(empty)"}`,
     );
 
-    const testContent = `memclaw-smoke-${Date.now()}`;
+    const testContent = `memclaw-smoke-${Date.now()}`; // legacy-name-floor: floor
     let writtenId: string | null = null;
     // Hoisted out of the try so the finally-block cleanup DELETE can pass
     // the tenant_id the backend requires (see below).

--- a/plugin/src/paths.ts
+++ b/plugin/src/paths.ts
@@ -8,7 +8,7 @@ export function getOpenClawBaseDir(): string {
 
 /** ~/.openclaw/plugins/memclaw */ // legacy-name-floor: frozen install path
 export function getPluginDir(): string {
-  return join(getOpenClawBaseDir(), "plugins", "memclaw");
+  return join(getOpenClawBaseDir(), "plugins", "memclaw"); // legacy-name-floor: floor
 }
 
 /** ~/.openclaw/openclaw.json */

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -77,7 +77,7 @@ export const PROTECTED_SKILLS: ReadonlySet<string> = new Set(["memclaw"]);
 // Choosing a per-skill marker over a central manifest makes the safety
 // property fail-safe: a missing marker means "leave it alone", never
 // "delete it".
-export const OWNED_MARKER = ".memclaw-owned";
+export const OWNED_MARKER = ".memclaw-owned"; // legacy-name-floor: floor
 const OWNED_MARKER_BODY =
   "This skill directory is managed by the Caura plugin reconciler.\n" +
   "Do not edit by hand — it is overwritten/removed to match the catalog.\n";


### PR DESCRIPTION
## What

Adds `legacy-name-floor: floor` markers to 13 lines across 10 files where
`scripts/do_not_touch_sentinel.py` already pins an exact "memclaw" literal
in application code — meaning something outside this repo (a saved
prompt, an already-deployed plugin install, an existing tenant settings
row, an existing agent row) breaks if the string disappears. The marker
had never actually landed on the matched line itself in any of these
files; only `sentinel.py`'s own copy of each string was annotated (it
also contains "memclaw" and needs its own marker to pass the ratchet, but
that's a different physical line from the one it's protecting).

No renames, no behavior change — every edit is a trailing comment (Python
`#` / TypeScript `//`, or a bash `#` comment inside the f-string install
script in `plugin.py` — same style as the already-annotated line 562 in
that file from #1247).

Touched:
- `core-api/src/core_api/mcp_server.py` — the `memclaw_*` dispatch shim
  (`name.startswith("memclaw_")` + its `removeprefix` pair)
- `core-api/src/core_api/app.py` — the frozen `/api/v1/memclaw/keystones`
  route mount (reformatted to multi-arg so the marker and the literal
  share a line — see note below)
- `core-api/src/core_api/agent_ids.py` — `INSIGHTER_AGENT_ID` /
  `DOC_INDEXER_AGENT_ID`, seeded by migration 030
- `core-api/src/core_api/routes/fleet.py` and
  `core-api/src/core_api/services/organization_settings.py` — the
  `"memclaw"` tenant-settings namespace and its dotted-key spelling
- `core-api/src/core_api/services/report_corpus.py` — the
  `memclaw-smoke` probe-title filter (pairs with the plugin-side literal
  below)
- `core-api/src/core_api/routes/plugin.py` — the install script's
  `~/.openclaw/plugins/memclaw` dir and its rc-marker comment string
- `plugin/src/context-engine.ts` — the health-check probe's
  `memclaw-smoke-` title (the emitter half of the report_corpus.py pair)
- `plugin/src/reconcile-skills.ts` — the `.memclaw-owned` per-skill marker
- `plugin/src/paths.ts` — the plugin install-dir helper

## What's deliberately NOT in this PR

`core-storage-api`'s two migrations that also carry sentinel-protected
`memclaw` text (`030_register_memclaw_insighter.py`,
`019_tenant_suppression.py`) are untouched: their occurrences sit inside
an `op.execute("""...""")` SQL string or a module docstring. There's no
way to attach a same-line marker there without either altering
already-applied migration SQL (forbidden — rule 2, immutable history) or
corrupting `__doc__`. Same structural gap already noted for the
`ARG MEMCLAW_VERSION=` Dockerfile default and the JSON manifests in
earlier PRs — a ratchet-side limitation worth raising separately, not
something this PR can fix with a text edit.

## Verification

- `python3 scripts/legacy_name_ratchet.py --base origin/main` → `No new
  lines. 13 annotated, 1 removed, 0 excused moves (-14 net).` EXIT 0
- `python3 scripts/do_not_touch_sentinel.py` → `All 39 protected strings
  survive.`
- `ruff format --check core-api/src/` → `203 files already formatted`
- `ruff check core-api/src/` → All checks passed
- `pytest tests/test_tool_rename_aliases.py tests/test_api_plugin.py core-api/tests/test_report_corpus.py -v`
  → 27 passed (covers the mcp_server dispatch shim, the plugin install
  script's TLS/rc-marker behavior, and the report-corpus smoke-probe
  filter)
- Plain import of every touched core-api module succeeds
- `npx tsc --noEmit` (plugin) → clean
- `npm test` (plugin) → 426/426 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)