### PR TITLE
fix(ingest): batch a commit larger than one bulk request instead of 500ing

### DIFF
--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -16,7 +16,7 @@ from fastapi import HTTPException
 
 from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
-from core_api.constants import MEMORY_TYPES
+from core_api.constants import BULK_MAX_ITEMS, MEMORY_TYPES
 from core_api.providers._retry import call_with_fallback
 from core_api.schemas import (
     BulkMemoryCreate,
@@ -1067,45 +1067,94 @@ async def ingest_commit(request: IngestCommitRequest) -> dict:
                     metadata=metadata,
                 )
             )
-        bulk_data = BulkMemoryCreate(
-            tenant_id=request.tenant_id,
-            fleet_id=request.fleet_id,
-            agent_id=request.agent_id,
-            items=bulk_items,
-        )
-        try:
-            bulk_response = await create_memories_bulk(bulk_data, bulk_attempt_id=run_id)
-            created = bulk_response.created
-            skipped_in_loop = bulk_response.duplicates
-            errored = bulk_response.errors
-            # Surface per-item error reasons in the logs so the cleanup
-            # message at the bottom of this function still points at the
-            # offending facts.
-            for item in bulk_response.results:
-                if item.status == "error":
-                    # Mirror the legacy "fact[N]" log format the
-                    # P1.C-lite runbook + operator greps depend on.
-                    logger.warning(
-                        "ingest_commit: fact[%d] write failed (run_id=%s): %s",
-                        item.index,
-                        run_id,
-                        item.error,
-                    )
-        except HTTPException as e:
-            # A 4xx/5xx from the bulk endpoint aborts the whole batch
-            # (e.g. 504 from the bulk-embedding timeout). Mirror the
-            # prior behaviour where a non-409 escape raised through
-            # gather and aborted the run — but now the run_id is still
-            # logged so the operator can locate any partial rows.
-            logger.exception(
-                "ingest_commit: bulk write failed with HTTP %d (run_id=%s) — "
-                "0 facts persisted on this attempt; safe to retry",
-                e.status_code,
-                run_id,
+        # H-07: chunked, because ``BulkMemoryCreate.items`` carries
+        # ``max_length=BULK_MAX_ITEMS`` (100) and nothing upstream caps the
+        # fact count — not ``IngestCommitRequest.facts``, not preview. Preview
+        # accepts documents up to 100k tokens, sections them at ~2k tokens, and
+        # asks the extractor for 5-20 facts per section, so a ~40k-token
+        # document routinely clears 100 facts.
+        #
+        # Building one oversized model raised ``pydantic.ValidationError`` —
+        # and it was constructed OUTSIDE the try below, which catches only
+        # ``HTTPException`` anyway. core-api registers no handler for the raw
+        # pydantic error (``RequestValidationError`` is FastAPI's request-body
+        # wrapper and a hand-built model does not raise it), so it reached the
+        # global handler as an opaque 500. Every fact was lost, the retry
+        # re-extracted the same over-100 set and 500'd again, and the user's
+        # only recourse was a smaller document.
+        #
+        # Batches share ONE ``bulk_attempt_id`` — ``run_id``, unchanged. That
+        # is only correct because H-08 made the per-item key content-derived:
+        # batch boundaries no longer enter the key at all. Per-batch attempt
+        # ids (``f"{run_id}:batch{n}"``) would actively hurt, because the
+        # pre-dedup above shrinks the survivor list between attempts, so a
+        # retry re-cuts the boundaries and the same fact lands in a different
+        # batch — computing a different key and losing the
+        # ``duplicate_attempt`` resolution that reusing ``run_id`` exists for.
+        #
+        # Sequential, not gathered: each batch already fans out its own
+        # embed/enrich internally and takes a per-tenant storage slot, so
+        # concurrency here would multiply pressure on the same bulkhead. It
+        # also keeps the abort-on-failure semantics below honest.
+        created = 0
+        skipped_in_loop = 0
+        errored = 0
+        for batch_start in range(0, len(bulk_items), BULK_MAX_ITEMS):
+            batch = bulk_items[batch_start : batch_start + BULK_MAX_ITEMS]
+            bulk_data = BulkMemoryCreate(
+                tenant_id=request.tenant_id,
+                fleet_id=request.fleet_id,
+                agent_id=request.agent_id,
+                items=batch,
             )
-            created = 0
-            skipped_in_loop = 0
-            errored = len(survivors)
+            try:
+                bulk_response = await create_memories_bulk(bulk_data, bulk_attempt_id=run_id)
+                created += bulk_response.created
+                skipped_in_loop += bulk_response.duplicates
+                errored += bulk_response.errors
+                # Surface per-item error reasons in the logs so the cleanup
+                # message at the bottom of this function still points at the
+                # offending facts.
+                for item in bulk_response.results:
+                    if item.status == "error":
+                        # Mirror the legacy "fact[N]" log format the
+                        # P1.C-lite runbook + operator greps depend on.
+                        # ``item.index`` is batch-relative, so it is offset back
+                        # into the survivor list the format has always counted
+                        # in — otherwise every batch would restart at fact[0]
+                        # and point an operator at the wrong fact.
+                        logger.warning(
+                            "ingest_commit: fact[%d] write failed (run_id=%s): %s",
+                            batch_start + item.index,
+                            run_id,
+                            item.error,
+                        )
+            except HTTPException as e:
+                # A 4xx/5xx from the bulk endpoint aborts this batch (e.g. 504
+                # from the bulk-embedding timeout). Stop rather than carry on:
+                # these failures are overwhelmingly systemic (storage down,
+                # budget burned), so the remaining batches would queue behind
+                # the same wall and turn one failure into N.
+                #
+                # Counts accumulated by EARLIER batches are kept. This used to
+                # log "0 facts persisted on this attempt" and zero them, which
+                # was true when there was only ever one batch and would now be
+                # a false statement to an operator deciding whether to clean
+                # up. Everything from this batch onward is reported errored.
+                unattempted = len(bulk_items) - batch_start
+                logger.exception(
+                    "ingest_commit: bulk write failed with HTTP %d (run_id=%s) on the "
+                    "batch starting at fact[%d] — %d fact(s) persisted before it, "
+                    "%d not attempted; safe to retry, which re-sends every fact and "
+                    "resolves the committed ones as duplicates",
+                    e.status_code,
+                    run_id,
+                    batch_start,
+                    created,
+                    unattempted,
+                )
+                errored += unattempted
+                break
     else:
         # All facts pre-deduped by the content-hash sweep above; nothing
         # to do here.

--- a/tests/test_ingest_commit.py
+++ b/tests/test_ingest_commit.py
@@ -57,6 +57,11 @@ def captured(monkeypatch):
     state = SimpleNamespace(
         writes=[],
         bulk_calls=[],
+        # One entry per ``create_memories_bulk`` call. H-07 made a commit of
+        # >BULK_MAX_ITEMS facts issue several, and every one of them must
+        # carry the SAME attempt id — see the batching comment in
+        # ``ingest_commit``.
+        bulk_attempt_ids=[],
         bulk_find_calls=[],
         resolve_config_calls=[],
         bulk_find_result={},
@@ -66,6 +71,10 @@ def captured(monkeypatch):
         # as per-item ``status="error"`` results rather than raising
         # through ``asyncio.gather``.
         write_raise_for={},
+        # Whole-CALL failure injection, keyed on the 0-based batch number —
+        # distinct from ``write_raise_for``, which produces per-item error
+        # results. This is the 504-from-the-bulk-endpoint shape.
+        raise_http_on_batch={},
     )
 
     async def fake_resolve_config(tenant_id):
@@ -100,7 +109,11 @@ def captured(monkeypatch):
         from core_api.schemas import BulkItemResult, BulkMemoryResponse
         from core_api.services.memory_service import _content_hash as ch_fn
 
+        batch_no = len(state.bulk_calls)
         state.bulk_calls.append(data)
+        state.bulk_attempt_ids.append(bulk_attempt_id)
+        if batch_no in state.raise_http_on_batch:
+            raise state.raise_http_on_batch[batch_no]
         if state.write_delay_ms:
             await asyncio.sleep(state.write_delay_ms / 1000.0)
 
@@ -721,3 +734,114 @@ async def test_response_always_carries_errored_field(captured):
     result = await ingest_service.ingest_commit(request=req)
     assert "errored" in result
     assert result["errored"] == 0
+
+
+# ---------------------------------------------------------------------------
+# H-07 — a commit larger than one bulk batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_commit_larger_than_one_batch_persists_every_fact(captured):
+    """H-07. ``BulkMemoryCreate.items`` caps at ``BULK_MAX_ITEMS``; nothing upstream did.
+
+    ``IngestCommitRequest.facts`` carries no ``max_length`` and preview caps
+    nothing either — it accepts documents up to 100k tokens, sections them at
+    ~2k, and asks for 5-20 facts per section, so clearing 100 facts is routine
+    rather than exotic.
+
+    Building one oversized ``BulkMemoryCreate`` raised
+    ``pydantic.ValidationError``, outside the ``try`` below it (which catches
+    only ``HTTPException``), and core-api registers no handler for the raw
+    pydantic error — ``RequestValidationError`` is FastAPI's request-body
+    wrapper and a hand-built model does not raise it. So it surfaced as an
+    opaque 500 with ZERO facts persisted, and the retry re-extracted the same
+    over-100 set and failed identically.
+
+    The assertion that matters is the last one: every fact's content reaches
+    the write path exactly once, in order. Counting batches alone would pass on
+    a chunking bug that dropped or duplicated a fact at a boundary.
+    """
+    from core_api.constants import BULK_MAX_ITEMS
+
+    n = BULK_MAX_ITEMS + 50
+    facts = [f"h07 fact number {i}" for i in range(n)]
+
+    req = _request("t1", *facts)
+    result = await ingest_service.ingest_commit(request=req)
+
+    assert result["facts_extracted"] == n
+    assert result["memories_created"] == n, result
+    assert result["errored"] == 0
+
+    sizes = [len(c.items) for c in captured.bulk_calls]
+    assert sizes == [BULK_MAX_ITEMS, 50], sizes
+
+    written = [w.content for w in captured.writes]
+    assert written == facts, "chunking dropped, duplicated or reordered a fact"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_every_batch_shares_one_attempt_id(captured):
+    """Batches share ``run_id`` as the attempt id, and must keep sharing it.
+
+    Per-batch ids (``f"{run_id}:batch{n}"``) look tidier and are wrong: the
+    pre-loop dedup shrinks the survivor list between attempts, so a retry
+    re-cuts the boundaries and the same fact lands in a different batch. With
+    the batch number in the key, that fact would compute a DIFFERENT id on
+    every retry, losing the ``duplicate_attempt`` resolution that reusing
+    ``run_id`` exists to provide.
+
+    Safe only because H-08 made the per-item key content-derived — batch
+    boundaries do not enter the key at all.
+    """
+    from core_api.constants import BULK_MAX_ITEMS
+
+    facts = [f"h07 shared attempt id {i}" for i in range(BULK_MAX_ITEMS + 5)]
+    req = _request("t1", *facts, run_id="run-h07")
+    await ingest_service.ingest_commit(request=req)
+
+    assert len(captured.bulk_attempt_ids) == 2, captured.bulk_attempt_ids
+    assert captured.bulk_attempt_ids == ["run-h07", "run-h07"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_failed_batch_stops_the_run_and_reports_what_landed(captured, caplog):
+    """A batch failing mid-run must not be reported as if nothing persisted.
+
+    This path previously zeroed the counts and logged "0 facts persisted on
+    this attempt" — true when there was only ever one batch, and a false
+    statement to an operator once there can be several. The earlier batches'
+    rows are real, and the cleanup decision depends on knowing that.
+
+    It also stops rather than pressing on: these failures are overwhelmingly
+    systemic (storage down, budget burned), so continuing would queue every
+    remaining batch behind the same wall and turn one failure into N.
+    """
+    from fastapi import HTTPException
+
+    from core_api.constants import BULK_MAX_ITEMS
+
+    n = BULK_MAX_ITEMS * 2 + 10
+    facts = [f"h07 partial {i}" for i in range(n)]
+    # Second batch (0-based index 1) fails; the third must never be attempted.
+    captured.raise_http_on_batch = {1: HTTPException(status_code=504, detail="burned")}
+
+    req = _request("t1", *facts)
+    with caplog.at_level("ERROR"):
+        result = await ingest_service.ingest_commit(request=req)
+
+    assert len(captured.bulk_calls) == 2, "the run continued past a failed batch"
+    # Batch 1 landed and is still counted.
+    assert result["memories_created"] == BULK_MAX_ITEMS, result
+    # The failed batch and the un-attempted one are both errored.
+    assert result["errored"] == n - BULK_MAX_ITEMS, result
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert not any("0 facts persisted" in m for m in msgs), (
+        f"the log claims nothing persisted while {result['memories_created']} rows exist: {msgs}"
+    )
+    assert any("not attempted" in m for m in msgs), msgs


### PR DESCRIPTION
Closes audit finding **H-07**. Depends on the content-keyed idempotency from #1283 — see *Why one attempt id* below.

## The defect

`ingest_commit` packed every surviving fact into a single `BulkMemoryCreate`, whose `items` field carries `max_length=BULK_MAX_ITEMS` (**100**). Nothing upstream caps the fact count:

- `IngestCommitRequest.facts` has no `max_length`.
- Preview caps nothing either — it accepts documents up to **100k tokens**, sections them at ~2k, and asks the extractor for **5-20 facts per section**. A ~40k-token document routinely clears 100 facts.

The model was built **outside** the `try` below it — which catches only `HTTPException` in any case — and core-api registers no handler for a raw `pydantic.ValidationError` (`RequestValidationError` is FastAPI's *request-body* wrapper, and a hand-built model doesn't raise it). So it reached the global handler as an **opaque 500 with zero facts persisted**, and the retry re-extracted the same set and failed identically. The user's only recourse was a smaller document.

## Reproduced before fixing

Straight out of the pre-fix path:

```
ingest_service.py:1070: pydantic_core._pydantic_core.ValidationError:
1 validation error for BulkMemoryCreate
```

## The fix

Survivors are chunked into batches of `BULK_MAX_ITEMS` and committed sequentially.

### Why one attempt id, not one per batch

Every batch shares **`run_id`, unchanged** — and this is the part worth reading twice.

It is correct **only because #1283 made the per-item idempotency key content-derived**, so batch boundaries no longer enter the key at all.

The audit's suggested `f"{run_id}:batch{n}"` would have been *actively harmful*: the pre-loop dedup shrinks the survivor list between attempts, so a retry re-cuts the boundaries and the same fact lands in a different batch — computing a different key each time and losing the `duplicate_attempt` resolution that reusing `run_id` exists to provide. **A test pins the shared id** so a later change cannot quietly reintroduce per-batch keys.

### Sequential, not gathered

Each batch already fans out its own embed/enrich internally and takes a per-tenant storage slot, so concurrency here would multiply pressure on the same bulkhead — and it keeps the abort-on-failure semantics below honest.

### A mid-run failure no longer lies about what landed

A batch failing with `HTTPException` now **stops the run and keeps the counts earlier batches earned**.

It previously zeroed them and logged *"0 facts persisted on this attempt"* — true while there could only ever be one batch, and a **false statement to an operator** once there can be several, at exactly the moment they are deciding whether to clean up. The message now names how many landed, how many were not attempted, and which fact index the failing batch started at.

Stopping rather than continuing is deliberate: these failures are overwhelmingly systemic (storage down, budget burned), so the remaining batches would queue behind the same wall and turn one failure into N.

### The `fact[N]` log format

The per-item warning offsets `item.index` by the batch start. That format is what the P1.C-lite runbook and operator greps key on; without the offset every batch would restart at `fact[0]` and point an operator at the wrong fact. The frame of reference is unchanged — it counts within the **survivor** list, as it always has, not within the caller's original fact list.

## Tests

Three, all confirmed to fail without the fix (the first two with the `ValidationError` above):

1. **The over-100 commit persists every fact.** Asserted by comparing the full written-content list against the input — not just the batch count — so a chunking bug that dropped, duplicated or reordered a fact at a boundary cannot pass.
2. **The attempt id is shared** across batches.
3. **A mid-run failure** keeps the earlier count, stops rather than continuing, and does not log the now-false *"0 facts persisted"*.

The `captured` fixture gains two knobs: `bulk_attempt_ids` records the id each call received, and `raise_http_on_batch` injects a whole-call failure keyed on batch number — distinct from the existing `write_raise_for`, which produces per-item error *results* rather than an `HTTPException` from the call.

## Verification

- Full root suite: **6078 passed, 5 skipped, 1 xfailed, 0 failed**.
- `ruff check` and `ruff format --check` run **separately** at CI's exact scopes — clean.
- `mypy` clean apart from 2 pre-existing `types-python-dateutil` stub errors in an untouched file.
- **Broker OpenAPI baseline checked** — current. (Added to my routine after #1283, where a route docstring turned out to be a published OpenAPI description and only CI caught it. Nothing here touches a route, but the check is cheap.)
- `legacy_name_ratchet.py` → *No new lines.* · `do_not_touch_sentinel.py` → *All 39 protected strings survive.* · `tenant_scope_gate.py` → exit 0. All after `git add`.
- Checked for an open PR on this subsystem before starting; only #524 touches ingest commit and does not overlap.
- Branched from `origin/main`, rebased onto `c2ac9e87`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
