### PR TITLE
fix(core-api): stamp provenance on bulk re-embed fallbacks

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2649,7 +2649,7 @@ async def create_memories_bulk(
             # just captures the batch-level exception.
             track_task(
                 tracked_task(
-                    _reembed_memories_bulk(reembed_batch, data.tenant_id),
+                    _reembed_memories_bulk(reembed_batch, data.tenant_id, data.fleet_id),
                     f"reembed_bulk[{len(reembed_batch)}]",
                     None,
                     data.tenant_id,
@@ -3019,19 +3019,86 @@ async def _reembed_memory(
 async def _reembed_memories_bulk(
     items: list[tuple[UUID, str]],
     tenant_id: str,
+    fleet_id: str | None,
 ) -> None:
     """Batched background re-embed for bulk-originated memories.
 
     One ``get_embeddings_batch`` call covers all items, preserving the
     packing behaviour the hot-path bulk code used. Any per-item failure
-    falls back to ``_reembed_memory`` so a partial batch doesn't leave
-    some rows without embeddings forever.
+    routes through ``_schedule_embed_or_reembed`` so a partial batch
+    doesn't leave some rows without embeddings forever.
+
+    ``fleet_id`` exists so those fallbacks can stamp provenance. All five
+    of them used to omit ``content_hash``, and the omission is silent all
+    the way down: ``_schedule_embed_or_reembed`` forwards ``None``,
+    ``handle_embed_request`` passes it to ``update_memory_embedding``, and
+    that writes the vector while leaving ``embedded_content_hash`` NULL --
+    deliberately, because "unknown provenance is honest, a wrong hash is
+    not". The row lands in ``unknown_provenance``, which is documented as
+    meaning "written before migration 037" and which nothing re-embeds
+    (both embedding backfills select ``embedding IS NULL``, and these rows
+    have one), so it leaves the staleness detector's reach permanently. No
+    error, no log, no failed request. Measured 2026-09-04: 241 such rows,
+    all bulk-created, one tenant.
+
+    Threaded in rather than derived here, because ``_content_hash`` hashes
+    ``tenant:fleet:content``: computing it without the fleet would produce
+    a wrong hash for every fleet-scoped memory, which is worse than the
+    NULL it replaces, since a wrong hash reads as verified freshness. A
+    scalar because a bulk batch is single-fleet by construction --
+    ``memory_add_all`` rejects a batch whose items disagree on ``fleet_id``
+    -- and the route resolves ``body.fleet_id`` before the insert, so this
+    is the value the rows carry.
     """
     from core_api.services.contradiction import Trigger, run_contradiction_detection
     from core_api.services.organization_settings import resolve_config
 
     if not items:
         return
+
+    def _fallback(memory_id: UUID, content: str) -> None:
+        """Hand one item to the per-item retry, provenance included.
+
+        One helper rather than five copies at the call sites below, because
+        the copies were the defect: five siblings, the same omitted
+        ``content_hash`` at each, so repairing them individually would
+        leave five places for it to come back. There is now one place to
+        omit it from, and ``test_embed_provenance_call_sites.py`` fails
+        statically if a sixth call site appears that bypasses this.
+
+        Routes through the inline/deferred router rather than calling
+        ``_reembed_memory`` directly. In deferred mode this hands the item
+        to EMBED_REQUESTED, so the retry lives on Pub/Sub (redelivery +
+        DLQ) instead of in this process.
+
+        That is what makes the fallback DURABLE. Direct in-process retry
+        meant a failed 50-item batch fanned out to 50 x
+        _REEMBED_MAX_RETRIES x EMBEDDING_RETRY_ATTEMPTS provider calls, all
+        contending for the same saturated backend; when they exhausted, the
+        rows stayed embedding=NULL with no further recovery -- a manual CLI
+        backfill was the only way out. That is exactly how ~430 memories
+        were stranded in the 2026-07-27 incident.
+
+        ``is_failure_fallback=True`` still gives the INLINE branch its
+        thundering-herd backoff (the provider just failed, for this item or
+        for the whole batch); the deferred branch ignores it because
+        Pub/Sub owns backoff.
+        """
+        track_task(
+            tracked_task(
+                _schedule_embed_or_reembed(
+                    memory_id,
+                    content,
+                    tenant_id,
+                    content_hash=_content_hash(tenant_id, fleet_id, content),
+                    is_failure_fallback=True,
+                ),
+                "reembed",
+                memory_id,
+                tenant_id,
+            )
+        )
+
     try:
         tenant_config = await resolve_config(tenant_id)
     except Exception:
@@ -3069,32 +3136,7 @@ async def _reembed_memories_bulk(
         # Exception, so shutdown-path cancellations still propagate.
         logger.exception("Bulk re-embed batch call failed; falling back to per-item re-embed")
         for memory_id, content in items:
-            track_task(
-                tracked_task(
-                    # Route through the inline/deferred router rather than
-                    # calling _reembed_memory directly. In deferred mode this
-                    # hands each item to EMBED_REQUESTED, so the retry lives on
-                    # Pub/Sub (redelivery + DLQ) instead of in this process.
-                    #
-                    # That is what makes the fallback DURABLE. Direct in-process
-                    # retry meant a failed 50-item batch fanned out to 50 x
-                    # _REEMBED_MAX_RETRIES x EMBEDDING_RETRY_ATTEMPTS provider
-                    # calls, all contending for the same saturated backend; when
-                    # they exhausted, the rows stayed embedding=NULL with no
-                    # further recovery — a manual CLI backfill was the only way
-                    # out. That is exactly how ~430 memories were stranded in
-                    # the 2026-07-27 incident.
-                    #
-                    # is_failure_fallback=True still gives the INLINE branch its
-                    # thundering-herd backoff (the provider just failed for the
-                    # whole batch); the deferred branch ignores it because
-                    # Pub/Sub owns backoff.
-                    _schedule_embed_or_reembed(memory_id, content, tenant_id, is_failure_fallback=True),
-                    "reembed",
-                    memory_id,
-                    tenant_id,
-                )
-            )
+            _fallback(memory_id, content)
         return
 
     # Materialise the strict zip up front so a length mismatch surfaces as
@@ -3108,14 +3150,7 @@ async def _reembed_memories_bulk(
             len(items),
         )
         for memory_id, content in items:
-            track_task(
-                tracked_task(
-                    _schedule_embed_or_reembed(memory_id, content, tenant_id, is_failure_fallback=True),
-                    "reembed",
-                    memory_id,
-                    tenant_id,
-                )
-            )
+            _fallback(memory_id, content)
         return
 
     sc = get_storage_client()
@@ -3131,16 +3166,7 @@ async def _reembed_memories_bulk(
 
     for ((memory_id, content), embedding), mem in zip(pairs, mems):
         if embedding is None:
-            track_task(
-                tracked_task(
-                    # Per-item None after a partial batch success is
-                    # still a provider partial-failure — back off.
-                    _schedule_embed_or_reembed(memory_id, content, tenant_id, is_failure_fallback=True),
-                    "reembed",
-                    memory_id,
-                    tenant_id,
-                )
-            )
+            _fallback(memory_id, content)
             continue
         if isinstance(mem, BaseException):
             # A transient get_memory failure here would otherwise strand
@@ -3151,14 +3177,7 @@ async def _reembed_memories_bulk(
                 memory_id,
                 exc_info=mem,
             )
-            track_task(
-                tracked_task(
-                    _schedule_embed_or_reembed(memory_id, content, tenant_id, is_failure_fallback=True),
-                    "reembed",
-                    memory_id,
-                    tenant_id,
-                )
-            )
+            _fallback(memory_id, content)
             continue
         if mem is None or mem.get("deleted_at") is not None:
             continue
@@ -3204,14 +3223,7 @@ async def _reembed_memories_bulk(
                 "Bulk re-embed PATCH failed for memory %s; scheduling per-item retry",
                 memory_id,
             )
-            track_task(
-                tracked_task(
-                    _schedule_embed_or_reembed(memory_id, content, tenant_id, is_failure_fallback=True),
-                    "reembed",
-                    memory_id,
-                    tenant_id,
-                )
-            )
+            _fallback(memory_id, content)
             continue
         track_task(
             tracked_task(

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -36,6 +36,11 @@ pytestmark = pytest.mark.asyncio
 
 
 TENANT_ID = f"test-594-{uuid.uuid4().hex[:8]}"
+# Non-None on purpose. ``_content_hash`` hashes ``tenant:fleet:content``, so a
+# None fleet would make a hash computed without the fleet indistinguishable
+# from one computed with it — and that is precisely the bug the provenance
+# assertions below are guarding against.
+FLEET_ID = f"fleet-594-{uuid.uuid4().hex[:8]}"
 
 
 def _input(
@@ -491,7 +496,7 @@ async def test_bulk_reembed_preserves_batching() -> None:
             new=AsyncMock(return_value=None),
         ),
     ):
-        await memory_service._reembed_memories_bulk(items, TENANT_ID)
+        await memory_service._reembed_memories_bulk(items, TENANT_ID, FLEET_ID)
 
     assert batch_calls == [5], "expected ONE batch call covering all 5 items"
     # update_embedding once per item; contradiction detection scheduled once per item.
@@ -702,11 +707,168 @@ async def test_bulk_reembed_fallback_passes_is_failure_fallback() -> None:
         ),
     ):
         items = [(uuid.uuid4(), f"m{i}") for i in range(3)]
-        await memory_service._reembed_memories_bulk(items, TENANT_ID)
+        await memory_service._reembed_memories_bulk(items, TENANT_ID, FLEET_ID)
 
     assert len(called_with) == 3
     for call in called_with:
         assert call["kwargs"].get("is_failure_fallback") is True
+
+
+# Every way ``_reembed_memories_bulk`` can decide to hand an item to the
+# per-item fallback. The five call sites are one helper now, so these cover
+# the helper being reached correctly from each branch rather than five copies
+# of it; a sixth site that bypasses the helper entirely is caught statically
+# by ``test_schedule_embed_or_reembed_call_sites_pass_hash`` below.
+_PROVENANCE_BRANCHES = (
+    "batch-raise",
+    "batch-short",
+    "batch-none",
+    "get-memory-raise",
+    "update-raise",
+)
+
+
+@pytest.mark.parametrize("branch", _PROVENANCE_BRANCHES)
+async def test_bulk_reembed_fallback_carries_provenance(branch: str) -> None:
+    """A fallback re-embed must still say WHICH text it embedded.
+
+    See ``_reembed_memories_bulk``'s docstring for the failure mode. The short
+    version: omitting ``content_hash`` is silent end to end and parks the row
+    in ``unknown_provenance``, which nothing sweeps.
+
+    Asserting the exact hash rather than merely "a hash is present", because
+    ``_content_hash`` covers ``tenant:fleet:content`` — a value computed
+    without the fleet would be present, wrong, and read downstream as verified
+    freshness. That is worse than the NULL it replaced.
+    """
+    from core_api.services import memory_service
+
+    scheduled, patched = await _provenance_harness(branch, n_items=3)
+
+    assert scheduled, f"branch={branch!r} scheduled no fallback; it was not reached"
+    for content, content_hash in scheduled.items():
+        assert content_hash == memory_service._content_hash(
+            TENANT_ID, FLEET_ID, content
+        ), (
+            f"fallback for {content!r} carried {content_hash!r}; a re-embed that does not "
+            "name the text it embedded lands the row in unknown_provenance forever"
+        )
+
+    # The direct PATCH path, on whichever branch reaches it — ``update-raise``
+    # fails only the first item, so its siblings land here. Vacuous on the
+    # branches that never PATCH.
+    #
+    # This does NOT prove the two paths agree on the fleet: the harness hands
+    # ``_get_memory`` the same FLEET_ID the fallback uses, so that equality is
+    # constructed by the harness, not tested. What it does catch is the direct
+    # path dropping its provenance stamp altogether, which is the regression
+    # actually reachable from an edit here.
+    for content, content_hash in patched.items():
+        assert content_hash == memory_service._content_hash(
+            TENANT_ID, FLEET_ID, content
+        ), f"direct PATCH for {content!r} carried {content_hash!r}"
+
+
+async def _provenance_harness(
+    branch: str,
+    *,
+    n_items: int,
+) -> tuple[dict[str, str | None], dict[str, str | None]]:
+    """Drive ``_reembed_memories_bulk`` down one branch and report both stamps.
+
+    Returns ``({content: content_hash}, {content: embedded_content_hash})`` —
+    fallback schedules first, direct PATCHes second. ``_content_hash`` itself
+    is deliberately NOT patched: the value it returns is the thing under test,
+    so a stand-in would assert the harness against itself.
+    """
+    from core_api.services import memory_service
+
+    if branch not in _PROVENANCE_BRANCHES:
+        raise AssertionError(
+            f"unknown branch {branch!r}; expected one of {_PROVENANCE_BRANCHES}"
+        )
+
+    items = [(uuid.uuid4(), f"provenance-body-{i}") for i in range(n_items)]
+    first_id = str(items[0][0])
+    by_id = {str(mid): content for mid, content in items}
+
+    scheduled: dict[str, str | None] = {}
+    patched: dict[str, str | None] = {}
+
+    def _capture_schedule(_memory_id, content, _tenant_id, **kwargs):
+        scheduled[content] = kwargs.get("content_hash")
+
+        async def _noop() -> None:
+            return None
+
+        return _noop()
+
+    async def _batch(texts, _cfg, *, budget_s=None, **_kwargs):
+        if branch == "batch-raise":
+            raise RuntimeError("simulated provider outage")
+        if branch == "batch-short":
+            # Provider partial-failed mid-batch: strict zip raises ValueError.
+            return [[0.1] * VECTOR_DIM for _ in texts[:-1]]
+        if branch == "batch-none":
+            return [None for _ in texts]
+        return [[0.1] * VECTOR_DIM for _ in texts]
+
+    async def _get_memory(mid: str, _tenant_id: str, **_kw):
+        if branch == "get-memory-raise":
+            raise RuntimeError("storage transient error")
+        # ``fleet_id`` is what the row actually carries, and it is FLEET_ID
+        # because memory_add_all wrote the whole batch under one fleet. The
+        # direct path hashes this field, so a harness that returned some other
+        # fleet here would be testing a batch that cannot exist.
+        return {"id": mid, "deleted_at": None, "fleet_id": FLEET_ID, "embedding": None}
+
+    async def _update_embedding(
+        mid: str, _tenant_id, _embedding, embedded_content_hash=None
+    ):
+        # First item only, so one item takes the fallback while its siblings
+        # take the direct PATCH — both stamps observable in a single run.
+        if branch == "update-raise" and mid == first_id:
+            raise RuntimeError("connection pool exhausted for the first item")
+        patched[by_id[mid]] = embedded_content_hash
+
+    sc = MagicMock()
+    sc.get_memory = AsyncMock(side_effect=_get_memory)
+    sc.update_embedding = AsyncMock(side_effect=_update_embedding)
+
+    def _fake_detect(*_a, **_kw):
+        async def _noop() -> None:
+            return None
+
+        return _noop()
+
+    def _stub_tracked_task(coro, _name, *_a, **_k):
+        coro.close()
+        return None
+
+    with (
+        patch.object(memory_service, "get_embeddings_batch", new=_batch),
+        patch.object(memory_service, "get_storage_client", return_value=sc),
+        patch.object(
+            memory_service, "_schedule_embed_or_reembed", new=_capture_schedule
+        ),
+        patch(
+            "core_api.services.contradiction_detector.detect_contradictions_async",
+            new=_fake_detect,
+        ),
+        patch.object(memory_service, "track_task"),
+        patch.object(
+            memory_service,
+            "tracked_task",
+            new=MagicMock(side_effect=_stub_tracked_task),
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await memory_service._reembed_memories_bulk(items, TENANT_ID, FLEET_ID)
+
+    return scheduled, patched
 
 
 async def test_bulk_reembed_fallback_catches_unexpected_exception_types() -> None:
@@ -752,7 +914,7 @@ async def test_bulk_reembed_fallback_catches_unexpected_exception_types() -> Non
         ),
     ):
         items = [(uuid.uuid4(), f"m{i}") for i in range(3)]
-        await memory_service._reembed_memories_bulk(items, TENANT_ID)
+        await memory_service._reembed_memories_bulk(items, TENANT_ID, FLEET_ID)
 
     # All 3 items land in the per-item fallback despite the auth error
     # being outside the original narrow except list.
@@ -815,7 +977,7 @@ async def test_bulk_reembed_reschedules_items_whose_get_memory_failed() -> None:
         ),
     ):
         await memory_service._reembed_memories_bulk(
-            [(mem_a_id, "body a"), (mem_b_id, "body b")], TENANT_ID
+            [(mem_a_id, "body a"), (mem_b_id, "body b")], TENANT_ID, FLEET_ID
         )
 
     # Item B went through the normal write pass.
@@ -889,7 +1051,7 @@ async def test_bulk_reembed_patch_failure_reschedules_item() -> None:
         ),
     ):
         await memory_service._reembed_memories_bulk(
-            [(mem_a_id, "body a"), (mem_b_id, "body b")], TENANT_ID
+            [(mem_a_id, "body a"), (mem_b_id, "body b")], TENANT_ID, FLEET_ID
         )
 
     # Both PATCH calls attempted (loop didn't abort on item A's failure).
@@ -966,7 +1128,7 @@ async def test_bulk_reembed_respects_existing_embedding_per_item() -> None:
         ),
     ):
         await memory_service._reembed_memories_bulk(
-            [(mem_a_id, "body a"), (mem_b_id, "body b")], TENANT_ID
+            [(mem_a_id, "body a"), (mem_b_id, "body b")], TENANT_ID, FLEET_ID
         )
 
     # mem_a: race guard → no PATCH, contradiction on the EXISTING embedding
