### PR TITLE
chore: rename the memclaw literals with no live-infra or wire-format tie

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -328,7 +328,7 @@ class Settings(BaseSettings):
     # Local developers can set LOG_FORMAT_JSON=false for structlog's
     # coloured ConsoleRenderer.
     log_format_json: bool = True
-    # On-prem deployments set this to /var/log/memclaw/core-api/core-api.log so
+    # On-prem deployments set this to /var/log/caura/core-api/core-api.log so
     # logs land on disk too (daily-rotated, 5-day retention). Empty = stdout only.
     log_file: str = ""
     # Default False: standalone=True bypasses tenant auth, so it must be an explicit opt-in.

--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -341,7 +341,7 @@ mkdir -p "$PLUGIN_DIR/src"
 echo "[2/7] Writing package.json..."
 cat > "$PLUGIN_DIR/package.json" << PACKAGE_EOF
 {{
-  "name": "@caura/memclaw",
+  "name": "@caura/plugin",
   "version": "$CAURA_PLUGIN_VERSION",
   "description": "OpenClaw plugin for Caura central memory",
   "private": true,

--- a/core-api/src/core_api/services/forge/cron_handler.py
+++ b/core-api/src/core_api/services/forge/cron_handler.py
@@ -1,7 +1,7 @@
 """Forge cron tick — the production scheduler entry point (SF-CR3).
 
 Mirrors the manual ``scripts/forge_dry_run.py`` harness but wired into the
-``memclaw.lifecycle.forge-distill-requested`` consumer so the autonomous
+``caura.lifecycle.forge-distill-requested`` consumer so the autonomous
 scheduler (Cloud Scheduler / k8s CronJob → ``POST /admin/lifecycle/
 fanout/forge-distill``) drives one tick per opted-in tenant.
 

--- a/core-operations/src/core_operations/config.py
+++ b/core-operations/src/core_operations/config.py
@@ -80,7 +80,7 @@ class Settings(BaseSettings):
     # subscription and dead-letter topic are Terraform-provisioned (the bus
     # only auto-creates broadcast subscriptions), so until infra lands, a fire
     # would publish into a topic nothing consumes. Flip this on after
-    # provisioning ``memclaw.lifecycle.embed-backfill-requested``.
+    # provisioning ``caura.lifecycle.embed-backfill-requested``.
     embed_backfill_enabled: bool = False
     # 04:00, deliberately NOT the 02:00 slot every other lifecycle tick
     # defaults to. That window is already congested enough that the nightly

--- a/core-storage-api/src/core_storage_api/config.py
+++ b/core-storage-api/src/core_storage_api/config.py
@@ -140,7 +140,7 @@ class Settings(BaseSettings):
     # Local developers can set LOG_FORMAT_JSON=false for structlog's
     # coloured ConsoleRenderer.
     log_format_json: bool = True
-    # On-prem deployments set this to /var/log/memclaw/<service>/<service>.log
+    # On-prem deployments set this to /var/log/caura/<service>/<service>.log
     # so logs land on disk too (daily-rotated, 5-day retention). Empty string
     # means stdout only — the SaaS default, unchanged.
     log_file: str = ""

--- a/docs/plans/interviewer-phase1-decisions.md
+++ b/docs/plans/interviewer-phase1-decisions.md
@@ -1,7 +1,7 @@
 # Interviewer Phase 1 — Open-Question Resolutions
 
 **Branch:** `interviewer-phase1` · **Date:** 2026-07-16
-**Parent specs:** MemClaw doc store `design_docs/interviewer-feature-plan`, `design_docs/interviewer-phase1-spec`
+**Parent specs:** Caura doc store `design_docs/interviewer-feature-plan`, `design_docs/interviewer-phase1-spec`
 
 Task #1 of the Phase-1 prep: the four questions that gated the build, resolved against source.
 

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@caura/memclaw",
+  "name": "@caura/plugin",
   "version": "2.19.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@caura/memclaw",
+      "name": "@caura/plugin",
       "version": "2.19.7",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@caura/memclaw",
+  "name": "@caura/plugin",
   "version": "2.19.7",
   "description": "OpenClaw plugin for Caura central memory",
   "license": "Apache-2.0",

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -108,7 +108,7 @@ async function searchMemories(
     const arr = parseSearchItems(results);
     return arr.map((m: Record<string, unknown>) => ({
       content: (m.content as string) || "",
-      path: `memclaw://${m.id}`,
+      path: `caura://${m.id}`,
       score: (m.score as number) ?? (m.similarity as number) ?? 0,
       metadata: {
         memory_type: m.memory_type,
@@ -702,7 +702,7 @@ const cauraPlugin = {
                 // probed. Cheap live check by attempting a tiny search; it
                 // updates the tracker as a side-effect via trackReachability.
                 try {
-                  await searchMemories("__memclaw_probe__", 1);
+                  await searchMemories("__caura_probe__", 1);
                   return { ok: true };
                 } catch (e: unknown) {
                   const msg = String((e as { message?: unknown })?.message ?? e);


### PR DESCRIPTION
## What

Renames the handful of occurrences the audit found genuinely free to
change — not sentinel-protected, not a live wire format, not paired with
a still-unrenamed sibling elsewhere:

- `core-api/src/core_api/services/forge/cron_handler.py` and
  `core-operations/src/core_operations/config.py`: stale comments naming
  the Lifecycle-family topic by its pre-flip spelling.
  `common/events/topics.py`'s actual `FORGE_DISTILL_REQUESTED` and
  `EMBED_BACKFILL_REQUESTED` constants have read `caura.lifecycle.*`
  since the 2026-08-28 flip — these two comments just never caught up.
- `plugin/src/index.ts`: the synthetic `memclaw://` URI scheme in a
  search-result `path` field, and the `__memclaw_probe__` health-check
  query string. Both internal; confirmed nothing else in the plugin
  parses either literal.
- `plugin/package.json`'s npm `name` (`@caura/memclaw` → `@caura/plugin`,
  matching the existing `@caura/client` / `@caura/sdk` convention):
  `private: true`, unpublished, and nothing reads the field back
  (confirmed — only `version` is, via `gen-version.sh`/`check:version`).
  Regenerated `package-lock.json`'s two mirrored root-package-name
  entries with `npm install` rather than hand-editing them.
- `core-api/src/core_api/routes/plugin.py`: the matching `name` field the
  install script writes into a fresh `package.json` on the customer's
  disk — kept in sync with `plugin/package.json`'s new name.
- `core-api/src/core_api/config.py` and
  `core-storage-api/src/core_storage_api/config.py`: the advisory on-prem
  log-path example in a comment (`log_file` is an operator-supplied free
  string; nothing parses this literal path in either codebase).
- `docs/plans/interviewer-phase1-decisions.md`: "MemClaw doc store" in a
  dated planning doc's spec-pointer line — prose only, not part of the
  actual decision record the doc exists to preserve.

None of these appear in `do_not_touch_sentinel.py`.

## Verification

- `python3 scripts/legacy_name_ratchet.py --base origin/main` → `No new
  lines. 0 annotated, 11 removed, 0 excused moves (-11 net).` EXIT 0
- `python3 scripts/do_not_touch_sentinel.py` → `All 39 protected strings
  survive.`
- `npx tsc --noEmit` (plugin) → clean
- `npm test` (plugin) → 426/426 passed
- `ruff format --check` / `ruff check` on `core-api/src/`,
  `core-storage-api/src/`, `core-operations/` → clean
- Plain import of every touched Python module succeeds
- `pytest tests/test_api_plugin.py` → 13/13 passed (covers the renamed
  install-script `package.json`)
- `pytest core-operations/tests/test_app.py core-operations/tests/test_tasks.py -k "embed_backfill or forge"`
  → 3/3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)