### PR TITLE
fix(mcp): enforce CAURA_API_KEY on /mcp before the header-trust path

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -225,6 +225,27 @@ _ADMIN_ERROR = _as_error_result(
 )
 
 
+async def _send_401(send: Send, message: str) -> None:
+    """Refuse the request outright with a JSON error envelope.
+
+    Refusing beats falling through to ``_UNAUTH``: a request that keeps going
+    with a different identity resolution lets a caller probe which headers
+    change the answer.
+    """
+    body = _error_response("UNAUTHORIZED", message).encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
 class MCPAuthMiddleware:
     """ASGI middleware that resolves X-API-Key to tenant_id before MCP handlers run."""
 
@@ -237,18 +258,81 @@ class MCPAuthMiddleware:
 
             headers = dict(scope.get("headers", []))
 
-            # Preferred path: enterprise nginx has already validated the
-            # session cookie / JWT / API key via auth_request and injected
-            # X-Tenant-ID. Trust that resolution verbatim — otherwise a
-            # browser dashboard call (which sends `Authorization: Bearer
-            # <session JWT>` alongside the gateway-injected X-Tenant-ID)
-            # falls into the Authorization→api_key fallback below, fails
-            # the admin-key comparison, and reports UNAUTH despite the
-            # gateway having already approved the caller.
             tenant_header = headers.get(b"x-tenant-id", b"").decode()
-            if tenant_header:
-                # Perimeter check (mirrors REST ``get_auth_context`` Path 4):
-                # the header-trust path accepts X-Tenant-ID / X-Agent-ID /
+            api_key = headers.get(b"x-api-key", b"").decode()
+            if not api_key:
+                auth_header = headers.get(b"authorization", b"").decode()
+                if auth_header.lower().startswith("bearer "):
+                    api_key = auth_header[7:]
+            admin_key = get_admin_key()
+            # CAURA_API_KEY. Read here for the first time: this middleware used
+            # to resolve identity without ever consulting it, so a deployment
+            # that set it as its ONLY perimeter — the configuration
+            # ``app.py``'s production boot guard explicitly blesses, on the
+            # grounds that REST's Path 2 "either authenticates the request
+            # against that key or raises 401 ... so Path 4 below it is
+            # UNREACHABLE" — got that guarantee on REST and not on ``/mcp``,
+            # which is a separate ASGI mount this middleware alone protects.
+            # Reads the RESOLVED dual-read field (``CAURA_API_KEY`` falling back
+            # to the legacy env var, merged in config.py) — the same one
+            # ``auth.py`` Path 2 reads. Reading ``caura_api_key`` directly would
+            # silently skip the gate for a deployment still setting the old
+            # variable, which is the population this most needs to protect.
+            shared_key = settings.memclaw_api_key  # legacy-name-ok: rule 3 dual-read field
+
+            via_gateway = False
+            if admin_key and api_key and _hmac.compare_digest(api_key, admin_key):
+                # ── Path 1: admin API key (REST ``auth.py`` Path 1) ──
+                _tenant_id_var.set(_ADMIN)
+            elif shared_key:
+                # ── Path 2: CAURA_API_KEY shared gate (REST Path 2) ──
+                #
+                # ORDER IS THE FIX, not merely the comparison. This runs BEFORE
+                # the header-trust path below for the same reason REST runs it
+                # before its Path 4: with the key configured, an unauthenticated
+                # caller must not be able to reach a path that accepts
+                # self-asserted identity headers. Previously ``X-Tenant-ID``
+                # was honored first, so on a shared-key deployment with no
+                # gateway secret anyone could name a tenant and be believed.
+                if not (api_key and _hmac.compare_digest(api_key, shared_key)):
+                    await _send_401(
+                        send,
+                        "Missing or invalid API key. This deployment sets "
+                        "CAURA_API_KEY; send it as X-API-Key (or a Bearer "
+                        "token) on every request, including MCP.",
+                    )
+                    return
+                # Key verified. Resolve the tenant exactly as REST does on this
+                # path: standalone's fixed tenant, else the caller's
+                # ``X-Tenant-ID``, else no tenant at all.
+                if settings.is_standalone:
+                    from core_api.standalone import get_standalone_tenant_id
+
+                    _tenant_id_var.set(get_standalone_tenant_id())
+                elif tenant_header:
+                    _tenant_id_var.set(tenant_header)
+                else:
+                    _tenant_id_var.set(_UNAUTH)
+                # ``via_gateway`` stays False: possessing the shared key proves
+                # the caller may reach this deployment, NOT which agent it is.
+                # The key is tenant-wide and binds no agent identity, so the
+                # gateway-injected attributes below (X-Agent-ID above all, which
+                # is the authorization principal for scope checks and the delete
+                # trust gate) are deliberately not honored here. Letting a
+                # shared-key holder self-assert an agent id would hand it any
+                # agent's scope.
+            elif tenant_header:
+                # ── Path 4: gateway header-trust (REST Path 4) ──
+                # Preferred path: enterprise nginx has already validated the
+                # session cookie / JWT / API key via auth_request and injected
+                # X-Tenant-ID. Trust that resolution verbatim — otherwise a
+                # browser dashboard call (which sends `Authorization: Bearer
+                # <session JWT>` alongside the gateway-injected X-Tenant-ID)
+                # falls into the Authorization→api_key fallback below, fails
+                # the admin-key comparison, and reports UNAUTH despite the
+                # gateway having already approved the caller.
+                #
+                # Perimeter check: this path accepts X-Tenant-ID / X-Agent-ID /
                 # X-Readable-Tenant-IDs / X-Capabilities with no credential of
                 # its own, so when a shared secret is configured the request
                 # must prove it came through the gateway. A caller reaching