@@ -1019,7 +1181,7 @@ async def test_bulk_reembed_falls_back_on_length_mismatch() -> None:
             new=AsyncMock(return_value=None),
         ),
     ):
-        await memory_service._reembed_memories_bulk(items, TENANT_ID)
+        await memory_service._reembed_memories_bulk(items, TENANT_ID, FLEET_ID)
 
     # No PATCHes landed — we never entered the per-item loop.
     sc.update_embedding.assert_not_called()

--- a/tests/test_embed_provenance_call_sites.py
+++ b/tests/test_embed_provenance_call_sites.py
@@ -1,0 +1,150 @@
+"""CI guard: no ``_schedule_embed_or_reembed`` call omits ``content_hash``.
+
+``content_hash`` is that shim's provenance argument, and omitting it fails
+silently in a way no reviewer or runtime test on the changed path will show
+you. The shim publishes ``EMBED_REQUESTED`` with ``content_hash=None``,
+``handle_embed_request`` forwards the None to ``update_memory_embedding``, and
+that writes the vector while deliberately leaving ``embedded_content_hash``
+NULL — "unknown provenance is honest, a wrong hash is not". The row lands in
+the ``unknown_provenance`` bucket, which is documented as meaning "written
+before migration 037" and which no sweep targets: both embedding backfills
+select ``embedding IS NULL``, and these rows have an embedding. So the row
+leaves the staleness detector's reach permanently, with no error, no log and
+no failed request.
+
+That is not hypothetical. Five sibling call sites in
+``_reembed_memories_bulk`` shared this omission and put 241 rows of one
+tenant's data into that bucket before anyone noticed, measured 2026-09-04.
+
+This is a guard rather than a review note for the same reason
+``test_embedding_calls_are_gated.py`` is: the identical shape — one fault
+inherited across sibling call sites — took six review cycles on caura#830,
+five of them finding a *different* site. A reviewer cannot see that a new
+call omits a keyword argument; this test can. It also covers the case the
+runtime tests structurally cannot: a SIXTH call site added later that
+bypasses the shared helper.
+
+To satisfy it, pass the hash of the text being embedded:
+
+    _schedule_embed_or_reembed(
+        memory_id, content, tenant_id,
+        content_hash=_content_hash(tenant_id, fleet_id, content),
+    )
+
+``_content_hash`` covers ``tenant:fleet:content``, so the fleet has to be the
+one the row carries — a hash computed without it is present, wrong, and reads
+downstream as verified freshness, which is worse than the NULL it replaced.
+
+Exemptions: tests (which call the shim directly to exercise its defaults) and
+the shim's own definition.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+_SHIM = "_schedule_embed_or_reembed"
+_REQUIRED_KWARG = "content_hash"
+
+_EXEMPT_PARTS = {
+    ".venv",
+    "site-packages",
+    "node_modules",
+    "__pycache__",
+    "tests",
+    "test",
+    "e2e",
+    "scripts",
+    "migrations",
+    "clients",
+}
+
+
+def _iter_service_py():
+    for p in REPO_ROOT.rglob("*.py"):
+        rel = p.relative_to(REPO_ROOT)
+        if set(rel.parts) & _EXEMPT_PARTS:
+            continue
+        yield p
+
+
+def _violations(path: pathlib.Path) -> list[int]:
+    """Line numbers of ``_SHIM`` calls that do not pass ``_REQUIRED_KWARG``.
+
+    ``**kwargs`` forwarding counts as passing: a caller that splats a dict may
+    well carry the hash, and this guard cannot see inside it. That is a
+    deliberate false-negative — the alternative is failing every legitimate
+    forwarder, which would get the guard deleted rather than obeyed.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = (
+            func.id
+            if isinstance(func, ast.Name)
+            else func.attr
+            if isinstance(func, ast.Attribute)
+            else None
+        )
+        if name != _SHIM:
+            continue
+        passed = {kw.arg for kw in node.keywords}
+        # ``kw.arg is None`` is ``**kwargs``; treat it as opaque-but-ok.
+        if _REQUIRED_KWARG in passed or None in passed:
+            continue
+        hits.append(node.lineno)
+    return hits
+
+
+def test_schedule_embed_or_reembed_call_sites_pass_hash():
+    offenders: dict[str, list[int]] = {}
+    for path in _iter_service_py():
+        v = _violations(path)
+        if v:
+            offenders[str(path.relative_to(REPO_ROOT))] = v
+    assert not offenders, (
+        f"{_SHIM} called without {_REQUIRED_KWARG}. The embedding will be written "
+        "with NULL provenance, landing the row in unknown_provenance where no sweep "
+        "will ever re-embed it — silently. Pass "
+        "content_hash=_content_hash(tenant_id, fleet_id, content). Offenders:\n"
+        + "\n".join(f"  {f}: lines {v}" for f, v in sorted(offenders.items()))
+    )
+
+
+def test_guard_detects_a_missing_hash():
+    """The guard must actually fail on a bad call site.
+
+    Without this, a mistake in ``_violations`` (a wrong node type, a renamed
+    shim) makes the guard above pass unconditionally and report a clean tree
+    forever — the same false-clean failure mode the guard itself exists to
+    catch. Both directions are asserted against source that is never
+    executed.
+    """
+    bad = ast.parse(f"{_SHIM}(mid, content, tenant_id, is_failure_fallback=True)")
+    good = ast.parse(f"{_SHIM}(mid, content, tenant_id, {_REQUIRED_KWARG}=h)")
+    splat = ast.parse(f"{_SHIM}(mid, content, tenant_id, **kw)")
+
+    def _scan(tree):
+        return [
+            n.lineno
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and n.func.id == _SHIM
+            and _REQUIRED_KWARG not in {kw.arg for kw in n.keywords}
+            and None not in {kw.arg for kw in n.keywords}
+        ]
+
+    assert _scan(bad) == [1], "guard would not have caught the omission it exists for"
+    assert _scan(good) == [], "guard would reject a correct call site"
+    assert _scan(splat) == [], "guard would reject **kwargs forwarding"


