### PR TITLE
test(recall): pin the omitted-filter identity binding

### DIFF
--- a/tests/test_h06_m30_recall_identity.py
+++ b/tests/test_h06_m30_recall_identity.py
@@ -196,6 +196,68 @@ async def test_recall_tenant_key_may_still_name_any_agent(client, sc, as_auth):
     assert resp.status_code == 200, resp.text
 
 
+async def test_recall_binds_an_omitted_filter_to_the_authenticated_agent(
+    client, sc, as_auth, monkeypatch
+):
+    """The DEFAULT path: no filter at all, which was the worse of the two holes.
+
+    Every other test here names an identity explicitly, so all of them passed
+    while this case went unpinned — and it is the one that needs no crafted
+    request. Pre-fix, ``caller_agent_id=body.filter_agent_id`` meant an omitted
+    filter passed ``None``, which is the tenant-wide visibility a tenant
+    credential gets, and the trust<2 fleet forcing sat inside
+    ``if body.filter_agent_id:`` so it did not run either. A trust-1 agent
+    issuing the most ordinary possible recall read across fleets.
+
+    Asserted on the ARGUMENTS reaching ``search_memories`` rather than on the
+    result set, because that is what distinguishes "bound to the caller" from
+    "happened to return the same rows": an unbound read can coincide with a
+    bound one whenever the caller has nothing hidden from it, and then a
+    results-parity assertion passes while the identity is still wrong.
+
+    Credit: this case, and the argument-level assertion, come from @zznate's
+    PR #995 — the fix for the report in #994. #1268 (this file) landed the
+    shared resolver first and covered a vector #995 did not, but shipped
+    without this test; it is theirs.
+    """
+    # Patched on ``memory_service``, NOT on the route module. ``/recall``
+    # re-imports the function inside the handler
+    # (``from core_api.services.memory_service import search_memories``), so it
+    # resolves the name at call time from the service module and never sees a
+    # patch applied to the route's own module-level binding — which is the one
+    # ``/search`` uses. Patching the route seam here silently no-ops and the
+    # real search runs, so the assertions below read whatever the last real
+    # call happened to leave. #995 patched this seam for this reason.
+    from core_api.services import memory_service
+
+    tenant_id, _, nonce, _peer, attacker = await _setup(client, sc)
+    as_auth(tenant_id, attacker)
+
+    seen: dict = {}
+
+    async def _capture(*args, **kwargs):
+        seen.update(kwargs)
+        return []
+
+    monkeypatch.setattr(memory_service, "search_memories", _capture)
+
+    resp = await client.post(
+        "/api/v1/recall",
+        json={"tenant_id": tenant_id, "query": nonce},  # no filter, no caller
+    )
+    assert resp.status_code == 200, resp.text
+    assert seen, "search_memories was never reached — test is vacuous"
+    assert seen.get("caller_agent_id") == attacker, (
+        "an omitted filter did not bind to the authenticated agent: "
+        f"caller_agent_id={seen.get('caller_agent_id')!r}, expected {attacker!r}"
+    )
+    # The filter itself must stay absent — binding the identity must not
+    # silently narrow the result set to the agent's own rows.
+    assert seen.get("filter_agent_id") is None, (
+        f"identity binding leaked into the filter: {seen.get('filter_agent_id')!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # M-30 — caller_agent_id is honoured, not dropped
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds the one test #1268 should have had, from [@zznate](https://github.com/zznate)'s [#995](https://github.com/caura-ai/caura/pull/995).

## The gap

#1268 fixed `/recall`'s identity resolution and shipped five tests. **Every one of them names an identity explicitly** — a spoofed `filter_agent_id`, a spoofed `caller_agent_id`, an agent naming itself, a tenant key naming a peer, `caller_agent_id` honoured. So the **default path went unpinned**: no filter, no caller id, just an ordinary recall.

That is also the worse of the two consequences in the original report ([#994](https://github.com/caura-ai/caura/issues/994)), because it needs no crafted request. Pre-fix, `caller_agent_id=body.filter_agent_id` meant an omitted filter passed `None` — the tenant-wide visibility a tenant credential gets — and the trust<2 fleet forcing sat inside `if body.filter_agent_id:`, so it did not run either. A trust-1 agent issuing the most ordinary possible recall read across fleets.

The behaviour is correct on `main` today. It just was not held there by anything.

## Confirmed, not assumed

Reverting only the `/recall` callsite to the pre-fix derivation:

```
AssertionError: an omitted filter did not bind to the authenticated agent:
  caller_agent_id=None, expected 'agent-a-5f54f57c'
```

`None` is precisely the tenant-wide identity the finding described.

## Asserted on arguments, not on results

The test captures what reaches `search_memories` rather than comparing result sets. A results-parity assertion cannot separate *"bound to the caller"* from *"happened to return the same rows"* — an unbound read coincides with a bound one whenever the caller has nothing hidden from it, and then the assertion passes while the identity is still wrong.

## The patch seam is the interesting part

`/recall` re-imports the function **inside the handler**:

```python
from core_api.services.memory_service import search_memories
```

So it resolves the name at call time from the service module and never sees a patch applied to the route module's own binding — which is the one `/search` uses. Patching the route seam silently no-ops: the real search runs and the assertions then read whatever that call left behind.

**My first attempt did exactly that** and passed for the wrong reason until the removal probe exposed it. #995 patched the `memory_service` seam from the start. Their choice was right where mine was wrong, and there is now a comment on the test saying why, so the next person does not re-learn it.

## Attribution

The case and the argument-level assertion are @zznate's, from #995 — their fix for their own report in #994. #1268 landed the shared resolver first and closed a vector #995 did not (a spoofed `caller_agent_id`, which `/recall` accepts because it parses `SearchRequest`), which is why #995 is superseded rather than merged. This test is not.

## Verification

- Full root suite: **6049 passed, 5 skipped, 1 xfailed, 0 failed**, run as `.venv/bin/python -m pytest`. The diff is one new test function.
- `ruff check` and `ruff format --check` at CI's `tests/` scope — clean.
- `legacy_name_ratchet.py` → *No new lines.* · `do_not_touch_sentinel.py` → *All 39 protected strings survive.* Both after `git add`.
- Branched fresh from `origin/main` at `7c94e1db`.
- Test-only, so `claude-review`'s source-file filter will skip this PR by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
