### PR TITLE
chore: floor-mark the staging-memclaw-tei Cloud Run comment

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -284,7 +284,7 @@ class Settings(BaseSettings):
     # joiners take no slot), so one hot tenant's search storm can't
     # occupy the whole embedding service and starve other tenants
     # (noisy-neighbor-search). The TEI backend is a fixed pool
-    # (``staging-memclaw-tei``: 2 instances x containerConcurrency 10 =
+    # (``staging-memclaw-tei``: 2 instances x containerConcurrency 10 =  # legacy-name-floor: live, mid-cutover — staging-caura-tei twin already exists
     # ~20 slots, no autoscale); with cap N on M core-api instances a
     # single tenant holds at most ``N * M`` of those, leaving headroom
     # for everyone else. Tighter than ``per_tenant_search_concurrency``


### PR DESCRIPTION
## What

Confirmed live via an infra check by the programme coordinator:
`staging-memclaw-tei` and its `caura`-named twin `staging-caura-tei`
both exist right now. This is a mid-cutover service pair, not an
un-migrated one — renaming the comment would misdescribe which Cloud
Run service `core-api`'s embedding-concurrency cap math is actually
about.

`scripts/capture_pg_locks_during_storm.py:7`'s matching
`staging-memclaw-core-storage-writer` reference (also confirmed live,
also has a `caura`-named twin) is left unmarked here — that occurrence
sits inside the module's docstring, so an inline marker would leak into
`__doc__`. Same accepted-debt class as the migration/docstring cases
from earlier PRs in this sweep.

## Verification

- `python3 scripts/legacy_name_ratchet.py --base origin/main` → `No new
  lines. 1 annotated, 0 removed, 0 excused moves (-1 net).` EXIT 0
- `python3 scripts/do_not_touch_sentinel.py` → `All 39 protected strings
  survive.`
- `ruff format --check core-api/src/` / `ruff check core-api/src/` →
  clean
- Comment-only change; no code path affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)