### PR TITLE
fix(storage): refuse a negative tenant usage counter

### DIFF
--- a/common/models/tenant_usage_counter.py
+++ b/common/models/tenant_usage_counter.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, Index, Text, text
+from sqlalchemy import BigInteger, CheckConstraint, DateTime, Index, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from common.models.base import Base
@@ -57,6 +57,8 @@ class TenantUsageCounter(Base):
         DateTime(timezone=True), nullable=False
     )
 
+    # Non-negative by CHECK, not merely by convention — see the constraint in
+    # ``__table_args__`` for why this column in particular earns one.
     count: Mapped[int] = mapped_column(
         BigInteger, nullable=False, server_default=text("0")
     )
@@ -68,9 +70,27 @@ class TenantUsageCounter(Base):
     )
 
     __table_args__ = (
-        # Names and columns must match migration 039 exactly, so a
+        # Names and columns must match migrations 039 and 042 exactly, so a
         # model-created schema (create_all / autogenerate) agrees with the
         # migration-created one.
+        #
+        # A negative count is not a smaller number here, it is a DISABLED plan
+        # limit. The platform's ``_is_over_plan_limits`` asks ``used > limit``,
+        # so a counter driven below zero reads as enormously under budget and
+        # silently stops enforcing for that tenant — the failure mode this
+        # constraint exists to convert into a loud one. That is what separates
+        # this column from the counts on ``capability_usage``, which are equally
+        # unconstrained but feed an adoption report: there a bad number skews a
+        # chart, here it stops refusing writes that should be refused.
+        #
+        # The reachable path is not hypothetical. ``tenant_usage_increment``
+        # upserts ``count = count + excluded.count`` and the router validates
+        # ``tenant_id``, ``operation`` and ``period_start`` but historically not
+        # ``count``, so a negative in the request body decremented the stored
+        # counter. The router now rejects that at the edge; this constraint is
+        # the floor under it, covering the correction-by-hand case the edge
+        # check cannot see.
+        CheckConstraint("count >= 0", name="ck_tenant_usage_counters_count_nonneg"),
         #
         # This unique index is the ``ON CONFLICT`` target. Without it the
         # upsert has nothing to bind to and concurrent writers quietly create

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/042_tenant_usage_counters_count_nonneg.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/042_tenant_usage_counters_count_nonneg.py
@@ -1,0 +1,61 @@
+"""``tenant_usage_counters.count`` >= 0.
+
+Migration 039 created the column as plain ``BigInteger NOT NULL DEFAULT 0`` with
+nothing forbidding a negative, and the upsert behind it adds rather than assigns
+(``count = count + excluded.count``). So any negative reaching the increment path
+does not merely record a smaller number — it drives the stored counter down, and
+a counter below zero reads as vastly UNDER budget in the platform's
+``_is_over_plan_limits`` (``used > limit``). The effect is that plan enforcement
+silently switches off for that tenant, which is the opposite of what a usage
+counter going wrong should do.
+
+The router now rejects a negative ``count`` at the edge (422). This constraint is
+the floor beneath that check, and it covers the case the edge cannot: a hand-run
+correction against the table, which is exactly how the gap was noticed.
+
+CLAMP BEFORE CONSTRAIN. Migrations here run in the FastAPI lifespan startup hook
+(see 038), so a migration that fails is a deploy that never becomes ready. Adding
+a validated CHECK to a table that already holds a negative row would do precisely
+that. Any such row is clamped to 0 first.
+
+Clamping to 0 rather than to a reconstructed value is deliberate: the true count
+is not recoverable — the table stores a running total, not the history that
+produced it — and 0 is both the documented floor and the conservative direction
+for enforcement, since it raises the tenant back toward their limit rather than
+leaving them under it. A clamped row is identifiable afterwards by an
+``updated_at`` matching this migration's run.
+
+``tenant_usage_counters`` is not one of the repo's declared large tables (see
+``test_no_plain_set_not_null_on_large_tables``) — it is bounded at one row per
+tenant per operation per period by the unique index 039 added — so the plain
+validated ``ADD CONSTRAINT`` is used rather than 038's NOT VALID / VALIDATE
+two-step. The clamp and the add share one transaction: the add takes
+AccessExclusive, so a concurrent writer cannot slip a negative in between them.
+
+Revision ID: 042
+Revises: 041
+Create Date: 2026-09-05
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "042"
+down_revision: str | None = "041"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CONSTRAINT = "ck_tenant_usage_counters_count_nonneg"
+
+
+def upgrade() -> None:
+    # Row locks on the offending rows only. Normally a no-op.
+    op.execute("UPDATE tenant_usage_counters SET count = 0, updated_at = now() WHERE count < 0")
+    op.execute(f"ALTER TABLE tenant_usage_counters ADD CONSTRAINT {_CONSTRAINT} CHECK (count >= 0)")
+
+
+def downgrade() -> None:
+    # The clamp is not undone: the pre-migration values were unrecoverable when
+    # they were overwritten and remain so now.
+    op.execute(f"ALTER TABLE tenant_usage_counters DROP CONSTRAINT IF EXISTS {_CONSTRAINT}")

--- a/core-storage-api/src/core_storage_api/routers/tenant_usage.py
+++ b/core-storage-api/src/core_storage_api/routers/tenant_usage.py
@@ -129,6 +129,23 @@ async def increment_tenant_usage(request: Request) -> dict:
         # prevent, instead of the intended 422.
         if not isinstance(r.get("period_start"), datetime):
             raise HTTPException(status_code=422, detail=f"row {i}: 'period_start' is required")
+        # ``count`` is ADDED to the stored total, never assigned, so a negative
+        # here decrements a billing counter rather than recording a small one.
+        # Left unchecked it is a plan-enforcement bypass and not a loud one: the
+        # platform asks ``used > limit``, so a counter pushed below zero reads as
+        # far under budget and simply stops refusing writes for that tenant.
+        #
+        # Absent is fine and means 1 (the service's default) — only a present
+        # value is judged. ``bool`` is excluded because it is an ``int`` in
+        # Python and a JSON ``true`` silently metering 1 operation is a coercion
+        # nobody asked for; the caller should say what it means.
+        if "count" in r:
+            c = r["count"]
+            if isinstance(c, bool) or not isinstance(c, int) or c < 0:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"row {i}: 'count' must be a non-negative integer, got {c!r}",
+                )
         coerced.append(r)
 
     try:

--- a/core-storage-api/tests/test_tenant_usage.py
+++ b/core-storage-api/tests/test_tenant_usage.py
@@ -102,6 +102,92 @@ class TestIncrementRequiresATenantPerRow:
         assert await _query(client, tenant_id=tenant, period_start=AUGUST) == {"periods": []}
 
 
+class TestTheCounterCannotBeDrivenNegative:
+    """A negative ``count`` is a plan-enforcement bypass, not a small number.
+
+    The upsert ADDS (``count = count + excluded.count``), so a negative in the
+    body decrements the stored total. The platform then asks ``used > limit``,
+    which a counter below zero answers "no" for any limit — enforcement stops
+    for that tenant and nothing says so. These pin the two places that is now
+    refused: the router, and the table underneath it.
+    """
+
+    async def test_a_negative_count_is_refused(self, client: AsyncClient):
+        tenant, operation = f"t-{_uid()}", f"op-{_uid()}"
+        await _increment(client, [_row(tenant, operation, AUGUST, 10)])
+
+        r = await client.post(
+            f"{PREFIX}/tenant-usage/increment",
+            json={"rows": [_row(tenant, operation, AUGUST, -50)]},
+        )
+
+        assert r.status_code == 422, r.text
+        assert "row 0" in r.text
+        assert "count" in r.text
+        # The established total is untouched — the batch was refused before any
+        # write, so the decrement never reached the upsert.
+        got = await _query(client, tenant_id=tenant, period_start=AUGUST)
+        assert got["periods"][0]["operations"][operation] == 10
+
+    async def test_a_boolean_count_is_refused(self, client: AsyncClient):
+        """``bool`` is an ``int`` in Python, so a JSON ``true`` would otherwise
+        meter exactly 1 operation by accident rather than by request."""
+        tenant, operation = f"t-{_uid()}", f"op-{_uid()}"
+
+        r = await client.post(
+            f"{PREFIX}/tenant-usage/increment",
+            json={"rows": [{**_row(tenant, operation, AUGUST, 1), "count": True}]},
+        )
+
+        assert r.status_code == 422, r.text
+        assert await _query(client, tenant_id=tenant, period_start=AUGUST) == {"periods": []}
+
+    async def test_a_zero_count_is_still_accepted(self, client: AsyncClient):
+        """The boundary the guard must not over-reach: zero is a legitimate
+        no-op flush, and refusing it would break the meter rather than protect
+        it."""
+        tenant, operation = f"t-{_uid()}", f"op-{_uid()}"
+
+        await _increment(client, [_row(tenant, operation, AUGUST, 0)])
+
+        got = await _query(client, tenant_id=tenant, period_start=AUGUST)
+        assert got["periods"][0]["operations"][operation] == 0
+
+    async def test_the_table_refuses_a_negative_count_beneath_the_router(self):
+        """The floor under the edge check, covering what it cannot see.
+
+        The router only guards the request path. The way this gap was actually
+        found was a correction run by hand against the table, which reaches the
+        column directly — so the constraint is tested directly too, not through
+        the endpoint that would reject the row before it got there.
+        """
+        from datetime import datetime
+
+        from sqlalchemy import text as _text
+        from sqlalchemy.exc import IntegrityError
+
+        from core_storage_api.services.postgres_service import get_session
+
+        with pytest.raises(IntegrityError, match="ck_tenant_usage_counters_count_nonneg"):
+            async with get_session() as session:
+                await session.execute(
+                    _text(
+                        "INSERT INTO tenant_usage_counters "
+                        "(tenant_id, operation, period_start, count) "
+                        "VALUES (:t, :o, :p, -1)"
+                    ),
+                    # A real ``datetime``: asyncpg rejects a str bound to a
+                    # timestamptz parameter outright rather than coercing it,
+                    # which is the same reason the router parses
+                    # ``period_start`` before it reaches the insert.
+                    {
+                        "t": f"t-{_uid()}",
+                        "o": f"op-{_uid()}",
+                        "p": datetime.fromisoformat(AUGUST),
+                    },
+                )
+
+
 # ``test_counts_sum_across_the_orgs_tenants`` lived here and is deliberately
 # gone (#1095, contract step). Summing an ORG's tenants was the capability the
 # plural ``tenant_ids`` existed for, and it moved to ``platform-admin-api``,

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -1084,7 +1084,7 @@ class TestMigrationChain:
         """
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"041"}, f"Expected single head '041', got {sorted(heads)}"
+        assert heads == {"042"}, f"Expected single head '042', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -1131,6 +1131,9 @@ class TestMigrationChain:
         assert chain.get("040") == "039", "040 must follow 039"
         # 041: lifecycle_audit.started_at recency index for cross-org summaries
         assert chain.get("041") == "040", "041 must follow 040"
