### PR TITLE
fix(ratchet): resolve the permanent-red completion case, add the central workflow

### DIFF
--- a/.github/workflows/legacy-name-ratchet.yml
+++ b/.github/workflows/legacy-name-ratchet.yml
@@ -20,7 +20,9 @@ name: Legacy-name ratchet
 #
 # It is NOT wired into this repo's own on-PR checks: see ci.yml's own
 # "legacy-name-ratchet" job for that. This file exists to be pointed at by
-# other repos' required-workflow rulesets, pinned by tag, never by branch.
+# other repos' required-workflow rulesets, pinned by branch (ratchet-stable),
+# never by tag -- confirmed empirically that tag refs never fire for this
+# ruleset rule type, despite GitHub's docs saying both are supported.
 on:
   pull_request:
   merge_group:
@@ -86,7 +88,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/legacy-name-ratchet.yml
+++ b/.github/workflows/legacy-name-ratchet.yml
@@ -1,0 +1,140 @@
+name: Legacy-name ratchet
+
+# The central copy of hard rule 7's gate, run as an org-required workflow
+# against every consumer repo's PRs directly -- see docs/plans/rebrand-sunset-plan.md.
+#
+# Nine repos used to each vendor scripts/legacy_name_ratchet.py byte-for-byte
+# and run it locally, with a SEPARATE required workflow (legacy-name-engine-
+# parity.yml, hosted in caura-onprem-installer) doing nothing but confirming
+# the eight copies stayed byte-identical to this one. That parity check is
+# what failed with no bypass actor and blocked unrelated PRs org-wide the day
+# this file was written -- and every consumer's own vendored engine still had
+# a bug this file's own two commits fix, discovered because ONE of the nine
+# copies (caura-bus) finally reached a state the bug could no longer hide in.
+#
+# This workflow replaces both: point an org ruleset at THIS file instead of
+# the parity checker, and there is nothing left to vendor, diverge, or
+# byte-compare. A consumer repo needs zero local YAML for this -- required
+# workflows run in the target repository, the same way the parity check
+# always has, so this file's only audience is the org ruleset that names it.
+#
+# It is NOT wired into this repo's own on-PR checks: see ci.yml's own
+# "legacy-name-ratchet" job for that. This file exists to be pointed at by
+# other repos' required-workflow rulesets, pinned by tag, never by branch.
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    name: Legacy-name ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out the candidate revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: candidate
+          fetch-depth: 2
+          persist-credentials: false
+
+      # Required workflows run in the TARGET repository, so the checkout
+      # above correctly gets the candidate but not this workflow's own
+      # sibling files (the engine script and its tests) -- ported verbatim
+      # from legacy-name-engine-parity.yml's "Identify the parity gate
+      # source" step, which solves the identical problem: prove the workflow
+      # actually executing is the one sourced from this repo at a real
+      # commit, not something a candidate PR substituted, before trusting
+      # anything it reads from "itself".
+      #
+      # Read through toJSON(job) because actionlint 1.7.12 predates GitHub's
+      # two workflow-identity fields and otherwise reports them as
+      # nonexistent (rhysd/actionlint#705). The explicit repository and SHA
+      # checks keep this compatibility shim fail-closed.
+      - name: Identify the ratchet gate source
+        id: ratchet-source
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        run: |
+          set -euo pipefail
+          repository=$(jq -r '.workflow_repository // empty' <<< "$JOB_CONTEXT")
+          sha=$(jq -r '.workflow_sha // empty' <<< "$JOB_CONTEXT")
+          if [[ "$repository" != "caura-ai/caura" ]]; then
+            echo "::error::unexpected ratchet workflow source repository: ${repository:-missing}"
+            exit 1
+          fi
+          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::invalid ratchet workflow source SHA: ${sha:-missing}"
+            exit 1
+          fi
+          echo "repository=$repository" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Check out the ratchet engine source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ steps.ratchet-source.outputs.repository }}
+          ref: ${{ steps.ratchet-source.outputs.sha }}
+          path: engine-source
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/legacy_name_ratchet.py
+            tests/test_legacy_name_ratchet.py
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      # The gate's own tests run before the gate does, against the exact copy
+      # about to judge the candidate -- a ratchet that has silently stopped
+      # matching reports a clean tree and passes every PR from then on, which
+      # is the one failure mode that hides itself. Mirrors the "gate's own
+      # tests" step several of the (soon to be former) vendoring repos already
+      # ran locally for the same reason.
+      - name: The gate's own tests
+        working-directory: engine-source
+        run: |
+          python -m pip install --disable-pip-version-check --quiet 'pytest>=9.1.1,<10.0'
+          python -m pytest tests/test_legacy_name_ratchet.py -q
+
+      # Run from INSIDE the candidate's checkout, not the engine source's --
+      # legacy_name_ratchet.py resolves its own repo root (and therefore
+      # scripts/legacy_name_ratchet.json) via `git rev-parse --show-toplevel`
+      # against the current working directory, not against its own file
+      # location. Running it from the candidate is what makes it read the
+      # CANDIDATE's config -- default_base, mirror_paths, and the rest stay
+      # genuinely per-repo data, never vendored, never touched by this file.
+      - name: No new old-brand names
+        working-directory: candidate
+        run: |
+          # Assert the merge shape before trusting HEAD^1. If a PR is not
+          # mergeable GitHub may serve a stale merge ref or none at all, and a
+          # single-parent HEAD would silently make "the base" this branch's
+          # own previous commit -- a comparison that passes while checking
+          # nothing.
+          #
+          # merge_group is a second, separate reason this can fail: a merge
+          # queue's temporary commit is not guaranteed to have the same
+          # 2-parent PR-merge shape this check assumes, and nobody has
+          # verified what shape it actually has, because no repo in this
+          # fleet runs a merge queue today. Both failure modes hit the same
+          # assertion, so the message names which one applies rather than
+          # reporting a bare assertion failure -- a fail-closed gate that
+          # cannot say what it is closed against just moves the diagnosis
+          # cost onto whoever hits it next.
+          PARENTS=$(git rev-list --parents -n1 HEAD | wc -w)
+          if [ "$PARENTS" -ne 3 ]; then
+            if [ "${GITHUB_EVENT_NAME:-}" = "merge_group" ]; then
+              echo "::error::This repo has a merge queue enabled, and the legacy-name ratchet has no merge_group base-detection yet -- HEAD^1 assumes a 2-parent PR-merge commit, and a merge-queue commit is not guaranteed to have that shape. Nothing about your change failed; this gate simply does not support this trigger yet. See caura-ai/caura's legacy-name-ratchet.yml for the assumption, and file an issue there rather than reworking your PR."
+            else
+              echo "::error::Expected a 2-parent merge commit at HEAD; found $((PARENTS - 1)) parent(s)."
+              echo "The ratchet's base would be wrong, so it is not run. Re-run once the PR is mergeable."
+            fi
+            exit 1
+          fi
+          python3 "$GITHUB_WORKSPACE/engine-source/scripts/legacy_name_ratchet.py" --base HEAD^1

