### PR TITLE
chore(plugin): floor-mark six more sentinel-adjacent memclaw literals

### DIFF
--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -187,7 +187,7 @@ export function autoFixAllowlist(options?: {
     if (previousSlot && !options?.forceSlotOverride) {
       console.warn(
         `[caura] plugins.slots.memory already set to "${previousSlot}" — ` +
-          `skipping auto-override. Run "openclaw gateway memclaw.allowlist.fix" ` +
+          `skipping auto-override. Run "openclaw gateway memclaw.allowlist.fix" ` + // legacy-name-floor: live gateway RPC name
           `or set CAURA_AUTO_FIX_CONFIG=true to force.`,
       );
     } else {
@@ -216,7 +216,7 @@ export function autoFixAllowlist(options?: {
     if (previousCe && !options?.forceSlotOverride) {
       console.warn(
         `[caura] plugins.slots.contextEngine already set to "${previousCe}" — ` +
-          `skipping auto-override. Run "openclaw gateway memclaw.allowlist.fix" ` +
+          `skipping auto-override. Run "openclaw gateway memclaw.allowlist.fix" ` + // legacy-name-floor: live gateway RPC name
           `or set CAURA_AUTO_FIX_CONFIG=true to force. ` +
           `Note: keystone rules will NOT inject without contextEngine="${PLUGIN_ID}".`,
       );

--- a/plugin/src/context-engine.ts
+++ b/plugin/src/context-engine.ts
@@ -125,7 +125,7 @@ export function _resetBootstrapForTests(): void {
  */
 export function isDuplicateMemoryError(e: unknown): boolean {
   if (!(e instanceof Error)) return false;
-  return /\b(?:MemClaw|Caura) API 409\b/.test(e.message);
+  return /\b(?:MemClaw|Caura) API 409\b/.test(e.message); // legacy-name-floor: legacy error text
 }
 
 function pushToBuffer(sessionKey: string, message: IngestMessage): void {

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -750,7 +750,7 @@ const cauraPlugin = {
     // --- Context engine ---
     try {
       if (typeof api.registerContextEngine === "function") {
-        api.registerContextEngine("memclaw", (config: Record<string, unknown> | undefined | null) => {
+        api.registerContextEngine("memclaw", (config: Record<string, unknown> | undefined | null) => { // legacy-name-floor: registers under the kept engine id (info.id)
           return new CauraContextEngine(config);
         });
         console.log("[caura] ContextEngine 'memclaw' registered");  // legacy-name-floor: names the kept engine id (info.id)

--- a/plugin/src/keystones.ts
+++ b/plugin/src/keystones.ts
@@ -333,7 +333,7 @@ async function _fetchAndCache(
     }
     const raw = await apiCall(
       "GET",
-      "/memclaw/keystones",
+      "/memclaw/keystones", // legacy-name-floor: live compatibility route
       undefined,
       query,
       controller.signal,

--- a/plugin/src/prompt-section.ts
+++ b/plugin/src/prompt-section.ts
@@ -40,7 +40,7 @@ function buildRecallLines(availableTools: Set<string>): string[] {
       "scratchpad). Operating rules (recall before; write durable " +
       "outcomes, supersede don't delete), quality rules, and per-tool " +
       "reference live in the " +
-      "**memclaw** skill, which your runtime loads automatically — open " +
+      "**memclaw** skill, which your runtime loads automatically — open " + // legacy-name-floor: shipped skill name
       "it via your skill system before your first Caura call this " +
       "session. Do NOT search the filesystem for it.",
   );

--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -650,7 +650,7 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
       if (k === "agent_id" && !enriched.fleet_id) continue;
       query[k] = String(v);
     }
-    return apiCall("GET", "/memclaw/keystones", undefined, query, signal);
+    return apiCall("GET", "/memclaw/keystones", undefined, query, signal); // legacy-name-floor: live compatibility route
   },
 
 };


### PR DESCRIPTION
## What

Same pattern as #1251, one file cluster later: each of these six lines
already has a `legacy-name-floor` comment describing the exact same
string one or two lines away — the marker just never landed on the
physical line the ratchet actually matches on.

- `context-engine.ts:128` — the `MemClaw|Caura` 409-detection regex; the
  floor marker was on the docstring line above it (124), not the code.
- `keystones.ts:336` and `tool-definitions.ts:653` — both call sites for
  the live `/memclaw/keystones` compatibility route mounted in
  `core-api/app.py` (floor-marked in #1251); each file already
  floor-marks a comment describing this exact route a couple of lines
  above the call.
- `prompt-section.ts:43` — the literal skill name injected into the
  system prompt every turn; the file's own `skills/memclaw/SKILL.md`
  path is already floor-marked a few lines up in the same docstring.
- `index.ts:753` — the `registerContextEngine("memclaw", ...)` call; the
  `console.log` three lines below it already reads "names the kept
  engine id (info.id)", describing this exact registration.
- `config.ts:190` and `:219` — the operator-facing `"openclaw gateway
  memclaw.allowlist.fix"` runbook text, unmarked in both of the two
  places it's printed to the console.

No renames, no behavior change — comment-only.

## Verification

- `python3 scripts/legacy_name_ratchet.py --base origin/main` → `No new
  lines. 7 annotated, 0 removed, 0 excused moves (-7 net).` EXIT 0
- `python3 scripts/do_not_touch_sentinel.py` → `All 39 protected strings
  survive.`
- `npx tsc --noEmit` → clean
- `npm test` → 426/426 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)