### PR TITLE
docs(core-api): correct the stale claim that MCP cannot see plan-limit mode

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -488,19 +488,32 @@ def _observe_plan_limit(op: MutatingOp, tenant_id: str) -> None:
     from the support queue.
 
     So: emit what WOULD be refused, ship it, read the logs, then enforce with
-    the number in hand. The log also answers a question that cannot be answered
-    from this repo at all — whether the gateway stamps ``x-org-read-only`` on
-    the ``/mcp`` route or only on ``/api/v1``. The header has no producer in
-    OSS; if this line never fires in production, that is the first thing to
-    check.
+    the number in hand.
 
-    READ SILENCE CAREFULLY. Three different things produce no log, and only one
-    of them is "nothing would be refused": the gateway may not stamp the header
-    on this route at all (above), or the tenant may never have been marked over
-    plan because the MCP batch path records no usage to compute that from —
-    which stays true while ``meters_mcp_bulk_write()`` is off, its default
-    (caura-ai/caura#1220). Rule those out before reading a quiet log as a
-    green light to enforce.
+    THE GATEWAY QUESTION IS ANSWERED — IT IS YES. This docstring used to say the
+    log was the only way to learn "whether the gateway stamps
+    ``x-org-read-only`` on the ``/mcp`` route or only on ``/api/v1``", because
+    the header has no producer in OSS. It has one in caura-enterprise, and it
+    was read there at ``origin/dev`` ``13564142``:
+    ``gateway/nginx.conf.template`` gives both
+    ``location = /mcp`` and ``location /mcp/`` the same
+    ``auth_request_set $org_read_only`` / ``proxy_set_header X-Org-Read-Only``
+    pair the ``/api/v1/`` catch-all has, alongside ``X-Gateway-Secret`` — so
+    ``via_gateway`` is true and the header is honoured. The value originates in
+    ``platform-auth-api``'s ``/_auth``, which sets it on an expired license, a
+    cached read-only verdict, or a live storage lookup.
+
+    READ SILENCE CAREFULLY — but one of the three causes is now ruled out. A
+    quiet log is NOT explained by the gateway skipping this route. What is left:
+    the tenant may never have been marked over plan, because the MCP batch path
+    records no usage to compute that from while ``meters_mcp_bulk_write()`` is
+    off, its default (caura-ai/caura#1220) — or there is genuinely nothing to
+    refuse. Rule the first out before reading a quiet log as a green light.
+
+    Note that ``/_auth`` fails OPEN on its own storage lookup: an exception
+    there returns without the header, so a storage outage reads as "not
+    read-only" for the cache TTL. That is a fourth reason a log can be quiet
+    while a tenant is genuinely over plan, and it lives outside this repo.
 
     Logged at WARNING rather than INFO because a firing line means real money:
     a write that the plan says should not have happened.

--- a/core-api/src/core_api/services/usage_service.py
+++ b/core-api/src/core_api/services/usage_service.py
@@ -116,12 +116,27 @@ OperationType = Literal["write", "search", "recall", "insights", "evolve"]
 WRITE_QUOTA_OPS: frozenset[str] = frozenset({"create", "bulk_create", "update", "redistribute"})
 
 # Ops refused when the org is over its plan limit. A subset of the above minus
-# ``update`` — see the note on it. REST-ONLY IN PRACTICE: the MCP surface
-# cannot consult this because it has no read-only signal at all — the MCP
-# middleware never reads the gateway's ``x-org-read-only`` header, so no MCP
-# tool can see plan-limit mode (caura-ai/caura#1205). Until that is closed, any
-# op listed here is gated on REST and ungated on MCP, which is exactly why
-# ``transition`` is deliberately NOT listed.
+# ``update`` — see the note on it.
+#
+# STILL REST-ONLY IN PRACTICE, BUT NO LONGER FOR THE REASON THIS COMMENT USED TO
+# GIVE. It said the MCP surface "has no read-only signal at all — the MCP
+# middleware never reads the gateway's ``x-org-read-only`` header". That was
+# true when written and is now false: ``MCPAuthMiddleware`` reads the header on
+# the gateway-verified path and ``mcp_server._is_org_read_only()`` exposes it.
+#
+# What remains true is the part that matters for this table: no MCP tool
+# REFUSES on the signal yet. ``_observe_plan_limit`` consults this set and logs
+# ``mcp_plan_limit_would_refuse`` at WARNING without blocking, which is step one
+# of caura-ai/caura#1205 — deliberately staged that way, because enforcing takes
+# capability away from tenants who have it today and the blast radius should be
+# read off the logs rather than the support queue. So an op listed here is still
+# gated on REST and ungated on MCP, and ``transition`` is still deliberately NOT
+# listed.
+#
+# The distinction is worth keeping straight because the stale version of this
+# comment is what #1205 was written from: it describes a missing signal, and the
+# work left is a missing refusal. ``redistribute`` is not exposed as an MCP tool,
+# so the observation covers every op on this list that MCP can actually reach.
 PLAN_LIMIT_GATED_OPS: frozenset[str] = frozenset({"create", "bulk_create", "redistribute"})
 
 # Typed so a mistyped verb is a mypy error at the call site rather than a


### PR DESCRIPTION
Comment-only. No behaviour change, and **deliberately no enforcement** — see below.

## What was wrong

`usage_service.PLAN_LIMIT_GATED_OPS` carried this:

> REST-ONLY IN PRACTICE: the MCP surface cannot consult this because it has no read-only signal at all — the MCP middleware never reads the gateway's `x-org-read-only` header, so no MCP tool can see plan-limit mode (caura-ai/caura#1205).

That was true when written and is now false. On `main`:

- `MCPAuthMiddleware` sets `_org_read_only_var` from `x-org-read-only`, gated on `via_gateway` (`mcp_server.py`, in the block right after `_install_uuid_var`).
- `_is_org_read_only()` exposes it.
- `_observe_plan_limit()` consults `PLAN_LIMIT_GATED_OPS` and logs `mcp_plan_limit_would_refuse` at WARNING — called for `create` and `bulk_create`.

So step one of #1205 is done. The issue describes a missing **signal**; the work actually left is a missing **refusal**.

This matters beyond tidiness: the stale comment is what #1205 was written from. Left as-is it will keep generating work items for a gap that has already been half-closed, and it invites someone to "fix" it by plumbing a header that is already plumbed.

## The precondition that was marked unobtainable

`_observe_plan_limit`'s docstring said the log was the only way to learn

> whether the gateway stamps `x-org-read-only` on the `/mcp` route or only on `/api/v1` […] a question that cannot be answered from this repo at all

Correct that it cannot be answered from *this* repo — the header has no producer in OSS. It can be answered from `caura-enterprise`, and I read it there:

- `gateway/nginx.conf.template` gives both `location = /mcp` and `location /mcp/` the same `auth_request_set $org_read_only $upstream_http_x_org_read_only` + `proxy_set_header X-Org-Read-Only $org_read_only` pair as the `/api/v1/` catch-all, alongside `X-Gateway-Secret` — so `via_gateway` is true and the header is honoured rather than discarded.
- The value originates in `platform-auth-api`'s `/_auth` (`routers/auth.py`), which sets `X-Org-Read-Only: "true"` on an expired license, a cached read-only verdict, or a live storage lookup.

**The answer is yes.** That removes one of the three causes the docstring lists for a quiet log, which is the whole point of recording it: a future reader now knows silence is *not* explained by the gateway skipping the route, and does not re-run an investigation that has an answer.

It adds a fourth cause in exchange, which is worth knowing before anyone reads a quiet log as a green light: `/_auth` **fails open on its own storage lookup** — an exception there returns without the header, so a storage outage reads as "not read-only" for the cache TTL.

## What this PR does not do

It does not add enforcement. `_observe_plan_limit`'s docstring stages that deliberately — enforcing takes capability away from tenants who have it today, and the blast radius should be read off the logs rather than off the support queue. The remaining precondition (whether tenants are ever marked over plan given the MCP batch path meters nothing while `meters_mcp_bulk_write()` is off, #1220) is still open. Closing #1205 is a sequencing decision with enterprise-side awareness, not a quiet fix, and this PR does not pre-empt it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)