### PR TITLE
fix(auth): scope the delete trust gate to agent credentials

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1390,7 +1390,17 @@ async def caura_manage(
                 # Trust gate (>= 3), mirroring single delete / REST DELETE. Blocks
                 # the cross-fleet bulk-delete-by-id IDOR for sub-admin agents; a
                 # trust>=3 admin agent retains tenant-wide delete (parity with
-                # enforce_fleet_write). No-op for tenant-scoped credentials.
+                # enforce_fleet_write).
+                #
+                # ``caller_agent_id is None`` (a tenant-scoped credential) skips
+                # the gate BY DESIGN, not by omission — the trust ladder governs
+                # agent credentials and a tenant key holds no trust level. See
+                # ``enforce_delete``'s contract. Do NOT "fix" this by falling
+                # back to the ``agent_id`` tool argument: that value is
+                # caller-asserted, so it would let a tenant key pass the gate by
+                # naming any trust>=3 agent, and ``caller_agent_id`` is also the
+                # principal for the ``authorize_memory_access`` scope checks
+                # below and on read / update / lineage.
                 if caller_agent_id:
                     await enforce_delete(tenant_id, caller_agent_id)
                 # HOME-tenant scoped soft-delete: the storage method applies the
@@ -1618,6 +1628,12 @@ async def caura_manage(
                 result = await update_memory(uid, tenant_id, MemoryUpdate(**fields), agent_id=agent_id)
                 return _with_latency(_serialize(result), t0)
             # op == "delete" — WRITE → home tenant only.
+            #
+            # ``caller_agent_id is None`` (a tenant-scoped credential) means both
+            # checks below are skipped, and that is the decided behaviour rather
+            # than a gap: the trust ladder governs agent credentials, tenant
+            # scope governs tenant keys (see ``enforce_delete``). The same
+            # distinction already governs read / update / lineage above.
             if caller_agent_id:
                 # Trust gate (>= 3) + cross-fleet / scope_agent row authorization,
                 # mirroring REST DELETE /memories/{id}.
@@ -2505,6 +2521,10 @@ async def caura_doc(
                 return _with_latency(_error_response("INVALID_ARGUMENTS", "op=delete requires 'doc_id'."), t0)
             # Admin-trust (>= 3) gate for agent credentials, parity with memory
             # deletes — a routine trust-1 agent must not destroy tenant documents.
+            # "for agent credentials" is the whole scope of the gate: a
+            # tenant-scoped credential has no trust level and is authorized by
+            # tenant scope instead, so ``caller_agent_id is None`` skipping this
+            # is the decided contract (``enforce_delete``), not a missing check.
             if caller_agent_id:
                 await enforce_delete(tenant_id, caller_agent_id)
             # Active-only existence gate for skills: an agent must not be

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1497,10 +1497,26 @@ async def delete_memory(
 ):
     auth.enforce_read_only()
     auth.enforce_tenant(tenant_id)
-    # Authenticated agent identity (gateway X-Agent-ID) takes precedence over
-    # the caller-supplied query param so an agent credential can't skip the
-    # trust gate by omitting/spoofing ``agent_id``.
-    caller_agent_id = auth.agent_id or agent_id
+    # AUTHORIZATION PRINCIPAL — the authenticated agent identity ONLY (gateway
+    # X-Agent-ID). Never the ``agent_id`` query param: the param is caller-
+    # asserted data, and treating it as a principal let a tenant key choose
+    # whether the trust gate applied at all — omit it and the gate was skipped,
+    # or name any trust>=3 agent in the tenant and it passed. The only caller it
+    # reliably stopped was the honest one naming a low-trust identity.
+    #
+    # ``None`` here means the credential carries no agent identity (a tenant
+    # key). That is not a missing check — see the gate's contract in
+    # ``enforce_delete``: the trust ladder governs AGENT credentials; a tenant
+    # key is authorized by tenant scope and holds no trust level to compare.
+    # This matches MCP, where the same distinction is already load-bearing on
+    # read / update / lineage / bulk_delete (mcp_server.py:1359-1365).
+    caller_agent_id = auth.agent_id
+    # ATTRIBUTION — deliberately NOT the same value. The audit row records who
+    # the caller says performed the delete, so the query param still counts
+    # here: dropping it would attribute a tenant key's deletes to ``None`` and
+    # lose the only identity the request carried. Authorization must not trust
+    # this value; the audit log must not discard it.
+    attribution_agent_id = auth.agent_id or agent_id
     if auth.tenant_id and caller_agent_id:
         await enforce_delete(tenant_id, caller_agent_id)
         # Cross-fleet / scope_agent row authorization (write threshold).
@@ -1531,7 +1547,7 @@ async def delete_memory(
         # Attribute to the effective identity (gateway X-Agent-ID wins over
         # the query param) — logging the raw param attributed a gateway
         # agent's deletes to None whenever it omitted ``agent_id``.
-        agent_id=caller_agent_id,
+        agent_id=attribution_agent_id,
         action="delete",
         resource_type="memory",
         resource_id=memory_id,

--- a/core-api/src/core_api/services/agent_service.py
+++ b/core-api/src/core_api/services/agent_service.py
@@ -501,7 +501,21 @@ async def enforce_delete(
     tenant_id: str,
     agent_id: str,
 ) -> None:
-    """Enforce delete permissions."""
+    """Enforce delete permissions for an AGENT credential.
+
+    Scope of the gate, decided 2026-09-03 after REST and MCP were measured
+    giving opposite answers to the same call: **the trust ladder governs agent
+    credentials; tenant scope governs tenant keys.**
+
+    A tenant key is not gated here, because it has no trust level to compare —
+    it is a tenant-wide credential, and deleting inside its own tenant is
+    within the authority it already holds for read, update and bulk delete.
+    Callers therefore invoke this only when they hold an authenticated agent
+    identity, and MUST NOT synthesize one from caller-supplied input to reach
+    it: a gate a caller can opt into by naming an identity is not a gate. See
+    ``routes.memories.delete_memory`` and the three MCP sites in
+    ``mcp_server`` for the guard shape this contract expects.
+    """
     agent = await lookup_agent(tenant_id, agent_id)
     if not agent:
         raise HTTPException(

--- a/tests/test_memory_byid_authz.py
+++ b/tests/test_memory_byid_authz.py
@@ -229,6 +229,50 @@ def as_agent(monkeypatch):
     _app.dependency_overrides.pop(_gac, None)
 
 
+@pytest.fixture
+def as_tenant_key(monkeypatch):
+    """Authenticate as a TENANT-scoped credential: a tenant, and no agent identity.
+
+    USE THIS, NOT ``get_test_auth()``, for anything touching the delete trust
+    gate. ``get_test_auth()`` returns the ADMIN key, which resolves to
+    ``AuthContext(tenant_id=None, is_admin=True)`` — so ``if auth.tenant_id and
+    caller_agent_id:`` is false on the ``tenant_id`` half before the identity
+    half is even read, and **the admin key cannot exercise this gate at all.**
+
+    Why that matters more than it looks: a test written with the admin key
+    passes identically before and after any change to the gate, because it
+    never reaches it. It does not fail loudly — it succeeds for the wrong
+    reason, which is indistinguishable from working. The first draft of the
+    tests below used it and would have been worthless in exactly that way;
+    reading the auth paths is the only way to catch it, since running it looks
+    like a pass.
+
+    The credential that actually reaches the gate without an agent identity is
+    a tenant key: ``tenant_id`` set, ``agent_id`` None. That is the shape the
+    REST/MCP parity smoke measured and the one this fixture installs.
+    """
+    from core_api.app import app
+    from core_api.auth import AuthContext, get_auth_context
+    from core_api.tenant_context import set_current_tenant
+
+    def _install(tenant_id: str):
+        async def _dep():
+            set_current_tenant(tenant_id)
+            return AuthContext(
+                tenant_id=tenant_id,
+                agent_id=None,
+                readable_tenant_ids=[tenant_id],
+            )
+
+        app.dependency_overrides[get_auth_context] = _dep
+
+    yield _install
+    from core_api.app import app as _app
+    from core_api.auth import get_auth_context as _gac
+
+    _app.dependency_overrides.pop(_gac, None)
+
+
 async def _write(
     client,
     headers,
@@ -463,3 +507,167 @@ async def test_rest_delete_all_tenant_key_unchanged(client):
         headers=headers,
     )
     assert r.status_code == 204, r.text
+
+
+# ---------------------------------------------------------------------------
+# The delete gate's scope: agent credentials only
+#
+# Decided 2026-09-03. REST and MCP were measured returning opposite answers to
+# the same call — the same credential, tenant and ``agent_id`` got 403 on
+# ``DELETE /memories/{id}`` and success on ``caura_manage op=delete``. REST was
+# the surface in the wrong: it built its authorization principal as
+# ``auth.agent_id or agent_id``, promoting a caller-supplied query parameter to
+# a principal. That gave a tenant key the choice of whether the gate applied —
+# omit the param to skip it, or name any trust>=3 agent to pass it — so the only
+# caller it reliably refused was the honest one naming a low-trust identity.
+#
+# The ruling: the trust ladder governs AGENT credentials; tenant scope governs
+# TENANT keys. A tenant key holds no trust level to compare and is authorized by
+# tenant scope, exactly as it already is on this route's bulk siblings
+# (``test_rest_delete_all_tenant_key_unchanged`` above) and on MCP read /
+# update / lineage / bulk_delete.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_rest_delete_byid_tenant_key_not_trust_gated(
+    client, as_tenant_key, patch_lookup
+):
+    """A tenant key naming a low-trust agent may delete; the gate is not its gate.
+
+    THIS IS THE TEST THAT FAILS WITHOUT THE FIX. Before the change the route
+    read the ``agent_id`` query param as its principal, so ``yanki-smoke``
+    (trust 1) was looked up, failed ``enforce_delete``'s trust>=3 bar, and the
+    request got 403 — while the identical call over MCP succeeded. Confirmed
+    failing on the parent commit: 403 != 204.
+    """
+    from tests.conftest import get_test_auth
+
+    tenant_id, headers = get_test_auth()
+    mem_id = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="yanki-smoke",
+        fleet_id=None,
+        visibility="scope_team",
+    )
+    # Resolve ``yanki-smoke`` as a real but low-trust agent. If the param were
+    # still a principal this is what would refuse the call.
+    patch_lookup(fleet_id=None, trust_level=1)
+    as_tenant_key(tenant_id)
+
+    r = await client.delete(
+        f"/api/v1/memories/{mem_id}?tenant_id={tenant_id}&agent_id=yanki-smoke",
+    )
+    assert r.status_code == 204, r.text
+
+
+@pytest.mark.integration
+async def test_rest_delete_byid_tenant_key_still_attributed_to_named_agent(
+    client, as_tenant_key, patch_lookup, monkeypatch
+):
+    """Dropping the param as a PRINCIPAL must not drop it as ATTRIBUTION.
+
+    The two uses sat one line apart behind a single variable, which is how the
+    defect was born; this pins them apart. The audit row must still name
+    ``yanki-smoke`` — attributing a tenant key's deletes to ``None`` would trade
+    an authorization bug for an accountability one.
+    """
+    from core_api.routes import memories as memories_route
+    from tests.conftest import get_test_auth
+
+    tenant_id, headers = get_test_auth()
+    mem_id = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="yanki-smoke",
+        fleet_id=None,
+        visibility="scope_team",
+    )
+    patch_lookup(fleet_id=None, trust_level=1)
+
+    seen: list[dict] = []
+    real_log_action = memories_route.log_action
+
+    async def _spy(**kwargs):
+        seen.append(kwargs)
+        return await real_log_action(**kwargs)
+
+    monkeypatch.setattr(memories_route, "log_action", _spy)
+    as_tenant_key(tenant_id)
+
+    r = await client.delete(
+        f"/api/v1/memories/{mem_id}?tenant_id={tenant_id}&agent_id=yanki-smoke",
+    )
+    assert r.status_code == 204, r.text
+
+    deletes = [k for k in seen if k.get("action") == "delete"]
+    assert deletes, f"no delete audit row logged; saw {[k.get('action') for k in seen]}"
+    assert deletes[0]["agent_id"] == "yanki-smoke", (
+        "tenant key's delete must stay attributed to the agent_id it supplied, "
+        f"got {deletes[0]['agent_id']!r}"
+    )
+
+
+@pytest.mark.integration
+async def test_rest_delete_byid_low_trust_agent_credential_still_403(
+    client, as_agent, patch_lookup
+):
+    """GUARD, NOT EVIDENCE — this passes both before and after the fix.
+
+    It exists so a future change cannot quietly widen the tenant-key exemption
+    into an agent-credential one. An authenticated trust-1 agent (identity from
+    the gateway's X-Agent-ID, never from the query param) is still refused.
+    Do not read this test's green as confirmation that the fix works: the test
+    above is the one that changes behaviour.
+    """
+    from tests.conftest import get_test_auth
+
+    tenant_id, headers = get_test_auth()
+    mem_id = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="bob",
+        fleet_id="fleet-beta",
+        visibility="scope_team",
+    )
+    as_agent(tenant_id, "bob")
+    patch_lookup(fleet_id="fleet-beta", trust_level=1)
+
+    r = await client.delete(f"/api/v1/memories/{mem_id}?tenant_id={tenant_id}")
+    assert r.status_code == 403, r.text
+    assert "not permitted to delete" in r.text
+
+
+@pytest.mark.integration
+async def test_rest_delete_byid_agent_credential_cannot_spoof_via_param(
+    client, as_agent, patch_lookup
+):
+    """GUARD, NOT EVIDENCE — passes before and after.
+
+    The precedence rule the old comment claimed (``auth.agent_id`` wins over the
+    param) held for agent credentials and still holds, now because the param is
+    not consulted for authorization at all. A trust-1 agent naming a trust-3
+    identity in the query string is still refused on its own trust level.
+    """
+    from tests.conftest import get_test_auth
+
+    tenant_id, headers = get_test_auth()
+    mem_id = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="bob",
+        fleet_id="fleet-beta",
+        visibility="scope_team",
+    )
+    as_agent(tenant_id, "bob")
+    patch_lookup(fleet_id="fleet-beta", trust_level=1)
+
+    r = await client.delete(
+        f"/api/v1/memories/{mem_id}?tenant_id={tenant_id}&agent_id=admin-agent"
+    )
+    assert r.status_code == 403, r.text