--- a/scripts/legacy_name_ratchet.py
+++ b/scripts/legacy_name_ratchet.py
@@ -138,6 +138,14 @@ from urllib.parse import urlsplit
 # a hole in the scan.
 LEGACY_NAME = "memclaw"  # legacy-name-ok: the pattern this gate searches for
 
+# The current brand, never gated on and never excluded or counted — the only
+# use is as a positive control in main(), proving a scan that finds zero
+# LEGACY_NAME can still find something, rather than finding nothing at all.
+# A finished migration cannot have removed it: the fleet is Caura-branded
+# software, so the name is load-bearing in package names and imports, not
+# merely present in prose that a sweep could plausibly have missed.
+NEW_NAME = "caura"
+
 # Kept deliberately ugly so they are never typed by accident and always read as a
 # decision rather than a formatting artifact.
 EXEMPT_MARKER = "legacy-name-ok"
@@ -836,6 +844,7 @@ def _grep(
     pathspec: str | list[str] = ":/",
     *,
     exclusions: bool = True,
+    pattern: str = LEGACY_NAME,
 ) -> list[tuple[str, str, str, str | None, _Deferred | None]]:
     """``(path, lineno, text, kind, deferred)`` for every matching line.
 
@@ -858,8 +867,15 @@ def _grep(
     the fields are NUL-separated and only the ``<tree>:`` prefix is colon-joined —
     and that one is a string this function passed in, so it can be stripped by
     length instead of by searching.
+
+    ``pattern`` defaults to the one thing this whole module counts, but is a
+    parameter rather than baked in so :func:`_pathspec_is_live` can run the
+    exact same tree/pathspec/exclusions through a different, known-present
+    string — the positive control ``main`` needs to trust a search that found
+    nothing, rather than a second definition of this function that could drift
+    from the first.
     """
