### PR TITLE
fix(fleet): gate the heartbeat behind enforce_read_only

### DIFF
--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -654,6 +654,39 @@ async def heartbeat(
     auth: AuthContext = Depends(get_auth_context),
 ):
     """Plugin pushes status; receives pending commands in response."""
+    # The heartbeat is a WRITE, despite reading like telemetry, and it was
+    # the only mutating route in this module without the gate — its five
+    # siblings (create/delete/purge fleet, create_command, command_result)
+    # all have it. What it mutates:
+    #
+    #   - ``upsert_node`` replaces the node row (hostname, versions, the
+    #     whole metadata blob);
+    #   - ``get_or_create_agent`` materialises agent rows per heartbeat;
+    #   - ``_maybe_queue_auto_upgrade`` can queue a deploy command;
+    #   - ``ack_commands`` DRAINS the node's pending queue and returns the
+    #     payloads in the response.
+    #
+    # That last one is why this is not merely an unwanted write. A
+    # read-only or demo credential naming an existing node could claim
+    # that node's queued commands — receiving payloads meant for it, and
+    # leaving nothing for the real node to collect, since acked commands
+    # are not redelivered. One request, unrecoverable: an operator sees a
+    # dispatched command that was acknowledged and never ran.
+    #
+    # Gate order matches the siblings (``create_fleet``,
+    # ``create_command``): the credential's own capability is judged
+    # first, then the target tenant. Nothing here depends on the order —
+    # ``enforce_read_only`` reads only the caller's own credential — so
+    # consistency is the whole argument.
+    #
+    # ``enforce_usage_limits`` is deliberately NOT added, though the
+    # write-shaped siblings carry it. This call recurs every ~60s from
+    # every node and is how a node stays live and commandable; gating it
+    # on plan limits would take a tenant that merely exceeded its quota
+    # and make its entire fleet go stale and uncommandable — including
+    # the commands an operator would use to reduce usage. ``create_command``
+    # sets the same precedent on this path: read-only gate, no usage gate.
+    auth.enforce_read_only()
     auth.enforce_tenant(body.tenant_id)
 
     if is_plugin_outdated(body.plugin_version) and _should_log_outdated_plugin(

--- a/tests/test_route_authz_gaps.py
+++ b/tests/test_route_authz_gaps.py
@@ -761,3 +761,154 @@ async def test_promote_refuses_a_quarantined_agent(client, as_auth, sc, _stm_ena
     )
     assert resp.status_code == 403, resp.text
     assert "not approved" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# H-04 — POST /fleet/heartbeat had no enforce_read_only
+#
+# The heartbeat reads like telemetry but is the most write-heavy route in the
+# fleet module, and it was the only mutating one in it without the gate. Its
+# five siblings all have it.
+# ---------------------------------------------------------------------------
+
+
+async def _queue_command_for(client, as_auth, tenant: str) -> tuple[str, str]:
+    """Register a node and queue one command for it. Returns (node_name, command_id)."""
+    node_name = f"node-{_uid()}"
+    as_auth(tenant)
+    resp = await client.post(
+        "/api/v1/fleet/heartbeat",
+        json={
+            "tenant_id": tenant,
+            "node_name": node_name,
+            "fleet_id": f"fleet-{_uid()}",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    node_id = resp.json()["node_id"]
+
+    resp = await client.post(
+        "/api/v1/fleet/commands",
+        json={
+            "tenant_id": tenant,
+            "node_id": node_id,
+            "command": "ping",
+            "payload": {"k": "v"},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return node_name, resp.json()["id"]
+
+
+@pytest.mark.parametrize(
+    "cred",
+    [
+        pytest.param({"capabilities": {"read"}}, id="read-only-key"),
+        pytest.param({"is_demo": True}, id="demo-sandbox"),
+    ],
+)
+async def test_heartbeat_refuses_a_non_writing_credential(client, as_auth, cred):
+    """A credential that cannot write must not be able to heartbeat.
+
+    ``upsert_node`` replaces the whole node row — hostname, versions, the
+    metadata blob — so a read-only or demo credential could rewrite another
+    node's identity, or register nodes that do not exist.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, **cred)
+    resp = await client.post(
+        "/api/v1/fleet/heartbeat",
+        json={
+            "tenant_id": tenant,
+            "node_name": f"node-{_uid()}",
+            "fleet_id": f"fleet-{_uid()}",
+        },
+    )
+    assert resp.status_code == 403, resp.text
+
+
+async def test_read_only_credential_cannot_drain_a_nodes_command_queue(client, as_auth):
+    """THE ATTACK, and the reason this is not merely an unwanted write.
+
+    The heartbeat response carries the node's pending commands and then
+    ``ack_commands`` them. Acked commands are not redelivered, so a caller
+    who names an existing node both RECEIVES payloads intended for it and
+    leaves nothing for the real node to collect. One request, unrecoverable:
+    the operator sees a command that was acknowledged and never ran.
+
+    Asserts both halves — the payload must not come back, and the command
+    must still be pending afterwards.
+    """
+    tenant = f"tenant-{_uid()}"
+    node_name, command_id = await _queue_command_for(client, as_auth, tenant)
+
+    as_auth(tenant, capabilities={"read"})
+    resp = await client.post(
+        "/api/v1/fleet/heartbeat",
+        json={"tenant_id": tenant, "node_name": node_name},
+    )
+    assert resp.status_code == 403, resp.text
+    # The command payload must not have been handed over.
+    assert "ping" not in resp.text
+
+    # And the queue must be intact: still pending, never acked.
+    as_auth(tenant)
+    listed = await client.get(f"/api/v1/fleet/commands?tenant_id={tenant}")
+    assert listed.status_code == 200, listed.text
+    mine = [c for c in listed.json() if c["id"] == command_id]
+    assert mine, f"command {command_id} vanished from the queue"
+    assert mine[0]["status"] == "pending", (
+        f"command was drained by a read-only caller: status={mine[0]['status']!r}, "
+        f"acked_at={mine[0]['acked_at']!r}"
+    )
+    assert mine[0]["acked_at"] is None
+
+
+@pytest.mark.parametrize(
+    "cred",
+    [
+        pytest.param({}, id="legacy-key-no-capabilities"),
+        pytest.param({"capabilities": {"read", "write"}}, id="read-write-key"),
+    ],
+)
+async def test_heartbeat_still_works_for_a_writing_credential(client, as_auth, cred):
+    """OVER-REFUSAL GUARD, and the one that matters most here.
+
+    The heartbeat is how every node stays live and commandable, on a ~60s
+    tick. Breaking it for legitimate plugins would take the fleet offline —
+    a worse outage than the bug being fixed. Legacy credentials carry
+    ``capabilities=None`` and must pass untouched.
+    """
+    tenant = f"tenant-{_uid()}"
+    as_auth(tenant, **cred)
+    resp = await client.post(
+        "/api/v1/fleet/heartbeat",
+        json={
+            "tenant_id": tenant,
+            "node_name": f"node-{_uid()}",
+            "fleet_id": f"fleet-{_uid()}",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ok"] is True
+
+
+async def test_heartbeat_delivers_commands_to_a_writing_credential(client, as_auth):
+    """OVER-REFUSAL GUARD. The command channel itself must still work.
+
+    Pairs with the drain test above: the same sequence, with a credential
+    that may write, must return the payload and ack it. Without this, a gate
+    that refused every caller would satisfy the refusal tests.
+    """
+    tenant = f"tenant-{_uid()}"
+    node_name, command_id = await _queue_command_for(client, as_auth, tenant)
+
+    as_auth(tenant)
+    resp = await client.post(
+        "/api/v1/fleet/heartbeat",
+        json={"tenant_id": tenant, "node_name": node_name},
+    )
+    assert resp.status_code == 200, resp.text
+    delivered = [c for c in resp.json()["commands"] if c["id"] == command_id]
+    assert delivered, f"command {command_id} was not delivered: {resp.text}"
+    assert delivered[0]["command"] == "ping"


### PR DESCRIPTION
Closes audit finding **H-04**.

## The gap

`POST /fleet/heartbeat` was the **only mutating route in the fleet module without `enforce_read_only`**. Its five siblings — `create_fleet`, `delete_fleet`, `purge_fleet`, `create_command`, `command_result` — all have it.

The heartbeat reads like telemetry. It isn't:

- `upsert_node` replaces the node row — hostname, versions, the whole metadata blob
- `get_or_create_agent` materialises per-agent rows on every tick
- `_maybe_queue_auto_upgrade` can queue a deploy command
- **`ack_commands` drains the node's pending queue**, after returning the payloads in the response

## Why this isn't just an unwanted write

A read-only (`capabilities={'read'}`) or demo credential naming an existing node could **claim that node's queued commands**. It receives the payloads intended for the node, and because acked commands are not redelivered, the real node never collects them.

One request, unrecoverable. The operator sees a dispatched command that was acknowledged and never ran.

The removal probe shows the exfiltration half directly — without the gate, a `capabilities={'read'}` caller gets back:

```
{"ok":true,...,"commands":[{"id":"9fb742d4…","command":"ping","payload":{"k":"v"}}]}
```

## The fix, and why it can't break real plugins

`enforce_read_only` blocks exactly two things: `is_demo`, and a credential whose `capabilities` are set and exclude `write`. Capabilities are populated from the gateway's `x-capabilities` header, so **legacy credentials carry `None` and pass through untouched**. The only callers newly refused are ones that were never entitled to write.

This was the question I most wanted answered before touching it, because the heartbeat is how every node stays live and commandable on a ~60s tick — breaking it would be a worse outage than the bug. Hence three of the six tests are over-refusal guards.

**Gate order** matches the siblings: credential capability first, then target tenant. Nothing depends on the order — `enforce_read_only` reads only the caller's own credential — so consistency is the whole argument.

**`enforce_usage_limits` is deliberately NOT added**, though the write-shaped siblings carry it. This call recurs every ~60s from every node; gating it on plan limits would take a tenant that merely exceeded its quota and make its entire fleet go stale and uncommandable — including the commands an operator would use to reduce usage. `create_command` sets the same precedent on this path: read-only gate, no usage gate.

## Tests

**Three fail without the gate**, confirmed by removing only `enforce_read_only`:

- a read-only key is refused
- a demo credential is refused
- the queue-drain attack is refused, with **both halves asserted**: the payload must not come back, and the command must still be `pending` with `acked_at` null afterwards

**Three are over-refusal guards:**

- a legacy credential (`capabilities=None`) still heartbeats
- a `{read, write}` credential still heartbeats
- the command channel still **delivers and acks** for a credential that may write

That last one is load-bearing: without it, a gate that refused *every* caller would satisfy all three refusal tests.

## Verification

- Full root suite: **6035 passed, 5 skipped, 1 xfailed, 0 failed** (6029 baseline + the 6 new tests), run as `.venv/bin/python -m pytest`.
- `ruff check` and `ruff format --check` run **separately** at CI's exact scopes — clean.
- `mypy` clean (2 pre-existing `types-python-dateutil` stub errors in an untouched file).
- `legacy_name_ratchet.py` → *No new lines.* · `do_not_touch_sentinel.py` → *All 39 protected strings survive.* · `tenant_scope_gate.py` → no allowlist movement in any category. All run **after `git add`**.
- Branched fresh from `origin/main` at `b0a576a5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