### PR DESCRIPTION
## The defect

REST and MCP gave **opposite answers to the same delete**. Same credential, same tenant, same `agent_id`:

- `DELETE /api/v1/memories/{id}?tenant_id=…&agent_id=yanki-smoke` → **403** `access policy: principals of fleet 'none' are not permitted to delete memories.`
- `caura_manage {op: "delete", memory_id: …, agent_id: "yanki-smoke"}` → **accepted**, row soft-deleted.

REST was the surface in the wrong. It built its authorization principal as `auth.agent_id or agent_id`, promoting a **caller-supplied query parameter** to a principal. For a tenant key (no gateway `X-Agent-ID`) that handed the caller the choice of whether the gate applied:

| Tenant key sends | Old behaviour |
|---|---|
| no `agent_id` | gate **skipped** — `caller_agent_id` falsy |
| `agent_id=<any trust≥3 agent>` | gate **passed** — borrows that agent's trust |
| `agent_id=<own low-trust identity>` | gate **refused** |

The only caller `enforce_delete` reliably stopped was the honest one. The old comment claimed the precedence rule stopped a caller *"skipping the gate by omitting/spoofing `agent_id`"* — true for an agent credential, where `auth.agent_id` wins, and false for a tenant key, which has none.

## The decision this encodes

**The trust ladder governs AGENT credentials; tenant scope governs TENANT keys.**