+        # 042: tenant_usage_counters.count >= 0 — a negative counter reads as
+        # under-limit and disables plan enforcement for the tenant
+        assert chain.get("042") == "041", "042 must follow 041"
 
     def test_no_plain_set_not_null_on_large_tables(self):
         """Tightening a column to NOT NULL on a large table must not full-scan


### PR DESCRIPTION
## The defect

`tenant_usage_counters.count` is **added** to on upsert — `count = count + excluded.count` — and nothing forbade a negative. Not the column (migration 039 created it as plain `BigInteger NOT NULL DEFAULT 0`), and not `POST /tenant-usage/increment`, which validates `tenant_id`, `operation` and `period_start` and then passes `count` straight through via `r.get("count", 1)`.

A negative there is not a smaller number, it is a **disabled plan limit**. The platform's `_is_over_plan_limits` asks `used > limit`, so a counter driven below zero reads as far under budget and silently stops refusing writes for that tenant. The counter going wrong makes enforcement *quieter* rather than louder — the wrong direction for the one table plan caps are computed from.

## What changed

- **Router (`tenant_usage.py`)** — a present `count` must be a non-negative `int`; otherwise 422 naming the row. This closes the reachable path. Zero is still accepted (a legitimate no-op flush). `bool` is refused because it is an `int` in Python, and a JSON `true` quietly metering 1 operation is a coercion nobody asked for.
- **Migration 042 + model** — `CHECK (count >= 0)`, named `ck_tenant_usage_counters_count_nonneg` in both so `create_all` and the migration agree (verified: the model's compiled DDL emits the identical constraint). This is the floor under the edge check, covering the hand-run correction the router cannot see — which is how the gap was noticed.

`capability_usage` leaves its counts equally unconstrained and is **deliberately left alone**: a bad number there skews an adoption report, not an enforcement decision.

## Migration safety

042 clamps any existing negative to 0 *before* adding the constraint. Migrations here run in the FastAPI lifespan startup hook (see 038's docstring), so a migration that fails on legacy data is a deploy that never becomes ready. Clamping to 0 rather than a reconstructed value is deliberate — the table stores a running total, not the history behind it, so the true value is unrecoverable — and 0 is the conservative direction, raising the tenant back toward their limit rather than leaving them under it.

`tenant_usage_counters` is not a declared large table (it is bounded at one row per tenant/operation/period by 039's unique index), so the plain validated `ADD CONSTRAINT` is used rather than 038's `NOT VALID` / `VALIDATE` two-step. The clamp and the add share one transaction, so a concurrent writer cannot slip a negative in between them.

**Verified against real violating data**: with a negative row present, the clamp-then-constrain sequence completed successfully — the deploy-stall case this guards is exercised, not just described.

## Tests

Four new tests, each confirmed to fail without its fix by mutation:

| Test | Mutation applied | Result |
|---|---|---|
| `test_a_negative_count_is_refused` | guard removed | FAILS (200, not 422) |
| `test_a_boolean_count_is_refused` | guard removed | FAILS (200, not 422) |
| `test_a_zero_count_is_still_accepted` | `c < 0` → `c <= 0` | FAILS (422, not 200) |
| `test_the_table_refuses_a_negative_count_beneath_the_router` | constraint dropped | FAILS (`DID NOT RAISE`) |

The constraint test goes through direct SQL rather than the endpoint, because the endpoint would reject the row before it reached the column the constraint protects.

Full `core-storage-api` suite run on this branch and on clean `origin/main` against fresh databases: the failure sets are **byte-identical** (17 pre-existing failures/errors in `test_migration_040_content_hash_cleanup.py` and `test_integration.py`, unrelated to this change), and this branch passes exactly 4 more — the 4 above.

`ruff check` / `ruff format --check` at CI's scopes, `mypy src/`, both naming gates, and the migration-chain guards all pass. `test_single_head` bumped 041 → 042, which that test's docstring asks for explicitly.

## Context

Found while tracing the plan-limit enforcement chain for caura-ai/caura#1205. It is the third of four items in that cluster; the others are reported separately.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)