### PR TITLE
fix(graph): apply the evidence-visibility filter on GET /graph

### DIFF
--- a/core-api/src/core_api/routes/entities.py
+++ b/core-api/src/core_api/routes/entities.py
@@ -15,7 +15,12 @@ from core_api.schemas import (
     RelationUpsertOut,
 )
 from core_api.services.audit_service import log_cross_tenant_read
-from core_api.services.entity_service import get_entity, upsert_entity, upsert_relation
+from core_api.services.entity_service import (
+    filter_relations_by_evidence_visibility,
+    get_entity,
+    upsert_entity,
+    upsert_relation,
+)
 from core_api.services.usage_service import check_and_increment_by_tenant as check_and_increment
 
 logger = logging.getLogger(__name__)
@@ -100,6 +105,31 @@ async def get_graph(
 
     entities = graph.get("entities", [])
     relations = graph.get("relations", [])
+
+    # Evidence-visibility filter, shared with ``GET /entities/{id}`` (audit
+    # H-03). The sibling has always dropped edges whose evidence memory the
+    # caller cannot read; this route returned every edge for the tenant —
+    # ``relation_type``, both endpoints, and ``evidence_memory_id`` verbatim —
+    # behind nothing but ``enforce_readable_tenant``. So an agent could read
+    # here exactly what the sibling refused it: the triple derived from a
+    # peer's ``scope_agent`` memory, plus that memory's id. ``fleet_id`` is
+    # optional, so omitting it asked for every fleet at once.
+    #
+    # The raw memory text was never exposed either way. The derived triple IS
+    # the leak — "(anna) -negotiates-> (zenith acquisition)" carries the
+    # secret without carrying the sentence.
+    #
+    # No-op for tenant / user / admin credentials (``agent_id`` None), matching
+    # the sibling's contract rather than narrowing this route for dashboards.
+    #
+    # Runs BEFORE the log line and the cross-tenant audit below, so both count
+    # what was actually disclosed. Counting pre-filter would overstate the
+    # disclosure and record a cross-tenant read of edges that were withheld.
+    relations = await filter_relations_by_evidence_visibility(
+        relations,
+        tenant_id=tenant_id,
+        caller_agent_id=auth.agent_id,
+    )
 
     logger.info(
         f"Graph query: tenant={tenant_id} fleet={fleet_id} → {len(entities)} entities, {len(relations)} relations"

--- a/core-api/src/core_api/services/entity_service.py
+++ b/core-api/src/core_api/services/entity_service.py
@@ -133,6 +133,94 @@ async def upsert_entity(
     )
 
 
+async def filter_relations_by_evidence_visibility(
+    relations: list[dict],
+    *,
+    tenant_id: str,
+    caller_agent_id: str | None,
+    caller_agent: dict | None = None,
+    pre_authorized_memory_ids: set[str] | None = None,
+) -> list[dict]:
+    """Drop relation edges whose evidence memory the caller may not read.
+
+    The scope contract (audit S5 / C14): an agent credential must not
+    enumerate relation edges or ``evidence_memory_id``s pointing at memories
+    it cannot read. The raw memory text stays unreadable either way — the leak
+    is the memory-DERIVED triple plus the private memory's id.
+
+    Shared deliberately. This filter used to live inside :func:`get_entity`,
+    which made the guarantee a property of ONE caller — and ``GET /graph``,
+    reading the same edges from a different storage call, had no filter at all
+    (audit H-03). The comment in ``get_entity`` about its tenant check already
+    names that defect class: a guarantee that lives in one caller is not a
+    guarantee. Route both readers through here so a third one cannot be added
+    without it.
+
+    ``caller_agent_id`` of ``None`` means a tenant / user / admin credential:
+    the list is returned unchanged, matching the linked-memory filter's
+    contract in the same module.
+
+    Args:
+        relations: dicts carrying ``evidence_memory_id`` (other keys ignored).
+        caller_agent: the caller's pre-fetched agent row, when the calling code
+            already resolved it. Resolved here once if not supplied — never
+            per-edge, which would be N+1 over the graph.
+        pre_authorized_memory_ids: ids the caller has already been shown by
+            the same response (``get_entity``'s linked memories), so their
+            edges need no second lookup.
+    """
+    if not caller_agent_id or not relations:
+        return relations
+
+    from core_api.services.agent_service import (
+        lookup_agent,
+        memory_access_allowed_for_agent,
+    )
+
+    sc = get_storage_client()
+    if caller_agent is None:
+        caller_agent = await lookup_agent(tenant_id, caller_agent_id)
+
+    authorized_ids = pre_authorized_memory_ids or set()
+    unknown_evidence_ids = list(
+        dict.fromkeys(
+            str(rel["evidence_memory_id"])
+            for rel in relations
+            if rel.get("evidence_memory_id") and str(rel["evidence_memory_id"]) not in authorized_ids
+        )
+    )
+    evidence_rows: dict[str, dict | None] = {}
+    if unknown_evidence_ids:
+        # One bulk round-trip (not per-relation); missing / cross-tenant ids
+        # come back as None in-slot.
+        fetched = await sc.bulk_get_memories(unknown_evidence_ids, tenant_id=tenant_id)
+        evidence_rows = dict(zip(unknown_evidence_ids, fetched))
+
+    def _visible(rel: dict) -> bool:
+        evidence_id = rel.get("evidence_memory_id")
+        if not evidence_id:
+            # No evidence ⇒ no memory-derived content and no id to leak.
+            return True
+        evidence_id = str(evidence_id)
+        if evidence_id in authorized_ids:
+            return True
+        row = evidence_rows.get(evidence_id)
+        if row is None:
+            # Deleted / nonexistent / cross-tenant evidence — don't leak the
+            # edge or the memory id. Fails CLOSED: an unresolvable evidence id
+            # is the one case where we cannot show the caller may read it.
+            return False
+        return memory_access_allowed_for_agent(
+            caller_agent,
+            caller_agent_id,
+            visibility=row.get("visibility"),
+            owner_agent_id=row.get("agent_id"),
+            fleet_id=row.get("fleet_id"),
+        )
+
+    return [rel for rel in relations if _visible(rel)]
+
+
 async def get_entity(entity_id: UUID, tenant_id: str, caller_agent_id: str | None = None) -> EntityOut | None:
     sc = get_storage_client()
     result = await sc.get_entity_with_linked_memories(str(entity_id), tenant_id)
@@ -245,45 +333,17 @@ async def get_entity(entity_id: UUID, tenant_id: str, caller_agent_id: str | Non
                 "evidence_memory_id": rel.get("evidence_memory_id"),
             }
         )
-    if caller_agent_id and relations_raw:
-        from core_api.services.agent_service import memory_access_allowed_for_agent
-
-        authorized_ids = {str(mem.get("id")) for mem in linked_memories_raw if mem.get("id")}
-        unknown_evidence_ids = list(
-            dict.fromkeys(
-                str(rel["evidence_memory_id"])
-                for rel in relations_raw
-                if rel.get("evidence_memory_id") and str(rel["evidence_memory_id"]) not in authorized_ids
-            )
-        )
-        evidence_rows: dict[str, dict | None] = {}
-        if unknown_evidence_ids:
-            # One bulk round-trip (not per-relation); missing / cross-tenant
-            # ids come back as None in-slot.
-            fetched = await sc.bulk_get_memories(unknown_evidence_ids, tenant_id=tenant_id)
-            evidence_rows = dict(zip(unknown_evidence_ids, fetched))
-
-        def _relation_visible(rel: dict) -> bool:
-            evidence_id = rel.get("evidence_memory_id")
-            if not evidence_id:
-                return True
-            evidence_id = str(evidence_id)
-            if evidence_id in authorized_ids:
-                return True
-            row = evidence_rows.get(evidence_id)
-            if row is None:
-                # Deleted / nonexistent / cross-tenant evidence — don't leak
-                # the edge or the memory id.
-                return False
-            return memory_access_allowed_for_agent(
-                caller_agent,
-                caller_agent_id,
-                visibility=row.get("visibility"),
-                owner_agent_id=row.get("agent_id"),
-                fleet_id=row.get("fleet_id"),
-            )
-
-        relations_raw = [rel for rel in relations_raw if _relation_visible(rel)]
+    # Shared with ``GET /graph`` — see
+    # :func:`filter_relations_by_evidence_visibility`. ``caller_agent`` is
+    # passed through because the linked-memory filter above already resolved
+    # it; the helper would otherwise repeat the lookup.
+    relations_raw = await filter_relations_by_evidence_visibility(
+        relations_raw,
+        tenant_id=tenant_id,
+        caller_agent_id=caller_agent_id,
+        caller_agent=caller_agent,
+        pre_authorized_memory_ids={str(mem.get("id")) for mem in linked_memories_raw if mem.get("id")},
+    )
     relations = [
         RelationOut(
             id=rel.get("id"),

--- a/tests/test_entity_relations_scope.py
+++ b/tests/test_entity_relations_scope.py
@@ -202,3 +202,296 @@ async def test_agent_row_resolved_once(fake_storage, patch_lookup):
     assert calls["n"] == 1
     assert len(out.linked_memories) == 5
     assert len(out.relations) == 5
+
+
+# ---------------------------------------------------------------------------
+# H-03 — the same filter, on the /graph surface
+#
+# S5 fixed ``get_entity``. ``GET /graph`` read the same edges from a different
+# storage call and had no filter at all: ``enforce_readable_tenant`` and then
+# every relation for the tenant, ``evidence_memory_id`` verbatim. The filter now
+# lives in one shared function both readers call, because a guarantee that
+# lives in one caller is not a guarantee — which is what H-03 demonstrated.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def graph_storage(monkeypatch):
+    """Fake storage for the shared filter: only ``bulk_get_memories`` matters."""
+
+    def _set(bulk_rows):
+        sc = MagicMock()
+        sc.bulk_get_memories = AsyncMock(return_value=bulk_rows)
+        from core_api.services import entity_service
+
+        monkeypatch.setattr(entity_service, "get_storage_client", lambda: sc)
+        return sc
+
+    return _set
+
+
+async def _filter(relations, caller_agent_id, **kwargs):
+    from core_api.services.entity_service import (
+        filter_relations_by_evidence_visibility,
+    )
+
+    return await filter_relations_by_evidence_visibility(
+        relations, tenant_id="t", caller_agent_id=caller_agent_id, **kwargs
+    )
+
+
+async def test_graph_drops_an_edge_whose_evidence_is_a_peers_private_memory(
+    graph_storage, patch_lookup
+):
+    """THE ATTACK from H-03, at the filter both surfaces now share.
+
+    Agent A writes a ``scope_agent`` memory; extraction persists an edge whose
+    evidence is that memory. Peer agent B must not read the derived triple or
+    the private memory's id. The raw text was never exposed — the triple is
+    the leak: "(anna) -negotiates-> (zenith acquisition)" carries the secret
+    without carrying the sentence.
+    """
+    secret_id = str(uuid.uuid4())
+    graph_storage(
+        [
+            {
+                "id": secret_id,
+                "visibility": "scope_agent",
+                "agent_id": "agent-a",
+                "fleet_id": "fleet-alpha",
+            }
+        ]
+    )
+    patch_lookup(fleet_id="fleet-alpha", trust_level=1)
+
+    out = await _filter([_rel(secret_id, name="zenith acquisition")], "agent-b")
+    assert out == []
+
+
+async def test_graph_keeps_the_owners_own_private_edge(graph_storage, patch_lookup):
+    """OVER-REFUSAL GUARD. The author of the evidence still sees their edge."""
+    secret_id = str(uuid.uuid4())
+    graph_storage(
+        [
+            {
+                "id": secret_id,
+                "visibility": "scope_agent",
+                "agent_id": "agent-a",
+                "fleet_id": "fleet-alpha",
+            }
+        ]
+    )
+    patch_lookup(fleet_id="fleet-alpha", trust_level=1)
+
+    out = await _filter([_rel(secret_id)], "agent-a")
+    assert len(out) == 1
+
+
+async def test_graph_drops_a_cross_fleet_edge_below_the_trust_bar(
+    graph_storage, patch_lookup
+):
+    """``fleet_id`` is optional on /graph, so omitting it asked for every fleet.
+
+    Cross-fleet evidence needs trust >= 2, the same bar ``enforce_fleet_read``
+    applies. A trust-1 agent in another fleet must not get the edge.
+    """
+    other_id = str(uuid.uuid4())
+    graph_storage(
+        [
+            {
+                "id": other_id,
+                "visibility": "scope_team",
+                "agent_id": "agent-x",
+                "fleet_id": "fleet-beta",
+            }
+        ]
+    )
+    patch_lookup(fleet_id="fleet-alpha", trust_level=1)
+
+    out = await _filter([_rel(other_id)], "agent-b")
+    assert out == []
+
+
+async def test_graph_keeps_a_cross_fleet_edge_at_or_above_the_trust_bar(
+    graph_storage, patch_lookup
+):
+    """OVER-REFUSAL GUARD. trust >= 2 is entitled to cross-fleet reads."""
+    other_id = str(uuid.uuid4())
+    graph_storage(
+        [
+            {
+                "id": other_id,
+                "visibility": "scope_team",
+                "agent_id": "agent-x",
+                "fleet_id": "fleet-beta",
+            }
+        ]
+    )
+    patch_lookup(fleet_id="fleet-alpha", trust_level=2)
+
+    out = await _filter([_rel(other_id)], "agent-b")
+    assert len(out) == 1
+
+
+async def test_graph_drops_an_edge_with_unresolvable_evidence(
+    graph_storage, patch_lookup
+):
+    """Deleted / nonexistent / cross-tenant evidence fails CLOSED.
+
+    An id that does not resolve is the one case where we cannot establish
+    that the caller may read it, so the edge and the id are both withheld.
+    """
+    graph_storage([None])
+    patch_lookup(fleet_id="fleet-alpha", trust_level=3)
+
+    out = await _filter([_rel(str(uuid.uuid4()))], "agent-b")
+    assert out == []
+
+
+async def test_graph_keeps_an_edge_with_no_evidence(graph_storage, patch_lookup):
+    """OVER-REFUSAL GUARD. No evidence ⇒ no memory-derived content, no id."""
+    sc = graph_storage([])
+    patch_lookup(fleet_id="fleet-alpha", trust_level=0)
+
+    out = await _filter([_rel(None)], "agent-b")
+    assert len(out) == 1
+    # Nothing to look up, so no round-trip at all.
+    sc.bulk_get_memories.assert_not_awaited()
+
+
+async def test_graph_keeps_scope_org_evidence(graph_storage, patch_lookup):
+    """OVER-REFUSAL GUARD. scope_org is readable tenant-wide by contract."""
+    org_id = str(uuid.uuid4())
+    graph_storage(
+        [
+            {
+                "id": org_id,
+                "visibility": "scope_org",
+                "agent_id": "agent-x",
+                "fleet_id": "fleet-beta",
+            }
+        ]
+    )
+    patch_lookup(fleet_id="fleet-alpha", trust_level=0)
+
+    out = await _filter([_rel(org_id)], "agent-b")
+    assert len(out) == 1
+
+
+async def test_graph_is_unfiltered_for_a_tenant_credential(graph_storage):
+    """OVER-REFUSAL GUARD, and the deliberate limit of this fix.
+
+    A tenant / user / admin credential carries no ``agent_id`` and sees the
+    whole graph, matching the linked-memory filter's contract in the same
+    module. Narrowing /graph for dashboards was the finding's other suggested
+    remedy and would have broken them; this keeps the surface intact and
+    filters only the credential class the contract is about.
+    """
+    sc = graph_storage([])
+    out = await _filter([_rel(str(uuid.uuid4())), _rel(str(uuid.uuid4()))], None)
+    assert len(out) == 2
+    sc.bulk_get_memories.assert_not_awaited()
+
+
+async def test_graph_filter_resolves_the_agent_row_once(graph_storage, patch_lookup):
+    """One lookup for the whole graph, not one per edge.
+
+    /graph returns every relation in the tenant, so a per-edge lookup would be
+    N+1 across the entire graph rather than across one entity's edges.
+    """
+    ids = [str(uuid.uuid4()) for _ in range(6)]
+    graph_storage(
+        [
+            {
+                "id": i,
+                "visibility": "scope_team",
+                "agent_id": "agent-x",
+                "fleet_id": "fleet-alpha",
+            }
+            for i in ids
+        ]
+    )
+    calls = patch_lookup(fleet_id="fleet-alpha", trust_level=1)
+
+    out = await _filter([_rel(i) for i in ids], "agent-b")
+    assert len(out) == 6
+    assert calls["n"] == 1
+
+
+async def test_the_graph_route_itself_withholds_the_private_edge(
+    monkeypatch, patch_lookup
+):
+    """END-TO-END through the route, which is what H-03 was actually about.
+
+    The filter tests above exercise the shared function. This one proves the
+    ROUTE is wired to it: a peer's ``scope_agent`` evidence must not appear in
+    the response body, neither as an edge nor as an ``evidence_memory_id``.
+    Without this, every test above would still pass with the route unchanged —
+    which is precisely the state H-03 described.
+    """
+    import json
+
+    from core_api.auth import AuthContext
+    from core_api.routes import entities as entities_routes
+
+    secret_id = str(uuid.uuid4())
+    visible_id = str(uuid.uuid4())
+    sc = MagicMock(name="storage_client")
+    sc.get_full_graph = AsyncMock(
+        return_value={
+            "entities": [
+                {"id": "e1", "canonical_name": "anna", "entity_type": "person"}
+            ],
+            "relations": [
+                {
+                    "id": "r-secret",
+                    "from_entity_id": "e1",
+                    "to_entity_id": "e2",
+                    "relation_type": "negotiates",
+                    "weight": 0.9,
+                    "evidence_memory_id": secret_id,
+                },
+                {
+                    "id": "r-open",
+                    "from_entity_id": "e1",
+                    "to_entity_id": "e3",
+                    "relation_type": "works_with",
+                    "weight": 0.5,
+                    "evidence_memory_id": visible_id,
+                },
+            ],
+        }
+    )
+    sc.count_memories_per_entity = AsyncMock(return_value={})
+    sc.bulk_get_memories = AsyncMock(
+        return_value=[
+            {
+                "id": secret_id,
+                "visibility": "scope_agent",
+                "agent_id": "agent-a",
+                "fleet_id": "fleet-alpha",
+            },
+            {
+                "id": visible_id,
+                "visibility": "scope_org",
+                "agent_id": "agent-a",
+                "fleet_id": "fleet-alpha",
+            },
+        ]
+    )
+    monkeypatch.setattr(entities_routes, "get_storage_client", lambda: sc)
+    from core_api.services import entity_service
+
+    monkeypatch.setattr(entity_service, "get_storage_client", lambda: sc)
+    patch_lookup(fleet_id="fleet-alpha", trust_level=1)
+
+    resp = await entities_routes.get_graph(
+        tenant_id="t",
+        fleet_id=None,
+        auth=AuthContext(tenant_id="t", agent_id="agent-b", readable_tenant_ids=["t"]),
+    )
+    payload = json.loads(resp.body)
+    edge_ids = {e["id"] for e in payload["edges"]}
+    assert edge_ids == {"r-open"}, f"private edge leaked: {payload['edges']}"
+    # The id itself must not appear anywhere in the serialised response.
+    assert secret_id not in resp.body.decode()


### PR DESCRIPTION
Closes audit finding **H-03**.

## The leak

`GET /entities/{id}` has enforced a scope contract since audit **S5**: *an agent credential must not enumerate relation edges or `evidence_memory_id`s pointing at memories it cannot read.*

`GET /graph` read the same edges from a different storage call and had **no filter at all** — `enforce_readable_tenant`, then every entity and every relation for the tenant, with `relation_type`, both endpoints, `weight` and `evidence_memory_id` verbatim. `fleet_id` is optional, so omitting it asked for every fleet at once.

The failure, as the finding describes it:

1. Agent A writes a `scope_agent` memory.
2. The extraction worker persists `(anna) -negotiates-> (zenith acquisition)` with `evidence_memory_id` pointing at that memory.
3. Peer agent B calls `GET /graph?tenant_id=T` and reads the triple **plus the private memory's id** — exactly what `GET /entities/{id}` would have withheld.

The raw memory text was never exposed on either route. **The derived triple is the leak** — it carries the secret without carrying the sentence.

## One filter, two readers

The filter now lives in `entity_service.filter_relations_by_evidence_visibility`, which both readers call. I deliberately did **not** reimplement it in the route: the reason H-03 existed is that the guarantee was a property of *one caller*. `get_entity`'s own comment about its tenant check already names the class —

> this comparison used to be the ONLY thing scoping this read … the defect class being that the guarantee lived in one caller

A second copy in the route would be two places that have to agree, which is how a third reader eventually gets added without either.

`get_entity` is behaviour-unchanged: same predicate, same bulk round-trip, same pre-authorized set from its linked memories, same single agent lookup.

**Not narrowed to tenant/admin credentials**, which was the finding's other suggested remedy — that would break dashboards, which read `/graph` with a tenant credential. The filter is a no-op when `caller_agent_id` is `None`, matching the linked-memory filter's contract in the same module.

**Ordering:** the filter runs before the log line and the cross-tenant audit, so both count what was actually disclosed. Counting pre-filter would overstate the disclosure and record a cross-tenant read of edges that were withheld.

## Two probes, because one wasn't enough

**Disabling only the route's call fails exactly one test** — the end-to-end one that drives `get_graph` and asserts the private edge is absent from the response body and the evidence id appears nowhere in it:

```
AssertionError: private edge leaked: [{'id': 'r-secret', 'relation_type': 'negotiates',
  'evidence_memory_id': '2e35cc3a-…'}, …]
```

The other eight tests exercise the shared function and **pass with the route unwired** — which is the H-03 state precisely. Without the end-to-end test, this PR could have shipped a correct filter that nothing called.

**Neutering the filter itself fails five:** three new refusal tests (peer `scope_agent` evidence, cross-fleet evidence below the trust bar, unresolvable evidence failing closed), the end-to-end, and **the pre-existing S5 test** — which is what shows `get_entity` genuinely routes through the shared function rather than keeping a duplicate.

## Tests

**Five fail without the fix.** Refusals: a peer's `scope_agent` evidence, cross-fleet evidence below the trust bar, and unresolvable evidence (deleted / nonexistent / cross-tenant) failing **closed** — an id that doesn't resolve is the one case where we can't establish the caller may read it.

**Five are over-refusal guards:** the evidence's own author still sees their edge, `trust >= 2` still gets cross-fleet edges, no-evidence edges stay, `scope_org` evidence stays, and a tenant credential still sees the whole graph. One more pins that the agent row is resolved **once for the entire graph** rather than per edge — `/graph` returns every relation in the tenant, so a per-edge lookup would be N+1 across the whole graph.

## Not fixed, and why

Each node still carries a `memory_count` from `count_memories_per_entity`, which takes no agent scoping — so the count includes memories the caller cannot read. I left it:

- it is an inference channel over a **count**, not a disclosure of content or ids;
- there is no sibling contract to mirror (`get_entity` returns filtered linked memories, not a count);
- scoping it needs a storage-side change, widening this PR into `core-storage-api`.

Flagging it rather than silently widening or silently ignoring. Say the word if you'd rather it were in scope.

Also worth stating: `get_entity` does not gate the entity **node** itself on fleet, only its memory-derived content. So `/graph` still returns cross-fleet entity names and attributes to an agent that omits `fleet_id`. That is the pre-existing contract on both surfaces rather than a regression here, and there is no established filter to mirror — but it is the natural next question and I'd rather name it than leave it implied.

## Verification

- Full root suite: **6045 passed, 5 skipped, 1 xfailed, 0 failed** (6035 baseline + the 10 new tests), run as `.venv/bin/python -m pytest`.
- `ruff check` and `ruff format --check` run **separately** at CI's exact scopes — clean.
- `mypy` clean (2 pre-existing `types-python-dateutil` stub errors in an untouched file).
- `legacy_name_ratchet.py` → *No new lines.* · `do_not_touch_sentinel.py` → *All 39 protected strings survive.* · `tenant_scope_gate.py` → no allowlist movement. All run **after `git add`**.
- `get_full_graph` has exactly one caller and there is no MCP graph tool, so REST `/graph` was the only unfiltered surface; MCP `entity_get` routes through `get_entity` and is covered by the shared filter.
- Branched fresh from `origin/main` at `352a4bc6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