A tenant key holds no trust level to compare and is authorized by tenant scope — exactly as it already is on this route's bulk siblings (`test_rest_delete_all_tenant_key_unchanged`, pre-existing) and on MCP `read` / `update` / `lineage` / `bulk_delete`, where the same distinction is documented as deliberate at `mcp_server.py:1359-1365`.

Written into `enforce_delete`'s docstring so it is a contract rather than an inference.

## The change

One behavioural line. `caller_agent_id = auth.agent_id` — the principal is the authenticated identity alone. `None` means "no agent identity", the gate does not apply, and REST stops returning a 403 the other surface does not. **The same edit closes the spoof**: the query param is no longer a principal, so it cannot be used to borrow another agent's trust.

**Attribution is deliberately kept separate.** `log_action` still records `auth.agent_id or agent_id`, so a tenant key's delete stays attributed to the identity it supplied rather than to `None`. The two uses sat one line apart behind a single variable — which is how this defect was born — and are now two names with a comment each saying which may trust caller input.

**MCP is unchanged by design.** The three `if caller_agent_id:` sites (`:1394` `bulk_delete`, `:1621` `delete`, `:2508` `caura_doc` op=delete) were already correct under this ruling, so they gain the **written exemption** rather than a code change — including an explicit warning not to "fix" them by falling back to the tool argument. That change was proposed and rejected: it would re-open the spoof, and because `caller_agent_id` is also the principal for the `authorize_memory_access` scope checks at `:1429` / `:1480` / `:1528` / `:1628`, it would widen it past delete to **read, lineage and update** — which the comment above `:1352` already forbids in as many words.

