### PR TITLE
fix(recall): resolve the read identity by the same rule as /search

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1714,6 +1714,69 @@ async def update_memory_endpoint(
     )
 
 
+def _resolve_read_identity(auth: AuthContext, body: SearchRequest) -> tuple[str | None, bool]:
+    """Resolve the identity a search-shaped read runs as, refusing a spoof.
+
+    Returns ``(eff_agent_id, identity_asserted)``.
+
+    An agent credential may only name ITSELF. ``eff_agent_id`` is body-first,
+    and it feeds BOTH the visibility identity (which ``scope_agent`` rows are
+    readable) AND the trust/fleet enforcement at the callsite, so a
+    caller-asserted id bought two escalations at once:
+
+      1. Disclosure — naming a peer made that peer the visibility identity, so
+         its scope_agent memories (and private STM notes surfaced through
+         search) came back with full content, not just ids.
+      2. Gate evasion — the trust < 2 fleet forcing runs against this same id,
+         so naming a trust-3 peer skipped the forcing entirely. That is the
+         identical escalation /memories/redistribute was fixed for in the
+         2026-06-11 audit, which ran its trust gate against a caller-supplied
+         agent_id.
+
+    A tenant/user credential (``auth.agent_id`` is None) is unaffected and may
+    still name any agent — the restriction is on agent-scoped credentials,
+    which is where the threat is.
+
+    SHARED because ``/recall`` shipped without any of it. It re-derived the
+    identity itself, straight from ``body.filter_agent_id``, so both
+    escalations above were live on that route while ``/search`` refused them —
+    and ``caller_agent_id``, which the schema documents as the way to assert an
+    identity, was silently dropped there. Two routes parsing the same
+    ``SearchRequest`` must not disagree about what the fields mean; one
+    implementation is the only way that stays true.
+    """
+    if auth.agent_id and body.filter_agent_id and body.filter_agent_id != auth.agent_id:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"filter_agent_id '{body.filter_agent_id}' does not match the "
+                f"authenticated agent identity '{auth.agent_id}'."
+            ),
+        )
+    # Same rule for the identity knob. ``caller_agent_id`` feeds exactly the two
+    # things ``filter_agent_id`` used to smuggle in — the visibility identity and
+    # the subject of the trust<2 fleet forcing — so leaving it unguarded would
+    # reopen the escalation the check above closes, by a new spelling.
+    if auth.agent_id and body.caller_agent_id and body.caller_agent_id != auth.agent_id:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"caller_agent_id '{body.caller_agent_id}' does not match the "
+                f"authenticated agent identity '{auth.agent_id}'."
+            ),
+        )
+    # Identity, in precedence order: an authenticated agent always wins, then an
+    # explicit assertion, then the legacy derivation from the filter so existing
+    # callers are untouched. The filter itself is passed separately at the
+    # callsite and is unchanged — it was already a distinct parameter all the way
+    # down to the storage predicate; only the identity was derived from it.
+    eff_agent_id = auth.agent_id or body.caller_agent_id or body.filter_agent_id
+    # True when the identity was ASSERTED by a tenant-scoped caller rather than
+    # authenticated. Gates the recall_count bump — see the note at the callsite.
+    identity_asserted = bool(not auth.agent_id and body.caller_agent_id)
+    return eff_agent_id, identity_asserted
+
+
 @router.post("/search", response_model=SearchResponse)
 @search_limit
 async def search(
@@ -1746,52 +1809,7 @@ async def _search_inner(
     # content, so this is a direct disclosure, not just id harvesting). A
     # tenant/user credential (auth.agent_id None, no filter) keeps full-tenant
     # search, unchanged.
-    # An agent credential may only filter to ITSELF. ``eff_agent_id`` below is
-    # body-first, and it feeds BOTH the visibility identity (which scope_agent
-    # rows are readable) AND the trust/fleet enforcement a few lines down, so a
-    # caller-asserted ``filter_agent_id`` bought two escalations at once:
-    #
-    #   1. Disclosure — naming a peer made that peer the visibility identity, so
-    #      its scope_agent memories (and private STM notes surfaced through
-    #      search) came back with full content, not just ids.
-    #   2. Gate evasion — the trust < 2 fleet forcing below runs against this
-    #      same id, so naming a trust-3 peer skipped the forcing entirely. That
-    #      is the identical escalation /memories/redistribute was fixed for in
-    #      the 2026-06-11 audit, which ran its trust gate against a
-    #      caller-supplied agent_id.
-    #
-    # A tenant/user credential (``auth.agent_id`` is None) is unaffected and may
-    # still filter by any agent — the restriction is on agent-scoped credentials,
-    # which is where the threat is.
-    if auth.agent_id and body.filter_agent_id and body.filter_agent_id != auth.agent_id:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                f"filter_agent_id '{body.filter_agent_id}' does not match the "
-                f"authenticated agent identity '{auth.agent_id}'."
-            ),
-        )
-    # Same rule for the identity knob. ``caller_agent_id`` feeds exactly the two
-    # things ``filter_agent_id`` used to smuggle in — the visibility identity and
-    # the subject of the trust<2 fleet forcing below — so leaving it unguarded
-    # would reopen the escalation the check above closes, by a new spelling.
-    if auth.agent_id and body.caller_agent_id and body.caller_agent_id != auth.agent_id:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                f"caller_agent_id '{body.caller_agent_id}' does not match the "
-                f"authenticated agent identity '{auth.agent_id}'."
-            ),
-        )
-    # Identity, in precedence order: an authenticated agent always wins, then an
-    # explicit assertion, then the legacy derivation from the filter so existing
-    # callers are untouched. The filter itself is passed separately below and is
-    # unchanged — it was already a distinct parameter all the way down to the
-    # storage predicate; only the identity was derived from it.
-    eff_agent_id = auth.agent_id or body.caller_agent_id or body.filter_agent_id
-    # True when the identity was ASSERTED by a tenant-scoped caller rather than
-    # authenticated. Gates the recall_count bump below — see the note there.
-    identity_asserted = bool(not auth.agent_id and body.caller_agent_id)
+    eff_agent_id, identity_asserted = _resolve_read_identity(auth, body)
     if auth.tenant_id:  # skip for admin
         if eff_agent_id:
             fleet_id_hint = body.fleet_ids[0] if body.fleet_ids and len(body.fleet_ids) == 1 else None
