### PR TITLE
fix(usage): stop metering bulk writes that wrote nothing

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1370,14 +1370,12 @@ async def _write_memories_bulk_inner(
     )
     if not body.fleet_id and agent.get("fleet_id"):
         body.fleet_id = agent["fleet_id"]
-    usage = None
-    if auth.tenant_id:  # skip enforcement + metering for admin
+    if auth.tenant_id:  # skip enforcement for admin
         await enforce_fleet_write(body.tenant_id, body.agent_id, body.fleet_id)
-        usage = await bulk_check_and_increment(body.tenant_id, len(body.items))
-    if usage:
-        response.headers["X-RateLimit-Limit"] = str(usage.get("limit", "unlimited"))
-        response.headers["X-RateLimit-Remaining"] = str(usage.get("remaining", "unlimited"))
 
+    # Metering deliberately does NOT happen here — see after the write. This
+    # used to be ``usage = await bulk_check_and_increment(...)`` on this line,
+    # before the try, and no failure path gave it back.
     try:
         result = await asyncio.wait_for(
             create_memories_bulk(body, bulk_attempt_id=bulk_attempt_id),
@@ -1509,6 +1507,32 @@ async def _write_memories_bulk_inner(
                 "Retry-After": str(app_settings.storage_network_error_retry_after_seconds),
             },
         )
+
+    # Meter here, AFTER the write, because every failure path above raises and
+    # so charges nothing. Charging up front meant a batch that wrote nothing was
+    # billed anyway, and the retry contract makes that compound rather than
+    # merely round: core-api answers a storage failure by telling the client to
+    # retry with the same ``X-Bulk-Attempt-Id``, so one un-writable batch was
+    # charged once per attempt, indefinitely. Measured on the 2026-09-02
+    # incident: ~648 attempts/hour for 41 hours against a 100-item batch that
+    # never wrote a row.
+    #
+    # Nothing here is an enforcement gate, which is what makes moving it safe.
+    # ``allowed`` has no reader in core-api (see ``usage_service._meter``) —
+    # enforcement travels via ``x-org-read-only`` — so this call only records.
+    # ``enforce_fleet_write`` above IS a gate and stays before the write.
+    #
+    # Still ``len(body.items)`` rather than ``result.created``, deliberately.
+    # That keeps the amount charged for a successful batch identical to before,
+    # so this fixes charging on FAILURE and is not a repricing of per-item
+    # duplicates or errors. Those are a billing decision, and
+    # ``meters_mcp_bulk_write``'s docstring is the precedent for treating one as
+    # such rather than shipping it as a deploy side effect.
+    if auth.tenant_id:
+        usage = await bulk_check_and_increment(body.tenant_id, len(body.items))
+        if usage:
+            response.headers["X-RateLimit-Limit"] = str(usage.get("limit", "unlimited"))
+            response.headers["X-RateLimit-Remaining"] = str(usage.get("remaining", "unlimited"))
 
     bulk_resp = _bulk_response(result)
     if idem:

--- a/tests/test_bulk_atomicity.py
+++ b/tests/test_bulk_atomicity.py
@@ -827,6 +827,143 @@ async def test_unmarked_storage_500_still_advises_retry(client, monkeypatch):
     assert "X-Bulk-Attempt-Id" in resp.json()["detail"]
 
 