@@ -261,43 +345,20 @@ class MCPAuthMiddleware:
                 if gw_secret and not _hmac.compare_digest(
                     headers.get(b"x-gateway-secret", b"").decode(), gw_secret
                 ):
-                    body = _error_response(
-                        "UNAUTHORIZED",
-                        "Direct access to this service is not permitted.",
-                    ).encode()
-                    await send(
-                        {
-                            "type": "http.response.start",
-                            "status": 401,
-                            "headers": [
-                                (b"content-type", b"application/json"),
-                                (b"content-length", str(len(body)).encode()),
-                            ],
-                        }
-                    )
-                    await send({"type": "http.response.body", "body": body})
+                    await _send_401(send, "Direct access to this service is not permitted.")
                     return
                 _tenant_id_var.set(tenant_header)
-                _via_gateway_var.set(True)
+                via_gateway = True
+            elif settings.is_standalone:
+                # ── Path 3: standalone, no key required (REST Path 3) ──
+                from core_api.standalone import get_standalone_tenant_id
+
+                _tenant_id_var.set(get_standalone_tenant_id())
+            elif not api_key:
+                _tenant_id_var.set(_UNAUTH if admin_key else _NO_AUTH)
             else:
-                _via_gateway_var.set(False)
-                api_key = headers.get(b"x-api-key", b"").decode()
-                if not api_key:
-                    auth_header = headers.get(b"authorization", b"").decode()
-                    if auth_header.lower().startswith("bearer "):
-                        api_key = auth_header[7:]
-                admin_key = get_admin_key()
-
-                if admin_key and api_key and _hmac.compare_digest(api_key, admin_key):
-                    _tenant_id_var.set(_ADMIN)
-                elif settings.is_standalone:
-                    from core_api.standalone import get_standalone_tenant_id
-
-                    _tenant_id_var.set(get_standalone_tenant_id())
-                elif not api_key:
-                    _tenant_id_var.set(_UNAUTH if admin_key else _NO_AUTH)
-                else:
-                    _tenant_id_var.set(_UNAUTH)
+                _tenant_id_var.set(_UNAUTH)
+            _via_gateway_var.set(via_gateway)
 
             # X-Agent-ID / X-Readable-Tenant-IDs / X-Capabilities are
             # gateway-injected identity attributes — only honor them on the
@@ -313,7 +374,14 @@ class MCPAuthMiddleware:
             # "single-tenant / full-scope" — make that explicit so a previous
             # request's cross-tenant read-set or read-only scope cannot bleed
             # through.