@@ -2089,15 +2107,26 @@ async def recall_endpoint(
     """
     # Read endpoint — readable set widening applies (see /search).
     auth.enforce_readable_tenant(body.tenant_id)
+    # Identity resolved by the SAME rule as /search. This route used to run the
+    # trust gate, the fleet forcing and the visibility identity all off the raw
+    # ``body.filter_agent_id``, so an agent-scoped credential naming a peer read
+    # that peer's private rows and inherited its trust level for the fleet
+    # forcing — the escalation /search already refuses.
+    eff_agent_id, identity_asserted = _resolve_read_identity(auth, body)
     if auth.tenant_id:
-        if body.filter_agent_id:
+        if eff_agent_id:
             fleet_id_hint = body.fleet_ids[0] if body.fleet_ids and len(body.fleet_ids) == 1 else None
-            _agent = await get_or_create_agent(body.tenant_id, body.filter_agent_id, fleet_id_hint)
+            _agent = await get_or_create_agent(body.tenant_id, eff_agent_id, fleet_id_hint)
             if not body.fleet_ids and _agent.get("fleet_id") and _agent.get("trust_level", 0) < 2:
                 body.fleet_ids = [_agent["fleet_id"]]
-            # Same widening as /search above — see the note there.
+            # Both halves matter and they are independent: EVERY requested
+            # fleet is gated (#1267), against the RESOLVED identity rather than
+            # the raw ``filter_agent_id`` (this change). Gating every fleet
+            # against a spoofable principal would still let an agent inherit a
+            # peer's trust level; gating the right principal on only the
+            # single-fleet case would still let it widen by naming two.
             if body.fleet_ids:
-                await enforce_fleet_read_many(body.tenant_id, body.filter_agent_id, body.fleet_ids)
+                await enforce_fleet_read_many(body.tenant_id, eff_agent_id, body.fleet_ids)
         # D13 — a recall is a recall, not a search: plans meter them separately
         # and the recalls counter never moved because this site (and the MCP
         # twin) billed "search". Flag-gated; see ``recall_operation``.
@@ -2122,7 +2151,19 @@ async def recall_endpoint(
         query=body.query,
         fleet_ids=body.fleet_ids,
         filter_agent_id=body.filter_agent_id,
-        caller_agent_id=body.filter_agent_id,
+        # The IDENTITY, not the filter. Hardwiring this to ``filter_agent_id``
+        # is what made a named peer the visibility identity, and it silently
+        # dropped ``caller_agent_id`` — a field the schema documents as
+        # "assert the agent identity this search runs as", honoured on /search
+        # and no-op'd here, so the same body returned different rows on the two
+        # routes with no error. The filter above stays a separate parameter.
+        caller_agent_id=eff_agent_id,
+        # Same ranking guard /search applies: an ASSERTED identity must not move
+        # recall_count unless the tenant opted in, or one integration adding
+        # caller_agent_id reshuffles results for every other caller. Carried
+        # here because honouring the field without this would fix a dropped
+        # knob by giving it a side effect /search deliberately suppresses.
+        allow_recall_bump=(not identity_asserted) or config.recall_for_asserted_identity,
         memory_type_filter=body.memory_type_filter,
         status_filter=body.status_filter,
         top_k=body.top_k,

--- a/tests/test_h06_m30_recall_identity.py
+++ b/tests/test_h06_m30_recall_identity.py
@@ -1,0 +1,235 @@
+"""H-06 + M-30 — /recall resolves identity by the same rule as /search.
+
+Two findings, one defect: ``recall_endpoint`` re-derived the read identity
+itself, straight from ``body.filter_agent_id``, instead of using the rule
+``/search`` applies.
+
+H-06 (high, disclosure + gate evasion). ``/search`` refuses an agent
+credential that names a peer::
+
+    if auth.agent_id and body.filter_agent_id != auth.agent_id: 403
+
+``/recall`` had no such check, and fed the raw ``filter_agent_id`` into three
+places at once: ``get_or_create_agent``, the trust<2 fleet forcing, and
+``caller_agent_id`` (the VISIBILITY identity). So agent-A, trust 1 in fleet
+F1, could POST ``{filter_agent_id: "agent-B"}`` where B is trust 3 in F2 and
+get B's private ``scope_agent`` rows AND a tenant-wide scope, because the
+forcing is keyed off B's trust level rather than A's.
+
+M-30 (medium, silent drop). ``SearchRequest.caller_agent_id`` is documented as
+"assert the agent identity this search runs as". ``/search`` honours it;
+``/recall`` hardwired ``caller_agent_id=body.filter_agent_id`` and never read
+the field. The same body returned different rows on the two routes, with no
+error — and the SDKs forward the field verbatim, so it no-op'd silently.
+
+Both are fixed by one shared ``_resolve_read_identity``, which is the point:
+two routes parsing the same ``SearchRequest`` must not disagree about what its
+fields mean.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.conftest import get_test_auth
+from tests.conftest import uid as _uid
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def as_auth(monkeypatch):
+    """Authenticate as a specific agent identity within a tenant.
+
+    ``get_test_auth()`` returns the ADMIN key, which resolves to
+    ``tenant_id=None``. The gate block is behind ``if auth.tenant_id:`` and the
+    spoof guard keys off ``auth.agent_id``, so the admin key exercises neither
+    — a test written with it would pass before and after any change here.
+    """
+    from core_api.app import app
+    from core_api.auth import AuthContext, get_auth_context
+    from core_api.tenant_context import set_current_tenant
+
+    def _install(tenant_id: str, agent_id: str | None = None):
+        async def _dep():
+            set_current_tenant(tenant_id)
+            return AuthContext(
+                tenant_id=tenant_id,
+                agent_id=agent_id,
+                readable_tenant_ids=[tenant_id],
+            )
+
+        app.dependency_overrides[get_auth_context] = _dep
+
+    yield _install
+    from core_api.app import app as _app
+    from core_api.auth import get_auth_context as _gac
+
+    _app.dependency_overrides.pop(_gac, None)
+
+
+async def _seed_agent(sc, tenant_id, agent_id, *, fleet_id, trust):
+    await sc.create_or_update_agent(
+        {
+            "tenant_id": tenant_id,
+            "agent_id": agent_id,
+            "fleet_id": fleet_id,
+            "trust_level": trust,
+        }
+    )
+
+
+async def _write_private(client, headers, tenant_id, *, content, agent_id, fleet_id):
+    """A ``scope_agent`` row — readable only by its own author."""
+    resp = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "content": content,
+            "agent_id": agent_id,
+            "fleet_id": fleet_id,
+            "visibility": "scope_agent",
+            "memory_type": "fact",
+            "write_mode": "strong",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _setup(client, sc):
+    """Peer B holds a private memory; attacker A is trust-1 in another fleet."""
+    tenant_id, headers = get_test_auth()
+    nonce = f"h06-{uuid.uuid4().hex}"
+    peer = f"peer-b-{_uid()}"
+    attacker = f"agent-a-{_uid()}"
+    await _seed_agent(sc, tenant_id, peer, fleet_id=f"fleet-f2-{_uid()}", trust=3)
+    await _seed_agent(sc, tenant_id, attacker, fleet_id=f"fleet-f1-{_uid()}", trust=1)
+    await _write_private(
+        client,
+        headers,
+        tenant_id,
+        content=f"{nonce} peer B private scope_agent memory",
+        agent_id=peer,
+        fleet_id=None,
+    )
+    return tenant_id, headers, nonce, peer, attacker
+
+
+# ---------------------------------------------------------------------------
+# H-06 — the spoof guard
+# ---------------------------------------------------------------------------
+
+
+async def test_recall_refuses_a_filter_agent_id_that_is_not_the_caller(
+    client, sc, as_auth
+):
+    """THE DISCLOSURE. Fails without the fix: 200 carrying peer B's private row.
+
+    Agent A names peer B. Pre-fix that made B the visibility identity, so B's
+    ``scope_agent`` content came back to A.
+    """
+    tenant_id, _, nonce, peer, attacker = await _setup(client, sc)
+    as_auth(tenant_id, attacker)
+
+    resp = await client.post(
+        "/api/v1/recall",
+        json={"tenant_id": tenant_id, "query": nonce, "filter_agent_id": peer},
+    )
+    assert resp.status_code == 403, (
+        f"recall let an agent name a peer; body={resp.text[:400]}"
+    )
+    assert "does not match the authenticated agent identity" in resp.text
+    # On the content too: a later change answering 200-with-filtering instead
+    # of 403 must still not surface the peer's private row.
+    assert "peer B private scope_agent memory" not in resp.text
+
+
+async def test_recall_refuses_a_caller_agent_id_that_is_not_the_caller(
+    client, sc, as_auth
+):
+    """The same escalation by the other spelling.
+
+    ``caller_agent_id`` feeds the identity directly, so guarding only
+    ``filter_agent_id`` would have left the hole open under a different field
+    name. Fails without the fix.
+    """
+    tenant_id, _, nonce, peer, attacker = await _setup(client, sc)
+    as_auth(tenant_id, attacker)
+
+    resp = await client.post(
+        "/api/v1/recall",
+        json={"tenant_id": tenant_id, "query": nonce, "caller_agent_id": peer},
+    )
+    assert resp.status_code == 403, resp.text
+    assert "does not match the authenticated agent identity" in resp.text
+
+
+async def test_recall_allows_an_agent_naming_itself(client, sc, as_auth):
+    """The gate must not over-refuse: naming yourself is the normal case."""
+    tenant_id, _, nonce, _peer, attacker = await _setup(client, sc)
+    as_auth(tenant_id, attacker)
+
+    resp = await client.post(
+        "/api/v1/recall",
+        json={"tenant_id": tenant_id, "query": nonce, "filter_agent_id": attacker},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def test_recall_tenant_key_may_still_name_any_agent(client, sc, as_auth):
+    """A tenant-scoped credential is unaffected — the restriction is on agent keys.
+
+    Pins the scope of the guard. Closing the hole by refusing every named agent
+    would break the dashboard and every tenant-key integration.
+    """
+    tenant_id, _, nonce, peer, _attacker = await _setup(client, sc)
+    as_auth(tenant_id, None)  # tenant-scoped: no agent identity
+
+    resp = await client.post(
+        "/api/v1/recall",
+        json={"tenant_id": tenant_id, "query": nonce, "filter_agent_id": peer},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# M-30 — caller_agent_id is honoured, not dropped
+# ---------------------------------------------------------------------------
+
+
+async def test_recall_honours_caller_agent_id_as_the_visibility_identity(
+    client, sc, as_auth
+):
+    """THE SILENT DROP. Fails without the fix.
+
+    A tenant-scoped caller asserts ``caller_agent_id`` exactly as the schema
+    instructs. On ``/search`` that surfaces the named agent's ``scope_agent``
+    rows; on ``/recall`` the field was never read, so the identical body
+    returned a result set missing them — no error, just different answers.
+
+    Asserted as a PARITY claim between the two routes rather than against a
+    hardcoded expectation, so the test states the contract the findings are
+    actually about.
+    """
+    tenant_id, _headers, nonce, peer, _attacker = await _setup(client, sc)
+    as_auth(tenant_id, None)
+
+    body = {"tenant_id": tenant_id, "query": nonce, "caller_agent_id": peer}
+
+    search = await client.post("/api/v1/search", json=body)
+    assert search.status_code == 200, search.text
+    search_ids = {m["id"] for m in search.json()["items"]}
+
+    recall = await client.post("/api/v1/recall", json=body)
+    assert recall.status_code == 200, recall.text
+    recall_ids = {m["id"] for m in recall.json()["memories"]}
+
+    assert search_ids, "fixture produced no searchable rows — test is vacuous"
+    assert recall_ids == search_ids, (
+        "/recall dropped caller_agent_id: same body, different rows. "
+        f"search={sorted(search_ids)} recall={sorted(recall_ids)}"
+    )


### PR DESCRIPTION
Closes **H-06** (high) and **M-30** (medium) — merged per the agreed dedup, because one shared resolver is the fix for both.

## Two findings, one defect

`recall_endpoint` re-derived the read identity itself, straight from `body.filter_agent_id`, instead of using the rule `/search` applies.

### H-06 — disclosure and gate evasion

`/search` refuses an agent credential that names a peer. `/recall` had no such check, and fed the raw `filter_agent_id` into **three** places at once: `get_or_create_agent`, the trust<2 fleet forcing, and `caller_agent_id` — which *is* the visibility identity.

So agent-A (trust 1, fleet F1) could `POST {filter_agent_id: "agent-B"}` where B is trust 3 in F2, and receive:

- **B's private `scope_agent` rows, with full content**, in the results and in the LLM summary — reproduced; the pre-fix response body contains the row verbatim;
- **a tenant-wide scope**, because the fleet forcing keys off *B's* trust level rather than A's, so naming a trust≥2 peer skipped the forcing entirely.

### M-30 — silent drop

`SearchRequest.caller_agent_id` is documented as *"assert the agent identity this search runs as"*. `/search` honours it; `/recall` hardwired `caller_agent_id=body.filter_agent_id` and **never read the field**. The same body returned different rows on the two routes, with no error — and both SDKs forward the field verbatim, so it no-op'd silently.

## The guard is extracted, not copied

`_resolve_read_identity` now holds the two 403s and the precedence rule, and both routes call it.

Copying it would have left exactly the drift that produced this: `/search` grew the guard in a prior audit and `/recall` was not updated, so the two routes disagreed about the same request shape for a release. Same reasoning the codebase already applies to `resolve_read_fleet_gate` and to `enforce_fleet_read_many` from #1267.

## One coupling worth naming

Honouring `caller_agent_id` on `/recall` also means carrying `/search`'s `allow_recall_bump` gate. Without it, an **asserted** identity would start moving `recall_count` on this route — reshuffling ranking for every other caller in the tenant, which is precisely what that gate exists to prevent.

Fixing a dropped knob by giving it a side effect the sibling route deliberately suppresses would not be a fix.

## Rebase note — this PR interacts with #1267

#1267 changed the same `/recall` line to `enforce_fleet_read_many`. The rebase conflicted there, as expected, and the resolution takes **both** halves:

```python
if body.fleet_ids:
    await enforce_fleet_read_many(body.tenant_id, eff_agent_id, body.fleet_ids)
```

They are independent and both required. Gating every fleet against a *spoofable principal* would still let an agent inherit a peer's trust level; gating the *right principal* on only the single-fleet case would still let it widen by naming two.

**Re-validated after the rebase**, not assumed: against post-#1267 `main`, this PR's three tests still fail and #1267's six now pass from `main`.

## Tests

**Three fail without the fix:**

```
test_recall_refuses_a_filter_agent_id_that_is_not_the_caller
test_recall_refuses_a_caller_agent_id_that_is_not_the_caller
test_recall_honours_caller_agent_id_as_the_visibility_identity
```

- The disclosure test asserts on the **leaked content**, not only the status code, so a later change answering 200-with-filtering instead of 403 would still have to not leak.
- The second covers the same escalation under the *other* field name — guarding only `filter_agent_id` would have left the hole open by a new spelling.
- The M-30 test asserts a **parity claim** — `/search` and `/recall` result sets for an identical body — rather than a hardcoded expectation, so it states the contract the finding is actually about. It also asserts the fixture produced rows at all, so it cannot pass vacuously by comparing two empty sets.

**Two are over-refusal guards:** an agent naming *itself* still works, and a tenant-scoped credential may still name any agent. Closing the hole by refusing every named agent would break the dashboard and every tenant-key integration.

As in #1259 / #1267, the tests authenticate as a real agent identity — `get_test_auth()` returns the ADMIN key, which resolves to `tenant_id=None`, and both the gate block (`if auth.tenant_id:`) and the spoof guard (`auth.agent_id`) are invisible to it. A test written with the admin key would pass before and after.

## Verification

- Full root suite: **54 failed / 5944 passed**. `main` baseline is 54 failed / 5939 passed — identical failures, **+5 exactly the new tests**. The 54 are pre-existing missing-optional-dep gaps in the local venv.
- `ruff check` and `ruff format --check` run **separately** at CI's exact scopes — clean.
- `mypy` clean on the changed file (2 pre-existing `types-python-dateutil` stub errors in an untouched file).
- `legacy_name_ratchet.py` → *No new lines.* · `do_not_touch_sentinel.py` → *All 39 protected strings survive.* · `tenant_scope_gate.py` → 0 added/removed/recategorised. All run **after `git add`** and again after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
