### PR TITLE
docs(skills): stop telling agents to discover permissions by attempting the operation

### DIFF
--- a/plugin/skills/caura/SKILL.md
+++ b/plugin/skills/caura/SKILL.md
@@ -191,11 +191,19 @@ Operations that escalate the required level:
 - `caura_manage op=delete` → trust 3
 
 **Knowing your own level.** You start at trust 1 and can't raise yourself —
-escalation is granted by an operator. There's no self-query, so don't
-pre-emptively avoid an operation you're unsure about: attempt it. A permission
-error names both your current level and the one required (e.g. *"Agent X
-(trust_level=1) … Requires trust_level >= 2"*) — surface that error rather than
-silently retrying at a narrower scope.
+escalation is granted by an operator. `GET /api/v1/whoami` reports it:
+`trust_level`, plus a `trust_source` saying how to read it — `lookup` (your
+level, authoritative), `none` (you hold a tenant-scoped credential, which the
+trust ladder does not govern), `unregistered` (no agent row yet), or
+`unavailable` (this deployment cannot resolve it — e.g. self-hosted with no
+gateway). Ask it rather than discovering your permissions by attempting the
+operation. That matters most for `op=delete`: it is irreversible, and its
+refusal — *"access policy: principals of fleet 'none' are not permitted to
+delete memories."* — names neither your level nor the one required, so probing
+with it teaches you nothing. Where `trust_source` is `unavailable` the refusal
+is still your only source of truth; the trust-ladder errors do name both levels
+(e.g. *"Agent X (trust_level=1) < required 2"*) — surface that error rather
+than silently retrying at a narrower scope.
 
 **Visibility (on write)** decides who can see a memory: `scope_agent` (private)
 · `scope_team` *(default — your fleet)* · `scope_org` (all fleets in tenant).

--- a/plugin/skills/memclaw/SKILL.md
+++ b/plugin/skills/memclaw/SKILL.md
@@ -191,11 +191,19 @@ Operations that escalate the required level:
 - `caura_manage op=delete` → trust 3
 
 **Knowing your own level.** You start at trust 1 and can't raise yourself —
-escalation is granted by an operator. There's no self-query, so don't
-pre-emptively avoid an operation you're unsure about: attempt it. A permission
-error names both your current level and the one required (e.g. *"Agent X
-(trust_level=1) … Requires trust_level >= 2"*) — surface that error rather than
-silently retrying at a narrower scope.
+escalation is granted by an operator. `GET /api/v1/whoami` reports it:
+`trust_level`, plus a `trust_source` saying how to read it — `lookup` (your
+level, authoritative), `none` (you hold a tenant-scoped credential, which the
+trust ladder does not govern), `unregistered` (no agent row yet), or
+`unavailable` (this deployment cannot resolve it — e.g. self-hosted with no
+gateway). Ask it rather than discovering your permissions by attempting the
+operation. That matters most for `op=delete`: it is irreversible, and its
+refusal — *"access policy: principals of fleet 'none' are not permitted to
+delete memories."* — names neither your level nor the one required, so probing
+with it teaches you nothing. Where `trust_source` is `unavailable` the refusal
+is still your only source of truth; the trust-ladder errors do name both levels
+(e.g. *"Agent X (trust_level=1) < required 2"*) — surface that error rather
+than silently retrying at a narrower scope.
 
 **Visibility (on write)** decides who can see a memory: `scope_agent` (private)
 · `scope_team` *(default — your fleet)* · `scope_org` (all fleets in tenant).

--- a/static/skills/caura/SKILL.md
+++ b/static/skills/caura/SKILL.md
@@ -171,11 +171,19 @@ Operations that escalate the required level:
 - `caura_manage op=delete` → trust 3
 
 **Knowing your own level.** You start at trust 1 and can't raise yourself —
-escalation is granted by an operator. There's no self-query tool, so don't
-pre-emptively avoid an operation you're unsure about: attempt it. A permission
-error names both your current level and the one required (e.g. *"Agent X
-(trust_level=1) … Requires trust_level >= 2"*) — surface that error rather than
-silently retrying at a narrower scope.
+escalation is granted by an operator. `GET /api/v1/whoami` reports it:
+`trust_level`, plus a `trust_source` saying how to read it — `lookup` (your
+level, authoritative), `none` (you hold a tenant-scoped credential, which the
+trust ladder does not govern), `unregistered` (no agent row yet), or
+`unavailable` (this deployment cannot resolve it — e.g. self-hosted with no
+gateway). Ask it rather than discovering your permissions by attempting the
+operation. That matters most for `op=delete`: it is irreversible, and its
+refusal — *"access policy: principals of fleet 'none' are not permitted to
+delete memories."* — names neither your level nor the one required, so probing
+with it teaches you nothing. Where `trust_source` is `unavailable` the refusal
+is still your only source of truth; the trust-ladder errors do name both levels
+(e.g. *"Agent X (trust_level=1) < required 2"*) — surface that error rather
+than silently retrying at a narrower scope.
 
 **Visibility (on write)** decides who can see a memory: `scope_agent` (private)
 · `scope_team` *(default — your fleet)* · `scope_org` (all fleets in tenant).

--- a/static/skills/memclaw/SKILL.md
+++ b/static/skills/memclaw/SKILL.md
@@ -171,11 +171,19 @@ Operations that escalate the required level:
 - `caura_manage op=delete` → trust 3
 
 **Knowing your own level.** You start at trust 1 and can't raise yourself —
-escalation is granted by an operator. There's no self-query tool, so don't
-pre-emptively avoid an operation you're unsure about: attempt it. A permission
-error names both your current level and the one required (e.g. *"Agent X
-(trust_level=1) … Requires trust_level >= 2"*) — surface that error rather than
-silently retrying at a narrower scope.
+escalation is granted by an operator. `GET /api/v1/whoami` reports it:
+`trust_level`, plus a `trust_source` saying how to read it — `lookup` (your
+level, authoritative), `none` (you hold a tenant-scoped credential, which the
+trust ladder does not govern), `unregistered` (no agent row yet), or
+`unavailable` (this deployment cannot resolve it — e.g. self-hosted with no
+gateway). Ask it rather than discovering your permissions by attempting the
+operation. That matters most for `op=delete`: it is irreversible, and its
+refusal — *"access policy: principals of fleet 'none' are not permitted to
+delete memories."* — names neither your level nor the one required, so probing
+with it teaches you nothing. Where `trust_source` is `unavailable` the refusal
+is still your only source of truth; the trust-ladder errors do name both levels
+(e.g. *"Agent X (trust_level=1) < required 2"*) — surface that error rather
+than silently retrying at a narrower scope.
 
 **Visibility (on write)** decides who can see a memory: `scope_agent` (private)
 · `scope_team` *(default — your fleet)* · `scope_org` (all fleets in tenant).


### PR DESCRIPTION
> ⚠️ **Merge [#1260](https://github.com/caura-ai/caura/pull/1260) first.** This documents `trust_level` / `trust_source`, which do not exist until that PR lands. Merging this alone would describe `/whoami` as returning something it does not yet return — the same defect in the opposite direction.

Follow-up to #1260, sequenced behind #1261 (see *Why this is a separate PR* below).

## The advice being removed

All four served skill copies told agents there was no way to ask:

> *"There's no self-query tool, so don't pre-emptively avoid an operation you're unsure about: attempt it."*

That was defensible only while it was true. #1260 adds `trust_level` and `trust_source` to `GET /api/v1/whoami`, so an agent can now ask instead of probing — which makes this advice **actively wrong rather than merely dated**.

## It was worst on the one operation where probing costs something

`caura_manage op=delete` is irreversible, so "attempt it and see" spends a real memory to learn a permission.

And the sentence that made the advice sound safe — *"a permission error names both your current level and the one required"* — **is false for exactly that case.** `enforce_delete` refuses with:

```
access policy: principals of fleet 'none' are not permitted to delete memories.
```

which names **neither** the caller's trust level **nor** the required one. So an agent following this guidance on a delete destroyed a row and learned nothing actionable from the refusal.

The claim holds only for the trust-ladder errors (`Agent 'alice' (trust_level=1) < required 2`) — and even there the example given was **misquoted**: the real format is `< required N`, not *"Requires trust_level >= 2"*. Both are corrected.

## What replaces it

The new text says what `/whoami` returns, including the `trust_source` values that keep a null `trust_level` unambiguous, and is **honest about when it cannot answer**: a self-hosted deployment with no gateway secret reports `unavailable`, because #1260 deliberately does not perform the lookup without a verified perimeter.

In that case the refusal really *is* the only source of truth — so that guidance is **kept rather than dropped**, scoped to the errors that genuinely do name both levels. The point is not "never read errors"; it is "don't use an irreversible operation as a permissions probe when you can just ask."

## Why this is a separate PR

The correction had to wait on #1261, which dual-path renamed these directories. Correcting them before that landed would have fixed the copies being **retired** while the new `caura` slug shipped the stale advice from pre-fix content — the path everyone migrates to would have kept the bad text indefinitely. Ordering was agreed with that lane; #1261 merged, so all four copies exist and are corrected together here.

## Scope

Applied to all four copies:

```
plugin/skills/memclaw/SKILL.md   plugin/skills/caura/SKILL.md
static/skills/memclaw/SKILL.md   static/skills/caura/SKILL.md
```

`plugin/` and `static/` had drifted — *"no self-query"* vs *"no self-query tool"* — and now carry identical text. The **slug-specific differences** between the `memclaw` and `caura` copies (frontmatter `name:`, install paths, the frozen `plugins.entries.memclaw.enabled` config key and its floor marker) are **untouched**; verified by diffing the pairs before and after and confirming the new paragraph is byte-identical across slugs while the slug-specific hunks survive.

## Verification

- Documentation only — no code, no behaviour change.
- `tests/test_install_skill_endpoint.py` + `tests/test_api_plugin.py` (the tests that actually serve these files): **31 passed**.
- Full root suite: **54 failed / 5915 passed**, identical to the `main` baseline — no delta, as expected for a docs-only change. The 54 are pre-existing missing-optional-dep gaps in the local venv.
- `legacy_name_ratchet.py --base origin/main` → *No new lines.* · `do_not_touch_sentinel.py` → *All 39 protected strings survive.* Both run **after `git add`**, since these gates are diff-based and cannot see an unstaged file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
