### PR TITLE
fix(storage): give a bulk batch one column list

### DIFF
--- a/common/permanent_failure.py
+++ b/common/permanent_failure.py
@@ -1,0 +1,92 @@
+"""Wire shape for "this write failed and a retry cannot clear it", shared by both services.
+
+Why this module exists. core-api's bulk route answers a storage 5xx with "504,
+retry with the same ``X-Bulk-Attempt-Id``", and ``app.upstream_http_error_handler``
+answers every *unhandled* upstream 5xx with "503, retry". Both are right for the
+failure they were written for — a lost response, a restart mid-commit, a
+transient upstream — and both are wrong for a failure that reproduces byte-for-
+byte on every attempt. A client that complies with either retries forever. In
+prod that ran at ~680 requests/hour for 29 hours against a batch that could
+never compile, and nothing on the wire distinguished it from noise.
+
+So storage has to be able to SAY "permanent", and the word has to survive the
+trip. Retryable stays the default: the costs are asymmetric. A wrong "retry" is
+a no-op by construction, because ``ix_memories_attempt_unique`` resolves an
+already-committed row to ``duplicate_attempt`` with its canonical id — while a
+wrong "do not retry" strands committed rows with nothing to recover them. Hence
+:func:`is_permanent` tests for the literal ``False`` rather than falsiness:
+an absent key, a null, a non-JSON body and a proxy's HTML error page must all
+read as "not marked".
+
+Pure data: no framework imports, so both services and their tests can use it —
+the same reason ``common/duplicate_memory.py`` is shaped this way, and for the
+same failure it was built to prevent. The marker key and the code strings used
+to be literals written once in the storage route and again in core-api's
+reader: two separately-deployed services required to agree byte-for-byte, with
+no symbol to grep and no import to follow.
+"""
+
+from __future__ import annotations
+
+# core-api's error code for a refused write that must not be retried. Named for
+# the ANSWER, not the cause: a caller's next move is the same whatever made the
+# failure permanent, and the specific cause travels in ``error`` below.
+PERMANENT_WRITE_FAILURE_CODE = "PERMANENT_WRITE_FAILURE"
+
+# The key storage sets to ``False``. Deliberately not ``permanent: true`` — the
+# question a caller asks is "may I retry?", and answering the question actually
+# asked is what keeps a reader from inverting it by accident.
+RETRYABLE_KEY = "retryable"
+
+# Causes. One per way a write can fail permanently; today there is one.
+# ``bulk_row_shape``: the rows of a bulk batch disagreed on which columns they
+# set, so the multi-values INSERT has no single column list to compile.
+CAUSE_BULK_ROW_SHAPE = "bulk_row_shape"
+
+
+class PermanentWriteFailure(Exception):
+    """Base for a write refusal that a retry cannot clear.
+
+    Both services raise a subclass of this — storage when it detects the fault,
+    core-api when it reads the marker back off the wire — so the "carries
+    structured fields beside the message" behaviour is defined once.
+
+    The single definition is not only tidiness. ``scripts/tenant_scope_gate.py``
+    resolves functions in the modules it scans by BARE NAME and refuses to run
+    when one is defined twice, so a second hand-written ``__init__`` in
+    ``postgres_service.py`` or ``storage_client.py`` takes the whole tenancy
+    invariant offline — with an error about ambiguous names that says nothing
+    about tenancy. Inheriting costs nothing and cannot trip it.
+
+    ``fields`` is the structured half. ``common/duplicate_memory.py`` records
+    why it exists: the alternative already cost us a uuid serialised into
+    English, shipped across two service boundaries, and recovered at the far
+    end with a regular expression.
+    """
+
+    def __init__(self, message: str, fields: dict | None = None) -> None:
+        super().__init__(message)
+        self.fields: dict = fields or {}
+
+
+def permanent_detail(*, cause: str, message: str, **fields: object) -> dict:
+    """Storage's ``detail`` for a failure a retry cannot clear.
+
+    ``message`` is prose for a human; ``cause`` is the stable string a program
+    branches on. Extra *fields* ride alongside rather than being formatted into
+    the message — ``common/duplicate_memory.py``'s docstring records what the
+    alternative cost us, a uuid serialised into English and recovered at the far
+    end with a regular expression.
+    """
+    return {"error": cause, RETRYABLE_KEY: False, "message": message, **fields}
+
+
+def is_permanent(detail: object) -> bool:
+    """Did storage explicitly mark this failure as one a retry cannot clear?
+
+    Takes the parsed ``detail`` — anything at all, because on an error path it
+    may be a string from FastAPI's default handler, a list, or absent entirely.
+    Only a mapping carrying ``retryable`` set to exactly ``False`` counts; see
+    the module docstring for why the default must stay retryable.
+    """
+    return isinstance(detail, dict) and detail.get(RETRYABLE_KEY) is False

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -32,8 +32,9 @@ logger = logging.getLogger(__name__)
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
+from common import permanent_failure
 from common.events.factory import get_event_bus
-from core_api.clients.storage_client import get_storage_client
+from core_api.clients.storage_client import PermanentStorageWriteError, get_storage_client
 from core_api.constants import VERSION, is_mcp_path
 from core_api.consumer import register_consumers
 from core_api.mcp_server import get_mcp_app, mcp_lifespan
@@ -909,6 +910,39 @@ async def global_exception_handler(request: Request, exc: Exception):
     if app_settings.environment != "production":
         content["error_type"] = type(exc).__name__
     return JSONResponse(status_code=500, content=content)
+
+
+@app.exception_handler(PermanentStorageWriteError)
+async def permanent_storage_write_handler(request: Request, exc: PermanentStorageWriteError) -> JSONResponse:
+    """A write storage refused permanently: 500, and explicitly not retryable.
+
+    The counterpart to ``upstream_http_error_handler`` below, and the reason
+    this exists as its own type. That handler answers every unhandled upstream
+    5xx with "503, retry" — correct for a dependency blip, and exactly inverted
+    for a failure that reproduces byte-for-byte. Three bulk callers (the MCP
+    write tool, ``ingest_service``, ``_insert_children_or_degrade``) do not
+    catch storage errors themselves, so without this they would land there and
+    be told to retry something that can never succeed.
+
+    500 rather than 503: there is nothing to wait for. The routes that own an
+    HTTP contract may still answer more specifically — ``/memories/bulk`` adds
+    the ``X-Bulk-Attempt-Id`` advice — and this is the floor under everyone
+    else.
+    """
+    from core_api.errors import make_error_payload
+
+    logger.error(
+        "permanent storage write refusal on %s %s: %s",
+        request.method,
+        request.url.path,
+        exc,
+    )
+    message = f"{exc}. Retrying this write unchanged cannot succeed."
+    body = {
+        "detail": message,
+        **make_error_payload(permanent_failure.PERMANENT_WRITE_FAILURE_CODE, message, exc.fields or None),
+    }
+    return JSONResponse(status_code=500, content=body)
 
 
 @app.exception_handler(httpx.HTTPStatusError)

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 import httpx
 