### PR DESCRIPTION
## The defect

`_reembed_memories_bulk` has five per-item failure fallbacks. All five called
`_schedule_embed_or_reembed` without `content_hash`, and the omission was silent
at every hop:

```
_schedule_embed_or_reembed(content_hash=None)
  -> publishes EMBED_REQUESTED with content_hash=None
  -> handle_embed_request forwards the None
  -> update_memory_embedding writes the vector, leaves embedded_content_hash NULL
```

That NULL is deliberate at the storage layer — *"unknown provenance is honest, a
wrong hash is not"*. The problem is where the row lands: the `unknown_provenance`
bucket, which is documented as meaning **"written before migration 037"** and
which nothing sweeps. Both embedding backfills select `embedding IS NULL`
(`core-worker/backfill.py` via `/memories/null-embedding-ids`, and
`backfill_embeddings.py`), and these rows *have* an embedding. So they are
invisible to the repair paths and to the staleness detector, permanently.

No error, no log, no failed request. Nothing to notice.

**Measured in production 2026-09-04: 241 rows, one tenant, all bulk-created.**
Those rows have been repaired separately (`embedded_content_hash = content_hash`,
verified row-by-row against a recomputed `sha256(tenant:fleet:content)` before the
write). This PR stops the source.

## The fix

`content_hash=_content_hash(tenant_id, fleet_id, content)` on the fallback, and a
new required `fleet_id` parameter to make that possible.

