### PR TITLE
feat: dual-path serve the bundled and standalone skills under caura alongside memclaw

### DIFF
--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -57,8 +57,14 @@ _plugin_files = [
 
 # Plugin-root-relative files served alongside the src/*.ts files.
 # - tools.json: tool SoT, loaded by tool-specs.ts.
-# - skills/memclaw/SKILL.md: shared plugin skill, discovered by OpenClaw
-#   via openclaw.plugin.json:skills (one copy per node).
+# - skills/memclaw/SKILL.md, skills/caura/SKILL.md: shared plugin skill.  # legacy-name-ok: dual-path skills transition, tracked for eventual retirement in docs/plans/skills-dual-path-transition.md
+#   Both are served during the rebrand transition (dual-path: "memclaw"  # legacy-name-ok: dual-path skills transition, tracked for eventual retirement in docs/plans/skills-dual-path-transition.md
+#   is the historical bundled skill already on disk on every existing
+#   install; "caura" is the new one). Discovered by OpenClaw via
+#   openclaw.plugin.json:skills (one copy per node). Removing either
+#   entry here without also updating reconcile-skills.ts's
+#   PROTECTED_SKILLS in the same change deletes that skill directory
+#   from every install within one heartbeat.
 # - openclaw.plugin.json: plugin manifest. Must be served (not baked into
 #   the install script as a HEREDOC) because the manifest changes
 #   periodically as OpenClaw evolves its plugin contract — e.g. the
@@ -70,6 +76,7 @@ _plugin_files = [
 _plugin_root_files = {
     "tools.json",
     "skills/memclaw/SKILL.md",
+    "skills/caura/SKILL.md",
     "openclaw.plugin.json",
 }
 
@@ -694,10 +701,15 @@ _VALID_SKILL_AGENTS = {"claude-code", "codex", "both"}
 # Skills installable via ``/install-skill?skill=…`` and served at
 # ``/skill/{skill}``. Strictly allowlisted — the value is interpolated into a
 # filesystem path and the generated script, so an arbitrary value must never
-# reach either. ``memclaw`` is the default (the operational manual); the
-# opt-in ``company-brain`` posture skill layers on top of it.
+# reach either. ``memclaw`` is the default (the operational manual, still  # legacy-name-ok: dual-path skills transition, tracked for eventual retirement in docs/plans/skills-dual-path-transition.md
+# the default during the rebrand transition — see
+# docs/plans/skills-dual-path-transition.md); ``caura`` is the same
+# operational manual under its new name, served independently so both
+# install paths can be verified on their own. The opt-in ``company-brain``
+# posture skill layers on top of either.
 _SKILL_LABELS = {
     "memclaw": "Caura",  # legacy-name-floor: wire — ?skill= param + on-disk dir
+    "caura": "Caura",
     "company-brain": "Company Brain",
 }
 _VALID_SKILLS = frozenset(_SKILL_LABELS)
@@ -827,7 +839,7 @@ async def install_skill_script(
     agent: str = Query(default="both", description="claude-code | codex | both"),
     skill: str = Query(
         default="memclaw",
-        description="Which skill to install: memclaw (default) | company-brain",
+        description="Which skill to install: memclaw (default) | caura | company-brain",  # legacy-name-ok: dual-path skills transition, tracked for eventual retirement in docs/plans/skills-dual-path-transition.md
     ),
     api_url: str | None = Query(
         default=None,
@@ -870,12 +882,6 @@ async def install_skill_script(
     return PlainTextResponse(script, media_type="text/plain")
 
 
-@router.get("/skill/caura", response_class=PlainTextResponse)
-async def skill_caura():
-    """Rebrand alias for /skill/memclaw — same content, new name."""
-    return await skill_memclaw()
-
-
 @router.get("/skill/memclaw", response_class=PlainTextResponse)
 async def skill_memclaw():
     """Serve the direct-MCP SKILL.md adapter.
@@ -899,7 +905,9 @@ async def skill_by_name(skill: str):
     guidance with no tenant data. ``memclaw`` is also served by the explicit
     ``/skill/memclaw`` route above (registered first, so it wins for that
     name and keeps the default path unchanged); this handles the rest of the
-    allowlist (e.g. ``company-brain``).
+    allowlist, including ``caura`` (served from ``static/skills/caura/``,
+    independent of and identical in structure to the sibling copy served
+    by the route above during the rebrand transition) and ``company-brain``.
 
     ``skill`` is used only as a key into the precomputed ``_SKILL_FILES`` map,
     so the served path is always a fixed constant — the request value never

--- a/docs/plans/skills-dual-path-transition.md
+++ b/docs/plans/skills-dual-path-transition.md
@@ -1,0 +1,78 @@
+# Skills dual-path transition
+
+**Status:** in progress · **Scope:** the bundled OpenClaw plugin skill
+(`plugin/skills/`) and the standalone Claude Code / Codex skill
+(`static/skills/`) · **Decided by:** Eldad, via the programme coordinator,
+2026-09-03.
+
+## What this covers
+
+Both skill populations are served under two slugs during this transition:
+the historical slug (`memclaw`, already on disk on every existing <!-- legacy-name-ok: dual-path skills transition -->
+install) and the new one (`caura`, shipped alongside it starting this
+change). Neither directory's content differs except in the handful of
+lines that self-reference their own install path — see the PR that
+introduced this doc for the exact diff.
+
+This is deliberately **not** a flag-day cutover. The two populations are
+governed by unrelated mechanisms in different languages
+(`PROTECTED_SKILLS` in `plugin/src/reconcile-skills.ts`, a Python dict
+`_SKILL_LABELS` in `core-api/src/core_api/routes/plugin.py`), so landing
+both correctly in one window and having each be independently verifiable
+is safer than a single synchronized flip.
+
+## Why the historical slug isn't dropped yet
+
+`plugin/skills/memclaw/` is protected from deletion by <!-- legacy-name-ok: dual-path skills transition -->
+`reconcile-skills.ts`'s `PROTECTED_SKILLS` set. That reconciler runs every
+60 seconds and deletes any on-disk skill slug that is neither in the
+server's dynamic catalog nor in `PROTECTED_SKILLS` — so removing the <!-- legacy-name-ok: dual-path skills transition -->
+historical slug from that set deletes the directory, and whatever an
+agent's already-generated `TOOLS.md`/`AGENTS.md` text still points at,
+from every existing install within one heartbeat of the next deploy. That
+is real user-facing breakage for any install that has not yet had a
+chance to pick up the new slug (auto-upgrade is on by default but not
+universal — some tenants opt out, and some installs are version-pinned;
+see `core-api/src/core_api/routes/fleet.py`'s
+`KNOWN_BROKEN_DEPLOY_VERSIONS` and `_auto_upgrade_enabled_for_tenant`).
+
+The standalone `static/skills/memclaw/` has no equivalent deletion risk — <!-- legacy-name-ok: dual-path skills transition -->
+nothing reconciles it — but has no update channel either: an existing
+curl-install sits untouched until the operator re-runs the installer, so
+there's equally no reason to remove server-side support for it while any
+such install might still exist.
+
+## Retirement condition
+
+Drop the historical slug from `PROTECTED_SKILLS`, drop its key from
+`_SKILL_LABELS` and `_plugin_root_files`, and delete both of its skill
+directories (`plugin/skills/` and `static/skills/`) only after **both**:
+
+1. At least one full plugin release has shipped with the new slug
+   available alongside the old one, confirmed present and stable on disk
+   (not just immediately after a deploy — the reconciler's 60-second
+   delete window means "present now" proves nothing; "still present
+   after the next heartbeat" does).
+2. Eldad (or whoever owns the rebrand at the time) explicitly approves the
+   cutover. This is not a fixed calendar date or release number, because
+   the actual constraint is real-world adoption on installs this
+   repository cannot measure (see the scoping document referenced below)
+   — an arbitrary date risks retiring the compatibility path before
+   installs that need it have upgraded.
+
+This is intentionally a **named decision gate**, not an open-ended
+"eventually": the condition is checkable (has a release shipped with both
+present and stable; has the owner signed off), even though it isn't a
+date on a calendar.
+
+## Related
+
+- The scoping analysis this transition was built from: shared with Eldad
+  directly (coupling sites, ordering constraints, blast radius, what
+  could and couldn't be established from this repo alone).
+- `docs/plans/rebrand-alias-retirement-policy.md` — a separate,
+  superseded, cross-repo policy for production machine-route aliases.
+  Not used here: that document's table is shaped for host/route
+  retirement across multiple repositories, not a single repo's
+  bundled-skill directory slug, and updating it is out of this change's
+  scope.

--- a/plugin/skills/caura/SKILL.md
+++ b/plugin/skills/caura/SKILL.md
@@ -1,0 +1,409 @@
+---
+name: caura
+description: The agent's persistent long-term memory — the only knowledge that survives across sessions, shared across the fleet under access control. Consult it at the start of a task to recall prior decisions, findings, and rules before acting, and write outcomes, decisions, and lessons as work completes. Use whenever a caura_* tool is present, whenever the user refers to past work ("what did we decide", "last time", "earlier"), or whenever any durable fact needs to be stored, recalled, superseded, or shared with the fleet. Do not use it for throwaway within-session scratch state.
+user-invocable: false
+metadata: {"openclaw": {"requires": {"config": ["plugins.entries.memclaw.enabled"]}}}  # legacy-name-floor: frozen plugin id (config key), independent of this skill's own slug
+---
+
+# Caura Skill
+
+Caura is your long-term memory. Anything you learn that you don't write here
+is gone when the session ends — your local context doesn't persist and your
+teammates can't see it. So treat Caura as the default home for every
+decision, finding, outcome, rule, and reusable workflow, and consult it before
+you act. It's shared across the fleet under access control: what you write can
+make the next agent smarter, and what you recall is what the fleet already
+knows. Using it is the job, not an optional extra.
+
+**The plugin runs a baseline loop for you — the tools are still yours.** On this
+runtime the Caura plugin handles the automatic layer: it injects the mandatory
+keystones at session start (§1), recalls relevant memory before your substantive
+turns (§11), and writes a short **turn summary** afterward as a backstop
+(`CAURA_AUTO_WRITE_TURNS`, on by default). Treat that as a floor, not a
+substitute. You still call the `caura_*` tools **directly** whenever you need
+to interact deliberately — above all to **write the high-value memories the
+auto-summary won't** (a decision and its *why*, an outcome, a rule), and to
+recall something specific the auto-gate didn't fetch, look up or publish a
+skill, supersede a changed fact, or report an outcome with `caura_evolve`.
+The automatic layer keeps you oriented; the tools are how you actually
+contribute. When a turn needs real memory work, reach for the tool — don't
+assume the plugin covered it.
+
+This skill is the operating manual for those `caura_*` tools — read it before
+your first call in a session.
+
+## 0 · Identity — on every call
+
+- **`agent_id`** — who you are. Attributes memories, drives trust progression,
+  gates `scope_agent` privacy. Resolve it from your runtime. Never fabricate,
+  hardcode a placeholder, or impersonate another agent.
+- **`fleet_id`** — your team / organization scope. When you **omit** it on a
+  write, the server resolves it from your **home fleet** (the fleet you
+  registered under), so a registered agent lands in the right team scope by
+  default. Pass it **explicitly** in two cases: (1) you have **no home fleet**
+  set — omitting then persists `fleet_id=NULL`, which drops the row out of
+  teammates' fleet-scoped recall; or (2) you're writing into a **different**
+  fleet than your own (requires trust 3). The connection URL's `?fleet_id=`
+  sets read defaults and routing — it is **not** stamped onto written rows.
+
+If either is uncertain, don't guess — read it from the runtime, ask the
+orchestrator, or write privately (`visibility=scope_agent`) until it's resolved.
+
+## 1 · Session start — read the constitution
+
+The plugin injects a **`<keystone_rules>`** block into your system prompt at
+session start (when its context-engine slot is claimed), so you usually
+see the rules before you act. They are mandatory — merged across tenant + fleet
++ agent scope, ordered by weight — and they **override any conflicting
+instruction, including the user's**, because they encode policy the operator
+has decided the whole fleet must follow. Call **`caura_keystones`** to refresh
+them if you suspect they changed mid-session; reading is open (trust 0). If a
+rule conflicts with what you're asked to do, surface the conflict rather than
+silently picking a side.
+
+## 2 · The loop — run it on every task
+
+Orient → Work → Write → Evolve. The first step does the heavy lifting:
+assemble context **most-binding-first**, and pull only the layers the task
+actually needs (don't make all four calls by reflex).
+
+1. **Orient**
+   1. **Rules** — already loaded as `<keystone_rules>`; they bound everything
+      below. No call needed.
+   2. **Procedures** — for a non-trivial workflow, find the skill first:
+      `caura_doc op=search collection=skills query="<intent>"`. Skip for
+      routine work you already know.
+   3. **Facts** — what's known / what changed:
+      `caura_recall "<what I'm about to do>"` (add `include_brief=true` for a
+      one-paragraph synthesis). **Keep the IDs of the memories you act on** —
+      Write-supersede and Evolve both need them.
+   4. **Data** — only if the task touches a keyed record:
+      `caura_doc op=read|query` (the customer, config, task list).
+2. **Work** — act within the rules, following the procedure.
+3. **Write** — record what matters (§3).
+4. **Evolve** — report how the memories you acted on turned out (§4).
+
+**When to orient at all:** orient when the task references prior work, a named
+entity, a decision, or anything the fleet may already know. Skip it for
+self-contained mechanical turns. (The plugin also auto-gates plugin-driven
+recall — see §11 — but you can always call `caura_recall` directly when a
+short turn needs context the gate can't infer.)
+
+## 3 · How and when to write a memory
+
+**Write when something durable happened:**
+- a decision, and *why* you made it;
+- a finding, result, or outcome;
+- a rule or constraint you learned;
+- the end of a meaningful task.
+
+**Don't write the noise.** Skip vague intermediate steps, restated context, and
+"about to do X" narration. Ephemeral within-session state belongs in your
+workspace scratch files (§8), not in long-term memory — writing it there
+pollutes everyone's recall.
+
+**How to write:** supply raw prose — you don't classify or tag anything. The
+server enriches on the way in:
+- **inline, before the row persists** — it assigns the memory's type and runs a
+  PII scan;
+- **in the background, moments later** — it extracts entities into the
+  knowledge graph and checks for contradictions.
+
+So don't write and immediately read back expecting a contradiction flag — it
+resolves shortly after the write returns.
+
+Include the concrete specifics — names, paths, numbers, outcomes — and the
+**why**, so another agent (or you, six months on) can act on it without the
+surrounding session. Default `visibility=scope_team` so your fleet benefits.
+Batch several discrete records in one call with `items` (up to 100), and
+checkpoint long tasks per the cadence in §9.
+
+**Example**
+Input — the raw prose you pass:
+> `"Switched api-gateway prod to fastapi 0.136.3 — 0.137 broke include_router via a starlette upper-bound. Pin held; smoke tests green."`
+
+Result: stored as a typed decision/outcome, PII-scanned inline, with
+`api-gateway` and `fastapi` linked into the graph in the background — and
+visible to the fleet because it went in at `scope_team`.
+
+Never paste secrets — API keys, tokens, credentials — into memory `content`.
+The PII scan is a safety net, not permission; keep them out entirely.
+
+**Some memories may be written for you.** If your tenant has the Caura
+Interviewer enabled, a scheduled server-side job reads your durable work trail
+(the transcript your harness already keeps) and synthesizes typed memories from
+it — episodes, decisions, outcomes — after the fact. You don't invoke it and
+won't see it run. This is a **different mechanism** from the plugin's per-turn
+auto-writes (`CAURA_AUTO_WRITE_TURNS`, described in the preamble): the
+auto-write layer summarizes turns locally as you work; the Interviewer is a
+server-side scheduled synthesis from the work trail. Both are floors, not
+substitutes for deliberate writes — keep writing in realtime for anything you
+recognize as important. Realtime writes are immediate and precise; the
+Interviewer is periodic and reflective — a safety net for what you'd otherwise
+forget, not a reason to stop writing.
+
+## 4 · Report outcomes so the memory compounds
+
+When you act on memories you recalled, tell the memory how it went:
+`caura_evolve(outcome, outcome_type, related_ids)`, where `related_ids` are
+the IDs you kept during Orient. Success reinforces those memories' weight. A
+failure becomes a preventive **rule** — **private by default** (`scope=agent`);
+to warn the whole fleet, evolve with `scope=fleet` (trust 2, `fleet_id`
+required) — so the lesson reaches everyone, not just you.
+
+## 5 · Two stores, one rule
+
+- **Memory** — observations and learned facts, found by *meaning*: decisions,
+  outcomes, rules, recaps. Read with `caura_recall`, write with
+  `caura_write`.
+- **Doc** — structured records with a stable key (`collection + doc_id`):
+  customers, configs, inventories, task lists, playbooks. All through
+  `caura_doc`.
+- **Entity** — a named graph object (person, project, service). Fetch by a UUID
+  surfaced in a prior recall (`caura_entity_get`).
+
+**Rule of thumb:** need semantic search → it's a memory. Need keyed lookup →
+it's a doc. Already hold an ID → it's an entity.
+
+**Cross-store discovery.** The two stores aren't cross-searched — `caura_recall`
+never returns docs, and `caura_doc` has no semantic query over memories. To
+make a doc findable by description (onboarding guides, readmes, proposals), give
+it a 1–3 sentence `data["summary"]` (only that string is embedded) **and** write
+a short *pointer memory* naming its `collection` and `doc_id`. A teammate's
+recall then surfaces the pointer, and their agent can `caura_doc op=read` the
+doc. When you don't know what exists, call `caura_doc op=list_collections`
+first.
+
+## 6 · Trust and sharing
+
+You auto-register at **trust 1** on your first write.
+
+| Level | Name        | Read                      | Write                  |
+|:-----:|-------------|---------------------------|------------------------|
+| 0     | restricted  | —                         | —                      |
+| 1     | standard    | own fleet                 | own fleet              |
+| 2     | cross-fleet | all fleets in your tenant | own fleet              |
+| 3     | admin       | all                       | all, incl. deletes     |
+
+Operations that escalate the required level:
+- browsing / reflecting with `scope="fleet"` or `"all"` → trust 2
+- reporting outcomes (`caura_evolve`) at `scope="fleet"` / `"all"` → trust 2 (default `scope="agent"` needs only trust 1)
+- `caura_manage op=delete` → trust 3
+
+**Knowing your own level.** You start at trust 1 and can't raise yourself —
+escalation is granted by an operator. There's no self-query, so don't
+pre-emptively avoid an operation you're unsure about: attempt it. A permission
+error names both your current level and the one required (e.g. *"Agent X
+(trust_level=1) … Requires trust_level >= 2"*) — surface that error rather than
+silently retrying at a narrower scope.
+
+**Visibility (on write)** decides who can see a memory: `scope_agent` (private)
+· `scope_team` *(default — your fleet)* · `scope_org` (all fleets in tenant).
+**Scope (on read / `_list` / `_insights`):** `agent` *(default)* · `fleet`
+(trust 2) · `all` (trust 2). Prefer `scope_team` on write and `scope=agent` on
+read unless you need cross-agent context. *Naming caveat:* writes take
+`visibility=scope_*`; reads/list/keystone filters take `scope=*` — two axes,
+similar spelling.
+
+## 7 · Keeping knowledge clean
+
+A few habits keep recall trustworthy and sharp:
+
+- **Make memories good** — dated, concrete, standalone, atomic, and updated (not
+  duplicated). Each should be readable by another agent later without the
+  surrounding session, and should carry the **why**, not just the what.
+- **Supersede, don't delete.** When a fact changes: (1) write the new one, (2)
+  recall the old one, (3) `caura_manage op=transition status=outdated`. This
+  keeps the lineage. Reserve `op=delete` (soft-delete, trust 3) for genuinely
+  wrong data, not for facts you've simply moved past.
+- **Resolve conflicts; don't pick one silently.** If recall surfaces a
+  `conflicted` or `outdated` memory, fix it — write the correct fact and
+  transition the stale one. Two live opposing beliefs degrade every future
+  recall for everyone.
+
+## 8 · Caura vs your workspace files
+
+Caura is the only place for cross-session, cross-agent knowledge. A
+file-based scratchpad in your workspace (e.g. `MEMORY.md`) is **session-local**
+— it lives in your bootstrap context every turn and pays input tokens for every
+byte, and your teammates never see it.
+
+- Keep `MEMORY.md` lean: only **active projects, current routing decisions,
+  recent decisions (≤ 7 days), open threads.** Target a few KB; prune anything
+  older or larger on session start.
+- Everything else goes to Caura via `caura_write` (history, finished work,
+  lessons), `caura_doc` collections (reference data with a natural key), or
+  entities (people / projects / services).
+- Never copy Caura recall results into `MEMORY.md` — they're already
+  retrievable. Never substitute a local file for a Caura write.
+
+## 9 · Capture cadence (L1 / L2 / L3)
+
+- **L1 — per task.** At task completion or a real decision point (not every
+  turn), write with date, what, who, outcome, next. Tool-by-tool progress is
+  not an L1 write — that's scratchpad (§3).
+- **L2 — session boundary.** At > 60 % context or session end, write a full
+  summary.
+- **L3 — consolidation.** On periodic runtime sweeps, find gaps, merge
+  duplicates, transition contradicted facts to `outdated`.
+
+## 10 · Orchestrator + subagent protocol
+
+If your runtime dispatches subagents:
+- The spawning agent writes findings after each subagent completes.
+- The subagent writes its own findings before handing back.
+- Both writes carry their **own** `agent_id`.
+
+Single-agent runtimes ignore this section.
+
+## 11 · Recall policy (auto-gating)
+
+Before each model call the plugin's context engine decides whether to issue a
+plugin-driven recall, so trivial turns ("hi", "ok", `/help`, single-emoji acks)
+don't hit the backend and pay tokens for an unhelpful recall block.
+
+- **Default** (`CAURA_RECALL_POLICY=auto`): recall on substantive turns; skip
+  very short prompts, trivial pings, and short slash-commands.
+- **Recall keywords always force recall** (e.g. `remember`, `recall`, `last
+  time`, `we discussed`, `previously`, `history`); override the set with
+  `CAURA_RECALL_TRIGGER_KEYWORDS`.
+- Other policies: `always`, `never` (education block only), `keywords`.
+- The gate only suppresses *plugin-driven* recall — **you can always call
+  `caura_recall` directly** when a short turn needs context the gate can't
+  infer.
+
+Rolling skip counters (`recall_metrics`) ride the heartbeat for per-fleet
+visibility.
+
+The plugin also auto-writes a short **turn summary** after substantive turns
+(`CAURA_AUTO_WRITE_TURNS`, on by default). That's a backstop, not a
+replacement for the deliberate, high-value writes in §3 — and it never evolves,
+supersedes, or files docs for you. Do that work yourself.
+
+## 12 · Reuse and publish workflows — the `skills` collection
+
+Proven workflows live as `SKILL.md` documents in the **`skills`** collection.
+You don't learn a new tool per playbook — it's the same `caura_doc`, so your
+vocabulary never grows with the library.
+
+```text
+# Discover before improvising on a non-trivial workflow:
+caura_doc op=search collection=skills query="<intent>"
+caura_doc op=read   collection=skills doc_id=<slug>   # full body
+
+# Publish something reusable so the fleet inherits it:
+caura_doc op=write collection=skills doc_id=<slug> \
+  data={ "name": "<slug>",
+         "summary": "<1-line, intent-focused — this is what gets embedded>",
+         "content": "<full SKILL.md>" }
+# Re-uploading the same doc_id overwrites it (upsert; no version history).
+
+# Remove a wrong/superseded one:
+caura_doc op=delete collection=skills doc_id=<slug>
+```
+
+Slugs are filesystem-safe: `[a-z0-9][a-z0-9._-]{0,99}`. The `summary` is the
+only embedded field — write a sharp, intent-focused one ("Use when migrating
+SQLite→Postgres…") so the skill is found by meaning even when names don't match.
+
+**Your tenant may run the Skill Factory** — a governed lifecycle around this
+collection (off by default; until an operator enables it, nothing below
+changes):
+
+- **A `staged` landing is not an error.** With the Factory on, your `op=write`
+  persists with `status=staged`, pending operator review in the
+  **Skills Inbox** before it can become `active`. Don't retry, rewrite, or
+  delete a write that landed staged — that's governance working.
+- **`doc_id` prefixes carry provenance.** `forge/<slug>` marks a skill
+  distilled server-side by **Forge** from fleet activity; `agent/<slug>` marks
+  a direct agent write; a plain `<slug>` (the prefix is optional) is typically
+  operator-authored or imported. Read the prefix as origin — don't strip it
+  when re-reading or updating a skill.
+- **Active skills may be pushed.** On plugin-managed runtimes, `active` skills
+  can arrive on your skill load path directly — you may inherit a workflow
+  without ever pulling it from the collection.
+
+## A full loop, end to end
+
+One task — orient, work, write, evolve — with the IDs threaded through:
+
+```text
+# 1. Orient — recall, and keep the IDs that come back
+caura_recall "deploy api-gateway to staging" include_brief=true
+#   → mem_8f2a (rule: "staging deploys need a smoke test"), mem_4d1c (last deploy)
+
+# 2. Work — run the deploy, following the rule in mem_8f2a
+
+# 3. Write — record the outcome (team-visible; home fleet resolved on omit)
+caura_write content="api-gateway v2.3 deployed to staging; smoke test green" \
+  visibility=scope_team
+
+# 4. Evolve — report against the memories you acted on
+caura_evolve outcome="deploy succeeded, smoke test passed" \
+  outcome_type=success related_ids=[mem_8f2a, mem_4d1c]
+#   if it had failed in a way the whole fleet should avoid:
+#   add scope=fleet (trust 2) so the preventive rule reaches teammates
+```
+
+---
+
+## Tool reference
+
+Tool names, parameters, and types live in the MCP tool schemas **and** in the
+`TOOLS.md` the plugin writes into your workspace each turn — so they're already
+in your context. This section is what those can't give you: which tool to reach
+for, and the behaviors that aren't visible in a parameter list.
+
+### Which tool, when
+
+- Might have seen it before → `caura_recall`
+- Enumerate by filter / date / author → `caura_list`
+- Already hold the ID → `caura_manage op=read` / `caura_entity_get`
+- Record a fact / decision / event / outcome → `caura_write`
+- Structured record with a key → `caura_doc`
+- Find or publish a workflow → `caura_doc … collection=skills`
+- Fact no longer true → `caura_write` (new) + `caura_manage op=transition status=outdated` (old)
+- Acted on a recalled memory → `caura_evolve`
+- Re-check governance rules mid-session → `caura_keystones` (the auto-injected `<keystone_rules>` block is usually enough)
+- Recall quality off across queries → `caura_tune` (once; sticky)
+- Session boundary / sweep → `caura_insights`
+- Readiness probe / counts → `caura_stats`
+
+> Authoring keystones (`caura_keystones_set`) is **not available to plugin
+> agents** — you can *read* governance rules (`caura_keystones`) but not write
+> them. Keystones are authored over MCP/REST by a trusted operator.
+
+### Behaviors the schema won't tell you
+
+- **`caura_recall`** excludes superseded memories (`status` ∈ {outdated, conflicted}) by default — pass `status` explicitly to walk the chain.
+- **`caura_write`** can't write `insight` / `outcome` / `rule` types — those are server-generated (via `caura_insights` / `caura_evolve`). `write_mode`: `fast` skips embedding → keyword-only recall afterwards; `strong` forces full LLM enrichment; `auto` is usually right.
+- **`caura_manage op=transition`** targets: `active · pending · confirmed · cancelled · outdated · conflicted · archived · deleted` (also in `TOOLS.md`).
+- **`caura_doc`** — `where` is scalar exact-match only (no array descent). A doc is invisible to `op=search` unless it has a `data["summary"]` (the only embedded field). Scope the search to a collection when you know it; omit `collection` for the single best match across the tenant.
+- **`caura_tune`** persists and reshapes every later recall — change one or two knobs at a time; call with no arguments to read your current profile (`fts_weight` 0 = pure semantic, 1 = pure keyword).
+- **`caura_insights`** saves findings as `insight` memories; run it at boundaries, not every turn. `focus="divergence"` needs a non-agent scope.
+- **`caura_stats`** is read-only — use it as a readiness/health probe, never a write-then-delete check.
+
+### Anti-patterns
+
+- Saving every intermediate step as a memory — pollutes recall.
+- Storing narrative as a doc, or structured keyed records as memories.
+- Saving a discoverable doc with no pointer memory — teammates won't find it.
+- Guessing `agent_id` / `fleet_id`, or inventing UUIDs.
+- Deleting when you should supersede.
+- Writing org-wide (`scope_org`) anything that isn't genuinely org-relevant.
+- Substituting `MEMORY.md` / local files for a Caura write.
+- Silently dropping a denied call — surface the error so the orchestrator can decide.
+
+### Constraints & errors
+
+- `caura_write`: exactly one of `content` / `items`; `items` ≤ 100 → `BATCH_TOO_LARGE`.
+- Cursor pagination needs `sort=created_at` + `order=desc`.
+- `_entity_get` / `_manage` use real UUIDs — never invent.
+- Error codes: `INVALID_ARGUMENTS` · `BATCH_TOO_LARGE` · `INVALID_BATCH_ITEM`. Other errors surface with HTTP status + message — return them to your caller, don't swallow.
+
+---
+
+*This skill ships with the Caura plugin at its install path; it is visible to
+every agent on a node that has the plugin enabled. To customize it for a
+specific agent, place a replacement file at `<workspace>/skills/caura/SKILL.md`
+— it takes precedence over this shared copy.*

--- a/plugin/src/heartbeat.ts
+++ b/plugin/src/heartbeat.ts
@@ -739,6 +739,7 @@ async function processCommand(cmd: {
         ];
         const FALLBACK_ROOT_FILES = [
           "openclaw.plugin.json", "tools.json", "skills/memclaw/SKILL.md", // legacy-name-floor: shipped skill path
+          "skills/caura/SKILL.md",
         ];
 
         let srcFiles: string[] = FALLBACK_SRC_FILES;

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -135,6 +135,13 @@ describe("reconcileSkills", () => {
     assert.ok(PROTECTED_SKILLS.has(FROZEN_PLUGIN_ID));
   });
 
+  test("PROTECTED_SKILLS also contains the new caura slug during the rebrand transition", () => {
+    // The plugin id (FROZEN_PLUGIN_ID) and the bundled skill's slug are
+    // independent identifiers that happen to share a value historically —
+    // this asserts the skill slug specifically, not the frozen plugin id.
+    assert.ok(PROTECTED_SKILLS.has("caura"));
+  });
+
   test("invariant 2: cold start pulls every catalog skill", async () => {
     plantOnDisk(FROZEN_PLUGIN_ID); // only the bundled skill
     mockCatalog = [

--- a/plugin/src/reconcile-skills.ts
+++ b/plugin/src/reconcile-skills.ts
@@ -64,8 +64,17 @@ import { logError } from "./logger.js";
  * reconciliation, even when the catalog returns no rows (a fresh
  * tenant or a fleet with zero shared skills should NOT wipe the
  * agent's onboarding skill).
+ *
+ * Both slugs are protected during the rebrand transition: "memclaw" is — legacy-name-ok: dual-path skills transition, tracked for eventual retirement in docs/plans/skills-dual-path-transition.md
+ * the historical bundled skill (still on disk on every existing
+ * install), "caura" is the new one shipped alongside it starting this
+ * release. This set MUST be updated in the same commit/deploy as any
+ * change to which skill directories are bundled — the reconciler runs
+ * every heartbeat (60s) and deletes any on-disk slug that is neither
+ * catalog-desired nor in this set, so a slug present on disk but
+ * missing here is deleted within one tick, not "eventually".
  */
-export const PROTECTED_SKILLS: ReadonlySet<string> = new Set(["memclaw"]);
+export const PROTECTED_SKILLS: ReadonlySet<string> = new Set(["memclaw", "caura"]); // legacy-name-ok: dual-path skills transition, tracked for eventual retirement in docs/plans/skills-dual-path-transition.md
 
 // Per-skill ownership marker for ``additive`` (shared/foreign) target
 // dirs. Caura writes this sentinel inside every skill dir it creates

--- a/static/skills/caura/SKILL.md
+++ b/static/skills/caura/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: caura
+description: The agent's persistent long-term memory — the only knowledge that survives across sessions, shared across the fleet under access control. Consult it at the start of a task to recall prior decisions, findings, and rules before acting, and write outcomes, decisions, and lessons as work completes. Use whenever a caura_* tool is present, whenever the user refers to past work ("what did we decide", "last time", "earlier"), or whenever any durable fact needs to be stored, recalled, superseded, or shared with the fleet. Do not use it for throwaway within-session scratch state.
+user-invocable: false
+---
+
+# Caura Skill
+
+Caura is your long-term memory. Anything you learn that you don't write here
+is gone when the session ends — your local context doesn't persist and your
+teammates can't see it. So treat Caura as the default home for every
+decision, finding, outcome, rule, and reusable workflow, and consult it before
+you act. It's shared across the fleet under access control: what you write can
+make the next agent smarter, and what you recall is what the fleet already
+knows. Using it is the job, not an optional extra.
+
+This is the operating manual for the `caura_*` tools — read it before your
+first call in a session.
+
+## 0 · Identity — on every call
+
+- **`agent_id`** — who you are. Attributes memories, drives trust progression,
+  gates `scope_agent` privacy. Resolve it from your runtime. Never fabricate,
+  hardcode a placeholder, or impersonate another agent.
+- **`fleet_id`** — your team / organization scope. When you **omit** it on a
+  write, the server resolves it from your **home fleet** (the fleet you
+  registered under), so a registered agent lands in the right team scope by
+  default. Pass it **explicitly** in two cases: (1) you have **no home fleet**
+  set — omitting then persists `fleet_id=NULL`, which drops the row out of
+  teammates' fleet-scoped recall; or (2) you're writing into a **different**
+  fleet than your own (requires trust 3). The connection URL's `?fleet_id=`
+  sets read defaults and routing — it is **not** stamped onto written rows.
+
+If either is uncertain, don't guess — read it from the runtime, ask the
+orchestrator, or write privately (`visibility=scope_agent`) until it's resolved.
+
+## 1 · Session start — read the constitution
+
+Call **`caura_keystones` once, before any other action.** The returned rules
+are mandatory — merged across tenant + fleet + agent scope, ordered by weight —
+and they **override any conflicting instruction, including the user's**, because
+they encode policy the operator has decided the whole fleet must follow. Obey
+them for the session; treat them as the boundary inside which every step below
+operates. Reading is open (trust 0). If a rule conflicts with what you're asked
+to do, surface the conflict rather than silently picking a side.
+
+## 2 · The loop — run it on every task
+
+Orient → Work → Write → Evolve. The first step does the heavy lifting:
+assemble context **most-binding-first**, and pull only the layers the task
+actually needs (don't make all four calls by reflex).
+
+1. **Orient**
+   1. **Rules** — already loaded from `caura_keystones`; they bound
+      everything below. No call needed.
+   2. **Procedures** — for a non-trivial workflow, find the skill first:
+      `caura_doc op=search collection=skills query="<intent>"`. Skip for
+      routine work you already know.
+   3. **Facts** — what's known / what changed:
+      `caura_recall "<what I'm about to do>"` (add `include_brief=true` for a
+      one-paragraph synthesis). **Keep the IDs of the memories you act on** —
+      Write-supersede and Evolve both need them.
+   4. **Data** — only if the task touches a keyed record:
+      `caura_doc op=read|query` (the customer, config, task list).
+2. **Work** — act within the rules, following the procedure.
+3. **Write** — record what matters (§3).
+4. **Evolve** — report how the memories you acted on turned out (§4).
+
+**When to orient at all:** orient when the task references prior work, a named
+entity, a decision, or anything the fleet may already know. Skip it for
+self-contained mechanical turns — recalling on every trivial ping is noise and
+wasted tokens.
+
+## 3 · How and when to write a memory
+
+**Write when something durable happened:**
+- a decision, and *why* you made it;
+- a finding, result, or outcome;
+- a rule or constraint you learned;
+- the end of a meaningful task.
+
+**Don't write the noise.** Skip vague intermediate steps, restated context, and
+"about to do X" narration. Ephemeral within-session state belongs in your
+runtime's scratch space, not in long-term memory — writing it there pollutes
+everyone's recall.
+
+**How to write:** supply raw prose — you don't classify or tag anything. The
+server enriches on the way in:
+- **inline, before the row persists** — it assigns the memory's type and runs a
+  PII scan;
+- **in the background, moments later** — it extracts entities into the
+  knowledge graph and checks for contradictions.
+
+So don't write and immediately read back expecting a contradiction flag — it
+resolves shortly after the write returns.
+
+Include the concrete specifics — names, paths, numbers, outcomes — and the
+**why**, so another agent (or you, six months on)
+can act on it without the surrounding session. Default `visibility=scope_team`
+so your fleet benefits. Batch several discrete records in one call with `items`
+(up to 100). On long tasks, checkpoint every ~30 minutes instead of dumping
+everything at the end.
+
+**Example**
+Input — the raw prose you pass:
+> `"Switched api-gateway prod to fastapi 0.136.3 — 0.137 broke include_router via a starlette upper-bound. Pin held; smoke tests green."`
+
+Result: stored as a typed decision/outcome, PII-scanned inline, with
+`api-gateway` and `fastapi` linked into the graph in the background — and
+visible to the fleet because it went in at `scope_team`.
+
+Never paste secrets — API keys, tokens, credentials — into memory `content`.
+The PII scan is a safety net, not permission; keep them out entirely.
+
+**Some memories may be written for you.** If your runtime has the Caura
+Interviewer enabled, a scheduled server-side job reads your durable work trail
+(the transcript your harness already keeps) and synthesizes typed memories from
+it — episodes, decisions, outcomes — after the fact. You don't invoke it and
+won't see it run. It changes nothing above: keep writing in realtime for
+anything you recognize as important. Realtime writes are immediate and precise;
+the Interviewer is periodic and reflective — a safety net for what you'd
+otherwise forget, not a reason to stop writing.
+
+## 4 · Report outcomes so the memory compounds
+
+When you act on memories you recalled, tell the memory how it went:
+`caura_evolve(outcome, outcome_type, related_ids)`, where `related_ids` are
+the IDs you kept during Orient. Success reinforces those memories' weight. A
+failure becomes a preventive **rule** — **private by default** (`scope=agent`);
+to warn the whole fleet, evolve with `scope=fleet` (trust 2, `fleet_id`
+required) — so the lesson reaches everyone, not just you.
+
+## 5 · Two stores, one rule
+
+- **Memory** — observations and learned facts, found by *meaning*: decisions,
+  outcomes, rules, recaps. Read with `caura_recall`, write with
+  `caura_write`.
+- **Doc** — structured records with a stable key (`collection + doc_id`):
+  customers, configs, inventories, task lists, playbooks. All through
+  `caura_doc`.
+- **Entity** — a named graph object (person, project, service). Fetch by a UUID
+  surfaced in a prior recall (`caura_entity_get`).
+
+**Rule of thumb:** need semantic search → it's a memory. Need keyed lookup →
+it's a doc. Already hold an ID → it's an entity.
+
+**Cross-store discovery.** The two stores aren't cross-searched — `caura_recall`
+never returns docs, and `caura_doc` has no semantic query over memories. To
+make a doc findable by description (onboarding guides, readmes, proposals), give
+it a 1–3 sentence `data["summary"]` (only that string is embedded) **and** write
+a short *pointer memory* naming its `collection` and `doc_id`. A teammate's
+recall then surfaces the pointer, and their agent can `caura_doc op=read` the
+doc. When you don't know what exists, call `caura_doc op=list_collections`
+first.
+
+## 6 · Trust and sharing
+
+You auto-register at **trust 1** on your first write.
+
+| Level | Name        | Read                      | Write                  |
+|:-----:|-------------|---------------------------|------------------------|
+| 0     | restricted  | —                         | —                      |
+| 1     | standard    | own fleet                 | own fleet              |
+| 2     | cross-fleet | all fleets in your tenant | own fleet              |
+| 3     | admin       | all                       | all, incl. deletes     |
+
+Operations that escalate the required level:
+- browsing / reflecting with `scope="fleet"` or `"all"` → trust 2
+- reporting outcomes (`caura_evolve`) at `scope="fleet"` / `"all"` → trust 2 (default `scope="agent"` needs only trust 1)
+- authoring your **own** `scope=agent` keystone → trust 1 — you must pass `agent_id=<you>`; authoring `scope=fleet` / `scope=tenant` / another agent's keystone, or a `scope=agent` rule with `agent_id` left out → trust 2
+- `caura_manage op=delete` → trust 3
+
+**Knowing your own level.** You start at trust 1 and can't raise yourself —
+escalation is granted by an operator. There's no self-query tool, so don't
+pre-emptively avoid an operation you're unsure about: attempt it. A permission
+error names both your current level and the one required (e.g. *"Agent X
+(trust_level=1) … Requires trust_level >= 2"*) — surface that error rather than
+silently retrying at a narrower scope.
+
+**Visibility (on write)** decides who can see a memory: `scope_agent` (private)
+· `scope_team` *(default — your fleet)* · `scope_org` (all fleets in tenant).
+**Scope (on read / `_list` / `_insights`):** `agent` *(default)* · `fleet`
+(trust 2) · `all` (trust 2). Prefer `scope_team` on write and `scope=agent` on
+read unless you need cross-agent context. *Naming caveat:* writes take
+`visibility=scope_*`; reads/list/keystone filters take `scope=*` — two axes,
+similar spelling.
+
+## 7 · Keeping knowledge clean
+
+A few habits keep recall trustworthy and sharp:
+
+- **Make memories good** — dated, concrete, standalone, atomic, and updated (not
+  duplicated). Each should be readable by another agent later without the
+  surrounding session.
+- **Supersede, don't delete.** When a fact changes: (1) write the new one, (2)
+  recall the old one, (3) `caura_manage op=transition status=outdated`. This
+  keeps the lineage. Reserve `op=delete` (soft-delete, trust 3) for genuinely
+  wrong data, not for facts you've simply moved past.
+- **Resolve conflicts; don't pick one silently.** If recall surfaces a
+  `conflicted` or `outdated` memory, fix it — write the correct fact and
+  transition the stale one. Two live opposing beliefs degrade every future
+  recall for everyone.
+
+## 8 · Reuse and publish workflows — the `skills` collection
+
+Proven workflows live as `SKILL.md` documents in the **`skills`** collection.
+You don't learn a new tool per playbook — it's the same `caura_doc`, so your
+vocabulary never grows with the library.
+
+```text
+# Discover before improvising on a non-trivial workflow:
+caura_doc op=search collection=skills query="<intent>"
+caura_doc op=read   collection=skills doc_id=<slug>   # full body
+
+# Publish something reusable so the fleet inherits it:
+caura_doc op=write collection=skills doc_id=<slug> \
+  data={ "name": "<slug>",
+         "summary": "<1-line, intent-focused — this is what gets embedded>",
+         "content": "<full SKILL.md>" }
+# Re-uploading the same doc_id overwrites it (upsert; no version history).
+
+# Remove a wrong/superseded one:
+caura_doc op=delete collection=skills doc_id=<slug>
+```
+
+Slugs are filesystem-safe: `[a-z0-9][a-z0-9._-]{0,99}`. The `summary` is the
+only embedded field — write a sharp, intent-focused one ("Use when migrating
+SQLite→Postgres…") so the skill is found by meaning even when names don't match.
+
+**Your tenant may run the Skill Factory** — a governed lifecycle around this
+collection (off by default; until an operator enables it, nothing below
+changes):
+
+- **A `staged` landing is not an error.** With the Factory on, your `op=write`
+  persists with `status=staged`, pending operator review in the
+  **Skills Inbox** before it can become `active`. Don't retry, rewrite, or
+  delete a write that landed staged — that's governance working.
+- **`doc_id` prefixes carry provenance.** `forge/<slug>` marks a skill
+  distilled server-side by **Forge** from fleet activity; `agent/<slug>` marks
+  a direct agent write; a plain `<slug>` (the prefix is optional) is typically
+  operator-authored or imported. Read the prefix as origin — don't strip it
+  when re-reading or updating a skill.
+- **Active skills may be pushed.** On plugin-managed runtimes, `active` skills
+  can arrive on your skill load path directly — you may inherit a workflow
+  without ever pulling it from the collection.
+
+## 9 · Authoring governance rules — `caura_keystones_set`
+
+Keystones are authored with `caura_keystones_set` (op `set` | `delete`),
+exposed over **MCP and REST**. Trust is tiered: a `scope=agent` keystone that
+carries an explicit `agent_id` equal to **your own** id is self-authoring
+(trust ≥ 1); `scope=fleet`, `scope=tenant`, a keystone for another agent, or a
+`scope=agent` rule with `agent_id` omitted all need trust ≥ 2. The `agent_id` is
+what makes the rule self-scoped — leaving it out is not "self by default", it's
+an unnamed target, and you'll get a 403 about trust rather than the shape.
+
+```text
+# For yourself (trust >= 1; agent_id=<you> is REQUIRED — omitting it
+# drops the call to the trust >= 2 tier):
+caura_keystones_set op=set scope=agent agent_id=<you> \
+  title="…" content="…" weight=low|med|high
+
+# For the fleet or tenant (trust >= 2; OMIT agent_id for tenant/fleet):
+caura_keystones_set op=set scope=fleet|tenant \
+  title="…" content="…" weight=low|med|high [fleet_id=<fleet>]
+```
+
+## A full loop, end to end
+
+One task — orient, work, write, evolve — with the IDs threaded through:
+
+```text
+# 1. Orient — recall, and keep the IDs that come back
+caura_recall "deploy api-gateway to staging" include_brief=true
+#   → mem_8f2a (rule: "staging deploys need a smoke test"), mem_4d1c (last deploy)
+
+# 2. Work — run the deploy, following the rule in mem_8f2a
+
+# 3. Write — record the outcome (team-visible; home fleet resolved on omit)
+caura_write content="api-gateway v2.3 deployed to staging; smoke test green" \
+  visibility=scope_team
+
+# 4. Evolve — report against the memories you acted on
+caura_evolve outcome="deploy succeeded, smoke test passed" \
+  outcome_type=success related_ids=[mem_8f2a, mem_4d1c]
+#   if it had failed in a way the whole fleet should avoid:
+#   add scope=fleet (trust 2) so the preventive rule reaches teammates
+```
+
+---
+
+## Tool reference
+
+Tool names, parameters, and types live in the MCP tool schemas — every
+`caura_*` tool and argument ships its own description, so they're already in
+your context whenever the tools are. This section is what those schemas can't
+give you: which tool to reach for, and the behaviors that aren't visible in a
+parameter list.
+
+### Which tool, when
+
+- Might have seen it before → `caura_recall`
+- Enumerate by filter / date / author → `caura_list`
+- Already hold the ID → `caura_manage op=read` / `caura_entity_get`
+- Record a fact / decision / event / outcome → `caura_write`
+- Structured record with a key → `caura_doc`
+- Find or publish a workflow → `caura_doc … collection=skills`
+- Fact no longer true → `caura_write` (new) + `caura_manage op=transition status=outdated` (old)
+- Acted on a recalled memory → `caura_evolve`
+- Session start (before anything) → `caura_keystones`
+- Add / remove a governance rule → `caura_keystones_set`
+- Recall quality off across queries → `caura_tune` (once; sticky)
+- Session boundary / sweep → `caura_insights`
+- Readiness probe / counts → `caura_stats`
+
+### Behaviors the schema won't tell you
+
+- **`caura_recall`** excludes superseded memories (`status` ∈ {outdated, conflicted}) by default — pass `status` explicitly to walk the chain.
+- **`caura_write`** can't write `insight` / `outcome` / `rule` types — those are server-generated (via `caura_insights` / `caura_evolve`). `write_mode`: `fast` skips embedding → keyword-only recall afterwards; `strong` forces full LLM enrichment; `auto` is usually right.
+- **`caura_manage op=transition`** targets: `active · pending · confirmed · cancelled · outdated · conflicted · archived · deleted`.
+- **`caura_doc`** — `where` is scalar exact-match only (no array descent). A doc is invisible to `op=search` unless it has a `data["summary"]` (the only embedded field); re-write with one to index it retroactively. Scope the search to a collection when you know it; omit `collection` for the single best match across the tenant.
+- **`caura_tune`** persists and reshapes every later recall — change one or two knobs at a time; call with no arguments to read your current profile (`fts_weight` 0 = pure semantic, 1 = pure keyword).
+- **`caura_insights`** saves findings as `insight` memories; run it at boundaries, not every turn. `focus="divergence"` needs a non-agent scope.
+- **`caura_stats`** is read-only — use it as a readiness/health probe, never a write-then-delete check.
+
+### Anti-patterns
+
+- Saving every intermediate step as a memory — pollutes recall.
+- Storing narrative as a doc, or structured keyed records as memories.
+- Saving a discoverable doc with no pointer memory — teammates won't find it.
+- Guessing `agent_id` / `fleet_id`, or inventing UUIDs.
+- Deleting when you should supersede.
+- Recalling on every trivial turn, or making all four Orient calls by reflex
+  when the task needs one.
+
+### Constraints & errors
+
+- `caura_write`: exactly one of `content` / `items`; `items` ≤ 100 → `BATCH_TOO_LARGE`.
+- Cursor pagination needs `sort=created_at` + `order=desc`.
+- `_entity_get` / `_manage` use real UUIDs — never invent.
+- Error codes: `INVALID_ARGUMENTS` · `BATCH_TOO_LARGE` · `INVALID_BATCH_ITEM`. Other errors surface with HTTP status + message — return them to your caller, don't swallow.
+
+---
+
+*Install on a Claude Code / Codex runtime with
+`curl -s "https://caura.ai/api/v1/install-skill?agent=both&skill=caura" | bash`, or copy
+this file to `~/.claude/skills/caura/SKILL.md` (Claude Code) or
+`~/.agents/skills/caura/SKILL.md` (Codex). Per-workspace override: place a copy
+under `.claude/skills/caura/` or `.agents/skills/caura/`. OpenClaw fleets use
+the variant shipped with the Caura plugin.*

--- a/tests/test_install_skill_endpoint.py
+++ b/tests/test_install_skill_endpoint.py
@@ -161,6 +161,22 @@ def test_skill_company_brain_installs_to_company_brain_dirs():
     assert f"skills/{FROZEN_PLUGIN_SLUG}" not in script
 
 
+def test_skill_caura_installs_to_caura_dirs():
+    """``?skill=caura`` swaps the skill name through the paths, the fetch
+    URL, and the title — same shape as company-brain, proving the new
+    slug is independently allowlisted rather than piggybacking on the
+    default. Never touches the historical slug's dirs."""
+    client = _client()
+    resp = client.get("/api/v1/install-skill?agent=both&skill=caura")
+    assert resp.status_code == 200
+    script = resp.text
+    assert "=== Caura Skill Installer (direct-MCP) ===" in script
+    assert "$HOME/.claude/skills/caura" in script
+    assert "$HOME/.agents/skills/caura" in script
+    assert "/api/v1/skill/caura" in script
+    assert f"skills/{FROZEN_PLUGIN_SLUG}" not in script
+
+
 def test_invalid_skill_returns_400():
     client = _client()
     resp = client.get("/api/v1/install-skill?skill=not-a-real-skill")
@@ -192,6 +208,29 @@ def test_serve_company_brain_skill():
     resp = client.get("/api/v1/skill/company-brain")
     assert resp.status_code == 200
     assert "name: company-brain" in resp.text
+
+
+def test_serve_caura_skill_independently_of_memclaw():  # legacy-name-ok: rule 3 compat-alias test, dual-path transition
+    """/skill/caura serves its own file (static/skills/caura/SKILL.md),
+    not a forwarded copy of the historical route's response. This is the
+    in-process proof that the two slugs are genuinely dual-served
+    rather than one aliasing the other — the thing an authenticated
+    request against the live deploy would otherwise be needed to show.
+    Proves the CODE is correct; does not by itself prove the deployed
+    edge reaches this code path (see PR body)."""
+    client = _client()
+    caura_resp = client.get("/api/v1/skill/caura")
+    legacy_resp = client.get(DEFAULT_SKILL_ENDPOINT)
+    assert caura_resp.status_code == 200
+    assert legacy_resp.status_code == 200
+    assert "name: caura" in caura_resp.text
+    assert f"name: {FROZEN_PLUGIN_SLUG}" in legacy_resp.text
+    # The two skills describe the same product and are mostly identical
+    # prose, but their self-referential install paths must differ —
+    # this is what would break if /skill/caura silently went back to
+    # forwarding the historical route's response.
+    assert "skills/caura/SKILL.md" in caura_resp.text
+    assert "skills/caura/SKILL.md" not in legacy_resp.text
 
 
 def test_serve_unknown_skill_returns_404():


### PR DESCRIPTION
## What

Ships `plugin/skills/caura/` and `static/skills/caura/` as genuine,
independently-served copies of the existing `memclaw`-slug skills — per
Eldad's direct instruction (slug: `caura`) and the coordinator's approved
plan: **dual-path, not a flag-day cutover**. The two populations are
governed by unrelated mechanisms in different languages (`PROTECTED_SKILLS`
in `reconcile-skills.ts`; the Python `_SKILL_LABELS` dict in
`routes/plugin.py`), so landing both correctly in one window and having
each be independently verifiable is safer than one synchronized flip.
**Neither slug is dropped in this change.**

## The non-negotiable ordering constraint

`reconcile-skills.ts`'s reconciler ("owned" mode, which governs
`plugin/skills/` by default) deletes any on-disk skill slug that is
neither server-catalog-desired nor in `PROTECTED_SKILLS` — unconditionally,
every 60 seconds, no grace period. `"caura"` is added to that set in the
**same commit** that adds the directory. This isn't "land the allowlist
first as a safe step" — there is no safe "ahead of," only "together":
core-api serves plugin source and skill content from this identical
checkout, and the plugin's auto-upgrade path fetches all files (code +
root files) into memory and only writes to disk if the whole batch
succeeds, so an instance can never end up with the new allowlist and old
content, or vice versa.

## What changed

- `plugin/src/reconcile-skills.ts`: `PROTECTED_SKILLS` now protects both
  `"memclaw"` and `"caura"`.
- `core-api/src/core_api/routes/plugin.py`: `_plugin_root_files` gained
  `skills/caura/SKILL.md` (so auto-upgrade actually delivers it to
  *existing* installs, not just fresh ones); `_SKILL_LABELS` gained a
  `"caura"` key mapping to real `static/skills/caura/` content; the
  now-redundant fixed `/skill/caura` route (which just forwarded to
  `/skill/memclaw`'s handler) is **removed** — `"caura"` is now a real
  `_SKILL_FILES` entry served independently by the generic
  `/skill/{skill}` route.
- `plugin/src/heartbeat.ts`: `FALLBACK_ROOT_FILES` (the offline fallback
  used only when `/plugin-manifest` is unreachable) gained the new file too.
- `plugin/skills/caura/SKILL.md`, `static/skills/caura/SKILL.md`: copies
  of the `memclaw`-slug files. Content is identical except the handful of
  self-referential install-path lines. The plugin copy deliberately keeps
  `plugins.entries.memclaw.enabled` wherever it appears — that's the
  frozen plugin id (held separately, unrelated to this skill's own slug).
- `tests/test_install_skill_endpoint.py`: two new tests — `caura` installs
  to its own dirs like `company-brain` does, and `/skill/caura` serves
  content **distinct** from `/skill/memclaw` rather than forwarding to it
  (the thing a regression back to the old alias-only behavior would break).
- `docs/plans/skills-dual-path-transition.md`: new. Why `memclaw` isn't
  dropped yet, and the retirement condition — not a fixed date, but a
  named, checkable decision gate (a stable release + explicit owner
  sign-off), since the real constraint is adoption on installs this repo
  cannot measure.

The RPC-name dual-read alias (six gateway command names) is a separate
concern, in a separate PR.

## What this proves, and what it doesn't

The new in-process test proves the **code** is correct — `/skill/caura`
and `/skill/memclaw` genuinely serve different files, not one aliasing
the other. That is a stronger and more useful claim than "both paths work
today": it's the precondition for ever retiring `memclaw`. If `/skill/caura`
had shipped as a thin delegate to `skill_memclaw()` (as the route did before
this PR), dropping the `memclaw`-slug directory in the eventual retirement
change would silently break the `caura` path too — and it would break at
the exact moment everyone had already migrated onto it. This test is what
rules that out in advance, not just what confirms the current state.

It does **not** prove the deployed edge reaches this code path for an
authenticated caller: both `caura.ai` and `memclaw.net` edge-gate
`/api/v1/skill/*` with a `401` for an unauthenticated request today
(confirmed live, both domains, both slugs — matches a pre-existing
docstring noting the hosted deploy 401s under either name), and neither I
nor the coordinator has a credential to get past that gate.

**Post-merge verification owed, not yet done:**
- An authenticated request to `/api/v1/skill/caura` and
  `/api/v1/skill/memclaw`, confirming each serves its own distinct content.
- Confirming both `plugin/skills/{memclaw,caura}/` directories are still
  present a full heartbeat (60s+) after deploy — not just immediately.

## Sequencing note

`memclaw-caura-b3` is independently fixing a stale self-query claim in
both `memclaw`-slug `SKILL.md` files (`static:174`, `plugin:194`) in a
follow-up PR, correcting all four resulting files (both slugs × both
populations) in one commit once this merges — agreed order, so the
corrected text lands on the slug everyone migrates to, not only on the
one being retired.

## Verification

- `python3 scripts/legacy_name_ratchet.py --base origin/main` → `No new
  lines. 0 annotated, 6 removed, 0 excused moves (-6 net).` EXIT 0
- `python3 scripts/do_not_touch_sentinel.py` → `All 39 protected strings
  survive.`
- `ruff format --check` / `ruff check` on `core-api/src/` and `tests/` → clean
- Real end-to-end: `alembic upgrade head` against a freshly-created
  `caura`-credentialed Postgres container → all 41 revisions clean
- `pytest tests/test_install_skill_endpoint.py` → 18/18 passed
- `pytest tests/test_api_plugin.py tests/test_f4_installer_api_url_default.py tests/test_plugin_source_manifest.py`
  → 40/40 passed (no regression from removing the old fixed alias route)
- `pytest tests/ -m "not benchmark"` → 5974 passed (full root suite)
- `npx tsc --noEmit` (plugin) → clean
- `npm test` (plugin) → 427/427 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