+from common import permanent_failure
 from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
 from common.http_retry import CONNECT_PHASE_MAX_ATTEMPTS, with_connect_phase_retry, with_retry
 from common.storage_auth import is_storage_shared_secret_rejection
@@ -21,6 +22,10 @@ from core_api.config import settings
 logger = logging.getLogger(__name__)
 
 _DUPLICATE_FALLBACK_DETAIL = "Duplicate memory exists"
+# Its own fallback rather than ``_storage_detail``'s: that one says "Duplicate
+# memory exists", which would be an actively wrong description of a failure that
+# has nothing to do with duplicates.
+_PERMANENT_FALLBACK_DETAIL = "storage refused the write; a retry cannot clear it"
 
 
 class DuplicateMemoryError(Exception):
@@ -46,6 +51,37 @@ class DuplicateMemoryError(Exception):
     def __init__(self, detail: str, fields: dict | None = None) -> None:
         super().__init__(detail)
         self.fields: dict = fields or {}
+
+
+class PermanentStorageWriteError(permanent_failure.PermanentWriteFailure):
+    """Storage refused a write and said a retry cannot clear it.
+
+    Translated here, at the client boundary, rather than in the route that
+    happened to notice first — the same reason ``DuplicateMemoryError`` is: every
+    memory insert funnels through this client, so no caller has to know that a
+    5xx carrying ``retryable: false`` is a thing this endpoint does.
+
+    Placement is load-bearing, not tidiness. While this stayed an
+    ``httpx.HTTPStatusError``, ``app.upstream_http_error_handler`` answered it
+    with ``503 "Upstream dependency unavailable; retry."`` for every caller that
+    does not catch that type — the MCP bulk tool, ``ingest_service``, and
+    ``_insert_children_or_degrade`` — so a failure storage had explicitly marked
+    permanent came back as an instruction to retry. Raising a type that handler
+    does not recognise is what stops the advice being inverted on the paths
+    nobody exercised. The bulk route's own answer is then just one more caller
+    of the same classification.
+
+    ``fields`` (inherited) carries storage's structured half — for the row-shape
+    cause, the divergent column names. Empty when talking to a storage that
+    predates the marker, which is the only reason this stays additive: an old
+    storage sends no marker, so nothing is classified permanent and every 5xx
+    keeps the retry advice it has today.
+
+    Inherited rather than redeclared, like ``BulkRowShapeError`` on the storage
+    side: a second hand-written ``__init__`` in this module would take
+    ``scripts/tenant_scope_gate.py`` offline, since it resolves functions by
+    bare name and refuses to run when one is defined twice.
+    """
 
 
 def _storage_detail(response: httpx.Response) -> str:
@@ -82,6 +118,35 @@ def _storage_duplicate_fields(response: httpx.Response) -> dict:
     if not isinstance(body, dict):
         return {}
     return {k: body[k] for k in ("reason", "existing_id", "existing_status") if k in body}
+
+
+def _storage_permanent(response: httpx.Response) -> tuple[str, dict] | None:
+    """Storage's permanence marker as ``(message, fields)``, or ``None``.
+
+    ``None`` means storage did not claim permanence — which is the answer for a
+    storage that predates the marker, and the reason this whole mechanism is
+    additive: no marker, no classification, and every 5xx keeps the retry advice
+    it has today. Fail-open is the right direction here, because the costs are
+    not symmetric: a wrong "retry" is a no-op (the per-attempt unique index
+    resolves an already-committed row to ``duplicate_attempt``), while a wrong
+    "do not retry" strands committed rows with nothing to recover them.
+
+    Same defensiveness as ``_storage_detail`` and for the same reason — this
+    runs on an error path, so a non-JSON body must not turn a clean failure into
+    a JSONDecodeError raised from inside the translation.
+    """
+    try:
+        detail = response.json().get("detail")
+    except (ValueError, AttributeError):
+        return None
+    if not permanent_failure.is_permanent(detail):
+        return None
+    message = detail.get("message")
+    # Everything except the prose travels as fields, ``error`` (the cause)
+    # included — a consumer branching on WHICH permanent failure this was needs
+    # it as data, not as a substring of the message.
+    fields = {k: v for k, v in detail.items() if k != "message"}
+    return (message if isinstance(message, str) and message else _PERMANENT_FALLBACK_DETAIL), fields
 
 
 def _reject_reserved_write_id(agent_id: str | None) -> None:
@@ -451,7 +516,29 @@ class CoreStorageClient:
         retry = with_retry if idempotent else with_connect_phase_retry
         resp = await self._execute(_do, retry=retry, label=f"POST {path}")
         self._maybe_evict_on_auth_error(resp, read=read)
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            # Translated here rather than in the two insert methods, because a
+            # ``retryable: false`` marker means the same thing on every path —
+            # unlike the 409 above, which those methods interpret per endpoint.
+            # Every write that goes through ``_post`` inherits the answer.
+            #
+            # It has to stop being an ``httpx.HTTPStatusError`` at this
+            # boundary. While it was one, ``app.upstream_http_error_handler``
+            # turned any 5xx no caller caught into ``503 "Upstream dependency
+            # unavailable; retry."`` — so the three bulk callers that do not
+            # catch that type (the MCP tool, ``ingest_service``,
+            # ``_insert_children_or_degrade``) were told to retry a failure
+            # storage had explicitly marked permanent.
+            #
+            # NOTE ``idempotent=True`` callers still burn their 5xx retries
+            # inside ``with_retry`` before reaching here. Bounded, so not the
+            # unbounded-loop defect, but wasted; the bulk insert is
+            # ``idempotent=False`` and is unaffected.
+            if (permanent := _storage_permanent(resp)) is None:
+                raise
+            raise PermanentStorageWriteError(*permanent) from exc
         return resp.json()
 
     async def _patch(self, path: str, data: dict) -> dict | None:

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -22,17 +22,19 @@ from fastapi import (
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
+from common import permanent_failure
 from common.enrichment.constants import SERVER_RESERVED_MEMORY_TYPES
 from core_api import openapi_responses as _oar
 from core_api.agent_ids import DEFAULT_AGENT_ID
 from core_api.auth import AuthContext, get_auth_context
-from core_api.clients.storage_client import get_storage_client
+from core_api.clients.storage_client import PermanentStorageWriteError, get_storage_client
 from core_api.config import settings as app_settings
 from core_api.constants import (
     DEFAULT_LIST_LIMIT,
     MAX_LIST_LIMIT,
     MEMORY_STATUSES_PATTERN,
 )
+from core_api.errors import coded_detail
 from core_api.middleware.idempotency import (
     IDEMPOTENCY_HEADER,
     IdempotencyGuard,
@@ -1425,6 +1427,34 @@ async def _write_memories_bulk_inner(
                 "committed items."
             ),
         )
+    except PermanentStorageWriteError as exc:
+        # Storage said this failure cannot clear, so the 504 branch below is
+        # exactly the wrong answer: its retry contract rests on the failure
+        # being transient, and a compliant client obeying it against a
+        # deterministic fault retries forever. That ran in prod at ~680
+        # requests/hour for 29 hours against a batch that could never compile.
+        #
+        # ``coded_detail`` rather than a bare string, because the entire point
+        # of this branch is that the caller's next action differs from every
+        # other 500 — and a bare detail collapses into the status-derived
+        # ``INTERNAL_ERROR``, leaving a client to tell them apart by grepping
+        # English. The code and storage's fields ride alongside; top-level
+        # ``detail`` stays the plain message for anyone already reading it.
+        #
+        # Deliberately silent on what was committed. The marker claims "will
+        # not clear", which is a different claim from "nothing was written" —
+        # only storage knows the latter for its own failure, and guessing here
+        # is exactly the kind of assertion a client would act on.
+        logger.error("bulk write permanently refused by storage; NOT advising retry: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail=coded_detail(
+                permanent_failure.PERMANENT_WRITE_FAILURE_CODE,
+                f"{exc}. Do NOT retry with the same {BULK_ATTEMPT_ID_HEADER}; "
+                "this batch cannot succeed unchanged.",
+                **exc.fields,
+            ),
+        ) from exc
     except httpx.HTTPStatusError as exc:
         # Storage 5xx (raised by ``resp.raise_for_status()`` in the storage
         # client) may have committed rows before failing — same shape as

--- a/core-storage-api/src/core_storage_api/app.py
+++ b/core-storage-api/src/core_storage_api/app.py
@@ -11,9 +11,13 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
+from common import permanent_failure
 from common.structlog_config import configure_logging
 from core_storage_api.config import settings
-from core_storage_api.services.postgres_service import DuplicateContentHashError
+from core_storage_api.services.postgres_service import (
+    BulkRowShapeError,
+    DuplicateContentHashError,
+)
 
 # Must run before any other module-level import emits a log record —
 # database.init and the routers below pull in SQLAlchemy, httpx, etc., all
@@ -115,6 +119,37 @@ def create_app() -> FastAPI:
         return JSONResponse(
             status_code=409,
             content={"detail": str(exc), **exc.fields},
+        )
+
+    @app.exception_handler(BulkRowShapeError)
+    async def _bulk_row_shape_handler(request: Request, exc: BulkRowShapeError) -> JSONResponse:
+        # App-wide for the same reason ``_duplicate_content_hash_handler`` above
+        # is: a route-local ``except`` can only serve the one route that writes
+        # it, and the answer here has to hold for every caller of the bulk
+        # insert. The first draft of this fix DID catch it in the route, and
+        # that is a trap — a second entry point (or an in-process caller) would
+        # have raised an unmarked 500, and core-api answers an unmarked
+        # upstream 5xx with "503, retry" from ``upstream_http_error_handler``.
+        # The advice would have been exactly inverted on the path nobody tested.
+        #
+        # ``retryable: false`` is the whole payload of this branch. 500 is
+        # honest — the caller's items were checked uniform before this raised,
+        # so the divergence is ours — but a bare 500 is indistinguishable from
+        # a transient one, and this failure reproduces byte-for-byte forever.
+        #
+        # Logged here because nothing else will say which column diverged: the
+        # response names it as data, but only an operator reading storage's own
+        # logs gets it attached to the request that produced it.
+        logger.error("Bulk insert rejected on mapped row shape: %s %s", exc, exc.fields)
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": permanent_failure.permanent_detail(
+                    cause=permanent_failure.CAUSE_BULK_ROW_SHAPE,
+                    message=str(exc),
+                    **exc.fields,
+                )
+            },
         )
 
     @app.exception_handler(json.JSONDecodeError)

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -47,7 +47,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import load_only
 from sqlalchemy.sql.dml import ReturningInsert
 
-from common import duplicate_memory
+from common import duplicate_memory, permanent_failure
 from common.constants import (
     CONTRADICTION_CANDIDATE_MAX,
     CONTRADICTION_SIMILARITY_THRESHOLD,
@@ -721,6 +721,26 @@ def _content_hash_fleet_scope(fleet_id: str | None):
     return func.coalesce(Memory.fleet_id, "") == (fleet_id or "")
 
 
+def _divergent_keys(key_sets: list[frozenset[str]]) -> list[str]:
+    """The keys not set by every one of *key_sets*, sorted. For messages only.
+
+    Callers detect divergence with a short-circuiting ``any`` and call this only
+    once they have found some, so the cost lands on the failure path.
+
+    Compares each set against the first rather than computing
+    ``union - intersection`` over all of them. The two agree — a key missing
+    from some set necessarily differs from the first set's membership in at
+    least one set, so the symmetric differences against the first cover exactly
+    the keys absent from the intersection (checked over 20,000 randomised
+    batches). And ``set().union(...) - set().intersection(...)`` is a trap
+    worth naming: ``set().intersection(*key_sets)`` starts from an EMPTY set
+    and so always returns empty, which reports every key as divergent — naming
+    the whole row instead of the one column that differs.
+    """
+    first = key_sets[0]
+    return sorted({k for ks in key_sets for k in first.symmetric_difference(ks)})
+
+
 class BulkValidationError(ValueError):
     """A bulk batch violated its input contract before any DB work started.
 
@@ -730,6 +750,34 @@ class BulkValidationError(ValueError):
     future in-session failure got mislabelled as a client error — the inverse
     of the bug that motivated the 422 in the first place. Subclasses
     ``ValueError`` so existing callers that catch it broadly still work.
+    """
+
+
+class BulkRowShapeError(permanent_failure.PermanentWriteFailure):
+    """A bulk batch's MAPPED rows disagreed on which columns they set.
+
+    Raised only after the items have been checked and found uniform, so the
+    divergence was introduced between the request and the statement. That is
+    what makes it a server fault rather than the 422 ``BulkValidationError``
+    answers, and the two must stay distinct: a validation failure is fixed by
+    changing the request, and this one is not fixed by anything the caller can
+    do. It does not subclass ``BulkValidationError`` for exactly that reason.
+
+    Which matters because of what the answer costs. A batch whose rows disagree
+    fails identically on every attempt, so any answer that invites a retry
+    invites an infinite one — core-api's bulk route maps storage 5xx to "504,
+    retry with the same ``X-Bulk-Attempt-Id``", and ``upstream_http_error_handler``
+    maps every unhandled upstream 5xx to "503, retry". A compliant client obeys
+    either one forever. Raising a distinct class is what lets storage mark the
+    answer permanent instead.
+
+    Inherits ``fields`` from the shared base rather than redeclaring
+    ``DuplicateContentHashError``'s ``__init__``, so the divergent column names
+    reach the wire as data. Writing that ``__init__`` out a second time here
+    does more than duplicate three lines — ``scripts/tenant_scope_gate.py``
+    resolves functions by bare name and refuses to run on a module defining one
+    twice, so it silently took the tenancy invariant offline until the base was
+    factored out.
     """
 
 
@@ -837,6 +885,40 @@ class PostgresService:
             and not out.get("embedded_content_hash")
         ):
             out["embedded_content_hash"] = out["content_hash"]