**Why `fleet_id` has to be threaded in.** `_content_hash` covers
`tenant:fleet:content`. A hash computed without the fleet would be *present,
wrong, and read downstream as verified freshness* — worse than the NULL it
replaces. It cannot be derived in the callee: `MemoryEmbedRequest` carries no
fleet, and the fallback paths have no row to read it off (the read may be exactly
what failed).

**Why a scalar is safe.** A bulk batch is single-fleet by construction —
`memory_add_all` rejects a batch whose items disagree on `fleet_id`, and
`BulkMemoryItem` has no per-item fleet — and the route resolves `body.fleet_id`
before the insert. Required rather than defaulted, so a future caller cannot
silently omit it.

**The five call sites are now one nested `_fallback` helper.** This is the part I
would push back on if I were reviewing: the repetition *was* the defect — five
siblings, the same omission at each — so repairing five copies while leaving five
copies preserves the shape that produced it. There is now one place to omit it
from.

## Tests

`test_bulk_reembed_fallback_carries_provenance` is parametrised over **all five**
branches that can reach the fallback — batch raised, embedding-count mismatch,
per-item `None`, `get_memory` raised, PATCH raised — and asserts the **exact**
expected hash rather than "a hash is present", since a wrong-fleet hash would
satisfy the weaker assertion.