-    args = ["git", "grep", "-I", "-i", "-n", "-z", "--full-name", "-e", LEGACY_NAME]
+    args = ["git", "grep", "-I", "-i", "-n", "-z", "--full-name", "-e", pattern]
     if tree is not None:
         args.append(tree)
     args.append("--")
@@ -1145,6 +1161,23 @@ def scan(
         deferred_by_file,
         tuple(deferred_problems),
     )
+
+
+def _pathspec_is_live(tree: str | None) -> bool:
+    """Whether a scan of this tree, exclusions and all, can find anything.
+
+    The positive control for the one ambiguity ``_grep`` cannot resolve on its
+    own: a pathspec matching nothing exits with an empty result, indistinguishable
+    from a genuinely clean tree. Searching for ``NEW_NAME`` through the exact same
+    pathspec and exclusions the real scan just used is what tells the two apart —
+    a hit proves the scan reached real content; a second miss proves only that
+    this configuration finds nothing, old name or new.
+
+    Exclusions stay on, matching the scan this checks: a mirror or CHANGELOG.md is
+    excluded everywhere else in this gate, and this is not the place to start
+    treating content living only there as evidence of anything.
+    """
+    return bool(_grep(tree, pattern=NEW_NAME))
 
 
 def _excluded_inventory() -> Counter[str]:
@@ -2424,19 +2457,50 @@ def main() -> int:
     if not head and not base:
         # A pathspec that matches nothing exits 1 with an empty stderr, exactly
         # like a clean tree — so a broken scan reads as "nothing to report" and
-        # the gate passes every PR from then on, silently, for the rest of the
-        # programme. Both trees empty is either that or a finished migration,
-        # and both want a human.
+        # the gate would otherwise pass every PR from then on, silently, for
+        # the rest of the programme. Both trees empty is either that or a
+        # finished migration, and the two used to be indistinguishable from
+        # here — so this used to fail either way and ask a human to tell them
+        # apart.
+        #
+        # It no longer has to guess: a positive control. The same scan, same
+        # tree, same exclusions — the exact configuration that just returned
+        # zero for LEGACY_NAME — run again for NEW_NAME, a name a finished
+        # migration cannot have removed. A hit proves this scan can reach real
+        # content through this pathspec, on this tree, right now, which is
+        # what makes the LEGACY_NAME zero next to it trustworthy instead of
+        # equivocal. A second zero proves nothing changed about the ambiguity:
+        # the scan found nothing at all, old name or new, and that is exactly
+        # the "matches nothing" failure mode this gate has always had to
+        # assume rather than rule out.
+        #
+        # Deliberately the SAME exclusions the real scan used, not a wider,
+        # unscoped one: a mirror or CHANGELOG.md is excluded by design
+        # everywhere else in this gate (see test_the_gate_says_nothing_about_
+        # mirrors) and content living only there has never been this gate's
+        # business. Widening the control to look past those exclusions would
+        # make this the one branch where an intentionally-hidden mirror
+        # suddenly counted again — a new inconsistency, not a fix for one.
         #
         # Unless a marker report above already named the precise problem, in
         # which case this would talk the reader out of the accurate diagnosis
         # they have just been given.
         if not head_scan.deferred_problems:
+            if _pathspec_is_live(None) and _pathspec_is_live(base_ref):
+                print(
+                    f"No '{LEGACY_NAME}' lines anywhere in either tree, and the "
+                    f"same scan finds '{NEW_NAME}' just fine in both — the "
+                    "pathspec works, the search is real, and the migration is "
+                    "complete. Delete this gate along with the last of the old "
+                    "name."
+                )
+                return 0
             print(
-                f"Found no '{LEGACY_NAME}' lines in either tree.\n"
-                "Either the pattern or the pathspec is broken — in which case this gate has\n"
-                "been passing without checking anything — or the migration is complete and\n"
-                "this gate should be deleted along with the last of the old names."
+                f"Found no '{LEGACY_NAME}' lines in either tree, and no "
+                f"'{NEW_NAME}' either: the same scan cannot find a name that has "
+                "to be there, so it is not finding anything, anywhere, and the "
+                "empty result above proves nothing. This needs a human, not a "
+                "green check."
             )
         return 1
 

--- a/tests/test_legacy_name_ratchet.py
+++ b/tests/test_legacy_name_ratchet.py
@@ -2000,13 +2000,57 @@ def test_a_failing_working_tree_scan_also_exits_two(tmp_path: Path) -> None:
     assert "Traceback" not in result.stderr
 
 
-def test_finding_nothing_at_all_fails_rather_than_passing(tmp_path: Path) -> None:
-    """The silent-pass hole, and the reason it needs its own guard.
+def test_a_repo_with_nothing_to_migrate_reads_as_finished(tmp_path: Path) -> None:
+    """The completion case: no legacy-name line anywhere, and the positive
+    control finds the current brand right where it should be.
 
