### PR TITLE
chore(plugin): floor-mark the remaining sentinel-protected lines in educate.ts and heartbeat.ts

### DIFF
--- a/plugin/src/educate.ts
+++ b/plugin/src/educate.ts
@@ -186,7 +186,7 @@ export function cleanupStaleHeartbeatEducation(
   // is `\n\n---\n\n` (2+2); after a previous strip leaves a reduced
   // form `\n---\n\n` (1+2), this still matches.
   const re =
-    /(?:\n{1,2}---\n{1,2})?You have been connected to MemClaw[^\n]*?always include your agent_id\.\n?/;
+    /(?:\n{1,2}---\n{1,2})?You have been connected to MemClaw[^\n]*?always include your agent_id\.\n?/; // legacy-name-floor: floor
   let cur = content;
   let cleaned = false;
   // Bounded loop: stale paragraphs accumulate one per upgrade. A few
@@ -217,7 +217,7 @@ function cleanupPhantomEducationFiles(baseDir: string): void {
       const content = readFileSync(fpath, "utf-8");
       const isPluginOrphan =
         (fname === "TOOLS.md" &&
-          (content.includes("MemClaw — Tools Available") ||
+          (content.includes("MemClaw — Tools Available") || // legacy-name-floor: floor
             content.includes("Caura — Tools Available"))) ||
         (fname === "AGENTS.md" && content.includes("## Memory V2"));
       if (isPluginOrphan) {
@@ -571,7 +571,7 @@ export function spliceFencedBlock(
   legacyHeadingPrefix: string,
   options: { force?: boolean; backupPath?: string } = {},
 ): SpliceResult {
-  const tag = `memclaw:${marker}`;
+  const tag = `memclaw:${marker}`; // legacy-name-floor: floor
   const innerContent = newBlock.replace(/^\n+|\n+$/g, "");
   const version = blockHash(innerContent);
   const fenced = `<!-- ${tag} v=${version} -->\n${innerContent}\n<!-- /${tag} -->\n`;
@@ -696,10 +696,10 @@ export function writeEducationFiles(
         // `## MemClaw — Long-Term Agent Memory (auto-added by plugin)` // legacy-name-floor: historical heading family
         // (0.98.5), and any future variant that keeps the same
         // `## MemClaw —` lead. // legacy-name-floor: historical heading family
-        "## MemClaw —",
+        "## MemClaw —", // legacy-name-floor: floor
         {
           force: options.force,
-          backupPath: toolsPath + ".memclaw-bak",
+          backupPath: toolsPath + ".memclaw-bak", // legacy-name-floor: pinned backup suffix
         },
       );
       if (toolsResult.updated) {
@@ -724,7 +724,7 @@ export function writeEducationFiles(
         "## Memory V2",
         {
           force: options.force,
-          backupPath: agentsPath + ".memclaw-bak",
+          backupPath: agentsPath + ".memclaw-bak", // legacy-name-floor: pinned backup suffix
         },
       );
       if (agentsResult.updated) {

--- a/plugin/src/heartbeat.ts
+++ b/plugin/src/heartbeat.ts
@@ -503,10 +503,10 @@ export async function sendHeartbeat(): Promise<void> {
         try {
           const hb =
             existsSync(join(wsPath, "HEARTBEAT.md")) &&
-            readFileSync(join(wsPath, "HEARTBEAT.md"), "utf-8").includes("memclaw");
+            readFileSync(join(wsPath, "HEARTBEAT.md"), "utf-8").includes("memclaw"); // legacy-name-floor: floor
           const tools =
             existsSync(join(wsPath, "TOOLS.md")) &&
-            readFileSync(join(wsPath, "TOOLS.md"), "utf-8").toLowerCase().includes("memclaw");
+            readFileSync(join(wsPath, "TOOLS.md"), "utf-8").toLowerCase().includes("memclaw"); // legacy-name-floor: floor
           workspaceFiles[d] = { heartbeat_md: !!hb, tools_md: !!tools };
         } catch {
           // Skip workspace on error
@@ -517,7 +517,7 @@ export async function sendHeartbeat(): Promise<void> {
     }
 
     // Shared plugin skill file — checked once, reported on setup_status.
-    const sharedSkillPath = join(getPluginDir(), "skills", "memclaw", "SKILL.md");
+    const sharedSkillPath = join(getPluginDir(), "skills", "memclaw", "SKILL.md"); // legacy-name-floor: shipped skill path
     const sharedSkillPresent = existsSync(sharedSkillPath);
 
     // Auto-educate every discovered workspace on each heartbeat. This is
@@ -541,7 +541,7 @@ export async function sendHeartbeat(): Promise<void> {
           const wsPath = join(ocBase, wsDir);
           workspaceFiles[wsDir].tools_md =
             existsSync(join(wsPath, "TOOLS.md")) &&
-            readFileSync(join(wsPath, "TOOLS.md"), "utf-8").toLowerCase().includes("memclaw");
+            readFileSync(join(wsPath, "TOOLS.md"), "utf-8").toLowerCase().includes("memclaw"); // legacy-name-floor: floor
         }
       }
     } catch (e: unknown) {
@@ -738,7 +738,7 @@ async function processCommand(cmd: {
           "interview-buffer.ts",
         ];
         const FALLBACK_ROOT_FILES = [
-          "openclaw.plugin.json", "tools.json", "skills/memclaw/SKILL.md",
+          "openclaw.plugin.json", "tools.json", "skills/memclaw/SKILL.md", // legacy-name-floor: shipped skill path
         ];
 
         let srcFiles: string[] = FALLBACK_SRC_FILES;


### PR DESCRIPTION
## What

Follow-up to #1251, which floor-marked `context-engine.ts`,
`reconcile-skills.ts`, and `paths.ts` from the same plugin-cluster audit
but missed these two files — genuinely an oversight in that PR's scope,
not a new judgment call.

- `educate.ts:189` — the stale on-disk paragraph regex
  (`You have been connected to MemClaw...`)
- `educate.ts:220` — the `"MemClaw — Tools Available"` orphan-file
  detector
- `educate.ts:574` — the `` `memclaw:${marker}` `` fence tag
- `educate.ts:699` — the `"## MemClaw —"` heading-prefix literal
- `educate.ts:702`, `:727` — the two `.memclaw-bak` backup-suffix call
  sites (a third, earlier in the file, was already floor-marked)
- `heartbeat.ts:506`, `:509`, `:544` — the three `HEARTBEAT.md`/`TOOLS.md`
  content sniffs that detect a pre-rename install
- `heartbeat.ts:520`, `:741` — the shared skill-file path and its
  fallback root-files list, both pointing at the frozen `skills/memclaw/`
  dir

All of these are exact `do_not_touch_sentinel.py` matches, except the
last two which mirror the "shipped skill path" concept already
floor-marked elsewhere in both files. No renames, no behavior change —
comment-only.

## Verification

- `python3 scripts/legacy_name_ratchet.py --base origin/main` → `No new
  lines. 11 annotated, 0 removed, 0 excused moves (-11 net).` EXIT 0
- `python3 scripts/do_not_touch_sentinel.py` → `All 39 protected strings
  survive.`
- `npx tsc --noEmit` → clean
- `npm test` → 426/426 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)