+        # The key must exist even when the stamp does not apply, because
+        # ``memory_add_all`` feeds these dicts to a multi-values INSERT and
+        # SQLAlchemy derives ONE column list for the whole statement. A batch
+        # mixing stamped and unstamped rows is not a batch with a missing
+        # value — it is two different statements, and which one you get
+        # depends on row order:
+        #
+        #   row 0 stamped, a later row not -> CompileError at execute time
+        #       ("explicitly rendered as a boundparameter"), the statement
+        #       never reaches Postgres, the whole batch fails.
+        #   row 0 unstamped, a later row stamped -> compiles, and the column
+        #       is dropped from the INSERT entirely, with no warning. The
+        #       stamped row's provenance is silently written NULL.
+        #
+        # Both were live: deferred deployments embed only ``write_mode=
+        # "strong"`` items (``memory_service`` bulk path), so a mixed batch
+        # hits one or the other purely on ordering. The second is the worse
+        # one — a NULL here reads as "written before migration 037" to
+        # ``memory_quality_metrics``, a bucket nothing re-embeds, so the row
+        # leaves the staleness detector's reach permanently.
+        #
+        # ``None`` is exactly what omission meant: the column is nullable
+        # with no default, so an explicit NULL and an absent key persist
+        # identically on the single-row path.
+        #
+        # It is not free, and the cost is worth stating because it is paid on
+        # every write rather than only on the mixed batches that used to fail.
+        # A fully-deferred batch previously omitted this column from the
+        # statement entirely; now it always carries it, which measures at
+        # roughly +8% on multi-values statement construction and one extra bind
+        # parameter per row (100 of asyncpg's ~32k ceiling, at the bulk path's
+        # 100-item cap). That buys uniformity unconditionally, which is the only
+        # form of it that cannot be defeated by row ordering.
+        out.setdefault("embedded_content_hash", None)
         return out
 
     async def memory_add(self, data: dict) -> Memory:
@@ -979,8 +1061,62 @@ class PostgresService:
         if any(d.get("fleet_id") != fleet_id for d in items):
             raise BulkValidationError("memory_add_all: all items must share the same fleet_id")
 
+        # A multi-values INSERT compiles ONE column list for the whole
+        # statement, so every row must set the same columns. A batch that
+        # disagrees is not a batch with a missing value — it is two different
+        # statements, and which one you get depends on row order:
+        #
+        #   row 0 sets the column, a later row does not -> CompileError at
+        #       execute time; the statement never reaches Postgres and the
+        #       whole batch fails.
+        #   row 0 does not, a later row does -> compiles, and SQLAlchemy drops
+        #       the column from the INSERT entirely, with no warning. That
+        #       row's value is silently discarded.
+        #
+        # Checked in two places because the two causes need opposite answers,
+        # and telling them apart requires looking at both lists. Guessing is
+        # what makes an answer wrong here: a caller told "permanent" about
+        # something it could fix will stop trying, and a caller told "retry"
+        # about something it cannot fix will never stop.
+        #
+        # Cause 1 — the ITEMS disagree. Caller-fixable, so it belongs with the
+        # tenant_id/fleet_id contract checks above and answers the same 422.
+        # Reachable today: the route hands ``request.json()`` straight here, and
+        # ``_filter_memory_fields`` passes each item's own subset of valid
+        # columns through, so two items differing on any optional column
+        # (``title``, ``run_id``, ``source_uri``, ``predicate``…) land here.
+        # core-api's own writers build fixed-key dict literals and never do,
+        # but they are not the only door.
+        #
+        # Intersected with ``_MEMORY_VALID_FIELDS`` rather than comparing raw
+        # keys, because the mapper drops everything else: two items differing
+        # only on an unrecognised key produce identical rows, and rejecting
+        # those would be a 422 for a batch that would have written correctly.
+        item_keys = [frozenset(d.keys() & _MEMORY_VALID_FIELDS) for d in items]
+        if any(ks != item_keys[0] for ks in item_keys[1:]):
+            raise BulkValidationError(
+                "memory_add_all: all items must set the same fields "
+                f"({', '.join(_divergent_keys(item_keys))} differ); a bulk "
+                "insert writes one column list for the whole batch"
+            )
+
+        rows = [self._filter_memory_fields(d) for d in items]
+        # Cause 2 — the items agreed and the MAPPER diverged. Nothing the
+        # caller sent explains it and re-sending cannot help, so this is a
+        # server fault and answers a permanent 5xx rather than a 422. That is
+        # the incident this guard exists for: ``_filter_memory_fields`` used to
+        # invent ``embedded_content_hash`` only for rows carrying a vector, and
+        # a deferred deployment embeds only ``write_mode="strong"`` items — so
+        # any mixed batch diverged here and surfaced three services away as a
+        # gateway 504 that named neither the batch nor the column.
+        row_keys = [frozenset(r) for r in rows]
+        if any(ks != row_keys[0] for ks in row_keys[1:]):
+            raise BulkRowShapeError(
+                "memory_add_all: mapped rows disagree on which columns they set",
+                {"columns": _divergent_keys(row_keys)},
+            )
+
         async with get_session() as session:
-            rows = [self._filter_memory_fields(d) for d in items]
             # The conflict target must mirror ``ix_memories_attempt_unique``
             # *expression-for-expression* — the planner only treats the
             # ON CONFLICT and the partial-unique index as matched if every

--- a/core-storage-api/tests/test_bulk_row_shape_uniformity.py
+++ b/core-storage-api/tests/test_bulk_row_shape_uniformity.py
@@ -1,0 +1,250 @@
+"""A bulk batch's rows must agree on which columns they set.
+
+``memory_add_all`` builds ONE multi-values INSERT for the whole batch, and
+SQLAlchemy derives a single column list for it. Rows that disagree therefore do
+not produce "a row with a missing value" — they produce a statement that either
+fails to compile or quietly writes a different set of columns than the caller
+asked for, decided by which row happens to be first.
+
+That is not theoretical. ``_filter_memory_fields`` stamps
+``embedded_content_hash`` only on rows carrying a vector, and a deferred
+deployment embeds only ``write_mode="strong"`` items — so a batch mixing strong
+and ordinary items diverges on exactly that column. In production this compiled
+0.6s of nothing 680 times an hour for 29 hours, surfacing three services away as
+a gateway 504 that named neither the batch nor the column.
+
+These tests compile the real statement rather than asserting on the mapper's
+output, because compilation is where the defect lives: a dict-level assertion
+would keep passing if SQLAlchemy changed how it treats an absent key.
+
+No database — ``.compile()`` is pure.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from common.models.memory import Memory
+from core_storage_api.services import postgres_service
+from core_storage_api.services.postgres_service import (
+    BulkRowShapeError,
+    BulkValidationError,
+    PostgresService,
+)
+
+# No ``integration`` marker deliberately: this suite reserves it for tests that
+# need a running PostgreSQL, and nothing here opens a connection.
+
+
+def _item(idx: int, *, embedded: bool) -> dict:
+    """One item shaped exactly as core-api's bulk path builds it.
+
+    The key set is fixed and identical for every item — that is what core-api
+    does (``memory_service`` builds ``mem_data`` from a dict literal), and it
+    matters: it means any divergence downstream was introduced by the storage
+    mapper, not inherited from the request.
+
+    ``embedded`` is the only difference, and it is the real one: under a
+    deferred deployment only ``write_mode="strong"`` items come back from the
+    embed call with a vector, and the rest arrive with ``embedding=None``.
+    """
+    return {
+        "tenant_id": "t-1",
+        "fleet_id": None,
+        "agent_id": "a-1",
+        "content": f"memory {idx}",
+        "content_hash": f"hash-{idx}",
+        "client_request_id": f"attempt-1:{idx}",
+        # A real vector for the strong item, None for the deferred one.
+        "embedding": [0.1, 0.2, 0.3] if embedded else None,
+    }
+
+
+def _compile(rows: list[dict]) -> str:
+    """Compile the statement ``memory_add_all`` builds, as it builds it."""
+    stmt = pg_insert(Memory).values(rows)
+    return str(stmt.compile(dialect=postgresql.dialect()))
+
+
+def _mapped(*items: dict) -> list[dict]:
+    return [PostgresService._filter_memory_fields(d) for d in items]
+
+
+def test_mixed_batch_compiles_when_the_stamped_row_is_first():
+    """The production failure: row 0 stamped, a later row not.
+
+    Without the fix this raises ``CompileError: INSERT value for column
+    memories.embedded_content_hash is explicitly rendered as a boundparameter
+    in the VALUES clause`` — the exact error the storage writer logged
+    throughout the incident, and the whole batch is lost.
+    """
+    rows = _mapped(_item(0, embedded=True), _item(1, embedded=False))
+
+    sql = _compile(rows)
+
+    assert "embedded_content_hash" in sql
+
+
+def test_mixed_batch_keeps_the_column_when_the_stamped_row_is_second():
+    """The silent twin: row 0 unstamped, a later row stamped.
+
+    This ordering never raised. It compiled cleanly, emitted no warning, and
+    dropped ``embedded_content_hash`` from the INSERT altogether — writing NULL
+    provenance for a row that HAD a vector and a known hash.
+
+    Asserting the column is present is the point. A test that only checked
+    "does not raise" passes on the broken code, which is precisely how this
+    half went unnoticed while the other half paged.
+    """
+    rows = _mapped(_item(0, embedded=False), _item(1, embedded=True))
+
+    sql = _compile(rows)
+
+    assert "embedded_content_hash" in sql, (
+        "the column was dropped from the INSERT: the stamped row's provenance "
+        "would persist as NULL, which reads downstream as 'written before "
+        "migration 037' — a bucket nothing re-embeds"
+    )
+
+
+def test_the_stamped_row_still_carries_its_hash():
+    """Uniformity must not be bought by dropping the stamp itself.
+
+    A fix that simply stopped stamping would also make every row agree, and
+    would also make both tests above pass, while silently disabling the
+    provenance tracking the column exists for.
+    """
+    stamped, deferred = _mapped(_item(0, embedded=True), _item(1, embedded=False))
+
+    assert stamped["embedded_content_hash"] == "hash-0"
+    # Present as an explicit NULL, not absent: identical on the wire for a
+    # nullable, default-less column, and it is what makes the batch uniform.
+    assert deferred["embedded_content_hash"] is None
+
+
+def test_a_homogeneous_batch_is_unaffected():
+    """Control. Both rows embedded — the case that always worked."""
+    rows = _mapped(_item(0, embedded=True), _item(1, embedded=True))
+
+    sql = _compile(rows)
+
+    assert "embedded_content_hash" in sql
+    assert [r["embedded_content_hash"] for r in rows] == ["hash-0", "hash-1"]
+
+
+async def test_items_that_disagree_are_the_callers_to_fix():
+    """Divergent ITEMS are a 422, not the permanent 500.
+
+    Reachable through the real mapper, with no patching: the route hands
+    ``request.json()`` straight to ``memory_add_all``, and
+    ``_filter_memory_fields`` passes each item's own subset of valid columns
+    through. Two items differing on ``title`` therefore produce two row shapes
+    — so this guard is load-bearing, not defence-in-depth.
+
+    It must NOT be ``BulkRowShapeError``: that one tells the caller a retry can
+    never succeed, and this batch succeeds the moment the caller sends the same
+    fields for every item. Getting that backwards is the same class of mistake
+    as the incident itself — advice that does not match the failure.
+    """
+    svc = PostgresService()
+    items = [
+        {"tenant_id": "t-1", "client_request_id": "a:0", "content": "one", "title": "has one"},
+        {"tenant_id": "t-1", "client_request_id": "a:1", "content": "two"},
+    ]
+
+    with pytest.raises(BulkValidationError) as exc:
+        await svc.memory_add_all(items)
+
+    # Names the offending field, and ONLY it. The production path's whole
+    # failure was that nothing anywhere said which column diverged, so a
+    # message listing every field in the row is barely better than silence.
+    message = str(exc.value)
+    assert "title" in message
+    assert "content" not in message, f"shared fields must not be reported as divergent: {message}"
+
+
+async def test_items_differing_only_on_a_dropped_key_are_not_rejected(monkeypatch):
+    """An unrecognised key is not a shape difference.
+
+    ``_filter_memory_fields`` drops anything outside ``_MEMORY_VALID_FIELDS``,
+    so two items differing only on such a key map to identical rows and write
+    correctly. Rejecting them would be a 422 for a batch that was always fine —
+    which is why the item check intersects with the valid-field set instead of
+    comparing raw keys.
+    """
+
+    class _ReachedTheSession(Exception):
+        pass
+
+    def _sentinel():
+        raise _ReachedTheSession
+
+    monkeypatch.setattr(postgres_service, "get_session", _sentinel)
+    svc = PostgresService()
+    items = [
+        {"tenant_id": "t-1", "client_request_id": "a:0", "content": "one", "not_a_column": 1},
+        {"tenant_id": "t-1", "client_request_id": "a:1", "content": "two"},
+    ]
+
+    with pytest.raises(_ReachedTheSession):
+        await svc.memory_add_all(items)
+
+
+async def test_a_mapper_divergence_is_the_permanent_one(monkeypatch):
+    """A divergence the ITEMS do not explain is the server's fault.
+
+    The mapper is stubbed to invent a key for one row while the items stay
+    uniform — which is exactly what the pre-fix ``_filter_memory_fields`` did
+    for ``embedded_content_hash``. That has to answer permanently rather than
+    422: nothing the caller sent explains it, so re-sending cannot help.
+
+    Reaching ``BulkRowShapeError`` also proves the check runs before
+    ``get_session()`` — there is no database in this test — and the divergent
+    column travels in ``fields`` as data, not as prose.
+    """
+
+    def _invents_a_key(d: dict) -> dict:
+        out = dict(d)
+        if d["client_request_id"].endswith(":0"):
+            out["embedded_content_hash"] = "h"
+        return out
+
+    monkeypatch.setattr(PostgresService, "_filter_memory_fields", staticmethod(_invents_a_key))
+    svc = PostgresService()
+    items = [
+        {"tenant_id": "t-1", "client_request_id": "a:0", "content": "one"},
+        {"tenant_id": "t-1", "client_request_id": "a:1", "content": "two"},
+    ]
+
+    with pytest.raises(BulkRowShapeError) as exc:
+        await svc.memory_add_all(items)
+
+    assert exc.value.fields == {"columns": ["embedded_content_hash"]}
+
+
+async def test_neither_guard_fires_on_a_uniform_batch(monkeypatch):
+    """Control for both guards: identical field sets must reach the session.
+
+    ``get_session`` is replaced with a sentinel-raising stub, so "the guards let
+    this through" is a positive assertion rather than the absence of one.
+    Asserting on whatever database error an unconfigured environment happens to
+    raise would pass for the wrong reason — including if a guard fired first.
+    """
+
+    class _ReachedTheSession(Exception):
+        pass
+
+    def _sentinel():
+        raise _ReachedTheSession
+
+    monkeypatch.setattr(postgres_service, "get_session", _sentinel)
+    svc = PostgresService()
+    items = [
+        {"tenant_id": "t-1", "client_request_id": "a:0", "content": "one"},
+        {"tenant_id": "t-1", "client_request_id": "a:1", "content": "two"},
+    ]
+
+    with pytest.raises(_ReachedTheSession):
+        await svc.memory_add_all(items)

--- a/tests/test_bulk_atomicity.py
+++ b/tests/test_bulk_atomicity.py
@@ -642,6 +642,191 @@ async def test_storage_4xx_does_not_get_5xx_recovery_hint(client, monkeypatch):
     assert exc_info.value.response.status_code == 404
 
 
+# ── A 5xx storage marks permanent must not be advertised as retryable ──
+#
+# The 504-with-retry-hint contract above rests on the failure being able to
+# clear: a lost response, a restart mid-commit, a slow upstream. When storage
+# reports a failure that reproduces identically on every attempt, that contract
+# inverts — a compliant client retries forever. Production ran exactly that:
+# ~680 requests/hour for 29 hours against a batch that could never compile,
+# because nothing at this layer separated "might have committed" from "will
+# never commit".
+
+
+def _permanent_response():
+    """A storage response carrying the explicit non-retryable marker.
+
+    Built literally rather than through ``common.permanent_failure`` on purpose:
+    this is the WIRE shape, and a test that constructs it with the same helper
+    the producer uses would keep passing if that helper renamed a key. The
+    storage side's own tests cover the builder.
+
+    Unannotated return, matching this module's convention of importing httpx
+    inside the functions that need it rather than at module scope.
+    """
+    import httpx
+
+    request = httpx.Request("POST", "https://storage.local/memories/bulk")
+    return httpx.Response(
+        500,
+        request=request,
+        json={
+            "detail": {
+                "error": "bulk_row_shape",
+                "retryable": False,
+                "message": "bulk write failed on an internal row-shape invariant",
+                "columns": ["embedded_content_hash"],
+            }
+        },
+    )
+
+
+def _serving(response, monkeypatch):
+    """Make the BULK INSERT call — and only that one — return *response*.
+
+    Patches ``_execute``, which sits BELOW ``_post``, so ``_post``'s real
+    ``raise_for_status`` and permanence translation both run. Patching
+    ``create_memories`` instead would stub out the very code under test, and
+    the tests would pass against a client that never learned to classify
+    anything.
+
+    Scoped by ``label`` rather than replacing ``_execute`` wholesale, because a
+    single bulk request makes several storage calls before the insert (tenant
+    config, dedup, agent upsert). Failing all of them raises from OUTSIDE the
+    route's ``try``, so the answer comes from ``upstream_http_error_handler``
+    instead of the branch under test — which is how the first draft of these
+    tests read 503 where it expected 504, and would just as happily have read
+    the right status for the wrong reason.
+    """
+    from core_api.clients import storage_client as sc_mod
+
+    real_execute = sc_mod.CoreStorageClient._execute
+
+    async def fake_execute(self, do_request, *, retry, label):
+        if label == "POST /memories/bulk":
+            return response
+        return await real_execute(self, do_request, retry=retry, label=label)
+
+    monkeypatch.setattr(sc_mod.CoreStorageClient, "_execute", fake_execute)
+
+
+async def test_the_marker_is_opt_in_and_only_the_literal_false_counts():
+    """Every shape that is not an explicit permanence claim stays retryable.
+
+    Fail-open is deliberate: a 5xx really may have committed rows, and
+    suppressing the retry on a guess would strand them with nothing to recover
+    them — whereas a needless retry is a no-op, because the per-attempt unique
+    index resolves an already-committed row to ``duplicate_attempt``. The
+    empty-body case is the one ``test_storage_5xx_returns_504_not_500`` above
+    constructs, so this doubles as a regression guard on that test's contract.
+
+    ``async`` purely to satisfy this module's ``pytest.mark.asyncio``
+    pytestmark; the function awaits nothing.
+    """
+    import httpx
+
+    from core_api.clients.storage_client import _storage_permanent
+
+    req = httpx.Request("POST", "https://storage.local/memories/bulk")
+
+    message, fields = _storage_permanent(_permanent_response())
+    assert message == "bulk write failed on an internal row-shape invariant"
+    # The cause and the divergent columns arrive as data, not as prose.
+    assert fields["error"] == "bulk_row_shape"
+    assert fields["columns"] == ["embedded_content_hash"]
+
+    for label, response in [
+        ("empty body", httpx.Response(503, request=req)),
+        (
+            "FastAPI's default string detail",
+            httpx.Response(500, request=req, json={"detail": "Internal Server Error"}),
+        ),
+        (
+            "dict detail without the key",
+            httpx.Response(500, request=req, json={"detail": {"error": "other"}}),
+        ),
+        (
+            "explicitly retryable",
+            httpx.Response(500, request=req, json={"detail": {"retryable": True}}),
+        ),
+        # ``None`` must not read as a permanence claim — the reason the check
+        # is ``is False`` rather than a falsy test.
+        (
+            "null",
+            httpx.Response(500, request=req, json={"detail": {"retryable": None}}),
+        ),
+        (
+            "a proxy's HTML error page",
+            httpx.Response(502, request=req, text="<html>bad gateway</html>"),
+        ),
+        ("a body that parses to a list", httpx.Response(500, request=req, json=[1, 2])),
+    ]:
+        assert _storage_permanent(response) is None, label
+
+
+async def test_permanent_storage_5xx_does_not_advise_retry(client, monkeypatch):
+    """A marked-permanent storage 5xx must break the retry loop, not feed it.
+
+    Asserts the three things a client acts on: a machine-readable code rather
+    than an English substring, plain "do not retry" prose, and — critically —
+    the ABSENCE of the ``X-Bulk-Attempt-Id`` hint the 504 branch emits, since
+    that string is what a complying client keys its retry off.
+    """
+    _serving(_permanent_response(), monkeypatch)
+
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"perm-{uid()}",
+        "items": [{"content": f"perm-content-{uid()}"}],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("perm")},
+    )
+
+    assert resp.status_code == 500
+    payload = resp.json()
+    assert payload["error"]["code"] == "PERMANENT_WRITE_FAILURE"
+    assert payload["error"]["details"]["columns"] == ["embedded_content_hash"]
+    detail = payload["detail"]
+    assert "Do NOT retry" in detail
+    assert "recover any committed items" not in detail
+
+
+async def test_unmarked_storage_500_still_advises_retry(client, monkeypatch):
+    """The default stays retryable, so this fix cannot strand committed rows.
+
+    Distinct from ``test_storage_5xx_returns_504_not_500``, which uses 503 with
+    an empty body: this is a 500 carrying FastAPI's ordinary string ``detail``,
+    the shape an unhandled storage exception actually produces. It is the case
+    that must NOT be caught by the permanence branch.
+    """
+    import httpx
+
+    request = httpx.Request("POST", "https://storage.local/memories/bulk")
+    _serving(
+        httpx.Response(500, request=request, json={"detail": "Internal Server Error"}),
+        monkeypatch,
+    )
+
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"unmarked-{uid()}",
+        "items": [{"content": f"unmarked-content-{uid()}"}],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("unmarked")},
+    )
+
+    assert resp.status_code == 504
+    assert "X-Bulk-Attempt-Id" in resp.json()["detail"]
+
+
 async def test_storage_network_error_returns_503_with_retry_after(client, monkeypatch):
     """A network-level error reaching storage (DNS, connect refused, broken
     pipe) maps to 503 + ``Retry-After`` for clean client backoff."""


### PR DESCRIPTION
## The incident

`POST /api/v1/memories/bulk` returned 504 continuously from **2026-09-02T19:00Z**, ~680/hour for 29 hours (~19,500 failures), for tenant `arkash24-4d270c`.

The 504 was a mapping, not a timeout — median latency 0.64s, max 15.7s. Three layers each renamed the fault:

```
core-storage-writer   sqlalchemy.exc.CompileError: INSERT value for column
                      memories.embedded_content_hash is explicitly rendered as a
                      boundparameter in the VALUES clause
core-api              WARNING  bulk write got 500 from storage;
                               client should retry with same X-Bulk-Attempt-Id
gateway               504
```

## Root cause

`memory_add_all` builds a multi-values INSERT, and `pg_insert(...).values(<list of dicts>)` compiles **one** column list for the whole statement. `_filter_memory_fields` invented `embedded_content_hash` only for rows carrying a vector, so a batch mixing embedded and deferred rows disagreed on that column.

Upstream is not at fault: `memory_service` builds each row from a fixed dict literal, so every item carries every key. The divergence was manufactured entirely inside the mapper — which is why this is the first such incident despite the multi-values call being old.

**Reachable through documented API usage, not misuse.** `BulkMemoryItem.write_mode` is a per-item field whose description explicitly invites per-item opt-in, and under `DEPLOYMENT_MODE=deferred` (prod's shape) `memory_service` embeds **only** `write_mode="strong"` items. Any batch mixing modes diverges.

Latent since #786 added the column on 2026-08-16. Verified this was **not** a deploy: zero storage-writer errors 17:00–19:00 on 09-02 (control query confirms 300 non-error logs in the same window), the cap hit 19:00–21:00, and the nearest core-api revisions are 09-02T04:30 and 09-03T05:00. What changed at 19:00Z was a client's workload. **A rollback would not have fixed it.**

## The second, silent failure — arguably the worse one

Row **order** decided which failure you got, and only one was loud:

| Row 0 | Later row | Outcome |
|---|---|---|
| sets the column | does not | `CompileError` at execute time; statement never reaches Postgres, whole batch fails — the 504 storm |
| does not | sets it | **compiles, and SQLAlchemy drops the column from the INSERT entirely, with no warning** |

I verified the second path emits **zero** warnings. The compiled SQL simply omits the column, so that row's provenance persists as `NULL` — which `memory_quality_metrics` buckets as `unknown_provenance`, a bucket whose own docstring defines it as *"written before migration 037"* and says *"it drains as rows are rewritten or re-embedded."* Nothing re-embeds them: the nightly sweep repairs only `missing` (`embedding IS NULL`), and `stale` requires `embedded_content_hash IS NOT NULL`. Those rows leave the staleness detector's reach permanently.

CI's own comments record that #786 already had one near-miss on exactly this outcome, caught only by human review because no automated check covered `core-worker`. This is a second route to the same place that no check covered either. The 504 was the *lucky* ordering — it is the one that told us something was wrong.

## What this changes

**1. Uniformity at the source.** `_filter_memory_fields` always emits the key, `None` when the inference does not apply — identical on the wire for a nullable, default-less column. Costs one bind parameter per row on batches that previously omitted it (~+8% on statement construction, 100 of asyncpg's ~32k ceiling at the 100-item cap). That is the price of uniformity that row ordering cannot defeat.

A blanket fixed-key projection would be worse: 8 of `Memory`'s 33 columns carry server defaults and are `NOT NULL`, so filling missing keys with `None` would write NULL over a default or violate the constraint. `embedded_content_hash` is the only key this function *invents*, so "always emit the key you invent" is a complete local invariant. **The escalation trigger for a second conditionally-set column is in the comments** — at that point the safe-to-fill set should be *derived* from the mapper, not hand-listed.

**2. Two guards, because the two causes need opposite answers.** Telling them apart requires looking at both the items and the mapped rows:

- **Items disagree** → caller-fixable → `422`, beside the existing tenant/fleet checks. This is the reachable case: the route hands `request.json()` straight through. Intersected with `_MEMORY_VALID_FIELDS`, so items differing only on a key the mapper drops are *not* rejected.
- **Rows disagree after uniform items** → server fault → permanent `500`.

Guessing either way is harmful: a caller told "permanent" about something it could fix stops trying; a caller told "retry" about something it cannot fix never stops. An earlier draft asserted "the caller's payload was fine" without checking, and the reachable case is precisely the one it mislabelled.

**3. A permanent failure is no longer advertised as retryable.** This is the amplifier that turned a bug into a 29-hour outage. Two layers were telling the client to retry:

- the bulk route: `504, retry with the same X-Bulk-Attempt-Id`
- `app.upstream_http_error_handler`: `503 "Upstream dependency unavailable; retry."` for **any** unhandled upstream 5xx

Both are right for a transient failure and inverted for one that reproduces byte-for-byte. Storage now marks such failures `retryable: false` (`common/permanent_failure`, following `common/duplicate_memory`'s precedent so the two services share one symbol instead of agreeing on literals), and the **storage client** translates it into a typed error at the boundary every write funnels through.

That placement is load-bearing, not tidiness. Three callers of the bulk storage endpoint — the MCP write tool, `ingest_service`, `_insert_children_or_degrade` — do not catch `httpx.HTTPStatusError`, so a route-local check would have left them being told to retry a permanently-refused write. `_insert_children_or_degrade` is the worst case: it would advertise a retry for a request whose parent row already committed.

Unmarked 5xx keep the retry advice, deliberately. The costs are asymmetric: a needless retry is a no-op, because `ix_memories_attempt_unique` resolves an already-committed row to `duplicate_attempt` with its canonical id — while a wrong "do not retry" strands committed rows with nothing to recover them. Hence `is False` rather than a falsy test; an absent key, a null, a proxy's HTML page and a non-JSON body all read as "not marked".

## Not a size problem

The failing payload was ~214KB and a succeeding one ~155KB, which looks like a threshold and is not. Batch size only changes the *probability* that a batch is heterogeneous. **A size-based fix — raising a limit, chunking by bytes — would appear to work for exactly as long as batches happened to stay uniform, then fail again with no new signal.** The sizes were also not constant (214214/214215/214216/214217), so this was a client continuously generating same-shaped batches, not one poisoned message.

## Verification

Tests were confirmed red by reverting the fix, under the pinned interpreter (`.venv/bin/python -m pytest`, Python 3.13.0, SQLAlchemy 2.0.51):

- the compile case fails with the production error **verbatim**
- the silent case fails showing `embedded_content_hash` absent from the compiled INSERT
- controls (homogeneous batch, single row) correctly stay green either way

A test asserting only "does not raise" passes on the broken code — which is how the silent half went unnoticed while the other half paged. The tests compile the real statement rather than asserting on the mapper's output, because compilation is where the defect lives.

No regressions: I reverted the source, ran the full root suite, saved the sorted failure names, restored, re-ran the identical command, and diffed — **byte-identical, 18 both ways**. Those 18 are environmental (the root conftest provisions via `create_all`, so migration 034's tsvector trigger is absent and FTS scores come back `None`), not properties of the codebase.

`328` storage tests and `144` core-api bulk/tenancy-gate tests pass; `ruff check` and `ruff format --check` clean at CI's exact separate scopes; `mypy` clean on both services.

One regression was caught this way and fixed: giving the new exception its own `__init__` took the **entire tenancy invariant offline**, because `scripts/tenant_scope_gate.py` resolves functions by bare name and refuses to run on a module defining one twice — and `postgres_service.py` already had one on `DuplicateContentHashError`. The error message says nothing about tenancy and you cannot rename `__init__`. Fixed by factoring the fields-carrying base into `common/permanent_failure.py`, which removed the same latent trap from `storage_client.py`.

## Stopping the bleeding

Separately from this PR, and not applied here: the client-side fix is to make `write_mode` uniform within each batch (or split `strong` items into their own batch). No deploy, no server config change, and unlike halting the agents it lets the backlog **drain** rather than discarding it. Request sizes plateaued by 09-02T20:00Z and were byte-stable for 28+ hours, so the pending set is frozen and bounded and plausibly still exists — whether it survives a restart is a question for the agents' owner, not the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
