### PR TITLE
fix(search): gate every requested fleet, not just the single-fleet case

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -52,7 +52,7 @@ from core_api.schemas import (
 from core_api.services.agent_service import (
     authorize_memory_access,
     enforce_delete,
-    enforce_fleet_read,
+    enforce_fleet_read_many,
     enforce_fleet_write,
     get_or_create_agent,
     resolve_write_agent,
@@ -969,8 +969,11 @@ async def caura_recall(
             ag_trust = _ag.get("trust_level", 0)
             if ag_fleet and ag_trust < 2:
                 fleet_ids = [ag_fleet]
-        if fleet_ids and len(fleet_ids) == 1:
-            await enforce_fleet_read(tenant_id, agent_id, fleet_ids[0])
+        # EVERY requested fleet — gating only the single-fleet case let a
+        # trust-1 agent widen its read by naming a second fleet (parity with
+        # REST /search and /recall).
+        if fleet_ids:
+            await enforce_fleet_read_many(tenant_id, agent_id, fleet_ids)
         # Cross-tenant recall widens via readable_tenant_ids when the caller
         # authenticated with a cross-tenant credential (kind=cross_tenant) — the
         # gateway plumbs ``X-Readable-Tenant-IDs`` and the MCP middleware parks

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -68,6 +68,7 @@ from core_api.services.agent_service import (
     broker_owned_agent_id,
     enforce_delete,
     enforce_fleet_read,
+    enforce_fleet_read_many,
     enforce_fleet_write,
     get_or_create_agent,
     lookup_agent,
@@ -1797,8 +1798,14 @@ async def _search_inner(
             _agent = await get_or_create_agent(body.tenant_id, eff_agent_id, fleet_id_hint)
             if not body.fleet_ids and _agent.get("fleet_id") and _agent.get("trust_level", 0) < 2:
                 body.fleet_ids = [_agent["fleet_id"]]  # Force fleet scoping for trust < 2
-            if body.fleet_ids and len(body.fleet_ids) == 1:
-                await enforce_fleet_read(body.tenant_id, eff_agent_id, body.fleet_ids[0])
+            # EVERY requested fleet, not just the single-fleet case. Gating only
+            # ``len == 1`` meant a trust-1 agent could read a fleet it has no
+            # rights to simply by naming a second one: the forcing branch above
+            # is skipped (the list is non-empty) and the ladder was skipped
+            # (length != 1), so the list reached storage unchecked and came back
+            # with full ``scope_team`` content.
+            if body.fleet_ids:
+                await enforce_fleet_read_many(body.tenant_id, eff_agent_id, body.fleet_ids)
         usage = await check_and_increment(body.tenant_id, "search")
     if usage:
         response.headers["X-RateLimit-Limit"] = str(usage.get("limit", "unlimited"))
@@ -2088,8 +2095,9 @@ async def recall_endpoint(
             _agent = await get_or_create_agent(body.tenant_id, body.filter_agent_id, fleet_id_hint)
             if not body.fleet_ids and _agent.get("fleet_id") and _agent.get("trust_level", 0) < 2:
                 body.fleet_ids = [_agent["fleet_id"]]
-            if body.fleet_ids and len(body.fleet_ids) == 1:
-                await enforce_fleet_read(body.tenant_id, body.filter_agent_id, body.fleet_ids[0])
+            # Same widening as /search above — see the note there.
+            if body.fleet_ids:
+                await enforce_fleet_read_many(body.tenant_id, body.filter_agent_id, body.fleet_ids)
         # D13 — a recall is a recall, not a search: plans meter them separately
         # and the recalls counter never moved because this site (and the MCP
         # twin) billed "search". Flag-gated; see ``recall_operation``.

--- a/core-api/src/core_api/services/agent_service.py
+++ b/core-api/src/core_api/services/agent_service.py
@@ -1,6 +1,7 @@
 """Agent trust-level enforcement for fleet-scoped access control."""
 
 import logging
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Any
 
@@ -284,23 +285,52 @@ async def enforce_fleet_read(
     fleet_id: str | None,
 ) -> None:
     """Enforce read permissions for search/list (read-only — never creates agents)."""
+    await enforce_fleet_read_many(tenant_id, agent_id, [fleet_id])
+
+
+async def enforce_fleet_read_many(
+    tenant_id: str,
+    agent_id: str,
+    fleet_ids: Sequence[str | None],
+) -> None:
+    """Enforce read permissions for EVERY requested fleet.
+
+    The multi-fleet form is the load-bearing one. The search/recall routes take
+    a ``fleet_ids`` LIST, and gating only the single-element case left a caller
+    able to widen its own read by naming extra fleets: a trust-1 agent sending
+    ``["victim-fleet", "own-fleet"]`` satisfied neither the "no fleets given, so
+    force own fleet" branch (the list is non-empty) nor the "exactly one fleet,
+    so check the ladder" branch (length is 2), and the unchecked list went
+    straight to the storage predicate, which returns ``scope_team`` rows with
+    full content for every fleet listed. Asking for MORE must never be the way
+    to be asked for LESS.
+
+    One ``lookup_agent`` for the whole list, not one per fleet — these routes
+    are the search hot path, and a per-element call would turn a widened
+    ``fleet_ids`` into a storage-call amplifier.
+
+    ``enforce_fleet_read`` delegates here so the single- and multi-fleet ladders
+    cannot drift apart, the same reason ``resolve_read_fleet_gate`` is shared
+    across its four surfaces. Semantics for a one-element list are unchanged.
+    """
     agent = await lookup_agent(tenant_id, agent_id)
 
     # Unknown agent — allow the read (agent registration happens on writes)
     if not agent:
         return
 
-    # Reading own fleet or tenant-wide is always allowed
-    if fleet_id is None or fleet_id == agent.get("fleet_id"):
-        return
-
-    # Cross-fleet read requires level >= 2
+    own_fleet = agent.get("fleet_id")
     trust = agent.get("trust_level", 0)
-    if trust < 2:
-        raise HTTPException(
-            status_code=403,
-            detail=f"fleet-scope policy: fleet '{fleet_id}' is not readable by principals of fleet '{agent.get('fleet_id') or 'none'}'.",
-        )
+    for fleet_id in fleet_ids:
+        # Reading own fleet or tenant-wide is always allowed
+        if fleet_id is None or fleet_id == own_fleet:
+            continue
+        # Cross-fleet read requires level >= 2
+        if trust < 2:
+            raise HTTPException(
+                status_code=403,
+                detail=f"fleet-scope policy: fleet '{fleet_id}' is not readable by principals of fleet '{own_fleet or 'none'}'.",
+            )
 
 
 async def resolve_read_fleet_gate(

--- a/tests/test_h05_multi_fleet_read_gate.py
+++ b/tests/test_h05_multi_fleet_read_gate.py
@@ -1,0 +1,256 @@
+"""H-05 — every requested fleet is gated, not just the single-fleet case.
+
+The cross-fleet trust ladder on ``POST /search``, ``POST /recall`` and MCP
+``caura_recall`` fired only when ``fleet_ids`` had exactly one element:
+
+    if not body.fleet_ids and _agent.fleet_id and trust < 2:
+        body.fleet_ids = [own]              # forcing: only when NONE given
+    if body.fleet_ids and len(body.fleet_ids) == 1:
+        await enforce_fleet_read(...)       # ladder: only when EXACTLY one
+
+A trust-1 agent sending ``fleet_ids=["victim-fleet", "own-fleet"]`` satisfied
+neither branch — the forcing is skipped because the list is non-empty, and the
+ladder is skipped because the length is 2. The unchecked list went straight to
+the storage predicate, which admits ``fleet_id IN (...)`` and returns
+``scope_team`` rows WITH FULL CONTENT for every fleet listed.
+
+So asking for MORE was the way to be asked for LESS: ``["victim"]`` was 403'd
+and ``["victim", "own"]`` succeeded. That is the exact escalation the
+single-fleet gate exists to stop.
+
+These tests are written so the PRE-FIX answer is the wrong one — a leak of
+victim content — rather than asserting a 403 that could pass for unrelated
+reasons.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.conftest import get_test_auth
+from tests.conftest import uid as _uid
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def as_auth(monkeypatch):
+    """Authenticate as a specific agent identity within a tenant.
+
+    ``get_test_auth()`` returns the ADMIN key, which resolves to
+    ``tenant_id=None`` — and the whole fleet-gate block is behind
+    ``if auth.tenant_id:  # skip for admin``. So the admin key cannot exercise
+    this gate at all, and a test written with it would pass before and after
+    any change. The credential that reaches the gate is an agent-scoped one.
+    """
+    from core_api.app import app
+    from core_api.auth import AuthContext, get_auth_context
+    from core_api.tenant_context import set_current_tenant
+
+    def _install(tenant_id: str, agent_id: str | None = None):
+        async def _dep():
+            set_current_tenant(tenant_id)
+            return AuthContext(
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                readable_tenant_ids=[tenant_id],
+            )
+
+        app.dependency_overrides[get_auth_context] = _dep
+
+    yield _install
+    from core_api.app import app as _app
+    from core_api.auth import get_auth_context as _gac
+
+    _app.dependency_overrides.pop(_gac, None)
+
+
+async def _seed_agent(sc, tenant_id: str, agent_id: str, *, fleet_id: str, trust: int):
+    await sc.create_or_update_agent(
+        {
+            "tenant_id": tenant_id,
+            "agent_id": agent_id,
+            "fleet_id": fleet_id,
+            "trust_level": trust,
+        }
+    )
+
+
+async def _write(client, headers, tenant_id, *, content, agent_id, fleet_id):
+    resp = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "content": content,
+            "agent_id": agent_id,
+            "fleet_id": fleet_id,
+            "visibility": "scope_team",
+            "memory_type": "fact",
+            # Keep embedding/indexing synchronous so the search below is
+            # deterministic the moment the 201 lands.
+            "write_mode": "strong",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _setup(client, sc):
+    """A victim fleet holding a secret, and a trust-1 attacker in another fleet."""
+    tenant_id, headers = get_test_auth()
+    nonce = f"h05-{uuid.uuid4().hex}"
+    victim_fleet = f"victim-fleet-{_uid()}"
+    own_fleet = f"own-fleet-{_uid()}"
+    attacker = f"attacker-{_uid()}"
+
+    await _write(
+        client,
+        headers,
+        tenant_id,
+        content=f"{nonce} victim fleet private team memory",
+        agent_id=f"victim-agent-{_uid()}",
+        fleet_id=victim_fleet,
+    )
+    await _seed_agent(sc, tenant_id, attacker, fleet_id=own_fleet, trust=1)
+    return tenant_id, headers, nonce, victim_fleet, own_fleet, attacker
+
+
+# ---------------------------------------------------------------------------
+# /search
+# ---------------------------------------------------------------------------
+
+
+async def test_search_single_foreign_fleet_is_refused(client, sc, as_auth):
+    """GUARD, NOT EVIDENCE — passes before and after.
+
+    The single-fleet case was already gated. Present so the pair below reads as
+    a comparison: this is the answer the multi-fleet form should have given.
+    """
+    tenant_id, _, nonce, victim_fleet, _own, attacker = await _setup(client, sc)
+    as_auth(tenant_id, attacker)
+
+    resp = await client.post(
+        "/api/v1/search",
+        json={"tenant_id": tenant_id, "query": nonce, "fleet_ids": [victim_fleet]},
+    )
+    assert resp.status_code == 403, resp.text
+    assert "fleet-scope policy" in resp.text
+
+
+async def test_search_cannot_widen_by_naming_a_second_fleet(client, sc, as_auth):
+    """THE LEAK. Fails without the fix: 200 carrying the victim's content.
+
+    Same caller, same victim fleet, one extra element in the list.
+    """
+    tenant_id, _, nonce, victim_fleet, own_fleet, attacker = await _setup(client, sc)
+    as_auth(tenant_id, attacker)
+
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "tenant_id": tenant_id,
+            "query": nonce,
+            "fleet_ids": [victim_fleet, own_fleet],
+        },
+    )
+    assert resp.status_code == 403, (
+        f"naming a second fleet skipped the trust ladder; body={resp.text[:400]}"
+    )
+    assert "fleet-scope policy" in resp.text
+    # Asserted on the CONTENT, not only the status: pre-fix this body carried
+    # the victim's memory text verbatim, and a future change that answered 200
+    # with filtered results instead of 403 must still not leak it.
+    assert "victim fleet private team memory" not in resp.text
+
+
+async def test_search_cannot_widen_by_repeating_the_same_fleet(client, sc, as_auth):
+    """Duplicates defeat a length check just as well as distinct ids.
+
+    ``["victim", "victim"]`` is length 2, so the old ``len == 1`` gate skipped
+    it while the storage predicate deduplicated it back to the victim fleet.
+    Fails without the fix.
+    """
+    tenant_id, _, nonce, victim_fleet, _own, attacker = await _setup(client, sc)
+    as_auth(tenant_id, attacker)
+
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "tenant_id": tenant_id,
+            "query": nonce,
+            "fleet_ids": [victim_fleet, victim_fleet],
+        },
+    )
+    assert resp.status_code == 403, resp.text
+
+
+async def test_search_own_fleet_listed_twice_still_allowed(client, sc, as_auth):
+    """The gate must not over-refuse: every element is the caller's own fleet.
+
+    Guards against "reject any multi-element list for trust < 2", which would
+    have closed the hole by breaking a legitimate caller.
+    """
+    tenant_id, _, nonce, _victim, own_fleet, attacker = await _setup(client, sc)
+    as_auth(tenant_id, attacker)
+
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "tenant_id": tenant_id,
+            "query": nonce,
+            "fleet_ids": [own_fleet, own_fleet],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def test_search_trust_2_may_still_read_across_fleets(client, sc, as_auth):
+    """The ladder still GRANTS what it is supposed to grant.
+
+    A cross-fleet read is a trust-2 privilege, not a forbidden operation — the
+    fix must gate the multi-fleet form, not remove the capability.
+    """
+    tenant_id, _, nonce, victim_fleet, own_fleet, attacker = await _setup(client, sc)
+    await _seed_agent(sc, tenant_id, attacker, fleet_id=own_fleet, trust=2)
+    as_auth(tenant_id, attacker)
+
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "tenant_id": tenant_id,
+            "query": nonce,
+            "fleet_ids": [victim_fleet, own_fleet],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# /recall — the identical gap, per the finding
+# ---------------------------------------------------------------------------
+
+
+async def test_recall_cannot_widen_by_naming_a_second_fleet(client, sc, as_auth):
+    """Fails without the fix, same shape as /search.
+
+    ``/recall`` keys the gate off ``filter_agent_id`` rather than the
+    authenticated identity, so the attacker names itself there.
+    """
+    tenant_id, _, nonce, victim_fleet, own_fleet, attacker = await _setup(client, sc)
+    as_auth(tenant_id, attacker)
+
+    resp = await client.post(
+        "/api/v1/recall",
+        json={
+            "tenant_id": tenant_id,
+            "query": nonce,
+            "filter_agent_id": attacker,
+            "fleet_ids": [victim_fleet, own_fleet],
+        },
+    )
+    assert resp.status_code == 403, (
+        f"recall skipped the trust ladder; body={resp.text[:400]}"
+    )


### PR DESCRIPTION
Closes audit finding **H-05** — cross-fleet content disclosure on `/search`, `/recall` and MCP `caura_recall`.

## The defect

The cross-fleet trust ladder fired only when `fleet_ids` had **exactly one** element:

```python
if not body.fleet_ids and _agent.fleet_id and trust < 2:
    body.fleet_ids = [own]          # forcing: only when NONE given
if body.fleet_ids and len(body.fleet_ids) == 1:
    await enforce_fleet_read(...)   # ladder: only when EXACTLY one
```

A trust-1 agent sending `fleet_ids=["victim-fleet", "own-fleet"]` satisfied **neither** branch — the forcing is skipped because the list is non-empty, the ladder is skipped because the length is 2. The unchecked list went straight to the storage predicate, which admits `fleet_id IN (...)` and returns `scope_team` rows **with full content** for every fleet listed.

| Request from a trust-1 agent | Before |
|---|---|
| `fleet_ids: ["victim"]` | **403** `fleet-scope policy…` |
| `fleet_ids: ["victim", "own"]` | **200 — victim's memory content returned** |
| `fleet_ids: ["victim", "victim"]` | **200 — same leak**, length 2 skips the gate, storage dedupes it back |

**Asking for MORE was the way to be asked for LESS.** This is direct content disclosure, not id harvesting — the test reproduces it by asserting the victim's memory text appears verbatim in the pre-fix response body, and the assertion output confirms it does.

## The fix

`enforce_fleet_read_many` checks **every** requested fleet against **one** `lookup_agent` call, rather than one lookup per fleet — these are the search hot path, and a per-element call would have turned a widened `fleet_ids` into a storage-call amplifier.

`enforce_fleet_read` now delegates to it, so the single- and multi-fleet ladders cannot drift apart — the same reasoning the codebase already applies to `resolve_read_fleet_gate` (*"All four share this one implementation so the ladder cannot drift between the surfaces"*). One-element semantics are unchanged.

Applied to all three sites the finding names (`memories.py` `/search` and `/recall`, `mcp_server.py` `caura_recall`) so the surfaces stay in parity.

## What I deliberately did not do

The finding offered an alternative: *"or reject multi-fleet reads for trust<2 agents"*. **That would close the hole by breaking a legitimate caller.** A trust-1 agent may name its own fleet — twice, if it likes — and a trust-2 agent may still read across fleets, because a cross-fleet read is a *privilege*, not a forbidden operation. Both are pinned by tests, because a gate that over-refuses is a different bug rather than a safe default.

## Tests

**Three fail without the fix**, confirmed by reverting all three source files to `origin/main` and re-running:

```
test_search_cannot_widen_by_naming_a_second_fleet
test_search_cannot_widen_by_repeating_the_same_fleet
test_recall_cannot_widen_by_naming_a_second_fleet
```

**Three are guards** that pass either way, labelled as such in-file: the single-fleet refusal (already gated pre-fix, present so the pair reads as a comparison), own-fleet-listed-twice, and trust-2 cross-fleet. The last two are the over-refusal guards described above.

The leak test asserts on the **content**, not only the status code, so a future change that answered `200` with filtered results instead of `403` would still have to not leak.

**A trap worth recording:** the suite's `get_test_auth()` returns the ADMIN key, which resolves to `tenant_id=None` — and this entire gate sits behind `if auth.tenant_id:  # skip for admin`. A test written with the admin key cannot reach the gate at all and would pass before and after any change. These tests authenticate as a real agent identity instead. That is the same shape as the admin-key trap in #1259 and the swallowed-assertion trap in #1260; three different fixes, one recurring failure mode.

## Verification

- Full root suite: **54 failed / 5939 passed**. `main` baseline is 54 failed / 5933 passed — identical failures, **+6 exactly the new tests**. The 54 are pre-existing missing-optional-dep gaps in the local venv.
- `ruff check` and `ruff format --check` run **separately** at CI's exact scopes — clean.
- `mypy` clean on all three changed source files (2 pre-existing `types-python-dateutil` stub errors in an untouched file).
- `legacy_name_ratchet.py` → *No new lines.* · `do_not_touch_sentinel.py` → *All 39 protected strings survive.* · `tenant_scope_gate.py` → 0 added/removed/recategorised. All run **after `git add`**, and re-run after rebasing onto current `main` (the pre-rebase run flagged two removed exempt lines, which was purely the stale base seeing #1266's markers as deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
