### PR TITLE
release(clients): bump caura-client to 1.0.2, caura to 1.0.1

### DIFF
--- a/clients/caura-meta/pyproject.toml
+++ b/clients/caura-meta/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "caura"
-version = "1.0.0"
+version = "1.0.1"
 description = "Caura — governed shared memory for AI agent fleets. Metapackage for caura-client."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "caura-client"
-version = "1.0.1"
+version = "1.0.2"
 description = "Official Python client for Caura (formerly MemClaw; the MemClaw class remains a permanent alias) — governed shared memory for AI agent fleets (multi-agent, multi-tenant, MCP-native)."  # legacy-name-ok: rule 3 permanent class alias
 readme = "README.md"
 requires-python = ">=3.9"

--- a/clients/python/src/caura_client/__init__.py
+++ b/clients/python/src/caura_client/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "DEFAULT_BASE_URL",
 ]
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"


### PR DESCRIPTION
## Summary

Neither of these versions is CI-proven under its current name: both `caura-client` 1.0.1 and `caura` 1.0.0 were published manually (`uv build && uv publish`, per [#870](https://github.com/caura-ai/caura/pull/870)'s own description), and no `caura-client-v*` or `caura-meta-v*` tag has ever been pushed. The first real tag-triggered release for either would hit PyPI's `400 File already exists` on the version already live from the manual publish — this is the exact failure already seen on `caura-client`'s 2026-09-01 CI run. This PR bumps both versions past what's already on PyPI so the first tag-triggered release is a clean publish, not a repeat of that failure.

- `clients/python/pyproject.toml`: `caura-client` 1.0.1 → 1.0.2
- `clients/python/src/caura_client/__init__.py`: `__version__` 1.0.1 → 1.0.2 (kept in sync — separate from `pyproject.toml`, not covered by any test)
- `clients/caura-meta/pyproject.toml`: `caura` 1.0.0 → 1.0.1

`clients/caura-sdk-meta/pyproject.toml` is deliberately untouched — `caura-sdk` doesn't exist on PyPI yet, so 1.0.0 is a clean first publish there.

**Checked before editing, not assumed**: `release-please-config.json` tracks exactly two packages, `.` (core-api/core-worker/core-storage-api via `extra-files`) and `plugin` — neither `clients/python` nor `clients/caura-meta` appears anywhere in it, confirmed by reading the full config and cross-checking `.github/workflows/release-please.yml` for any second/hidden config. Safe to hand-edit these version strings.

`caura-client`'s dependency on `caura` metapackage side is `caura-client>=1.0.0` (open lower bound) — needs no change for this bump.

## Test plan

- [x] Both edited `pyproject.toml` files parse as valid TOML (`tomllib.load`)
- [x] Confirmed via `release-please-config.json` + `.release-please-manifest.json` that neither file is release-please-managed
- [x] Confirmed no test in either package's `tests/` asserts the old version string
- [x] No `scripts/do_not_touch_sentinel.py` pin references either file

🤖 Generated with [Claude Code](https://claude.com/claude-code)