### PR TITLE
fix(skills): gate the STORED status, not just the written one

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -2216,23 +2216,39 @@ async def caura_doc(
                         # validator 422s it cleanly rather than us
                         # AttributeError-ing into a 500 here).
                         live_doc: dict | None = None
-                        if isinstance(data, dict) and data.get("kind") == "update":
+                        if isinstance(data, dict):
+                            # Fetched for EVERY skills write, not just
+                            # ``kind='update'``. The validator needs it for two
+                            # separate checks: update's hash-binding, and the
+                            # stored-status gate that stops a non-admin
+                            # replacing a live ACTIVE skill. Fetching only on
+                            # update made ``kind='create'`` the way around that
+                            # gate — the validator saw ``None`` and judged the
+                            # write purely on what the caller claimed.
+                            #
                             # Fail CLOSED, like the settings/flag gates: the
-                            # live-doc fetch feeds the validator's hash-
-                            # binding check, so a transient DB/network error
-                            # must abort with a curated message rather than
-                            # fall through to the outer handler (which would
-                            # leak the raw exception string).
+                            # live-doc fetch now feeds a security gate, so a
+                            # transient DB/network error must abort with a
+                            # curated message rather than fall through with
+                            # ``live_doc=None`` and skip the check.
                             try:
                                 sc_live = get_storage_client()
                                 live_doc = await sc_live.get_document(
                                     tenant_id=tenant_id,
                                     collection=SKILLS_COLLECTION,
                                     doc_id=doc_id,
+                                    # PRIMARY, not the replica — see the
+                                    # matching note on the REST fetch.
+                                    # This read backs an authorization
+                                    # decision, so replica lag would show
+                                    # the pre-transition status and the
+                                    # gate would authorise the overwrite
+                                    # the transition was meant to forbid.
+                                    read=False,
                                 )
                             except Exception:
                                 logger.exception(
-                                    "skills live-doc fetch failed for %s/%s; cannot gate update write",
+                                    "skills live-doc fetch failed for %s/%s; cannot gate skills write",
                                     tenant_id,
                                     doc_id,
                                 )

--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -289,24 +289,65 @@ async def upsert_document(
                 body_max_bytes=int(sf_settings.get("body_max_bytes", 40_000)),
             )
 
-            # For ``kind='update'`` we must fetch the live skill so the
-            # hash-binding check can compare against the current
-            # content_hash. Read-through storage; the validator handles
-            # the not-found case.
+            # Fetch the live skill for EVERY skills write, not just
+            # ``kind='update'``. Two checks need it and they need it for
+            # different reasons:
+            #
+            #   - ``kind='update'`` binds to the current content_hash;
+            #   - ANY kind aimed at an existing doc_id is a full replace,
+            #     so the validator has to see the stored status before
+            #     letting a non-admin overwrite it. Fetching only on
+            #     update meant ``kind='create'`` was the way around the
+            #     status RBAC: the validator was handed ``None`` and
+            #     judged the request purely on what the caller claimed.
+            #
+            # One extra read on skill creates, on a HITL-gated authoring
+            # path — not the hot path.
             #
             # Guarded by ``isinstance(body.data, dict)`` — a non-dict
             # body.data is a legitimate input (the validator below
             # rejects it with 422), but calling ``.get`` on it would
             # AttributeError into a 500 first. Cleanly punt that
             # rejection to the validator instead of crashing.
+            #
+            # Fail CLOSED, matching the MCP path: the fetch now feeds a
+            # security gate, so a transient storage error must abort with
+            # a curated message rather than fall through with
+            # ``live_doc=None`` and skip the check. An unhandled error
+            # here would already abort the write with a bare 500 — this
+            # keeps the two write paths identical and gets the failure
+            # into the log with the tenant and doc that hit it.
             live_doc: dict | None = None
-            if isinstance(body.data, dict) and body.data.get("kind") == "update":
-                sc_live = get_storage_client()
-                live_doc = await sc_live.get_document(
-                    tenant_id=body.tenant_id,
-                    collection=SKILLS_COLLECTION,
-                    doc_id=body.doc_id,
-                )
+            if isinstance(body.data, dict):
+                try:
+                    sc_live = get_storage_client()
+                    live_doc = await sc_live.get_document(
+                        tenant_id=body.tenant_id,
+                        collection=SKILLS_COLLECTION,
+                        doc_id=body.doc_id,
+                        # PRIMARY, not the replica. ``get_document``
+                        # defaults to ``read=True``; this fetch now backs
+                        # an authorization decision, so replica lag would
+                        # not be a benign stale read — it would show the
+                        # PRE-transition status (a staged row an admin
+                        # just approved to active) and the gate would
+                        # authorise the overwrite the transition was
+                        # meant to forbid. The upsert that follows does
+                        # no CAS on status, so nothing downstream catches
+                        # it. Same reason the inline dedup lookups pin
+                        # the primary.
+                        read=False,
+                    )
+                except Exception:
+                    logger.exception(
+                        "skills live-doc fetch failed for %s/%s; cannot gate skills write",
+                        body.tenant_id,
+                        body.doc_id,
+                    )
+                    raise HTTPException(
+                        status_code=503,
+                        detail="skill lifecycle gate unavailable",
+                    ) from None
 
             normalized, _scan = await validate_and_normalize_skill_write(
                 body.data,

--- a/core-api/src/core_api/services/skill_lifecycle.py
+++ b/core-api/src/core_api/services/skill_lifecycle.py
@@ -78,6 +78,36 @@ INTERNAL_ONLY_STATUSES: frozenset[str] = frozenset({"candidate"})
 # silently retire an active skill or hide a candidate from review.
 SYSTEM_ONLY_STATUSES: frozenset[str] = frozenset({"quarantined", "rejected", "stale", "deprecated"})
 
+# The same three sets, applied to the STORED status instead of the
+# incoming one. The invariant: a status a caller could not have
+# WRITTEN is a status that caller may not silently OVERWRITE.
+#
+# Without this the RBAC above gated only the string in the request
+# body, never the state of the row being replaced — so retiring an
+# active skill needed no privileged status at all, just the default
+# ``staged`` on a write aimed at an existing doc_id. The comment on
+# SYSTEM_ONLY_STATUSES named that exact threat ("silently retire an
+# active skill or hide a candidate from review") while the check it
+# annotates could not see the row it was protecting.
+#
+# Derived rather than spelled out so it cannot drift: adding a status
+# to any RBAC set above protects it here on the same commit.
+#
+# ``staged`` is deliberately absent, because an agent iterating on its
+# OWN not-yet-approved skill is the ordinary authoring loop. Note what
+# that sentence does and does not license: it is an exemption for the
+# author, not for everyone. Status alone cannot tell those apart, so
+# the ownership half is enforced separately at the gate — see
+# ``_live_owner`` below. Leaving it to this comment alone is how the
+# original bug read: a comment asserting a property no check enforced.
+PROTECTED_LIVE_STATUSES: frozenset[str] = ADMIN_ONLY_STATUSES | INTERNAL_ONLY_STATUSES | SYSTEM_ONLY_STATUSES
+
+# The value ``origin.agent_id`` carries when there was no caller
+# identity to stamp. Defined once and used by BOTH the stamping site
+# and the ownership check, so "unattributed" cannot come to mean two
+# different things in the two places.
+UNATTRIBUTED_AGENT_ID = "unknown"
+
 REQUIRED_TOP_LEVEL_KEYS: tuple[str, ...] = ("name", "slug", "description", "domain", "kind", "source")
 
 # ``slug`` regex mirrors the existing ``_SKILL_SLUG_RE`` in
@@ -269,6 +299,124 @@ async def validate_and_normalize_skill_write(
             "deprecation flow — not via caura_doc.",
         )
 
+    # ── Adjustment 5b: the STORED row is gated too ───────────────
+    #
+    # ACCEPTED LIMITATION: the fetch that produced ``live_skill_doc``
+    # and the upsert that follows are not in one transaction, so a
+    # status or owner change landing between them is not seen here.
+    # That is the same optimistic-concurrency model ``kind='update'``'s
+    # hash-binding already runs on, and the window is a single
+    # in-process hop on a HITL-gated authoring path. Worth knowing
+    # before treating this gate as serialization: it is authorization.
+    # Everything above inspects only the incoming body. A write aimed
+    # at an existing doc_id is a full replace (``document_upsert`` is
+    # ``on_conflict_do_update`` over the whole blob), so without this a
+    # caller with a writable key could point ``kind='create'`` at a
+    # live ACTIVE skill, let ``status`` default to ``staged``, and
+    # replace the row outright — dropping it from every
+    # ``status='active'`` surface and destroying its curated content,
+    # while its own content sat in the inbox looking like a routine
+    # submission. No privileged status was needed to retire a skill;
+    # the default one did it.
+    #
+    # Admin and the internal Forge worker are exempt: they are the
+    # legitimate writers of these states, and the Inbox edit path is
+    # already admin-gated by ``_require_inbox_admin`` before it gets
+    # here.
+    #
+    # ``kind='update'`` is deliberately NOT exempt, and this gate runs
+    # BEFORE Adjustment 7a's hash-binding on purpose. Hash-binding is
+    # optimistic concurrency, not authorization: it proves the caller
+    # read the current content, and reads are open to any tenant agent.
+    # So a caller can GET the live skill, copy its ``content_hash``,
+    # and submit ``kind='update'`` — ``status`` still defaults to
+    # ``staged`` (a non-admin cannot write ``active``; that arm is
+    # admin-only above) and the write still lands on the same ``doc_id``
+    # as a full replace. Exempting update to let hash-binding "handle
+    # it" therefore reopens this exact hole for the price of one extra
+    # read. Agent-driven revision of a live skill needs the Phase 4
+    # update-proposal flow, where a revision lands somewhere other than
+    # on top of the live row; until that exists an admin makes the
+    # change. Keep the message below in step with that — do not point
+    # callers at a remedy that is either blocked or unsafe.
+    if live_skill_doc is not None and not (ctx.is_admin or ctx.is_internal_forge):
+        live_data = live_skill_doc.get("data") if isinstance(live_skill_doc, dict) else None
+        live_status = (live_data or {}).get("status")
+        if live_status in PROTECTED_LIVE_STATUSES:
+            # The status is deliberately NOT echoed, for the same reason
+            # the owner is not named below. ``op=read``/``query``/
+            # ``search`` all treat a non-active row as non-existent to a
+            # non-admin caller (``_skill_hidden_from_agent``), so naming
+            # the status here would undo that: repeated writes against
+            # guessed slugs would enumerate which are quarantined,
+            # rejected, or under Forge review. The caller needs to know
+            # the slug is occupied by something they may not replace,
+            # which is what a refusal necessarily reveals; which state it
+            # is in is a separate fact and not theirs.
+            _raise(
+                403,
+                f"skills write: slug={out['slug']!r} already exists and cannot "
+                "be overwritten by a non-admin caller — a write to an existing "
+                "slug replaces the live row outright, whatever its kind. Ask an "
+                "admin to make the change, or to retire the existing skill first.",
+            )
+
+        # The ownership half. ``staged`` is exempt from the status set
+        # above so the authoring loop keeps working, but "iterating on
+        # its own draft" is a claim about WHO is writing, and status
+        # cannot express that. Without this, the exemption reads as
+        # "anyone may overwrite any staged draft": agent B points a
+        # write at agent A's slug and A's unreviewed work is gone, with
+        # no history and nothing in the inbox to show it happened.
+        #
+        # SCOPE — read this before relying on it as a boundary. The
+        # check is only as strong as ``ctx.caller_agent_id``, and that
+        # is an authenticated identity ONLY where agent identity is
+        # authenticated: the gateway-verified path, where
+        # ``_get_agent_id()`` returns the ``X-Agent-ID`` the gateway
+        # signed and it wins over anything the caller passes. On the
+        # standalone / shared-key surfaces there is no verified agent
+        # identity, so ``agent_id`` falls back to the caller's own
+        # self-declared tool parameter — and a caller who can declare an
+        # id can declare the victim's. There, this is protection against
+        # cooperative agents colliding on a slug, NOT a boundary against
+        # a hostile co-tenant. That is not a gap to patch here: it is the
+        # standing ruling that the trust ladder governs AGENT
+        # credentials while tenant scope governs TENANT keys, so on a
+        # shared tenant credential the tenant IS the boundary. Any
+        # attempt to harden this in the validator would be theatre —
+        # every input it could check is supplied by the same caller.
+        #
+        # Refuse only when the live row names a DIFFERENT owner. An
+        # unattributed draft (no origin, or the ``unknown`` stamp) is
+        # left writable on purpose: deployments with no agent identity
+        # stamp every draft that way, and gating on it would 403 the
+        # ordinary loop for all of them. Where the row does name an
+        # owner, a caller who cannot show that identity — including one
+        # with no agent_id at all — is not it.
+        live_origin = (live_data or {}).get("origin")
+        live_owner = (live_origin or {}).get("agent_id") if isinstance(live_origin, dict) else None
+        if live_owner == UNATTRIBUTED_AGENT_ID:
+            live_owner = None
+        if live_owner is not None and live_owner != ctx.caller_agent_id:
+            # The owner is deliberately NOT named. A refusal has to admit
+            # the slug is occupied — otherwise it could not refuse — but
+            # who owns it is a separate fact, and the read path already
+            # treats it as one: ``op=read`` on a non-active skill answers
+            # "Not found" rather than confirm it exists, expressly so
+            # there is no existence leak. Naming the author here would
+            # hand an unauthorized caller more than a permitted read
+            # gives them, and agent ids are not opaque — deployments use
+            # human names in them. Resist adding it back for debugging;
+            # the admin who fields the request can see the row.
+            _raise(
+                403,
+                f"skills write: slug={out['slug']!r} is taken by another "
+                "agent's unreviewed draft and cannot be overwritten. Author "
+                "the skill under a slug of your own, or ask an admin to "
+                "reassign this one.",
+            )
+
     # ── Adjustment 2: description cap ────────────────────────────
     desc_bytes = _bytes_len(out["description"])
     if desc_bytes > ctx.description_max_bytes:
@@ -318,7 +466,7 @@ async def validate_and_normalize_skill_write(
     # message_id) ride through unchanged — the client may legitimately
     # set them.
     origin = dict(out.get("origin") or {})
-    origin["agent_id"] = ctx.caller_agent_id or "unknown"
+    origin["agent_id"] = ctx.caller_agent_id or UNATTRIBUTED_AGENT_ID
     out["origin"] = origin
 
     # ── Adjustment 7a: kind='update' hash-binding ────────────────

--- a/tests/test_api_documents_skills.py
+++ b/tests/test_api_documents_skills.py
@@ -274,3 +274,131 @@ async def test_skills_unshare_route_is_gone(client):
     assert resp.status_code == 404, (
         f"/api/v1/skills/<name> should be removed, got {resp.status_code}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Live-doc fetch: reads the primary, and fails closed
+# ---------------------------------------------------------------------------
+
+
+async def test_skills_write_gate_fetch_reads_the_primary(client, monkeypatch):
+    """The live-doc fetch must pin the PRIMARY, not the read replica.
+
+    ``get_document`` defaults to ``read=True``. Fine for an ordinary read, but
+    this fetch backs an authorization decision: on a replica, a ``staged`` row
+    an admin has just approved to ``active`` still reads as ``staged``, the
+    gate authorises the overwrite the transition was meant to forbid, and the
+    upsert that follows does no CAS on status — nothing downstream catches it.
+    Pinned here because the failure is invisible to any test that stubs
+    storage: the stub answers the same either way.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from core_api.routes import documents as docs
+
+    async def _raw(tenant_id):
+        return {"skills_factory": {"enabled": True}}
+
+    async def _display(tenant_id):
+        return {
+            "skills_factory": {
+                "enabled": True,
+                "body_max_bytes": 40_000,
+                "description_max_bytes": 160,
+            }
+        }
+
+    monkeypatch.setattr(docs, "get_raw_settings", _raw)
+    monkeypatch.setattr(docs, "get_settings_for_display", _display)
+
+    # The fetch aborts the request, so the assertion below is about the call
+    # that was made and nothing downstream needs stubbing. What is under test
+    # is the kwarg, not the outcome — the fail-closed behaviour has its own
+    # test.
+    sc = MagicMock(name="storage_client")
+    sc.get_document = AsyncMock(side_effect=RuntimeError("stop here"))
+    monkeypatch.setattr(docs, "get_storage_client", lambda: sc)
+
+    tenant_id, headers = get_test_auth()
+    await client.post(
+        "/api/v1/documents",
+        json={
+            "tenant_id": tenant_id,
+            "collection": "skills",
+            "doc_id": f"primary-read-{_uid()[:6]}",
+            "data": {
+                "name": "Primary read probe",
+                "slug": "primary-read-probe",
+                "description": "Short trigger description.",
+                "domain": "dev",
+                "kind": "create",
+                "source": "agent",
+                "content": "## When to use\nStep 1.\n",
+            },
+        },
+        headers=headers,
+    )
+    assert sc.get_document.await_args.kwargs["read"] is False
+
+
+async def test_skills_write_fails_closed_when_the_live_doc_fetch_errors(
+    client, monkeypatch
+):
+    """A storage error fetching the live skill must ABORT the write.
+
+    The fetch feeds the stored-status overwrite gate (H-11), so falling
+    through with ``live_doc=None`` would hand the validator exactly the
+    ``None`` that made ``kind='create'`` the way around that gate — a
+    transient DB blip would reopen an overwrite window on every active
+    skill. This pins the REST path to the same fail-closed behaviour its
+    MCP sibling has, rather than the bare unhandled 500 it had before.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from core_api.routes import documents as docs
+
+    async def _raw(tenant_id):
+        return {"skills_factory": {"enabled": True}}
+
+    async def _display(tenant_id):
+        return {
+            "skills_factory": {
+                "enabled": True,
+                "body_max_bytes": 40_000,
+                "description_max_bytes": 160,
+            }
+        }
+
+    monkeypatch.setattr(docs, "get_raw_settings", _raw)
+    monkeypatch.setattr(docs, "get_settings_for_display", _display)
+
+    sc = MagicMock(name="storage_client")
+    sc.get_document = AsyncMock(side_effect=RuntimeError("storage unreachable"))
+    sc.upsert_document_xmax = AsyncMock(return_value={"xmax": 0})
+    monkeypatch.setattr(docs, "get_storage_client", lambda: sc)
+
+    tenant_id, headers = get_test_auth()
+    resp = await client.post(
+        "/api/v1/documents",
+        json={
+            "tenant_id": tenant_id,
+            "collection": "skills",
+            "doc_id": f"fail-closed-{_uid()[:6]}",
+            "data": {
+                "name": "Fail closed probe",
+                "slug": "fail-closed-probe",
+                "description": "Short trigger description.",
+                "domain": "dev",
+                "kind": "create",
+                "source": "agent",
+                "content": "## When to use\nStep 1.\n",
+            },
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 503, (
+        f"expected 503 fail-closed, got {resp.status_code}: {resp.text}"
+    )
+    assert "unavailable" in resp.text.lower()
+    # The decisive assertion: nothing was written.
+    sc.upsert_document_xmax.assert_not_awaited()

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -17,6 +17,7 @@ ORM-row / tuple shapes.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -827,7 +828,9 @@ async def test_skill_write_rejects_caller_active_status_when_flag_on(
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+    sc = stub_storage_client(
+        monkeypatch, upsert_document_xmax={"xmax": 0}, get_document=None
+    )
     out = await mcp_server.caura_doc(
         op="write",
         collection="skills",
@@ -852,7 +855,9 @@ async def test_skill_write_rejects_forge_source_when_flag_on(mcp_env, monkeypatc
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+    sc = stub_storage_client(
+        monkeypatch, upsert_document_xmax={"xmax": 0}, get_document=None
+    )
     out = await mcp_server.caura_doc(
         op="write",
         collection="skills",
@@ -874,7 +879,9 @@ async def test_skill_write_defaults_to_staged_when_flag_on(mcp_env, monkeypatch)
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+    sc = stub_storage_client(
+        monkeypatch, upsert_document_xmax={"xmax": 0}, get_document=None
+    )
     out = await mcp_server.caura_doc(
         op="write",
         collection="skills",
@@ -891,6 +898,71 @@ async def test_skill_write_defaults_to_staged_when_flag_on(mcp_env, monkeypatch)
     assert sent_data["content_hash"].startswith("sha256:")
 
 
+async def test_skill_write_fails_closed_when_the_live_doc_fetch_errors(
+    mcp_env, monkeypatch
+):
+    """The CREATE-path counterpart to the update-path test below.
+
+    ``test_skill_update_write_fails_closed_on_live_doc_fetch_error`` already
+    pinned this for ``kind='update'``, which was the only kind that fetched.
+    This change makes ``kind='create'`` fetch too, so there is now a second
+    place to fail closed — and it is the security-relevant one: the fetch
+    feeds the stored-status overwrite gate, so falling through with
+    ``live_doc=None`` hands the validator exactly the ``None`` that made
+    ``kind='create'`` the way around that gate, turning a transient DB blip
+    into an open window on every active skill.
+    """
+    _patch_flag(monkeypatch, True)
+    _patch_sf_settings(monkeypatch)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    sc = stub_storage_client(
+        monkeypatch, upsert_document_xmax={"xmax": 0}, get_document=None
+    )
+    sc.get_document = AsyncMock(side_effect=RuntimeError("storage unreachable"))
+    out = await mcp_server.caura_doc(
+        op="write",
+        collection="skills",
+        doc_id="forge-x",
+        data=_valid_skill_data(),
+    )
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "INTERNAL_ERROR"
+    # The decisive assertion: nothing was written.
+    sc.upsert_document_xmax.assert_not_awaited()
+
+
+async def test_skill_write_gate_fetch_reads_the_primary(mcp_env, monkeypatch):
+    """The live-doc fetch must pin the PRIMARY, not the read replica.
+
+    ``get_document`` defaults to ``read=True``. That default is fine for an
+    ordinary read, but this fetch backs an authorization decision: on a
+    replica, a ``staged`` row an admin has just approved to ``active`` still
+    reads as ``staged``, the gate authorises the overwrite the transition was
+    meant to forbid, and the upsert that follows does no CAS on status, so
+    nothing downstream catches it. Pinning the kwarg here because the failure
+    is invisible in any test that stubs storage — the stub answers the same
+    either way.
+    """
+    _patch_flag(monkeypatch, True)
+    _patch_sf_settings(monkeypatch)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
+    )
+    sc = stub_storage_client(
+        monkeypatch, upsert_document_xmax={"xmax": 0}, get_document=None
+    )
+    out = await mcp_server.caura_doc(
+        op="write",
+        collection="skills",
+        doc_id="forge-x",
+        data=_valid_skill_data(),
+    )
+    assert parse_envelope(out)["ok"] is True
+    assert sc.get_document.await_args.kwargs["read"] is False
+
+
 async def test_skill_write_tolerates_misconfigured_byte_caps(mcp_env, monkeypatch):
     # A null / non-numeric per-tenant byte cap is a realistic admin
     # misconfiguration. It must degrade to the documented default via
@@ -904,7 +976,9 @@ async def test_skill_write_tolerates_misconfigured_byte_caps(mcp_env, monkeypatc
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
-    stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})
+    stub_storage_client(
+        monkeypatch, upsert_document_xmax={"xmax": 0}, get_document=None
+    )
     out = await mcp_server.caura_doc(
         op="write",
         collection="skills",

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -42,6 +42,7 @@ from core_api.services.skill_lifecycle import (
     ALLOWED_STATUSES,
     INTERNAL_ONLY_SOURCES,
     INTERNAL_ONLY_STATUSES,
+    PROTECTED_LIVE_STATUSES,
     REQUIRED_TOP_LEVEL_KEYS,
     SYSTEM_ONLY_STATUSES,
     SkillWriteContext,
@@ -594,6 +595,351 @@ class TestHashBindingAndScan:
         assert out["scan"]["state"] == "clean"
         assert out["scan"]["critical"] == 0
         assert scan.state == "clean"
+
+
+# --- H-11: the STORED status is gated, not just the written one -----------
+
+
+def _live(
+    status: str,
+    *,
+    content_hash: str = "sha256:live",
+    owner: str | None = None,
+) -> dict:
+    """A live skills doc in the shape storage returns it.
+
+    ``owner`` stamps ``origin.agent_id``. Left absent by default so the
+    status-gate tests exercise the status axis alone — an unattributed row,
+    which the ownership half deliberately leaves writable.
+    """
+    data = {"slug": "test-skill", "status": status, "content_hash": content_hash}
+    if owner is not None:
+        data["origin"] = {"agent_id": owner}
+    return {"data": data}
+
+
+@pytest.mark.unit
+class TestLiveStatusOverwriteGuard:
+    """H-11 — status RBAC gated the written value, never the stored row.
+
+    ``document_upsert`` is ``on_conflict_do_update`` over the whole blob, so a
+    write aimed at an existing ``doc_id`` replaces it outright. Because the
+    validator only ever inspected the incoming body, a caller with a writable
+    key could point ``kind='create'`` at a live ACTIVE skill, let ``status``
+    default to ``staged``, and retire it — dropping it from every
+    ``status='active'`` surface and destroying its curated content, with the
+    replacement sitting in the inbox looking like a routine submission.
+
+    No privileged status was needed. The DEFAULT one did it. That is the exact
+    threat ``SYSTEM_ONLY_STATUSES``' comment claims to defend against, and the
+    check it annotates could not see the row it was protecting.
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_cannot_overwrite_a_live_active_skill(self):
+        """THE ATTACK. Fails without the fix — the write was accepted."""
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(),  # kind='create', source='agent', status defaults to staged
+                ctx=_agent_ctx(),
+                live_skill_doc=_live("active"),
+            )
+        assert exc.value.status_code == 403
+        detail = str(exc.value.detail).lower()
+        assert "already exists" in detail
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("live_status", sorted(SYSTEM_ONLY_STATUSES))
+    async def test_agent_cannot_resurrect_a_system_managed_doc(self, live_status):
+        """Rejected / quarantined / stale / deprecated are equally resurrectable.
+
+        A rejected skill that a non-admin can overwrite is a rejection that
+        does not hold. Parametrized off the constant so a new system status is
+        covered the day it is added.
+        """
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(),
+                ctx=_agent_ctx(),
+                live_skill_doc=_live(live_status),
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_agent_cannot_clobber_a_candidate_under_review(self):
+        """``candidate`` is internal-only to write, so it is protected to overwrite.
+
+        The same comment names this half of the threat — "hide a candidate from
+        review". The finding listed only active/rejected/quarantined/stale/
+        deprecated; deriving the set from the RBAC constants covers this too.
+        """
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(),
+                ctx=_agent_ctx(),
+                live_skill_doc=_live("candidate"),
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_agent_may_still_overwrite_its_own_staged_skill(self):
+        """OVER-REFUSAL GUARD. Iterating on a not-yet-approved skill is the
+        ordinary authoring loop and must keep working — a gate that blocked it
+        would trade a security bug for a usability one."""
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(),
+            ctx=_agent_ctx(),
+            live_skill_doc=_live("staged"),
+        )
+        assert out["status"] == "staged"
+
+    @pytest.mark.asyncio
+    async def test_first_write_of_a_new_slug_is_unaffected(self):
+        """OVER-REFUSAL GUARD. No live doc → nothing to protect."""
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(), ctx=_agent_ctx(), live_skill_doc=None
+        )
+        assert out["status"] == "staged"
+
+    @pytest.mark.asyncio
+    async def test_admin_may_overwrite_an_active_skill(self):
+        """OVER-REFUSAL GUARD. Admin is the legitimate writer of these states —
+        the HITL Inbox edit path is admin-gated and routes through here."""
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(),
+            ctx=_admin_ctx(),
+            live_skill_doc=_live("active"),
+        )
+        assert out["status"] == "staged"
+
+    @pytest.mark.asyncio
+    async def test_internal_forge_may_overwrite_an_active_skill(self):
+        """OVER-REFUSAL GUARD. The lifecycle worker owns these transitions."""
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(source="forge"),
+            ctx=_forge_ctx(),
+            live_skill_doc=_live("active"),
+        )
+        assert out["status"] == "candidate"
+
+    @pytest.mark.asyncio
+    async def test_correct_hash_binding_does_not_buy_an_overwrite(self):
+        """A well-formed ``kind='update'`` with the RIGHT hash is still refused.
+
+        Hash-binding is optimistic concurrency, not authorization. Reads are
+        open to any tenant agent, so ``target_content_hash`` proves only that
+        the caller GET the live skill first — which an attacker can do. The
+        write still lands on the same ``doc_id`` as a full replace, and
+        ``status`` still defaults to ``staged`` because a non-admin cannot
+        write ``active``. Exempting update from the gate on the grounds that
+        7a "already checks it" would reopen H-11 for the price of one extra
+        read, so this test exists to make that regression loud.
+        """
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(
+                    kind="update",
+                    target={"target_content_hash": "sha256:live"},  # the CORRECT hash
+                ),
+                ctx=_agent_ctx(),
+                live_skill_doc=_live("active", content_hash="sha256:live"),
+            )
+        assert exc.value.status_code == 403
+        assert "already exists" in str(exc.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_refusal_does_not_advertise_an_unreachable_remedy(self):
+        """The 403 must not send callers to a door this gate holds shut.
+
+        An earlier revision of the message told the caller to "propose a
+        revision with kind='update'" — advice that is both blocked here and,
+        were it not, the vulnerability itself. Keep the message honest: an
+        admin is the remedy until the Phase 4 proposal flow lands.
+        """
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(), ctx=_agent_ctx(), live_skill_doc=_live("active")
+            )
+        detail = str(exc.value.detail).lower()
+        assert "kind='update'" not in detail
+        assert "admin" in detail
+
+    @pytest.mark.asyncio
+    async def test_agent_may_still_update_its_own_staged_skill(self):
+        """OVER-REFUSAL GUARD. ``kind='update'`` is not blocked as such — only
+        against a PROTECTED live status. Revising one's own staged draft, hash
+        bound, is the ordinary authoring loop and still works."""
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(
+                kind="update",
+                target={"target_content_hash": "sha256:live"},
+            ),
+            ctx=_agent_ctx(),
+            live_skill_doc=_live("staged", content_hash="sha256:live"),
+        )
+        assert out["status"] == "staged"
+
+    @pytest.mark.asyncio
+    async def test_agent_cannot_clobber_another_agents_staged_draft(self):
+        """The `staged` exemption is for the AUTHOR, not for everyone.
+
+        Excluding ``staged`` from the protected set keeps the authoring loop
+        working, but "iterating on its own draft" is a claim about who is
+        writing, and status cannot express it. Without the ownership half,
+        one agent points a write at another's slug and that unreviewed work is
+        gone — no history, nothing in the inbox to show it happened.
+
+        SCOPE: this is a boundary only where agent identity is authenticated
+        (the gateway-verified path, where the signed ``X-Agent-ID`` wins over
+        anything the caller passes). On standalone / shared-key surfaces
+        ``agent_id`` is the caller's own self-declared parameter, so a caller
+        who can declare an id can declare the victim's — there this prevents
+        cooperative agents colliding on a slug, and nothing more. See the
+        SCOPE note at the gate; do not read this test as proving more than it
+        does.
+        """
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(),
+                ctx=_agent_ctx(caller_agent_id="bob"),
+                live_skill_doc=_live("staged", owner="alice"),
+            )
+        assert exc.value.status_code == 403
+        assert "draft" in str(exc.value.detail).lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("live_status", sorted(PROTECTED_LIVE_STATUSES))
+    async def test_status_refusal_does_not_echo_the_protected_status(self, live_status):
+        """The refusal must not name WHICH protected state the row is in.
+
+        ``op=read``/``query``/``search`` all treat a non-active row as
+        non-existent to a non-admin caller, so echoing the status here would
+        undo that: repeated writes against guessed slugs would enumerate which
+        slugs are quarantined, rejected, or under Forge review. A refusal
+        necessarily reveals the slug is occupied; which state it is in is a
+        separate fact. Parametrized so a status added to the set is covered.
+        """
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(), ctx=_agent_ctx(), live_skill_doc=_live(live_status)
+            )
+        assert exc.value.status_code == 403
+        assert live_status not in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_ownership_refusal_does_not_name_the_other_agent(self):
+        """The refusal must not disclose WHO owns the draft.
+
+        A write refusal has to admit the slug is occupied — it could not
+        refuse otherwise — but authorship is a separate fact, and the read
+        path already treats it as one: ``op=read`` on a non-active skill
+        answers "Not found" rather than confirm it exists, expressly to avoid
+        an existence leak. Naming the author in this 403 would hand an
+        unauthorized caller strictly more than a permitted read gives them,
+        and agent ids are not opaque — real deployments put human names in
+        them. This guards the obvious debugging regression of putting it back.
+        """
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(),
+                ctx=_agent_ctx(caller_agent_id="bob"),
+                live_skill_doc=_live("staged", owner="alice-surname"),
+            )
+        assert exc.value.status_code == 403
+        assert "alice-surname" not in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_unidentified_caller_cannot_clobber_an_attributed_draft(self):
+        """A caller with no agent_id cannot BE the named owner.
+
+        The looser reading — refuse only when both sides are attributed —
+        would let a tenant key with no agent identity overwrite any named
+        author's draft. Where the row names an owner, a caller who cannot
+        show that identity is not it.
+        """
+        with pytest.raises(HTTPException) as exc:
+            await validate_and_normalize_skill_write(
+                _valid_doc(),
+                ctx=_agent_ctx(caller_agent_id=None),
+                live_skill_doc=_live("staged", owner="alice"),
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_author_may_still_overwrite_their_own_staged_draft(self):
+        """OVER-REFUSAL GUARD. The authoring loop, which is the whole point
+        of exempting ``staged``, must survive the ownership check."""
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(),
+            ctx=_agent_ctx(caller_agent_id="alice"),
+            live_skill_doc=_live("staged", owner="alice"),
+        )
+        assert out["status"] == "staged"
+
+    @pytest.mark.asyncio
+    async def test_unattributed_draft_stays_writable(self):
+        """OVER-REFUSAL GUARD. A deployment with no agent identity stamps
+        every draft ``unknown``; gating on that would 403 the ordinary loop
+        for all of them. Both the missing-origin and explicit-``unknown``
+        shapes must stay writable."""
+        from core_api.services.skill_lifecycle import UNATTRIBUTED_AGENT_ID
+
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(), ctx=_agent_ctx(), live_skill_doc=_live("staged")
+        )
+        assert out["status"] == "staged"
+
+        out2, _ = await validate_and_normalize_skill_write(
+            _valid_doc(),
+            ctx=_agent_ctx(caller_agent_id="bob"),
+            live_skill_doc=_live("staged", owner=UNATTRIBUTED_AGENT_ID),
+        )
+        assert out2["status"] == "staged"
+
+    @pytest.mark.asyncio
+    async def test_admin_may_overwrite_another_agents_staged_draft(self):
+        """OVER-REFUSAL GUARD. Admin is exempt from the whole gate, both
+        halves — the Inbox edit path is admin-gated and routes through here."""
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(),
+            ctx=_admin_ctx(),
+            live_skill_doc=_live("staged", owner="alice"),
+        )
+        assert out["status"] == "staged"
+
+    @pytest.mark.asyncio
+    async def test_unattributed_sentinel_is_shared_with_the_stamping_site(self):
+        """The constant must be the one the stamp actually writes.
+
+        If the check and the stamp spelled "unattributed" separately, a change
+        to one would silently turn every unattributed draft into an owned one
+        (or the reverse) — two places that have to agree, which is the shape
+        of the original bug.
+        """
+        from core_api.services.skill_lifecycle import UNATTRIBUTED_AGENT_ID
+
+        out, _ = await validate_and_normalize_skill_write(
+            _valid_doc(), ctx=_agent_ctx(caller_agent_id=None), live_skill_doc=None
+        )
+        assert out["origin"]["agent_id"] == UNATTRIBUTED_AGENT_ID
+
+    def test_protected_set_is_derived_from_the_rbac_constants(self):
+        """The set must not be a hand-maintained copy.
+
+        Spelling it out would let a status added to an RBAC set above go
+        unprotected here until someone noticed — which is the shape of the
+        original bug, two places that had to agree and did not.
+        """
+        from core_api.services.skill_lifecycle import (
+            ADMIN_ONLY_STATUSES,
+            PROTECTED_LIVE_STATUSES,
+        )
+
+        assert PROTECTED_LIVE_STATUSES == (
+            ADMIN_ONLY_STATUSES | INTERNAL_ONLY_STATUSES | SYSTEM_ONLY_STATUSES
+        )
+        # ``staged`` must stay out of it, or the authoring loop breaks.
+        assert "staged" not in PROTECTED_LIVE_STATUSES
 
 
 # --- Migration chain integrity --------------------------------------------


### PR DESCRIPTION
Closes audit finding **H-11** — integrity/availability attack on curated active skills.

## The defect

`validate_and_normalize_skill_write` applied RBAC only to the `status` and `source` strings **in the incoming body**. It never looked at the row the write was about to replace — and `document_upsert` is `on_conflict_do_update` over the whole blob, so a write aimed at an existing `doc_id` is a **full replace**.

With `skills_factory` enabled, any tenant agent holding a writable key could:

```
POST /documents  collection='skills'  doc_id=<a live ACTIVE skill>
                 kind='create'  source='agent'    (status omitted)
```

The validator defaults `status` to `staged` and passes every RBAC check — none of them are about the stored row — and the upsert replaces it. The active skill drops out of every `status='active'` surface (recall, harness reconciliation, MCP skills counts), its curated content is destroyed, and the replacement sits in the inbox looking like a routine staged submission.

**No privileged status was needed to retire a skill. The default one did it.**

## The module already named this threat

`SYSTEM_ONLY_STATUSES`' comment says letting an arbitrary write set those states *"would let a misbehaving agent silently retire an active skill or hide a candidate from review"* — while the check it annotates **could not see the row it was protecting**. Rejected and quarantined docs were equally resurrectable, so a rejection did not hold either.

## The fix is the same RBAC, applied to the stored value

```python
PROTECTED_LIVE_STATUSES = ADMIN_ONLY_STATUSES | INTERNAL_ONLY_STATUSES | SYSTEM_ONLY_STATUSES
```

The invariant: **a status a caller could not have WRITTEN is one they may not silently OVERWRITE.**

Derived rather than spelled out, so a status added to any RBAC set is protected on the same commit. A hand-maintained copy would be two places that have to agree — which is the shape of the original bug. A test pins the derivation.

`staged` is deliberately absent: an agent iterating on its own not-yet-approved skill is the ordinary authoring loop and must keep working. "Its own" is enforced, not just asserted — see the ownership half below. Admin and the internal Forge worker are exempt — they are the legitimate writers of these states, and the Inbox edit path is admin-gated before it reaches here.

**Beyond the finding:** it listed active/rejected/quarantined/stale/deprecated. Deriving the set from the RBAC constants also covers `candidate` — the other half of the comment's own threat statement ("hide a candidate from review"), which the finding omitted.

## Both surfaces now fetch the live doc for every skills write

Not just `kind='update'`. Fetching only on update is precisely what made `kind='create'` the way around the gate: the validator was handed `None` and judged the request purely on what the caller claimed. One extra read on a HITL-gated authoring path, not a hot path.

Both paths now fail **closed** on a fetch error — see the review round below.

## Review round: why `kind='update'` is NOT exempted

The review was right that the gate runs before `kind='update'`'s hash-binding, and that the old 403 message pointed callers at `kind='update'` as the remedy — a remedy this gate holds shut. **But its suggested fix (exempt `kind='update'`, since 7a already enforces hash-binding) would reopen H-11**, so I took the other branch it offered and corrected the message instead.

Hash-binding is **optimistic concurrency, not authorization**. It proves the caller read the current content, and reads are open to any tenant agent. So the exemption is defeated by one extra GET:

1. `GET` the live active skill — permitted — and copy its `content_hash`.
2. `POST` `kind='update'` with that `target_content_hash`. 7a is satisfied.
3. `status` is omitted, so it defaults to `staged`; a non-admin cannot write `active` (that arm is admin-only).
4. The write still lands on the same `doc_id` as a full replace.

Identical outcome to the original attack. I confirmed this rather than arguing it — applying the suggested exemption verbatim and re-running, the overwrite **succeeds**:

```
FAILED test_correct_hash_binding_does_not_buy_an_overwrite
  - Failed: DID NOT RAISE <class 'fastapi.exceptions.HTTPException'>
```

That test is new in this round and exists to make the regression loud if anyone tries the exemption again. A comment at the gate records the reasoning so the next reader doesn't have to re-derive it.

**On the functional concern:** there is no working non-admin revision path being removed here, because there was never a correct one. Pre-PR, a non-admin `kind='update'` against an active skill *demoted it to staged* — no status is preserved from the live doc, and `active` is admin-only to write. That demotion is the bug, not a feature. Agent-driven revision of a live skill needs the **Phase 4 update-proposal flow** the module docstring already anticipates, where a revision lands somewhere other than on top of the live row. Until then an admin makes the change, and the message now says exactly that. A second new test asserts the message no longer advertises the unreachable remedy.

`kind='update'` is *not* blocked as such — only against a protected live status. A third new test covers an agent hash-bound-updating its own `staged` draft, which still works.

## REST fail-closed parity

The review was also right that the REST fetch lacked the `try/except` its MCP sibling has. Fixed — it now logs with the tenant and doc and returns a curated 503.

One correction to the framing: this was **not** a fail-open. There is no enclosing handler in that route (verified), so an unhandled error already aborted the write with a bare 500 — the security property held on both paths. What differed was the error quality and the missing log line. Worth fixing for parity on a security-relevant fetch; not a second vulnerability.

Two tests pin the fail-closed behaviour on the **create** path, one per surface — the path this PR newly made fetch, and the security-relevant one. (`test_skill_update_write_fails_closed_on_live_doc_fetch_error` already covered the update path; I initially reported no such test existed, having grepped for the message text rather than the error code.) Both new tests fail if the handler is changed to swallow the error and continue with `live_doc=None`, which is the failure mode that actually matters.

## Second review round: the `staged` exemption now checks ownership

The re-review accepted the resolution above and raised one more Medium, which was fair and landed on a comment **I** wrote. The comment justified excluding `staged` on the grounds that "an agent iterating on its own not-yet-approved skill is the ordinary case" — but nothing compared the live row's `origin.agent_id` to the caller. So the exemption actually read *"anyone may overwrite any staged draft"*: agent B points a write at agent A's slug and A's unreviewed work is gone, with no history and nothing in the inbox to show it happened.

That is the same shape as the bug this PR fixes — a comment asserting a property no check enforces — so I took the review's option (a) and enforced it rather than documenting the gap away.

The gate now has two halves, and the comment says which is which. Refusal is limited to a live row naming a **different** owner:

- an **unattributed** draft (no `origin`, or the `unknown` stamp) stays writable on purpose. Deployments with no agent identity stamp every draft that way, and gating on it would 403 the ordinary loop for all of them.
- where the row **does** name an owner, a caller who cannot show that identity — including one with no `agent_id` at all — is not it. The looser "refuse only when both sides are attributed" reading would let an unbound tenant key overwrite any named author's draft.

`UNATTRIBUTED_AGENT_ID` is shared with the stamping site so "unattributed" cannot come to mean two different things in the two places, and a test pins that it is the value the stamp writes.

**On the TOCTOU suggestion:** added as an explicit `ACCEPTED LIMITATION` note at the gate. The fetch and the upsert are not in one transaction, which is the same optimistic-concurrency model hash-binding already runs on. The note exists so this gate is not later mistaken for serialization when it is authorization — the same distinction that settled the `kind='update'` question above.

Confirmed by disabling only the ownership condition: exactly the two new refusals fail, and all four over-refusal guards still pass.

## Third round: the refusal no longer names the owning agent

Verdict was **no blocking issues**, with two suggestions. I acted on the first and left the second, which the review itself said not to restructure.

The ownership 403 included the other agent's id. The review flagged this as low-risk-but-consider; checking the read path made it clearly worth fixing, because **the codebase already treats authorship as privileged one module over**: `op=read` on a non-active skill answers *"Not found"* rather than confirm it exists, expressly so there is no existence leak. My 403 both named the author and confirmed the draft existed — strictly more than a permitted read gives that caller. And agent ids are not opaque here; real deployments put human names in them.

A refusal has to admit the slug is occupied, or it could not refuse. Who owns it is a separate fact, and it is now omitted. A test pins that the owner's id does not appear in the detail — the regression this invites is someone adding it back while debugging.

**Left alone:** the duplicated `live_skill_doc.get("data")` between Adjustment 5b and 7a. Cosmetic, on a HITL-gated path, and the review judged it not worth restructuring against this repo's established trade-off. I agree — the two blocks read independently, and threading one extracted local through both would couple two checks that are deliberately separate.

## Fourth round: a replica read, a status leak, and a scoped claim

Three findings, all verified against source and fixed.

**High — the gate was reading from a replica.** `get_document` is `read: bool = True`; its own docstring says `read=False` forces the primary. So the fetch backing this gate could serve a *pre-transition* status: a `staged` row an admin has just approved to `active` still reads as `staged`, the gate authorises the overwrite the approval was meant to forbid, and the upsert that follows is a blind full replace with no CAS on status. Both sites now pass `read=False`, the same way the inline dedup lookups in that client do.

This is worth separating from the `ACCEPTED LIMITATION` note above it. That note covers the in-process fetch-to-upsert window — narrow, and inherent to the optimistic model. **The replica read was a different and much wider window, and unlike the first it was not a considered trade-off but a default I had not looked at.** Both surfaces now have a test pinning the kwarg, because this failure is invisible to any test that stubs storage: the stub answers identically either way.

**Medium — the refusal echoed the protected status.** The same leak I had just fixed for the owner, still present two lines up for the status. `_skill_hidden_from_agent` and the query/search filters treat a non-active row as non-existent to a non-admin caller, so echoing the status let a caller enumerate which slugs are `quarantined`, `rejected`, or under Forge review by writing at guessed slugs. Dropped, with a test parametrized over `PROTECTED_LIVE_STATUSES` asserting the name never appears.

**Medium — the ownership check trusts a self-declared `agent_id`.** Confirmed: `caura_doc` does `agent_id = _get_agent_id() or agent_id`, and that value becomes `SkillWriteContext.caller_agent_id`. Where the gateway signs `X-Agent-ID` the check is sound; where there is no verified agent identity the value is the caller's own parameter, and a caller who can declare an id can declare the victim's.

I did not try to harden this in the validator — every input available there comes from the same caller, so any added check would be theatre. It is also the standing ruling rather than an oversight: the trust ladder governs *agent* credentials, tenant scope governs *tenant* keys, so on a shared tenant credential the tenant is the boundary. What changed is the honesty of the claim: the gate carries a `SCOPE` note, and the test docstring carries it too, so neither is later read as proving a boundary it does not test.

Leaving "agent B cannot clobber agent A" standing unqualified would have been **the fourth instance in this PR of a comment asserting what no check enforces** — the defect the PR exists to fix.

## A test-fixture change, and why it is not a product change

Four tests in `test_mcp_doc.py` stubbed the storage client without `get_document`. They exercise `kind='create'`, so the fetch never ran and the plain `MagicMock` was never awaited; now it is, and they failed with `'MagicMock' object can't be awaited`. Passing `get_document=None` is the semantically correct stub — those tests write **new** skills, so no live doc exists. In production `get_storage_client()` returns a real async client.

Worth stating plainly rather than folding in silently: the four were a real regression in the test suite that my change caused, not pre-existing noise.

## Tests

**Thirteen fail without their fix**, each confirmed by disabling only the thing it guards.

Eleven are refusals:

- the active-skill overwrite (the attack itself)
- all four system-managed statuses, **parametrized off the constant** so a new one is covered the day it is added
- the candidate clobber
- a hash-bound `kind='update'` overwrite (fails if update is exempted)
- a 403 that advertises an unreachable remedy
- a cross-agent staged clobber
- an unidentified caller clobbering an attributed draft
- a refusal that names the owning agent

Two pin **fail-closed** on the live-doc fetch for the create path, one per surface, and fail if the error is swallowed.

**Eight are over-refusal guards:** an agent may still overwrite *and* still hash-bound-update its own `staged` skill, an author may still overwrite their own attributed draft, unattributed drafts stay writable in both the missing-`origin` and explicit-`unknown` shapes, a first write of a new slug is unaffected, and admin and Forge may still write — including admin over another agent's draft.

**Two pin the anti-drift properties:** that the protected set stays derived from the RBAC constants, and that the unattributed sentinel is the value the stamping site actually writes.

*A process note:* my first removal probe cut a line range and broke the file — 35 unrelated tests failed, which looks alarming and means nothing. An invalid probe proves neither direction. I re-ran it by disabling only the guard's condition, which gave the clean signal above.

## Verification

- Full root suite: **6029 passed, 5 skipped, 1 xfailed, 0 failed.**
- `ruff check` and `ruff format --check` run **separately** at CI's exact scopes — clean.
- `mypy` clean on all three changed source files (2 pre-existing `types-python-dateutil` stub errors in an untouched file).
- `legacy_name_ratchet.py` → *No new lines.* · `do_not_touch_sentinel.py` → *All 39 protected strings survive.* · `tenant_scope_gate.py` → no allowlist movement. All run **after `git add`**, and again after rebasing onto `f1d7b909`. Head `b547cac9`.

**A correction to my earlier verification claims on this PR.** I previously reported this suite as "54 failed / 5947 passed — back to the exact baseline". That 54-failure baseline was an environment artifact, not a property of the codebase: `core-api/.venv/bin/pytest` has a stale shebang pointing at the pre-rename `…/memclaw/core-api/.venv/bin/python`, so invoking `pytest` through `PATH` fails its exec and the shell falls through to the *system* pytest (Python 3.14, system site-packages), which is missing the project's pinned deps. Invoked as `.venv/bin/python -m pytest`, the suite is clean. The 54→58 delta that caught the `test_mcp_doc.py` regression was still a valid comparison — same wrong interpreter on both sides — so that finding stands. But the absolute number was wrong, and any future run should use `python -m pytest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