+# ── A batch that wrote nothing must not be metered ──
+#
+# Charging up front is round-trip-neutral for a one-off failure but compounds
+# under the retry contract: core-api answers a storage failure by telling the
+# client to retry with the same X-Bulk-Attempt-Id, so one un-writable batch was
+# charged once per attempt, indefinitely. On the 2026-09-02 incident that ran at
+# ~648 attempts/hour for 41 hours against a 100-item batch that never wrote a
+# row.
+
+
+def _as_tenant(monkeypatch, tenant_id):
+    """Run the route under a TENANT-scoped credential rather than the admin key.
+
+    Load-bearing for every metering assertion below. ``get_test_auth()`` returns
+    the ADMIN key, which yields ``AuthContext(tenant_id=None)``, and the bulk
+    route guards metering with ``if auth.tenant_id:`` — so under the default
+    fixture the meter is never called at all and a "was not metered" assertion
+    passes no matter what the code does. The first draft of these tests did
+    exactly that: two of them went green against the unfixed route.
+
+    ``monkeypatch.setitem`` so the override is torn down with the test.
+    """
+    from core_api.app import app
+    from core_api.auth import AuthContext, get_auth_context
+
+    monkeypatch.setitem(
+        app.dependency_overrides,
+        get_auth_context,
+        lambda: AuthContext(tenant_id=tenant_id, org_role="admin"),
+    )
+
+
+def _metering_recorder(monkeypatch):
+    """Record calls to the route's metering call, returning the call list.
+
+    Patches the ROUTE module's binding, not ``usage_service``'s: the route does
+    ``from ... import bulk_check_and_increment`` at module load, so rebinding
+    the source module would leave the route holding the original — the same trap
+    ``test_bulk_budget_burn_returns_504_with_retry_hint`` documents for
+    ``create_memories_bulk``.
+    """
+    from core_api.routes import memories as routes_mem
+
+    calls: list[tuple[str, int]] = []
+
+    async def recorder(tenant_id, count):
+        calls.append((tenant_id, count))
+        return None
+
+    monkeypatch.setattr(routes_mem, "bulk_check_and_increment", recorder)
+    return calls
+
+
+async def test_a_permanently_failed_bulk_write_is_not_metered(client, monkeypatch):
+    """Nothing was written, so nothing may be charged."""
+    _as_tenant(monkeypatch, "default")
+    calls = _metering_recorder(monkeypatch)
+    _serving(_permanent_response(), monkeypatch)
+
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"meter-perm-{uid()}",
+        "items": [{"content": f"meter-perm-content-{uid()}"}],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("meter-perm")},
+    )
+
+    assert resp.status_code == 500
+    assert calls == [], f"a batch that wrote nothing was metered: {calls}"
+
+
+async def test_a_bulk_write_that_504s_is_not_metered(client, monkeypatch):
+    """The incident's own shape: storage 5xx mapped to a retryable 504.
+
+    This is the one that compounded — the client is told to retry, so charging
+    here bills the same never-written batch once per attempt.
+    """
+    import httpx
+
+    _as_tenant(monkeypatch, "default")
+    calls = _metering_recorder(monkeypatch)
+    request = httpx.Request("POST", "https://storage.local/memories/bulk")
+    _serving(
+        httpx.Response(500, request=request, json={"detail": "Internal Server Error"}),
+        monkeypatch,
+    )
+
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"meter-504-{uid()}",
+        "items": [{"content": f"meter-504-content-{uid()}"}],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("meter-504")},
+    )
+
+    assert resp.status_code == 504
+    assert calls == [], f"a batch that wrote nothing was metered: {calls}"
+
+
+async def test_a_successful_bulk_write_is_still_metered_per_item(client, monkeypatch):
+    """The control, and the one that stops this becoming a free-writes bug.
+
+    Deleting the charge would satisfy both tests above. This asserts the
+    successful path still bills, and still bills ``len(items)`` — the amount is
+    unchanged, so the fix is about charging on failure and not a repricing.
+    """
+    _as_tenant(monkeypatch, "default")
+    calls = _metering_recorder(monkeypatch)
+
+    tenant_id, headers = get_test_auth()
+    body = {
+        "tenant_id": tenant_id,
+        "agent_id": f"meter-ok-{uid()}",
+        "items": [
+            {"content": f"meter-ok-alpha-{uid()}"},
+            {"content": f"meter-ok-beta-{uid()}"},
+            {"content": f"meter-ok-gamma-{uid()}"},
+        ],
+    }
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json=body,
+        headers={**headers, "X-Bulk-Attempt-Id": _attempt_id("meter-ok")},
+    )
+
+    assert resp.status_code == 200
+    assert calls == [(tenant_id, 3)]
+
+
 async def test_storage_network_error_returns_503_with_retry_after(client, monkeypatch):
     """A network-level error reaching storage (DNS, connect refused, broken
     pipe) maps to 503 + ``Retry-After`` for clean client backoff."""


### PR DESCRIPTION
Follow-up to #1274, from measuring the same incident's blast radius against production.

## The defect

`bulk_check_and_increment(body.tenant_id, len(body.items))` ran **before** the write, and no failure path gave it back. A batch that persisted nothing was billed for every item in it.

On its own that would round out over time. The retry contract makes it compound instead: core-api answers a storage failure by telling the client to retry with the same `X-Bulk-Attempt-Id`, so **one un-writable batch is charged once per attempt, indefinitely.**

Measured on the 2026-09-02 bulk incident: ~648 attempts/hour for 41 hours against a 100-item batch that could never compile. On the order of **2.7M metered write units for zero rows**, against a tenant whose real write rate is ~150/hour.

## The change

Metering moves to after the write. Every failure path raises before it, so a failed batch now charges nothing.

**Safe to move because nothing here gates.** `allowed` has no reader in core-api — `usage_service._meter`'s own docstring says so, and notes that enforcement travels via `x-org-read-only` instead — so this call only records. `enforce_fleet_write` *is* a gate and stays where it was, ahead of the write.

**Not a repricing.** Still `len(body.items)` rather than `result.created`, deliberately: the amount charged for a *successful* batch is byte-identical to before. This fixes charging on failure and nothing else. Whether per-item duplicates and per-item errors should be charged is a billing decision, and `meters_mcp_bulk_write`'s docstring is the standing precedent in this file for not shipping one as a deploy side effect.

**Idempotent replays are unaffected.** They return at the `cached_replay` check before this function is entered, so they are neither charged twice nor newly charged — and the comment there ("Replays bypass the per-tenant slot and the bulk quota-increment") stays accurate.

## The tests needed fixing before they meant anything

Worth calling out, because the first version of them was worthless.

`get_test_auth()` returns the **admin** API key, which yields `AuthContext(tenant_id=None)`, and the route guards metering with `if auth.tenant_id:`. So under the default fixture the meter is never called at all, and a "was not metered" assertion passes regardless of what the code does. Two of these tests were green against the unfixed route.

They now override `get_auth_context` to supply a tenant-scoped credential. With that override they fail without the fix, reporting the batch metered as `[('default', 1)]`. Verified by reverting the route change and watching them go red.

The third test is the control: a successful batch must still bill, and still bill `len(items)`. Deleting the charge outright would satisfy the other two, so without this one the "fix" could ship as a free-writes bug.

## Verification

25 tests in `tests/test_bulk_atomicity.py` pass. `ruff check` and `ruff format --check` clean at CI's exact separate scopes; `mypy` clean on `core-api/src`.

No regressions, by the same method as #1274 — revert, run the full suite, save the sorted failure names, restore, re-run, diff: **identical failure sets, 18 both ways**. Those 18 are environmental (the root conftest provisions via `create_all`, so migration 034's tsvector trigger is absent and FTS scores come back `None`), not properties of the codebase.

## Not addressed here

The ~2.7M units already recorded are historical and this change does not retract them. If that counter feeds over-plan enforcement or invoicing for `arkash24-4d270c`, it needs a separate correction — flagging rather than fixing, because retracting recorded usage is a billing action, not a code one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