## For the reviewer: this makes REST more permissive, and nothing is lost

An authorization check is being deleted, so that deserves stating plainly rather than waiting to be asked. The check was **already bypassable by omitting the parameter**. It protected nobody who did not volunteer to be protected, and it refused exactly one caller: the one honest enough to name its own low-trust identity. Removing it loses no real protection and removes a 403 that the other surface never returned.

Callers who were legitimately authorised before are unaffected. There is no breaking change: the surface that becomes permissive was refusing calls MCP already accepted.

## Tests

Both behavioural tests were **confirmed failing on the parent commit**, not assumed:

- `test_rest_delete_byid_tenant_key_not_trust_gated` — fails without the fix with the exact 403 above (`403 != 204`).
- `test_rest_delete_byid_tenant_key_still_attributed_to_named_agent` — also fails against a **naive** fix that drops the param from attribution as well as authorization; asserted failure message `got None`. Verified by probe.

Two further tests are **labelled in-file as guards that pass both before and after**, so nobody later reads their green as evidence the fix worked: a trust-1 agent credential is still refused, and an agent credential still cannot borrow a trust-3 identity via the query param.

The suite also needed a new `as_tenant_key` fixture: `get_test_auth()` returns the **admin** key, which resolves to `tenant_id=None` and so cannot reach the gate's `if auth.tenant_id and …` at all. The credential that reaches the gate without an agent identity is a tenant key, and that is the shape the parity smoke measured.

## Verification

- Full root suite: **54 failed / 5913 passed**. Pristine `origin/main` baseline: **54 failed / 5909 passed** — identical failures, +4 being exactly the new tests. All 54 are pre-existing environment gaps (missing optional deps) in the local venv, none related to this change.
- `ruff check` and `ruff format --check` run separately at CI's exact scopes (`core-api/src/`, `tests/`) — clean.
- `mypy` clean on all three changed source files (2 pre-existing `types-python-dateutil` stub errors in an untouched file).
- `legacy_name_ratchet.py --base origin/main` → *No new lines.* · `do_not_touch_sentinel.py` → *All 39 protected strings survive.* · `tenant_scope_gate.py` → 0 added/removed/recategorised. **All run after `git add`**, so the diff-based gates actually saw the files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