**Verified by reverting the fix: all five go red, and each branch's log line
confirms it reached its own code path.** Restored, all green.

`tests/test_embed_provenance_call_sites.py` is a static AST guard modelled on the
existing `test_embedding_calls_are_gated.py`, failing if any
`_schedule_embed_or_reembed` call omits `content_hash`. It covers what the runtime
tests structurally cannot: **a sixth call site added later that bypasses the
helper.** `**kwargs` forwarding is treated as passing — a deliberate false
negative, since failing every legitimate forwarder gets a guard deleted rather
than obeyed.

That guard carries its own meta-test. A guard whose detection logic silently
breaks reports a clean tree forever, which is the same false-clean failure it
exists to catch, so both directions are asserted against source that never runs.

Full suite: **6041 passed vs 6034 on the base commit, +7 = exactly the tests added.
The 18 failures are identical in both runs** (pre-existing local FTS/search
environment gaps, none near this code) — failure sets diffed by name, zero new and
zero fixed.

## Things a reviewer should push on

**1. This is not the deepest possible fix.** `_schedule_embed_or_reembed` has 10
production call sites and, after this PR, all 10 pass a value that is always
`_content_hash(tenant_id, fleet_id, <the content being passed>)`. The parameter is
therefore fully derivable, and the stronger change is to drop `content_hash`
entirely in favour of a required `fleet_id` on the shim, computing the hash
inside. That makes the omission *unrepresentable* rather than *guarded*. I did not
do it here because it touches 10 sites across two more files and I wanted the
241-row bleed stopped on a reviewable diff; the AST guard buys most of the safety
at a fraction of the blast radius. Say the word and I'll do it as a follow-up.