-    A pathspec matching nothing exits 1 with an empty stderr — indistinguishable
-    from a clean tree. Without this, breaking the pattern or the pathspec turns
-    the gate into a no-op that reports success on every PR for the rest of the
-    programme, which is the worst possible failure for a gate.
+    Used to fail here, deliberately: a pathspec matching nothing exits 1 with an
+    empty stderr, indistinguishable from a clean tree by output alone, and this
+    fixture cannot tell "the pattern or the pathspec broke" from "there was
+    never anything here" any more than the gate itself once could — it is
+    exactly the same zero either way. The control is what tells them apart: this
+    tree still has to say "caura" somewhere, same as every real repo in the
+    fleet, so a scan that finds it proves the pathspec is live and the
+    legacy-name zero next to it is real. See
+    ``test_a_dead_control_still_fails_rather_than_passing`` below for the
+    case this fixture never could be: a scan too broken to find either name.
+    """
+    r = tmp_path / "empty"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "t@example.com")
+    _git(r, "config", "user.name", "t")
+    (r / "clean.py").write_text("# built by Caura\nVALUE = 1\n")
+    _write_config(r)
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "base")
+
+    result = _run(r)
+
+    assert result.returncode == 0, result.stdout
+    assert "migration is complete" in result.stdout
+
+
+def test_a_dead_control_still_fails_rather_than_passing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """The other half of the ambiguity the control exists to resolve.
+
+    If the control ALSO comes back empty, the gate must not read that as two
+    confirmations of a clean tree — it is one scan finding nothing, asked
+    twice with different bait.
+
+    A pathspec dead enough to swallow ``NEW_NAME`` too is not otherwise
+    constructible through this script's own config validation, which already
+    rejects the one way ``mirror_paths`` could do it this bluntly — an empty
+    entry nukes the whole tree, not just one path, and ``_load_config`` refuses
+    it outright. So the control's own answer is forced directly here, the same
+    way ``test_change_summary_falls_back_when_replay_cannot_spawn_git``
+    elsewhere in this file forces a git failure: by replacing the function
+    under monkeypatch, not by trying to make git agree to something its own
+    input validation already refuses.
     """
     r = tmp_path / "empty"
     r.mkdir()
@@ -2018,11 +2062,16 @@ def test_finding_nothing_at_all_fails_rather_than_passing(tmp_path: Path) -> Non
     _git(r, "add", "-A")
     _git(r, "commit", "-qm", "base")
 
-    result = _run(r)
+    namespace = runpy.run_path(str(SCRIPT))
+    main = namespace["main"]
+    monkeypatch.setitem(main.__globals__, "_pathspec_is_live", lambda _tree: False)
+    monkeypatch.chdir(r)
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT), "--base", "HEAD"])
 
-    assert result.returncode == 1
-    assert "no-op" not in result.stdout  # it should explain, not merely fail
-    assert "passing without checking" in result.stdout
+    assert main() == 1
+    out = capsys.readouterr().out
+    assert "proves nothing" in out
+    assert "migration is complete" not in out
 
 
 def test_report_mode_never_fails(repo: Path) -> None:


### PR DESCRIPTION
## What

Two changes, landed together deliberately (see "Why this PR doesn't merge yet" below):

1. **The permanent-red fix.** The gate's own "found nothing anywhere" branch couldn't tell a finished migration from a broken pathspec finding nothing, so it always failed. `caura-bus` just hit this for real, permanently, when its migration actually finished. Adds a positive control (`NEW_NAME = "caura"` — a name a finished migration cannot have removed) that reruns the exact same scan/exclusions for the current brand before trusting a zero result for the legacy one: both live but empty → genuinely done, pass; either dead → same failure as today, fail. Exclusions stay on in the control, matching how the rest of the gate already treats mirror/CHANGELOG content as invisible.

2. **`legacy-name-ratchet.yml`** — a standalone, required-workflow-shaped copy of this gate, self-identifying via `job.workflow_repository`/`job.workflow_sha` (ported from `caura-onprem-installer`'s existing parity-checker workflow) so a candidate PR can't substitute its own checker. Not wired into this repo's own CI — hosted here to eventually be pointed at by an org ruleset, pinned by tag, replacing nine repos' vendored copies of the engine and the separate byte-parity check that exists only to keep those copies in sync.

## Why this PR doesn't merge yet

The existing byte-parity check (`check-legacy-name-engine-parity.sh`, required org-wide on 8 consumer repos) fetches this repo's `main` branch **live** at CI time and does a byte comparison. Merging this PR while that check is still what the 8 repos are gated on would instantly desync every vendored copy and fail all 8 — the same failure mode as this morning's org-wide outage, this time triggered by a merge here instead of a consumer PR.

This PR exists now specifically so its branch head can be tagged and pointed at by a scoped test ruleset (dry-running `legacy-name-ratchet.yml` against one low-risk consumer, then all 8) *before* anything merges to `main` — full sequencing in the tracking plan. One thing this PR's own CI *can* prove right now, with no ruleset involved: that `legacy-name-ratchet.yml`'s self-identification step fails closed on an ordinary PR like this one, where `job.workflow_repository`/`job.workflow_sha` aren't populated the way they would be under a real required-workflow invocation. Expect its own check to fail here — that's the point of opening this PR before merging it.

## Testing

- 184/184 existing + 2 new tests pass (`pytest tests/test_legacy_name_ratchet.py`).
- Both new tests confirmed to fail (red) when the fix is reverted, confirmed to pass when restored.
- `ruff check` / `ruff format --check` clean.
- `python3 scripts/legacy_name_ratchet.py --base origin/main` — no new lines.
- `actionlint legacy-name-ratchet.yml` — clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>