-            via_gateway = bool(tenant_header)
+            # NOT ``bool(tenant_header)``. The presence of X-Tenant-ID is not
+            # the same question as "did this request arrive gateway-verified":
+            # a shared-key (Path 2) caller may send X-Tenant-ID too, and
+            # deriving the flag from the header would silently re-honor
+            # X-Agent-ID for it — handing a tenant-wide key any agent's
+            # identity, which is the authorization principal for scope checks
+            # and the delete trust gate. Use the value the resolution above
+            # decided; only Path 4 sets it True.
             agent_header = headers.get(b"x-agent-id", b"").decode() if via_gateway else ""
             _agent_id_var.set(agent_header or None)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -128,6 +128,12 @@ The identity headers are trusted on the gateway-header auth path. Set
 set `CAURA_API_KEY`; that shared-key path authenticates first and prevents the
 header-trust path from being reached.
 
+This holds on **both** surfaces. `/mcp` is a separate ASGI mount with its own
+auth middleware rather than a route behind `get_auth_context`, so "authenticates
+first" is a property each surface has to implement for itself. When the key is
+set, send it as `X-API-Key` (or a Bearer token) on MCP calls too; without it the
+request is refused `401` before any identity header is consulted.
+
 **Rate limiting (managed platform)**
 
 These limits apply to the managed platform at `caura.ai`. A self-hosted deployment enforces its own, looser per-route limits out of the box — see the [self-hosted rate limiting](../README.md#rate-limiting) section.

--- a/tests/test_mcp_gateway_secret.py
+++ b/tests/test_mcp_gateway_secret.py
@@ -42,6 +42,13 @@ def _reset_mcp_context_vars():
     mcp_server._org_read_only_var.set(False)
 
 
+# The settings attribute is the RESOLVED dual-read field (CAURA_API_KEY
+# falling back to the legacy env var), which is the one ``auth.py`` Path 2
+# reads and therefore the one the MCP gate must read too. Named once here so
+# the tests below carry the current name rather than nine legacy references.
+_SHARED_KEY_FIELD = "memclaw_api_key"  # legacy-name-ok: rule 3 dual-read field
+
+
 async def _call_middleware(headers: list[tuple[bytes, bytes]]):
     """Invoke ``MCPAuthMiddleware`` once with a synthetic ASGI scope.
 
@@ -253,3 +260,210 @@ async def test_org_read_only_requires_the_gateway_secret_when_configured(monkeyp
     )
     assert app_called is False
     assert mcp_server._is_org_read_only() is False
+
+
+# ---------------------------------------------------------------------------
+# S2 — CAURA_API_KEY shared gate on /mcp
+#
+# The middleware never read the shared-key setting at all. ``/mcp`` is a
+# separate ASGI mount, so REST's Path 2 does not cover it, and the docs plus
+# ``app.py``'s production boot guard both treat CAURA_API_KEY as a sufficient
+# perimeter on the strength of that path making header-trust UNREACHABLE.
+#
+# Three consequences, all pinned below:
+#   1. keyless caller + X-Tenant-ID  → was believed verbatim (cross-tenant)
+#   2. keyless caller + standalone   → was handed the standalone tenant
+#   3. CORRECT key, no standalone    → was refused (_UNAUTH), so the
+#      documented shared-gate client could not use MCP at all
+#
+# Note these tests set ``is_standalone`` explicitly. The suite runs with
+# IS_STANDALONE=true, which silently decides several of these branches.
+# ---------------------------------------------------------------------------
+
+
+async def test_shared_key_gate_refuses_a_keyless_tenant_header(monkeypatch):
+    """THE CROSS-TENANT HOLE. Keyless caller naming a tenant must be refused.
+
+    With CAURA_API_KEY set and no gateway secret — the documented
+    network-exposed OSS shape, blessed by app.py's boot guard — the old
+    middleware honored X-Tenant-ID verbatim, so anyone who could reach /mcp
+    became any tenant they named. Fails without the fix: the request reached
+    the app with tenant ``victim`` resolved.
+    """
+    monkeypatch.setattr(settings, _SHARED_KEY_FIELD, "sh4red")
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(settings, "is_standalone", False)
+
+    app_called, sends = await _call_middleware([(b"x-tenant-id", b"victim")])
+
+    assert app_called is False, "request reached the app without the shared key"
+    start = next(m for m in sends if m["type"] == "http.response.start")
+    assert start["status"] == 401
+    assert mcp_server._get_tenant() != "victim"
+
+
+async def test_shared_key_gate_refuses_a_keyless_caller_in_standalone(monkeypatch):
+    """Keyless caller must not be handed the standalone tenant.
+
+    ``elif settings.is_standalone`` used to fire before any key comparison, so
+    a standalone deployment that set CAURA_API_KEY precisely to expose itself
+    to a network granted every unauthenticated caller full read/write/delete
+    of the standalone tenant.
+    """
+    monkeypatch.setattr(settings, _SHARED_KEY_FIELD, "sh4red")
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(settings, "is_standalone", True)
+
+    app_called, sends = await _call_middleware([])
+
+    assert app_called is False, "keyless caller reached the app in standalone"
+    start = next(m for m in sends if m["type"] == "http.response.start")
+    assert start["status"] == 401
+
+
+async def test_shared_key_gate_refuses_a_wrong_key(monkeypatch):
+    monkeypatch.setattr(settings, _SHARED_KEY_FIELD, "sh4red")
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(settings, "is_standalone", True)
+
+    app_called, sends = await _call_middleware([(b"x-api-key", b"wrong")])
+
+    assert app_called is False
+    start = next(m for m in sends if m["type"] == "http.response.start")
+    assert start["status"] == 401
+
+
+async def test_shared_key_gate_accepts_the_correct_key_with_tenant_header(monkeypatch):
+    """GUARD, NOT EVIDENCE — passes before and after the fix.
+
+    The documented shared-gate client (X-API-Key + X-Tenant-ID) reached the
+    app before this change too, but by falling through to HEADER-TRUST: the
+    key was never compared, and an attacker omitting it got the same result.
+    So this pins that the accept path still works, not that the gate exists.
+    The refusal tests above are the evidence.
+
+    Worth recording because the finding overstated this half. H-01 claimed a
+    correct key "falls to _UNAUTH" in shared-gate mode; that is true only for
+    a caller sending NO X-Tenant-ID, and such a caller still resolves no
+    tenant after the fix — there is nothing to resolve. The documented client
+    sends both headers and always worked. The security half of the finding is
+    the real defect.
+    """
+    monkeypatch.setattr(settings, _SHARED_KEY_FIELD, "sh4red")
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(settings, "is_standalone", False)
+
+    app_called, sends = await _call_middleware(
+        [(b"x-api-key", b"sh4red"), (b"x-tenant-id", b"tenant-A")]
+    )
+
+    assert app_called is True
+    assert not any(m["type"] == "http.response.start" for m in sends)
+    assert mcp_server._get_tenant() == "tenant-A"
+
+
+async def test_shared_key_accepted_as_a_bearer_token(monkeypatch):
+    """GUARD, NOT EVIDENCE — passes before and after, same reason as above.
+
+    Pins that the Bearer form of the key is accepted, since the install docs
+    show both shapes and the gate reads them through one code path.
+    """
+    monkeypatch.setattr(settings, _SHARED_KEY_FIELD, "sh4red")
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(settings, "is_standalone", False)
+
+    app_called, _ = await _call_middleware(
+        [(b"authorization", b"Bearer sh4red"), (b"x-tenant-id", b"tenant-A")]
+    )
+
+    assert app_called is True
+    assert mcp_server._get_tenant() == "tenant-A"
+
+
+async def test_shared_key_bearer_form_is_actually_verified(monkeypatch):
+    """The Bearer path must be GATED, not just accepted.
+
+    Distinguishes the guard above from real coverage: a wrong Bearer token
+    with a tenant header used to sail through on header-trust. Fails without
+    the fix.
+    """
+    monkeypatch.setattr(settings, _SHARED_KEY_FIELD, "sh4red")
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(settings, "is_standalone", False)
+
+    app_called, sends = await _call_middleware(
+        [(b"authorization", b"Bearer wrong"), (b"x-tenant-id", b"tenant-A")]
+    )
+
+    assert app_called is False
+    start = next(m for m in sends if m["type"] == "http.response.start")
+    assert start["status"] == 401
+
+
+async def test_shared_key_holder_cannot_self_assert_an_agent_identity(monkeypatch):
+    """A tenant-wide key must not pick an agent identity.
+
+    The shared key proves the caller may reach this deployment, not WHICH
+    agent it is. ``X-Agent-ID`` is the authorization principal for scope checks
+    and (since #1259) the delete trust gate, so honoring it here would let any
+    shared-key holder borrow any agent's scope.
+
+    This is the trap in the fix: ``via_gateway`` was derived downstream as
+    ``bool(tenant_header)``, which would have silently re-honored the header
+    for exactly this caller. Fails if that derivation comes back.
+    """
+    monkeypatch.setattr(settings, _SHARED_KEY_FIELD, "sh4red")
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(settings, "is_standalone", False)
+
+    app_called, _ = await _call_middleware(
+        [
+            (b"x-api-key", b"sh4red"),
+            (b"x-tenant-id", b"tenant-A"),
+            (b"x-agent-id", b"privileged-agent"),
+            (b"x-capabilities", b"read,write"),
+            (b"x-readable-tenant-ids", b"tenant-B,tenant-C"),
+        ]
+    )
+
+    assert app_called is True
+    assert mcp_server._get_tenant() == "tenant-A"
+    assert mcp_server._get_agent_id() is None, "shared key self-asserted an agent id"
+    assert mcp_server._get_scopes() is None
+    assert mcp_server._get_readable_tenants() == []
+
+
+async def test_shared_key_unset_leaves_every_path_unchanged(monkeypatch):
+    """Scope guard: with CAURA_API_KEY unset nothing about this middleware moves.
+
+    That is the entire existing deployment surface — enterprise (gateway
+    secret) and plain standalone both leave the key unset — so this pins that
+    the new gate is inert for them rather than a behaviour change everyone
+    absorbs.
+    """
+    monkeypatch.setattr(settings, _SHARED_KEY_FIELD, None)
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(settings, "is_standalone", True)
+
+    app_called, sends = await _call_middleware([(b"x-tenant-id", b"tenant-A")])
+
+    assert app_called is True
+    assert not any(m["type"] == "http.response.start" for m in sends)
+    assert mcp_server._get_tenant() == "tenant-A"
+
+
+async def test_admin_key_still_works_when_the_shared_gate_is_configured(monkeypatch):
+    """Admin is Path 1 and stays ahead of the gate, as in REST.
+
+    Without this ordering an operator holding the admin key would be refused
+    by the shared-gate comparison on a deployment that configures both.
+    """
+    monkeypatch.setattr(settings, _SHARED_KEY_FIELD, "sh4red")
+    monkeypatch.setattr(settings, "gateway_shared_secret", None)
+    monkeypatch.setattr(settings, "is_standalone", False)
+    monkeypatch.setattr(mcp_server, "get_admin_key", lambda: "adm1n")
+
+    app_called, _ = await _call_middleware([(b"x-api-key", b"adm1n")])
+
+    assert app_called is True
+    assert mcp_server._get_tenant() == mcp_server._ADMIN


### PR DESCRIPTION
Closes audit findings **H-01** and **H-13** — one defect with two faces, merged per the agreed dedup so a docs-only fix could not document a live auth hole as intended behaviour.

## The defect

`MCPAuthMiddleware` never read `settings.memclaw_api_key`. `/mcp` is a **separate ASGI mount** with its own auth middleware, not a route behind `get_auth_context`, so REST's Path 2 does not cover it — and nothing else did either.

That matters because the rest of the system treats `CAURA_API_KEY` as a *sufficient perimeter* on the strength of that path. `app.py`'s production boot guard says so in as many words:

> when it is set, `auth.py`'s "Path 2" either authenticates the request against that key or raises 401 for everything else, so "Path 4" below it is **UNREACHABLE** and there is no header-trust surface left to protect

`docs/api-reference.md` makes the same promise. On `/mcp`, neither was true.

## The security consequence

In the exact configuration the boot guard blesses — `CAURA_API_KEY` set, no gateway:

| Caller | Old behaviour |
|---|---|
| keyless, sends only `X-Tenant-ID: victim` | **believed verbatim** → `caura_write` / `caura_recall` / `caura_manage` across that tenant. Unauthenticated cross-tenant read, write and delete. |
| keyless, standalone deployment | `elif settings.is_standalone` fired **before any key comparison** → full standalone tenant to every anonymous caller |
| correct key | worked, but via header-trust — the key was never compared |

The second row is the sharp one: setting `CAURA_API_KEY` *precisely in order to expose the service to a network* was what granted anonymous access.

## Order is the fix, not the comparison

The gate runs **before** the header-trust path, mirroring `auth.py` Path 2 sitting above Path 4. Adding a key check *after* header-trust would have left the hole exactly as it was, since `X-Tenant-ID` was consulted first.

**Deliberately not a faithful reordering of the whole chain.** REST also puts standalone above header-trust; MCP does the reverse, and that difference has its own test (`test_tenant_header_honored_when_secret_unset`) pinning intentional behaviour. Reordering those too would be an unrelated behaviour change riding along with a security fix, so only Path 2 was inserted.

**With `CAURA_API_KEY` unset — enterprise (gateway secret) and plain standalone, i.e. every deployment that exists today — this middleware is unchanged in behaviour.** There is a test pinning exactly that, so the new gate is inert for them rather than a change everyone absorbs.

Path 1 (admin key) moved ahead of header-trust to match REST, so an operator holding the admin key is not refused by the shared-key comparison on a deployment configuring both.

## One trap worth naming

`via_gateway` was derived downstream as `bool(tenant_header)`. A shared-key caller may legitimately send `X-Tenant-ID`, so that derivation would have **silently re-honored `X-Agent-ID`** for it — handing a tenant-wide key any agent's identity, which since #1259 is the authorization principal for scope checks *and* the delete trust gate. It now uses the value the resolution decided; only Path 4 sets it `True`, and a test pins that a shared-key holder cannot self-assert an agent id, capability set, or readable-tenant set.

## The docs half (H-13)

`api-reference.md` already **claimed** the shared-key path authenticates first and prevents header-trust from being reached. That claim was true for REST and false for MCP — so the resolution is the code, not a correction. One sentence is added making the `/mcp` coverage explicit, since that was the silently untrue part. `AGENT-INSTALL.md`, which tells operators to point MCP at the shared gate key, likewise becomes accurate rather than aspirational.

## Where the finding was wrong

H-01's *"valid key rejected in shared-gate mode"* half does not hold up. It claims a correct key falls to `_UNAUTH`; that is true only for a caller sending **no** `X-Tenant-ID`, and such a caller still resolves no tenant after this change — there is nothing to resolve. The documented client sends both headers and always worked, by accident, via header-trust. (H-13's own verifier note caught this: *"the documented client also sends X-Tenant-ID and would succeed on MCP."*) **The security half is the real defect**, and it is understated rather than overstated.

## Tests

**Five fail without the fix**, confirmed by reverting `mcp_server.py` to `origin/main` and re-running:

```
test_shared_key_gate_refuses_a_keyless_tenant_header
test_shared_key_gate_refuses_a_keyless_caller_in_standalone
test_shared_key_gate_refuses_a_wrong_key
test_shared_key_bearer_form_is_actually_verified
test_shared_key_holder_cannot_self_assert_an_agent_identity
```

**Two are labelled in-file as guards that pass either way** — the documented client reached the app before this change too, so they pin the accept path, not the gate. Labelled explicitly so nobody later reads their green as proof the fix works. That distinction is why the wrong-Bearer test exists separately from the accepts-Bearer one.

The new tests also set `is_standalone` explicitly. The suite runs with `IS_STANDALONE=true`, which silently decides several of these branches — the same class of trap as the admin-key default that would have made an earlier PR's tests vacuous.

## Verification

- Full root suite: **54 failed / 5924 passed**. `main` baseline is 54 failed / 5915 passed — identical failures, **+9 exactly the new tests**. The 54 are pre-existing missing-optional-dep gaps in the local venv.
- `ruff check` and `ruff format --check` run **separately** at CI's exact scopes — clean.
- `mypy` clean on the changed file (2 pre-existing `types-python-dateutil` stub errors in an untouched file).
- **Legacy-name ratchet initially failed** — legitimately, not a stale base: reading `settings.memclaw_api_key` adds the legacy name. That field is the *resolved dual-read* value (`CAURA_API_KEY` falling back to the legacy env var) and is the one `auth.py` Path 2 reads, so the gate must read the same one — reading `caura_api_key` directly would silently skip the gate for deployments still setting the old variable, which is the population this most needs to protect. Marked `legacy-name-ok: rule 3 dual-read field` on the source line, and the test file's nine references collapsed into a single named constant carrying one marker. Ratchet now reports *No new lines.*
- `do_not_touch_sentinel.py` → *All 39 protected strings survive.* Both gates run **after `git add`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