**2. `create_memories_bulk` already computed this hash and throws it away.**
`hashes` (built for the dedup query) is indexed by the same `orig_idx` used to
build `reembed_batch`, and is the value actually written to the row. Widening the
batch tuple to carry it would delete this PR's new parameter, the recomputation,
and the prose defending the scalar-fleet argument. I judged the tuple-shape change
plus its test churn to be the larger diff for the same outcome, but it is a fair
call to make the other way.

**3. The systemic gap this does *not* close.** Nothing anywhere selects
`embedding IS NOT NULL AND embedded_content_hash IS NULL`. The bucket is counted
(`core-operations/tasks.py`) but deliberately non-alerting, on the recorded premise
that it is *"a measurement gap closing, so do not alert on it"* — a premise that
assumes the population only ever drains. This defect made it grow, and the one
number that would have shown 241 was the one chosen not to alert. Alerting on the
**delta** rather than the level would have caught this in hours. Worth its own
issue.

**4. `backfill_embeddings.py` is itself a producer.** Its `UPDATE ... SET
embedding = ...` writes no `embedded_content_hash`, so the OSS sweep moves rows
from `missing` (repairable) to `unknown_provenance` (repaired by nothing). Same
one-line class of fix; out of scope here but it means the population can still
grow via that path.

## Not a defect (checked, and I had this wrong first)

I initially flagged `update_memory` as a fourth site, since it writes
`patch["embedding"]` and `patch["content_hash"]` but never
`patch["embedded_content_hash"]`. It is covered: `memory_update` in
core-storage-api derives the provenance hash for exactly that column combination,
including correctly clearing it when the embedding is None. That site is fine, and
is in fact the model for what the scheduling path lacks.

## Coordination

Open PR #1278 also touches `memory_service.py` and adds its own
`_schedule_embed_or_reembed` call — it already passes `content_hash`, so it
satisfies the new guard and there is no semantic conflict (different function).
Textual conflict risk on that file is low but non-zero depending on merge order.

Not merging this myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
