### PR TITLE
fix(autochunk): degrade a failed child embed instead of 500ing a persisted write

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -296,10 +296,18 @@ def _drop_duplicate_facts(
       discard would be the dominant cost of deduping at all.
 
     Dropping rather than collapsing-and-reporting is deliberate: these children
-    are derived rows, not caller-submitted items. Nothing upstream holds an
-    index into them — both auto-chunk handlers discard ``create_memories``'
-    return value entirely — so there is no per-item result to point at a
-    survivor, and the parent memory is what the caller gets back either way.
+    are derived rows, not caller-submitted items. Nothing the CALLER holds
+    indexes into them — the parent memory is what a caller gets back either
+    way — so there is no per-item result to point at a survivor.
+
+    Both auto-chunk handlers do now consume ``create_memories``' return value
+    (H-09, to queue a re-embed for a child that landed unembedded), which an
+    earlier version of this docstring cited as "discarded entirely". That does
+    not reopen the question: the results are joined by ``client_request_id``,
+    which each surviving payload carries, so a fact dropped HERE — before any
+    payload is built — simply has no entry to be misaligned against. It is a
+    positional index into the pre-dedup facts that this ordering would break,
+    and nothing takes one.
     """
     kept: list[dict] = []
     seen: set[str] = set()
@@ -345,8 +353,24 @@ async def _insert_children_or_degrade(
     tenant_id: str,
     parent_id: str,
     source: str,
-) -> None:
+) -> list[dict] | None:
     """Insert auto-chunk children; a duplicate refusal degrades, never raises.
+
+    Returns ``create_memories``' per-item results — one entry per input
+    payload, each carrying its ``client_request_id`` and its ``id``, the
+    latter populated whether or not this attempt was the one that committed
+    the row. Callers need them to queue a re-embed for a child inserted
+    without a vector.
+
+    ``None`` means NOTHING WAS WRITTEN by this call (the duplicate refusal
+    below); ``[]`` means there was nothing to write. The distinction is not
+    cosmetic — see :func:`_queue_child_reembeds`, which must not report N
+    unrepairable rows for a batch that never reached the table.
+
+    Consumers pair results to payloads by ``client_request_id`` rather than by
+    position — see ``_queue_child_reembeds``. The order IS input order, but
+    describing the return by its order invites a positional join, and the
+    mispairing that would cause on this path is silent.
 
     The parent row is ALREADY COMMITTED by the time this runs. Raising here would
     hand the caller a 500 for a write that persisted, and leave the parent
@@ -370,10 +394,10 @@ async def _insert_children_or_degrade(
     and the storage-side statement would build an INSERT with no VALUES.
     """
     if not payloads:
-        return
+        return []
     async with per_tenant_storage_slot("storage_write", tenant_id):
         try:
-            await get_storage_client().create_memories(payloads)
+            return await get_storage_client().create_memories(payloads)
         except DuplicateMemoryError:
             logger.warning(
                 "auto-chunk children refused as duplicates; parent kept without them",
@@ -382,6 +406,230 @@ async def _insert_children_or_degrade(
                     "parent_memory_id": parent_id,
                     "children_dropped": len(payloads),
                 },
+            )
+            # ``None``, NOT ``[]``: nothing was written by this call, which is a
+            # different fact from "written, and here are the results". The repair
+            # loop has to tell them apart — an empty RESULT list against a
+            # non-empty payload list is a broken contract worth shouting about,
+            # while this case is already fully explained by the warning above.
+            return None
+
+
+async def _embed_children_or_degrade(
+    child_texts: list[str],
+    tenant_config,
+    *,
+    parent_id: str,
+) -> list[list[float] | None]:
+    """Batch-embed auto-chunk children; a provider failure degrades, never raises.
+
+    Audit H-09. ``get_embeddings_batch`` raises on every provider-side error,
+    gate saturation, quota and misconfig — its own docstring notes that both
+    bulk callers wrap it. Both auto-chunk callers run it AFTER the parent row
+    is committed and OUTSIDE the request's ``try/finally``, so an escaping
+    exception produced:
+
+      - silent data loss: no children written, while the parent's metadata
+        claimed ``auto_chunked`` and ``child_count=N``, leaving the source
+        document unrecallable and nothing recording why;
+      - no backfills: parent enrich, entity extraction and parent embed all
+        sit below this call, so a parent inserted with ``embedding=None``
+        stayed unembedded — the 2026-07-27 stranded-rows shape;
+      - a PERMANENT wedge, the part that made it unrecoverable: the retry
+        re-chunks, hits the same full-document ``content_hash``, and migration
+        040's live-row uniqueness answers 409 against the childless parent.
+        The children could never be written without deleting the parent by
+        hand.
+
+    Two asymmetries settle the policy. The parent's own embed already degrades
+    to ``None`` on these same failures, so the parent commits unembedded rather
+    than failing; and the child INSERT already degrades for this exact reason —
+    see :func:`_insert_children_or_degrade`. The child EMBED between them was
+    the only step that still raised.
+
+    Deliberately NOT mode-dependent like the bulk path, which fails the request
+    under ``inline_embedding``. There nothing has persisted when the embed
+    fails, so refusing is clean. Here the parent is committed, which inverts
+    the trade: refusing loses the children AND wedges every retry, while
+    degrading keeps the facts and leaves a repair queued.
+
+    SHARED by the pipeline and legacy handlers on purpose. The legacy path is
+    dormant, not dead — the flag at the top of this module documents flipping
+    it as the emergency-rollback lever — and an emergency rollback is
+    plausibly happening BECAUSE something is degraded, which is the same
+    condition that trips this. Two copies of a degrade policy is how the two
+    paths diverge; one is how they cannot.
+    """
+    try:
+        return await get_embeddings_batch(child_texts, tenant_config, background=False)
+    except Exception:
+        logger.warning(
+            # Conditional throughout, and BOTH clauses had to become so. This
+            # fires before the insert has been attempted, so it knows only that
+            # the embed failed: a duplicate refusal writes nothing, and a child
+            # returned without a usable id gets no repair. Neither "persisting"
+            # nor "a re-embed queued" is a fact here, and stating either as one
+            # would be this module's own bug class in a log line — the first
+            # draft fixed the second clause and left the first asserting the
+            # same thing one clause earlier.
+            "auto-chunk child embed failed after the parent committed; "
+            "%d child(ren) will be inserted unembedded if the write proceeds — "
+            "a re-embed is queued for each one that lands with a usable id",
+            len(child_texts),
+            extra={"parent_memory_id": parent_id, "child_count": len(child_texts)},
+            exc_info=True,
+        )
+        return [None] * len(child_texts)
+
+
+def _mark_child_embedding_pending(child_meta: dict, child_embedding) -> None:
+    """Flag a child that is persisting without a vector.
+
+    ``embedding_pending`` is public API, not bookkeeping: ``MemoryOut.metadata``
+    documents an ABSENT flag as "that stage ran inline", so omitting it here
+    would state the opposite of the truth and make these rows
+    indistinguishable from fully-embedded ones to every consumer. Same flag the
+    atomic-fact fan-out sets, for the same reason.
+    """
+    if child_embedding is None:
+        child_meta["embedding_pending"] = True
+
+
+def _queue_child_reembeds(
+    child_payloads: list[dict],
+    child_results: list[dict] | None,
+    *,
+    tenant_id: str,
+    parent_id: str,
+) -> None:
+    """Queue a re-embed for every child that landed without a vector.
+
+    Only does anything when the embed above degraded; the healthy path leaves
+    this with nothing to do, which matters because the alternative would queue
+    N pointless tasks on every ordinary auto-chunk write.
+
+    ``child_results is None`` means the insert wrote NOTHING (duplicate
+    refusal), and this returns silently. Every payload would otherwise fall
+    through to the no-id branch below and report N rows "persisted unembedded"
+    that were never persisted at all — false alarms whose most likely moment is
+    the retry-after-degradation case this whole fix targets, telling an on-call
+    engineer to hunt for orphaned rows that do not exist. The refusal already
+    has its own WARNING, with the count, in
+    :func:`_insert_children_or_degrade`.
+
+    Scheduled explicitly rather than left to the nightly sweep: the sweep is
+    gated on ``embed_backfill_enabled``, which defaults FALSE, and a deployment
+    that never enabled it is how ~430 memories were stranded in the 2026-07-27
+    incident this module already carries a postmortem for.
+    ``_schedule_embed_or_reembed`` publishes EMBED_REQUESTED in deferred mode
+    and retries in-process otherwise, so it covers both.
+
+    Payloads are joined to results by ``client_request_id``, NOT by position,
+    mirroring ``create_memories_bulk``. Position would in fact work today —
+    ``memory_add_all`` builds its response by iterating the input and looking
+    each id up in a dict, so "one entry per item in input order" is guaranteed
+    by construction rather than merely documented. The join is what makes that
+    guarantee stop mattering, and it is free: ``client_request_id`` is
+    MANDATORY on every item (``memory_add_all`` refuses a batch without it),
+    so there is no case where the key is absent to key on.
+
+    Worth the paranoia because of what this loop does with the pairing rather
+    than how likely it is to break. A mispaired entry does not drop a repair —
+    it embeds THIS payload's text and persists the vector against ANOTHER
+    child's row, leaving that row's embedding silently inconsistent with its
+    own stored content. That is a recall-quality corruption with no error and
+    no log, on a path that only runs when the provider is already degraded.
+    A missing entry now takes the loud no-id branch instead of shifting every
+    subsequent pair by one.
+
+    NOTHING here may raise. This runs after the parent AND the children are
+    committed, so an escaping exception would answer a fully-persisted write
+    with a 500 — the exact H-09 shape, moved from the embed step to the repair
+    step. The scheduling is guarded per child, so one bad id costs one
+    unrepaired row rather than the whole sweep.
+    """
+    if child_results is None:
+        return
+    if child_payloads and not child_results:
+        # Rows went to the table and the insert reported on none of them — a
+        # broken contract, not a per-child outcome, so it gets ONE line rather
+        # than N. Distinct from the ``None`` above, which is the honest
+        # "nothing was written" answer.
+        logger.error(
+            "auto-chunk insert returned no per-item results for %d child(ren) of "
+            "parent %s; NO re-embed scheduled for any of them",
+            len(child_payloads),
+            parent_id,
+        )
+        return
+    by_request_id = {
+        r["client_request_id"]: r for r in child_results if isinstance(r, dict) and r.get("client_request_id")
+    }
+    for payload in child_payloads:
+        if payload.get("embedding") is not None:
+            continue
+        # ``.get``, not ``[]``: a payload without a request id cannot be joined
+        # to anything, so it belongs in the no-id branch below rather than
+        # raising a KeyError out of a request whose rows are already committed.
+        request_id = payload.get("client_request_id")
+        result = by_request_id.get(request_id) if request_id else None
+        child_id = result.get("id") if isinstance(result, dict) else None
+        if not child_id:
+            # Loud, and deliberately not folded in with the repaired ones: this
+            # row is unembedded with NO repair queued, which is strictly worse
+            # than the counted case, and only the off-by-default sweep would
+            # ever find it. Logs the response SHAPE, never the response —
+            # ``result`` belongs to a row carrying the fact text, so
+            # interpolating it would put memory content, and any PII in it,
+            # into an ERROR log. The request id is safe to name and is the only
+            # handle on WHICH child this was: it is ``auto-chunk:<uuid4>``,
+            # minted server-side, and derived from nothing the caller sent.
+            logger.error(
+                "auto-chunk child persisted unembedded but the bulk insert returned "
+                "no usable id (request_id=%s, result keys: %s) for parent %s; "
+                "NO re-embed scheduled",
+                request_id,
+                sorted(result) if isinstance(result, dict) else type(result).__name__,
+                parent_id,
+            )
+            continue
+        try:
+            child_uuid = UUID(str(child_id))
+            track_task(
+                tracked_task(
+                    _schedule_embed_or_reembed(
+                        child_uuid,
+                        payload["content"],
+                        tenant_id,
+                        content_hash=payload["content_hash"],
+                        is_failure_fallback=True,
+                    ),
+                    "embed_or_publish",
+                    # The CHILD, not the parent: a backfill logged against the
+                    # wrong row repairs nothing and misdirects the operator.
+                    child_uuid,
+                    tenant_id,
+                )
+            )
+        except Exception:
+            # This whole helper runs AFTER the rows are committed, which is the
+            # invariant H-09 is about — so the repair step must not be the thing
+            # that raises. ``UUID(str(child_id))`` is the concrete way it could:
+            # a storage id that stopped being a UUID string would take a request
+            # whose parent and children all persisted and answer it 500, which
+            # is the defect this PR removes, moved one step later. Same shape as
+            # the audit-hook guard a few lines below the call sites.
+            #
+            # PER-CHILD rather than around the loop, and that is the point: a
+            # catch outside would let one malformed id cancel the repairs for
+            # every other child, turning one unrepaired row into N. Logged with
+            # the request id and never the payload, which holds the fact text.
+            logger.error(
+                "auto-chunk child re-embed could not be scheduled "
+                "(request_id=%s) for parent %s; this row stays unembedded",
+                request_id,
+                parent_id,
+                exc_info=True,
             )
 
 
@@ -933,7 +1181,12 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
         child_texts = [fact["content"] for fact in facts]
         # Auto-chunk children of a synchronous create: same priority as the
         # parent embed, which is already background=False.
-        child_embeddings = await get_embeddings_batch(child_texts, tenant_config, background=False)
+        #
+        # Degrades rather than raising — the parent is already committed. See
+        # ``_embed_children_or_degrade``, shared with the legacy handler.
+        child_embeddings = await _embed_children_or_degrade(
+            child_texts, tenant_config, parent_id=str(parent_id)
+        )
 
         child_payloads = []
         for fact, child_embedding in zip(facts, child_embeddings):
@@ -946,6 +1199,7 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
             # parent row, so the children cannot end up labelled differently
             # from the row they were cut out of.
             _inherit_governance_signals(child_meta, parent_metadata)
+            _mark_child_embedding_pending(child_meta, child_embedding)
             child_payloads.append(
                 {
                     "tenant_id": data.tenant_id,
@@ -968,11 +1222,20 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
         # Auto-chunk children — second storage roundtrip in this request after
         # the parent insert above. The parent is committed, so a refusal here
         # degrades rather than raising; see ``_insert_children_or_degrade``.
-        await _insert_children_or_degrade(
+        child_results = await _insert_children_or_degrade(
             child_payloads,
             tenant_id=data.tenant_id,
             parent_id=str(parent_id),
             source="auto_chunk",
+        )
+
+        # Queue a repair for any child that landed without a vector; a no-op on
+        # the healthy path. Shared with the legacy handler.
+        _queue_child_reembeds(
+            child_payloads,
+            child_results,
+            tenant_id=data.tenant_id,
+            parent_id=str(parent_id),
         )
 
         # #856: the two deferred-path backfills. Until this, the multi-fact exit
@@ -1304,11 +1567,26 @@ async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:
             child_texts = [fact["content"] for fact in facts]
             # Auto-chunk children of a synchronous create — see the sibling
             # call in the ctx-based auto-chunk handler.
-            child_embeddings = await get_embeddings_batch(child_texts, tenant_config, background=False)
+            #
+            # Same degrade as the pipeline path, via the same helper. This path
+            # is dormant rather than dead: the flag at the top of this module
+            # documents flipping it as the emergency-rollback lever, and an
+            # emergency rollback is plausibly happening BECAUSE something is
+            # degraded — the same condition that trips H-09. Leaving the defect
+            # here would have meant it resurfacing during exactly the incident
+            # that lever exists for.
+            child_embeddings = await _embed_children_or_degrade(
+                child_texts, tenant_config, parent_id=str(parent_id)
+            )
 
             child_payloads = []
             for fact, child_embedding in zip(facts, child_embeddings):
                 child_ch = _content_hash(data.tenant_id, data.fleet_id, fact["content"])
+                child_meta = {
+                    "parent_memory_id": str(parent_id),
+                    "source": "auto_chunk",
+                }
+                _mark_child_embedding_pending(child_meta, child_embedding)
                 child_payloads.append(
                     {
                         "tenant_id": data.tenant_id,
@@ -1320,10 +1598,7 @@ async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:
                         "weight": weight,
                         "source_uri": data.source_uri,
                         "run_id": data.run_id,
-                        "metadata_": {
-                            "parent_memory_id": str(parent_id),
-                            "source": "auto_chunk",
-                        },
+                        "metadata_": child_meta,
                         "content_hash": child_ch,
                         "client_request_id": _auto_chunk_request_id(),
                         "expires_at": data.expires_at.isoformat() if data.expires_at else None,
@@ -1334,11 +1609,17 @@ async def _create_memory_legacy(data: MemoryCreate) -> MemoryOut:
             # Legacy-path auto-chunk children. See
             # ``_handle_auto_chunk_from_ctx`` for the pipeline-path equivalent;
             # the parent is committed here too, so the same degrade applies.
-            await _insert_children_or_degrade(
+            child_results = await _insert_children_or_degrade(
                 child_payloads,
                 tenant_id=data.tenant_id,
                 parent_id=str(parent_id),
                 source="auto_chunk_legacy",
+            )
+            _queue_child_reembeds(
+                child_payloads,
+                child_results,
+                tenant_id=data.tenant_id,
+                parent_id=str(parent_id),
             )
 
             if tenant_config.entity_extraction_enabled:
@@ -2119,9 +2400,22 @@ async def create_memories_bulk(
                 ) from exc
 
         # Map each storage result back to its source item via
-        # ``client_request_id``. Postgres ``RETURNING`` order is
-        # unspecified for ``ON CONFLICT DO NOTHING``, so we never
-        # zip on positional index.
+        # ``client_request_id``, never by positional index.
+        #
+        # The reason is NOT that this list arrives in an arbitrary order.
+        # Postgres ``RETURNING`` order is indeed unspecified under
+        # ``ON CONFLICT DO NOTHING``, but ``memory_add_all`` absorbs that: it
+        # collects RETURNING into a dict and then builds its response by
+        # iterating the INPUT, so "one entry per item in input order" holds by
+        # construction and is documented at all three layers it crosses. This
+        # comment used to attribute the join to the raw SQL behaviour, which
+        # reads as a claim that the RESPONSE is unordered — it is not, and a
+        # reviewer took the mismatch for a bug in a sibling caller.
+        #
+        # The join stays regardless, because it makes the guarantee stop
+        # mattering across a service boundary we do not deploy in lockstep,
+        # and because ``client_request_id`` is mandatory on every item, so it
+        # costs nothing.
         by_request_id = {r["client_request_id"]: r for r in storage_results}
 
         # Track the (orig_idx, mem_data, mem_id) trios for the

--- a/tests/test_h09_autochunk_embed_degrade.py
+++ b/tests/test_h09_autochunk_embed_degrade.py
@@ -1,0 +1,590 @@
+"""H-09 — the auto-chunk child embed raised after the parent had committed.
+
+``_handle_auto_chunk_from_ctx`` commits the parent, then batch-embeds the
+children. ``get_embeddings_batch`` raises on every provider-side error, gate
+saturation, quota and misconfig — its own docstring notes both bulk callers
+wrap it — and this third caller did not. The call also sits OUTSIDE the
+request's ``try/finally``, because the auto-chunk branch returns before that
+block is entered, so the exception escaped as an error response for a write
+that had already persisted:
+
+* the parent's metadata claimed ``auto_chunked`` and ``child_count=N`` while
+  zero children existed, so the facts were silently lost and the source
+  document was unrecallable;
+* none of the backfills below the embed ran — parent enrich, entity
+  extraction, parent embed — so a parent inserted with ``embedding=None``
+  stayed unembedded;
+* and the retry WEDGED. Re-chunking produces the same full-document
+  ``content_hash``, migration 040's live-row uniqueness answers 409 against
+  the childless parent, and the children could never be written without
+  deleting the parent by hand.
+
+Two asymmetries make it unambiguous rather than a judgement call. The parent's
+own embed already degrades to ``None`` on these same failures. And the child
+INSERT one line later already degrades for precisely this reason — its
+docstring reads "the parent row is ALREADY COMMITTED... raising here would hand
+the caller a 500 for a write that persisted". The child EMBED between them was
+the only step that still raised.
+
+The fix degrades: children persist unembedded, carry ``embedding_pending``, and
+each gets a re-embed queued. Deliberately NOT mode-dependent like the bulk
+path, which fails the request under ``inline_embedding`` — there nothing has
+persisted when the embed fails, so refusing is clean; here the parent is
+committed, which inverts the trade.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core_api.clients.storage_client import DuplicateMemoryError
+from core_api.schemas import MemoryCreate
+from core_api.services import memory_service
+from core_api.services.organization_settings import ResolvedConfig
+
+pytestmark = [pytest.mark.unit]
+
+TENANT = "t-h09"
+FLEET = "f1"
+AGENT = "a"
+CHUNKS = ("chunk one", "chunk two", "chunk three")
+
+
+class EmbedDown(RuntimeError):
+    """Stands in for the whole class: provider error, gate timeout, quota, misconfig."""
+
+
+def _parent_row() -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "tenant_id": TENANT,
+        "fleet_id": FLEET,
+        "agent_id": AGENT,
+        "memory_type": "fact",
+        "title": None,
+        "content": "body",
+        "weight": 0.5,
+        "status": "active",
+        "visibility": "scope_team",
+        "recall_count": 0,
+        "created_at": datetime(2026, 9, 4, tzinfo=UTC),
+        "metadata_": {},
+        "embedding": None,
+        "deleted_at": None,
+    }
+
+
+async def _noop() -> None:
+    """A real coroutine, so ``tracked_task``'s ``coro.close()`` stays honest."""
+    return None
+
+
+class _Run:
+    def __init__(self) -> None:
+        self.parent_id = ""
+        self.children: list[dict] = []
+        self.tasks: list[tuple[str, str]] = []
+        self.raised: BaseException | None = None
+        # crid -> the id the fake bulk insert assigned to that payload.
+        self.assigned_ids: dict[str, str] = {}
+        # (memory_id, content, content_hash) per scheduled re-embed, captured at
+        # CALL time — the coroutine is never awaited, so an async double would
+        # record nothing.
+        self.reembeds: list[tuple[str, str, str]] = []
+
+    @property
+    def labels(self) -> set[str]:
+        return {label for label, _ in self.tasks}
+
+    def scheduled_for(self, label: str) -> set[str]:
+        return {mid for lbl, mid in self.tasks if lbl == label}
+
+
+async def _run(
+    *,
+    embed_raises: bool,
+    return_ids: bool = True,
+    inline: bool = True,
+    legacy: bool = False,
+    rotate_results: bool = False,
+    duplicate_refusal: bool = False,
+    bad_id_index: int | None = None,
+) -> _Run:
+    """Drive the multi-fact auto-chunk exit.
+
+    ``embed_raises`` makes the CHILD batch embed fail the way a degraded
+    provider does. ``return_ids`` controls whether the bulk insert reports a
+    usable id per row, which is the difference between a queued repair and the
+    loud no-id log. ``legacy`` flips ``_USE_PIPELINE_WRITE`` and enters through
+    ``create_memory``, so the rollback path is exercised through the real
+    dispatch rather than by calling its private handler.
+
+    ``rotate_results`` returns the bulk-insert results in an order that matches
+    no payload position, to pin the payload-to-result join. Storage guarantees
+    input order today, so this is a contract-drift probe rather than a
+    reproduction of live behaviour — see the shuffled-order test.
+
+    ``duplicate_refusal`` makes the child insert answer migration 040's 409, so
+    NOTHING is written. Combined with ``embed_raises`` it reproduces the
+    retry-after-degradation case: the provider is still down and the children
+    already exist from an earlier attempt.
+
+    ``bad_id_index`` gives ONE child a truthy but unparseable id, so it clears
+    the no-id branch and reaches ``UUID()``. One rather than all, so the test
+    can tell a per-child guard from one wrapped around the whole loop.
+    """
+    run = _Run()
+    parent_row = _parent_row()
+    run.parent_id = parent_row["id"]
+
+    sc = AsyncMock(name="storage_client")
+    sc.create_memory = AsyncMock(return_value=parent_row)
+    sc.bulk_find_by_content_hashes = AsyncMock(return_value={})
+    # The legacy path runs a dedup pre-check the pipeline path does not. A bare
+    # AsyncMock answers it with a truthy mock, which the handler reads as "this
+    # content already exists" and 409s before ever reaching the embed — so
+    # without this the legacy tests fail on a duplicate that does not exist.
+    sc.find_by_content_hash = AsyncMock(return_value=None)
+
+    async def _create_memories(payloads):
+        if duplicate_refusal:
+            raise DuplicateMemoryError("a live row already holds this content")
+        # Mirrors the documented contract: one entry per input payload,
+        # ``id`` populated regardless of who committed the row.
+        out = []
+        for i, p in enumerate(payloads):
+            mem_id = str(uuid.uuid4()) if return_ids else None
+            if i == bad_id_index:
+                # Truthy, so it clears the no-id branch, but not parseable —
+                # the one shape that reaches ``UUID()``.
+                mem_id = "not-a-uuid"
+            elif mem_id:
+                run.assigned_ids[p["client_request_id"]] = mem_id
+            out.append(
+                {
+                    "client_request_id": p["client_request_id"],
+                    "id": mem_id,
+                    "was_inserted": True,
+                }
+            )
+        if rotate_results:
+            # Rotate rather than reverse: reversing an odd-length list leaves
+            # the middle element on its own index, so a positional join would
+            # still pair one child correctly and the test could read as a
+            # partial pass. A rotation moves every element.
+            out = out[1:] + out[:1]
+        return out
+
+    sc.create_memories = AsyncMock(side_effect=_create_memories)
+
+    data = MemoryCreate(
+        tenant_id=TENANT,
+        fleet_id=FLEET,
+        agent_id=AGENT,
+        content="a body long enough to be worth chunking " * 60,
+    )
+    config = ResolvedConfig(
+        {
+            "chunking": {"auto_chunk_enabled": True},
+            "entity_extraction": {"enabled": False},
+            "enrichment": {"enabled": False},
+        }
+    )
+    ctx = SimpleNamespace(
+        data={
+            "input": data,
+            "memory_fields": {
+                "memory_type": "fact",
+                "title": None,
+                "weight": 0.5,
+                "status": "active",
+                "metadata": {},
+            },
+            "enrichment": None,
+            "embedding": [0.0] * 8 if inline else None,
+            "t0": 0.0,
+        },
+        tenant_config=config,
+    )
+
+    async def _chunk_content(_content, _x, _cfg):
+        return [{"content": c, "suggested_type": "fact"} for c in CHUNKS]
+
+    async def _embeddings(texts, _cfg, background=False):
+        if embed_raises:
+            raise EmbedDown("provider degraded")
+        return [[0.0] * 8 for _ in texts]
+
+    def _tracked_task(coro, label, memory_id, tenant_id, *a, **k):
+        run.tasks.append((label, str(memory_id)))
+        coro.close()
+        return MagicMock()
+
+    def _schedule(memory_id, content, _tenant_id, *, content_hash=None, **k):
+        # Sync on purpose: records when CALLED, which is the only moment that
+        # happens here — ``_tracked_task`` closes the coroutine unawaited.
+        run.reembeds.append((str(memory_id), content, content_hash))
+        return _noop()
+
+    with (
+        patch.object(
+            memory_service.settings,
+            "deployment_mode",
+            "inline" if inline else "deferred",
+        ),
+        patch.object(memory_service, "get_storage_client", lambda: sc),
+        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(memory_service, "tracked_task", _tracked_task),
+        patch.object(memory_service, "get_embeddings_batch", new=_embeddings),
+        patch.object(memory_service, "_schedule_embed_or_reembed", new=_schedule),
+        patch("core_api.services.ingest_service._chunk_content", new=_chunk_content),
+        patch.object(memory_service, "_USE_PIPELINE_WRITE", not legacy),
+        # Both dedup pre-checks are legacy-path-only and answer truthy off a
+        # bare AsyncMock, which the handler reads as "already exists" and 409s
+        # before reaching the embed. Neither is what these tests are about.
+        patch.object(
+            memory_service, "_find_semantic_duplicate", AsyncMock(return_value=None)
+        ),
+        # The legacy handler resolves its OWN config rather than taking the
+        # ctx one, so ``auto_chunk_enabled`` has to be supplied here or the
+        # branch under test is never entered and the run looks like a pass.
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            AsyncMock(return_value=config),
+        ),
+    ):
+        try:
+            if legacy:
+                # Through the public entry point, so the dispatch that selects
+                # the rollback handler is part of what is under test.
+                await memory_service.create_memory(data)
+            else:
+                await memory_service._handle_auto_chunk_from_ctx(data, ctx)
+        except Exception as exc:
+            # Captured rather than propagated: the escape IS the defect, so the
+            # tests assert on ``run.raised`` instead of wrapping each call in
+            # ``pytest.raises`` and inverting it per case.
+            run.raised = exc
+
+    if sc.create_memories.await_args_list:
+        run.children = sc.create_memories.await_args_list[0].args[0]
+    return run
+
+
+# ---------------------------------------------------------------------------
+# The defect
+# ---------------------------------------------------------------------------
+
+
+async def test_a_failed_child_embed_does_not_escape_the_request() -> None:
+    """THE DEFECT. The parent is already committed when this runs.
+
+    Fails without the fix with ``EmbedDown`` propagating out of
+    ``_handle_auto_chunk_from_ctx`` — an error response for a persisted write.
+    """
+    run = await _run(embed_raises=True)
+    assert run.raised is None, (
+        f"child embed failure escaped as {type(run.raised).__name__}: {run.raised}"
+    )
+
+
+async def test_the_children_are_still_written_when_the_embed_fails() -> None:
+    """The facts must survive. This is the silent data loss half.
+
+    Without the fix zero children were written while the parent's metadata
+    claimed ``child_count=3``, so the source document became unrecallable and
+    nothing recorded why.
+    """
+    run = await _run(embed_raises=True)
+    assert len(run.children) == len(CHUNKS)
+    assert [c["content"] for c in run.children] == list(CHUNKS)
+    # Unembedded, not silently zero-vectored — a zero vector would be a row
+    # that looks embedded and never matches anything.
+    assert all(c["embedding"] is None for c in run.children)
+
+
+async def test_unembedded_children_are_marked_pending() -> None:
+    """``embedding_pending`` is public API, not bookkeeping.
+
+    ``MemoryOut.metadata`` documents an ABSENT flag as "that stage ran
+    inline", so leaving it off states the opposite of the truth for these rows
+    and makes them indistinguishable from fully-embedded ones.
+    """
+    run = await _run(embed_raises=True)
+    # Anti-vacuity, and it earned its place: ``all()`` over an empty list is
+    # True, so without this the test PASSED with the guard removed — the
+    # pre-fix behaviour writes no children at all. Caught by the removal probe.
+    assert len(run.children) == len(CHUNKS), "no children written — test is vacuous"
+    assert all(c["metadata_"].get("embedding_pending") is True for c in run.children)
+
+
+async def test_each_unembedded_child_gets_a_re_embed_queued() -> None:
+    """Scheduled explicitly, because the sweep is the floor and not the mechanism.
+
+    ``embed_backfill_enabled`` defaults FALSE, and a deployment that never
+    enabled it is how ~430 rows were stranded on 2026-07-27. The repair must be
+    queued per child and must target the CHILD — a backfill logged against the
+    parent repairs nothing.
+    """
+    run = await _run(embed_raises=True)
+    assert "embed_or_publish" in run.labels
+    scheduled = run.scheduled_for("embed_or_publish")
+    assert len(scheduled) == len(CHUNKS), (
+        f"expected one re-embed per child, got {len(scheduled)}: {scheduled}"
+    )
+    assert run.parent_id not in scheduled, "re-embed was queued against the parent"
+
+
+async def test_the_repair_pairs_each_child_id_with_its_own_content() -> None:
+    """The payload-to-result join is by ``client_request_id``, not by position.
+
+    A mispaired entry does not merely lose a repair. It embeds THIS child's
+    text and persists the vector against ANOTHER child's row, so that row's
+    embedding silently stops matching its own stored content — a recall-quality
+    corruption with no error and no log, on a path that only runs when the
+    provider is already degraded.
+
+    Storage does guarantee input order today: ``memory_add_all`` collects
+    ``RETURNING`` into a dict and builds its response by iterating the input.
+    So this is a contract-drift probe, not a reproduction of live behaviour —
+    it fails if the join ever regresses to ``zip``.
+    """
+    run = await _run(embed_raises=True, rotate_results=True)
+    assert run.raised is None
+    assert len(run.children) == len(CHUNKS), "no children written — test is vacuous"
+
+    expected = {
+        run.assigned_ids[c["client_request_id"]]: (c["content"], c["content_hash"])
+        for c in run.children
+    }
+    child_ids = set(expected)
+    actual = {
+        mid: (content, chash)
+        for mid, content, chash in run.reembeds
+        if mid in child_ids
+    }
+    assert len(actual) == len(CHUNKS), f"expected one repair per child, got {actual}"
+    assert actual == expected, (
+        "a child's re-embed was queued against another child's row"
+    )
+
+
+async def test_a_duplicate_refusal_reports_no_unrepairable_rows(caplog) -> None:
+    """Nothing was written, so nothing may be reported as written.
+
+    A batch refused by migration 040 persists NO children. Every payload still
+    carries ``embedding=None`` from the degraded embed, so without the
+    ``None``-vs-``[]`` distinction each one falls through to the no-id branch
+    and claims a row was "persisted unembedded" with "NO re-embed scheduled" —
+    N false alarms for rows that never reached the table.
+
+    That matters because of WHEN it fires. Embed degraded plus children already
+    present is the retry-after-degradation case this fix exists for, so the
+    false alarms would land in the middle of the incident, pointing an on-call
+    engineer at orphaned rows that do not exist.
+
+    A regression of my own making: the positional ``zip`` this replaced paired
+    against an empty list and iterated zero times, so the join is what exposed
+    this branch.
+    """
+    with caplog.at_level("DEBUG"):
+        run = await _run(embed_raises=True, duplicate_refusal=True)
+
+    assert run.raised is None
+    assert run.reembeds == [], "a repair was queued for a row that was never written"
+
+    errors = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert errors == [], (
+        "a duplicate refusal is a fully-explained WARNING-level outcome; "
+        f"it must not raise ERRORs: {[r.getMessage()[:90] for r in errors]}"
+    )
+    # Anti-vacuity: the run must actually have reached the refusal, and the
+    # cause must still be on the record. Asserting only the absence above would
+    # pass just as well if the handler had never got that far.
+    assert any("refused as duplicates" in r.getMessage() for r in caplog.records), (
+        f"the refusal itself went unlogged: {[r.getMessage()[:60] for r in caplog.records]}"
+    )
+
+
+async def test_an_unparseable_child_id_does_not_escape_the_request(caplog) -> None:
+    """The repair step must not become the thing that raises after the commit.
+
+    ``UUID(str(child_id))`` runs after the parent AND the children are
+    committed, and outside the request's ``try/finally``. An id that stopped
+    being a UUID string would answer a fully-persisted write with a 500 — the
+    exact H-09 shape this PR removes, moved from the embed step to the repair
+    step.
+
+    The guard is PER CHILD, and the second assertion is what proves it: a catch
+    around the whole loop would swallow the error just as well while silently
+    cancelling every other child's repair, turning one unrepaired row into N.
+    """
+    with caplog.at_level("ERROR"):
+        run = await _run(embed_raises=True, bad_id_index=0)
+
+    assert run.raised is None, f"the repair step escaped the request: {run.raised!r}"
+    # The other two children still get theirs — the guard skipped one child, not
+    # the sweep.
+    assert len(run.reembeds) == len(CHUNKS) - 1, (
+        f"expected the surviving children to still be repaired, got {run.reembeds}"
+    )
+    assert any("could not be scheduled" in r.getMessage() for r in caplog.records), (
+        "the unrepairable child was dropped silently"
+    )
+
+
+async def test_the_degrade_warning_does_not_promise_a_repair_it_cannot_make(
+    caplog,
+) -> None:
+    """The embed-degrade warning fires BEFORE the insert, so it cannot know.
+
+    TWO claims, and both had to become conditional. Whether a repair is
+    scheduled is settled two steps later; whether the children are persisted at
+    all is settled one step later, and a duplicate refusal writes none of them.
+    This run is that case, so in these logs the warning sits directly above
+    "children refused as duplicates" — an unconditional wording would read as
+    contradicting the line beneath it, during exactly the incident this fix is
+    for.
+
+    The first draft made only the repair clause conditional and left
+    "persisting" asserting the same thing one clause earlier, which is why both
+    are pinned here.
+    """
+    with caplog.at_level("WARNING"):
+        run = await _run(embed_raises=True, duplicate_refusal=True)
+
+    # Anti-vacuity: the refusal must actually have happened, or the warning
+    # under test was never a premature claim about anything. NOT
+    # ``run.children == []`` — that field holds the payloads SUBMITTED, which
+    # exist either way; the refusal is what decides whether any were written.
+    assert any("refused as duplicates" in r.getMessage() for r in caplog.records), (
+        "the run never reached the refusal, so this proves nothing"
+    )
+    assert run.reembeds == [], "a repair was queued despite nothing being written"
+    degrade = [
+        r.getMessage() for r in caplog.records if "child embed failed" in r.getMessage()
+    ]
+    assert degrade, "the embed degrade went unlogged"
+    assert not any("unembedded with a re-embed queued" in m for m in degrade), (
+        "the warning asserts a repair that this run never queued"
+    )
+    assert not any("persisting" in m for m in degrade), (
+        f"the warning asserts a write that this run never made: {degrade}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Over-refusal / no-op guards
+# ---------------------------------------------------------------------------
+
+
+async def test_the_healthy_path_schedules_no_child_re_embeds() -> None:
+    """OVER-REFUSAL GUARD. A working provider must cost nothing.
+
+    The children carry vectors, so the repair loop must find nothing to do —
+    otherwise every ordinary auto-chunk write would queue N pointless tasks.
+    """
+    run = await _run(embed_raises=False)
+    assert run.raised is None
+    assert len(run.children) == len(CHUNKS)
+    assert all(c["embedding"] is not None for c in run.children)
+    assert all("embedding_pending" not in c["metadata_"] for c in run.children)
+    assert run.scheduled_for("embed_or_publish") == set()
+
+
+async def test_a_child_with_no_returned_id_is_logged_not_silently_dropped(
+    caplog,
+) -> None:
+    """The one case that cannot be repaired must be loud.
+
+    A row that persisted unembedded with no queued repair is strictly worse
+    than the counted case, and only the nightly sweep — off by default — would
+    ever find it. It must not pass quietly.
+    """
+    with caplog.at_level("ERROR"):
+        run = await _run(embed_raises=True, return_ids=False)
+    assert run.raised is None
+    assert run.scheduled_for("embed_or_publish") == set()
+    assert any(
+        "no usable id" in r.message or "no usable id" in r.getMessage()
+        for r in caplog.records
+    ), (
+        f"expected a loud no-id error; got {[r.getMessage()[:80] for r in caplog.records]}"
+    )
+
+
+async def test_the_legacy_handler_degrades_too(caplog) -> None:
+    """The rollback path carries the same fix, driven through the real handler.
+
+    ``_create_memory_legacy`` had the identical shape and I first left it alone
+    on the grounds that it was dead behind ``_USE_PIPELINE_WRITE=True``. That
+    was wrong: the flag's own comment documents flipping it as the
+    emergency-rollback lever, so the path is DORMANT, not dead. And the
+    correlation is adverse — an emergency rollback is plausibly happening
+    BECAUSE something is degraded, which is the same condition that trips this
+    bug. The defect would have resurfaced during exactly the incident the lever
+    exists for.
+
+    Driven with the flag flipped, so this exercises the dispatch too rather
+    than calling the private handler directly.
+    """
+    run = await _run(embed_raises=True, legacy=True)
+    assert run.raised is None, (
+        f"legacy child embed failure escaped as {type(run.raised).__name__}: {run.raised}"
+    )
+    assert len(run.children) == len(CHUNKS), "legacy path wrote no children"
+    assert all(c["embedding"] is None for c in run.children)
+    assert all(c["metadata_"].get("embedding_pending") is True for c in run.children)
+    assert len(run.scheduled_for("embed_or_publish")) == len(CHUNKS)
+
+
+async def test_the_legacy_healthy_path_schedules_nothing() -> None:
+    """OVER-REFUSAL GUARD for the rollback path, same as the pipeline one."""
+    run = await _run(embed_raises=False, legacy=True)
+    assert run.raised is None
+    assert all(c["embedding"] is not None for c in run.children)
+    assert run.scheduled_for("embed_or_publish") == set()
+
+
+async def test_both_paths_share_one_degrade_policy() -> None:
+    """Anti-drift: the two handlers must not grow separate copies.
+
+    H-09 existed in two places at once because the auto-chunk logic was
+    written twice. The embed-degrade, the pending flag and the repair
+    scheduling now live in one helper each; this pins that both handlers route
+    through them, so a change to one cannot silently miss the other.
+    """
+    import inspect
+
+    src = inspect.getsource(memory_service)
+    # The raw call must appear nowhere outside the shared helper.
+    raw = src.count("await get_embeddings_batch(child_texts")
+    assert raw == 1, (
+        f"expected the child batch embed to be called in exactly one place "
+        f"(the shared helper); found {raw}"
+    )
+    assert src.count("_embed_children_or_degrade(") >= 3, (
+        "both handlers must call the helper"
+    )
+    assert src.count("_queue_child_reembeds(") >= 3, "both handlers must queue repairs"
+    assert src.count("_mark_child_embedding_pending(") >= 3, (
+        "both handlers must mark pending"
+    )
+
+
+async def test_the_no_id_log_carries_no_memory_content(caplog) -> None:
+    """The log names the response SHAPE, never the response.
+
+    The bulk result belongs to a row carrying the fact text; interpolating it
+    would put memory content, and any PII in it, into an ERROR log.
+    """
+    with caplog.at_level("ERROR"):
+        await _run(embed_raises=True, return_ids=False)
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    for chunk in CHUNKS:
+        assert chunk not in joined, f"memory content leaked into a log: {chunk!r}"


### PR DESCRIPTION
Closes audit finding **H-09**.

## The defect

`_handle_auto_chunk_from_ctx` commits the parent, then batch-embeds the children:

```python
parent = await _create_memory_or_409(...)   # committed
...
child_embeddings = await get_embeddings_batch(child_texts, tenant_config, background=False)
```

`get_embeddings_batch` raises on every provider-side error, gate saturation, quota and misconfig — **its own docstring says both bulk callers wrap it** — and this third caller did not. The call also sits **outside** the request's `try/finally`, because the auto-chunk branch returns before that block is entered. So the exception escaped as an error response for a write that had already persisted.

## Three harms, and the third is what made it unrecoverable

1. **Silent data loss.** Zero children written, while the parent's metadata claimed `auto_chunked` and `child_count=N`. The facts were gone, the source document unrecallable, and nothing recorded why.
2. **No backfills.** Parent enrich, entity extraction and parent embed all sit *below* the embed and never ran, so a parent inserted with `embedding=None` stayed unembedded — the 2026-07-27 stranded-rows shape.
3. **A permanent wedge.** The retry re-chunks, produces the same full-document `content_hash`, and migration 040's live-row uniqueness answers **409 against the childless parent**. The children could never be written without deleting the parent by hand.

## Why this is unambiguous rather than a judgement call

Two asymmetries, both inside the same function:

- **The parent's own embed already degrades** to `None` on these same failures, so the parent commits unembedded rather than failing.
- **The child INSERT one line later already degrades**, for precisely this reason. `_insert_children_or_degrade`'s docstring: *"the parent row is ALREADY COMMITTED… raising here would hand the caller a 500 for a write that persisted."*

The child **embed**, between those two, was the only step in the sequence that still raised.

## The fix

Children persist unembedded, carry `embedding_pending`, and each gets a re-embed queued.

**Deliberately not mode-dependent like the bulk path**, which fails the request under `inline_embedding`. There nothing has persisted when the embed fails, so refusing is clean. Here the parent is committed, which inverts the trade: refusing loses the children *and* wedges every retry, while degrading keeps the facts and leaves a repair queued.

**`embedding_pending`** is set because `MemoryOut.metadata` documents an *absent* flag as "that stage ran inline" — leaving it off states the opposite of the truth for these rows and makes them indistinguishable from fully-embedded ones. Same flag the atomic-fact fan-out sets for the same reason.

**The re-embed is scheduled explicitly**, not left to the nightly sweep: `embed_backfill_enabled` defaults **FALSE**, and a deployment that never enabled it is how ~430 memories were stranded in the incident this module already carries a postmortem for. `_schedule_embed_or_reembed` publishes `EMBED_REQUESTED` in deferred mode and retries in-process otherwise, so it works in both.

**`_insert_children_or_degrade` now returns** `create_memories`' per-item results, which is what makes the scheduling possible. Payloads are paired to results by **`client_request_id`**, not by position — see round 2 below for why, given that storage does guarantee input order. The return distinguishes `None` ("nothing was written") from `[]` ("nothing to write"), which round 3 below shows is not a cosmetic difference. The task is logged against the **child**, not the parent; a backfill recorded against the wrong row repairs nothing and misdirects the operator.

**The legacy handler had the same gap and is now fixed too**, via the same helpers — see the review round below.

## Review round: the legacy path, and why my reason for skipping it was wrong

Review flagged the legacy auto-chunk handler as carrying the identical defect. It was right, and **my stated justification was factually wrong.**

I said the path was *dead* behind `_USE_PIPELINE_WRITE=True`. The flag's own comment says otherwise:

> If an emergency rollback is needed, flip these to False and ship a hotfix

So it is **dormant, not dead** — a designated rollback lever. And the correlation is adverse in the worst way: H-09 trips on *embedding-provider degradation*, which is plausibly the very reason someone pulls that lever. The defect would have resurfaced during exactly the incident the rollback exists for, at the moment the system was least able to absorb it.

**Fixed via shared helpers rather than a second copy**, which is the review's own closing suggestion and the right call independently: H-09 existed in two places at once *because* the auto-chunk sequence was written twice. Three helpers now carry the policy —

- `_embed_children_or_degrade` — the embed with its degrade
- `_mark_child_embedding_pending` — the flag, with the reason it exists
- `_queue_child_reembeds` — the per-child repair, with the no-id log

— and both handlers route through all three. **A test asserts the raw `get_embeddings_batch(child_texts…)` call appears in exactly ONE place** and that both handlers call each helper, so a future change to one cannot silently miss the other.

The legacy tests drive `create_memory` with the flag flipped, so the dispatch that selects the rollback handler is part of what is under test rather than assumed.

Getting there surfaced two things the pipeline path hides: the legacy handler runs **two dedup pre-checks** the pipeline path does not (both answer truthy off a bare `AsyncMock`, so it 409'd before reaching the embed), and it **resolves its own config** rather than taking the ctx one, so `auto_chunk_enabled` has to be supplied separately or the branch under test is never entered and the run looks like a pass. Both are now stubbed explicitly with comments saying why.

## Review round 2: the payload-to-result join

Review read the positional `zip` in `_queue_child_reembeds` as a live mispairing bug, citing `create_memories_bulk`'s comment that *"Postgres `RETURNING` order is unspecified for `ON CONFLICT DO NOTHING`"*.

**That premise is wrong at this boundary.** `memory_add_all` collects `RETURNING` into a dict keyed by `client_request_id` and then builds its response by iterating the **input**, so one-entry-per-item in input order holds by construction — and all three layers the value crosses document it.

**The fix went in anyway**, because the trade is one-sided:

- **Zero cost.** `client_request_id` is mandatory on every item (`memory_add_all` refuses a batch without it) and both handlers already mint one per child.
- **Asymmetric consequence.** A mispaired entry would not lose a repair — it would embed one child's text and persist the vector against **another child's row**, leaving that row's embedding silently inconsistent with its own content. No error, no log, on a path that only runs when the provider is already degraded.
- A **missing** entry now takes the loud no-id branch instead of shifting every subsequent pair by one.

**The comment that produced the finding is corrected too.** It attributed the join to raw SQL behaviour, which reads as a claim that the *response* is unordered. The practice stays; the reason is now accurate. That is this backlog's usual defect class inverted — a comment asserting a property the code doesn't have normally hides a missing check; this one invented one.

**The Low was correct.** `_drop_duplicate_facts` cited "both auto-chunk handlers discard `create_memories`' return value entirely", which this PR falsifies. Corrected — and the underlying reasoning survives: results join by `client_request_id`, so a fact dropped before any payload is built has no entry to misalign against.

## Review round 3: the join's own regression

Review found that the `client_request_id` join introduced a false alarm — and it was right.

`_insert_children_or_degrade` returned `[]` both when a duplicate refusal wrote **nothing** and when an insert succeeded. With the old positional `zip`, `zip(payloads, [])` iterated zero times and the case was unreachable. With the join, every degraded payload found no matching entry and logged **"child persisted unembedded … NO re-embed scheduled"** — N ERRORs for rows that never reached the table.

Reproduced before fixing: three false ERRORs, zero rows written.

The severity is about *when*: embed degraded plus children already present **is** the retry-after-wedge case this PR targets, so the alarms would fire mid-incident and send an on-call engineer hunting orphaned rows that don't exist, while the real cause sits one correct WARNING above.

**Fix:** `None` for "nothing was written", `[]` for "nothing to write", and `_queue_child_reembeds` returns silently on `None` — signalling the reason rather than inferring it from emptiness. A **non-empty** payload list against an **empty** result list is a broken contract rather than a per-child outcome, so it keeps one batch-level ERROR instead of N.

Also (Low, correct): the embed-degrade warning said *"with a re-embed queued"* before the insert had run, asserting an outcome that is settled two steps later and can be no for every child — this module's own bug class in a log line. Now conditional.

## Review round 4: the repair step could itself raise

The sharpest of the four. This PR's whole argument is *nothing may raise after the parent commits* — and the step added to enforce it was unguarded. `UUID(str(child_id))` runs after the parent **and** the children are committed, and outside the request's `try/finally`, so a malformed id answers a fully-persisted write with a 500. Not an analogue of H-09 — H-09, relocated from the embed step to the repair step. Reproduced: `ValueError('badly formed hexadecimal UUID string')` escaping the request.

**Guarded per child, not around the loop**, and the difference is the whole value of it: a catch around the loop stops the escape while silently cancelling every remaining child's repair, turning one unrepaired row into N — a worse outcome than the one prevented, reached by code that looks like it handled the problem.

`payload["client_request_id"]` also became `.get()`: unreachable today, but a payload without one cannot be joined to anything, so it belongs in the no-id branch rather than raising a `KeyError` out of a committed request.

## Review round 5: the other half of the sentence

Round 5 traced the full call graph and found the logic sound — one Low left, and it was mine from round 3. I had made *"with a re-embed queued"* conditional and left *"persisting N child(ren) unembedded"* asserting the same thing one clause earlier, in the same line.

The reason it matters: in a duplicate refusal those two WARNINGs land **adjacent in the same incident's logs**, so the unconditional wording reads as contradicting the line directly beneath it. Both clauses are conditional now, and the test pins both.

## Tests

**Five fail without the pipeline guard:** the escape itself, the children not being written, the pending flag, the queued repair, and the no-id log.

Reverting only the **legacy** call site fails two more: the legacy behavioural test and the anti-drift test — which is the point of having both.

**Two more from round 3:** the duplicate-refusal test (no repairs queued, and **no ERROR records at all**, with an anti-vacuity assertion that the refusal WARNING *is* present so it can't pass by never reaching the refusal), and the degrade-warning test, which fails with the old unconditional wording restored.

**Restoring the `zip` fails one more:** the rotated-results test. The fake returns bulk results rotated by one and asserts each child id is paired with its own content and hash. Rotation rather than reversal on purpose — reversing an odd-length list leaves the middle element on its own index, so a positional join would still pair one child correctly and the test could read as a partial pass. Its docstring records that the storage guarantee holds today and that this is a contract-drift probe, so nobody later reads it as evidence of a live bug.

**Two are over-refusal guards.** The healthy path must schedule **nothing** — otherwise every ordinary auto-chunk write queues N pointless tasks. And a child whose insert returns no usable id must be logged **loudly** rather than dropped quietly: that row is unembedded with no repair queued, which is strictly worse than the counted case, and only the off-by-default sweep would ever find it.

A further test asserts that log carries **no memory content**. The bulk result belongs to a row holding the fact text, so interpolating it would put content — and any PII in it — into an ERROR log.

### One test needed fixing, and the probe is what caught it

The pending-flag assertion used `all()` over the children. `all()` over an empty list is `True`, and the pre-fix behaviour writes **no children at all** — so the test **passed with the guard removed**. It now asserts the count first, with a comment saying why. Probe re-run: four failures became five.

That is the second time in this backlog that "confirm it fails without the fix" caught a test that would have shipped green and proved nothing.

## Verification

- Full root suite: **6067 passed, 5 skipped, 1 xfailed, 0 failed**, run as `.venv/bin/python -m pytest`.
- The 42 existing auto-chunk tests (`test_h856_*`, `test_h852_*`, `test_child_dedup_*`) pass unchanged — the return-value change to `_insert_children_or_degrade` is additive.
- `ruff check` and `ruff format --check` run **separately** at CI's exact scopes — clean.
- `mypy` clean (2 pre-existing `types-python-dateutil` stub errors in an untouched file).
- `legacy_name_ratchet.py` → *No new lines.* · `do_not_touch_sentinel.py` → *All 39 protected strings survive.* · `tenant_scope_gate.py` → no allowlist movement. All after `git add`.
- No open PR touches this subsystem (checked before starting, per the lesson from the H-12 duplicate).
- Rebased onto `origin/main` at `fb64377f`; head `005d8740`. The remote branch has been rebased under me twice now; each time I inspected the remote head before pushing rather than widening the lease — this round by **patch-id**, which matched my own pre-review commit exactly. Re-ran the ratchet and the full suite on the new base, since the commit main gained (#1275) changes the ratchet itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
