### PR TITLE
docs: drop the MemClaw trademark assertion from NOTICE and README

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,7 +4,7 @@ Copyright 2026 Caura (https://caura.ai)
 This product is licensed under the Apache License, Version 2.0.
 See the LICENSE file for the full license text.
 
-"MemClaw" and "Caura" are trademarks of Caura. See the README for details.
+"Caura" is a trademark of Caura. See the README for details.
 
 ================================================================================
 Third-Party Software

--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ See [NOTICE](NOTICE) for copyright and third-party attributions.
 
 ## Trademarks
 
-"MemClaw" and "Caura" are trademarks of Caura. The Apache License 2.0 grants
+"Caura" is a trademark of Caura. The Apache License 2.0 grants
 permission to use the source code but does not grant permission to use these
 names, logos, or branding in a way that suggests endorsement of, or affiliation
 with, any derivative work. See Apache License 2.0 §6 for the full legal terms.


### PR DESCRIPTION
## Summary

This is Eldad's explicit decision to stop asserting "MemClaw" as a trademark of Caura — not an agent-driven rename cleanup. NOTICE and the README's Trademarks section previously read:

> "MemClaw" and "Caura" are trademarks of Caura.

Both now read:

> "Caura" is a trademark of Caura.

The MemClaw assertion is dropped entirely; the Caura assertion is unchanged.

## Files changed

- `NOTICE` (line 7)
- `README.md` (Trademarks section)

## Test plan

- [x] `python3 scripts/legacy_name_ratchet.py --base origin/main` — clean, 2 removed, 0 added
- [x] DCO sign-off present (`git commit -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)