### PR TITLE
docs(ratchet): note that release_please_changelogs is now inert

### DIFF
--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -173,6 +173,12 @@ class Config(NamedTuple):
     """The complete per-repository surface of the canonical engine."""
 
     default_base: str
+    # No longer has any effect: _excluded_changelogs excludes every
+    # CHANGELOG.md unconditionally, before this flag (or the authenticated
+    # check it used to gate) is ever consulted. Kept in the schema rather
+    # than removed -- a schema change across every repo's config file is a
+    # separate, larger change than this one -- so a repo can still set it
+    # to either value with no observable difference in gate behavior.
     release_please_changelogs: bool
     mirror_paths: tuple[str, ...]
     mirror_manifest: str | None


### PR DESCRIPTION
## Summary

Small follow-up to #1265. A review on the same change landing in `caura-bus` correctly pointed out (High severity) that `release_please_changelogs` is now silently a no-op: `_excluded_changelogs()` excludes every `CHANGELOG.md` unconditionally, before this config flag (or the authenticated check it used to gate) is ever consulted — so a repo that sets it to `false` expecting full CHANGELOG.md gate coverage silently doesn't get that anymore.

#1265 already documented the internal dead-code path (`_release_please_pull_request()`), but not the config field itself — the surface a repo owner would actually look at when trying to understand what the flag does. This adds that note directly on the field.

Not removing the field or the dead code: per #1265's own reasoning, that's a separate, larger cleanup (a schema change across every repo's `scripts/legacy_name_ratchet.json`), not a comment.

## Test plan

- [x] `ruff check scripts/` and `ruff format --check scripts/` clean
- [x] `pytest tests/test_legacy_name_ratchet.py` — 183 passed
- [x] `python3 scripts/legacy_name_ratchet.py --base origin/main` — no new lines
- [x] DCO sign-off present

🤖 Generated with [Claude Code](https://claude.com/claude-code)