### PR TITLE
docs: floor-mark two more memclaw mentions in the integration guide

### DIFF
--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -305,11 +305,11 @@ The plugin registers 11 tools (the MCP surface minus the MCP-only `caura_keyston
   - `restart` — gateway restart
 - **Auto-education** — on first load, writes SKILL.md, TOOLS.md, AGENTS.md to all agent workspaces. New workspaces are auto-educated on heartbeat
 - **Auto-resolve** — `tenant_id` is resolved from the API key at startup, so agents never need to specify it
-- **Gateway RPC** — exposes `memclaw.status`, `memclaw.deploy`, `memclaw.deploy.status`, `memclaw.educate`, `memclaw.allowlist.check`, `memclaw.allowlist.fix` methods
+- **Gateway RPC** — exposes `memclaw.status`, `memclaw.deploy`, `memclaw.deploy.status`, `memclaw.educate`, `memclaw.allowlist.check`, `memclaw.allowlist.fix` methods <!-- legacy-name-floor: live gateway RPC method names -->
 
 ### Educating agents
 
-On first plugin load, agents are **auto-educated** — the plugin writes SKILL.md, TOOLS.md, and AGENTS.md to all agent workspaces automatically. The `.educated` flag at `~/.openclaw/plugins/memclaw/.educated` prevents re-running on subsequent restarts.
+On first plugin load, agents are **auto-educated** — the plugin writes SKILL.md, TOOLS.md, and AGENTS.md to all agent workspaces automatically. The `.educated` flag at `~/.openclaw/plugins/memclaw/.educated` prevents re-running on subsequent restarts. <!-- legacy-name-floor: frozen install path -->
 
 For manual or targeted education via the Fleet page:
 


### PR DESCRIPTION
## What

Matches the treatment `static/docs/integration-guide.md` already gives
sibling lines 232, 290, and 722: both newly-marked lines describe a
currently-real, unrenamed thing, so rewording either would make the doc
factually wrong rather than just differently branded.

- Line 308 — the six gateway RPC method names the plugin actually
  registers (`memclaw.status`, `.deploy`, `.deploy.status`, `.educate`,
  `.allowlist.check`, `.allowlist.fix`).
- Line 312 — the `.educated` flag path, which lives under the frozen
  plugin install directory.

## What's NOT in this PR

The rest of this file's unannotated `memclaw` mentions (~13 lines) sit
inside bash/JSON code fences illustrating exact commands and config a
reader is meant to copy-paste (`mkdir -p ~/.openclaw/plugins/memclaw`,
`"allow": ["memclaw"]`, etc.). A trailing `<!-- legacy-name-floor -->`
there would land inside the pasted text itself — corrupting a real shell
command or invalidating a JSON snippet. That's the same structural gap
already flagged for the Dockerfile `ARG` default and the JSON manifests
in earlier PRs: something for whoever owns `legacy_name_ratchet.py` to
decide on, not something a text edit here can fix.

## Verification

- `python3 scripts/legacy_name_ratchet.py --base origin/main` → `No new
  lines. 2 annotated, 0 removed, 0 excused moves (-2 net).` EXIT 0
- `python3 scripts/do_not_touch_sentinel.py` → `All 39 protected strings
  survive.`
- Docs-only change; no code/tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)