### PR TITLE
fix(storage): record provenance in the embedding backfill

### DIFF
--- a/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
+++ b/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
@@ -66,8 +66,16 @@ Usage:
         --rewrite-hint-prefixed --tenant-id tenant-abc --dry-run
 
 Scope:
-- ``memories.embedding`` — re-embedded from ``memories.content``.
+- ``memories.embedding`` — re-embedded from ``memories.content``, and
+  ``memories.embedded_content_hash`` stamped in the same statement with the
+  ``content_hash`` read alongside that content. Without the stamp this sweep
+  moved rows out of ``embedding IS NULL`` — the population both backfills
+  scan — and into ``embedding IS NOT NULL AND embedded_content_hash IS
+  NULL``, which nothing scans, so the row silently left every repair path
+  and the staleness detector at once.
 - ``entities.name_embedding`` — re-embedded from ``entities.canonical_name``.
+  No provenance stamp: migration 037 added ``embedded_content_hash`` to
+  ``memories`` only, and ``entities`` carries no content hash to record.
 - ``documents.embedding`` — NOT handled. Documents store opaque JSON and
   the embed source is fixed to ``data["summary"]`` (with a back-compat
   fallback to ``data["description"]`` for ``collection="skills"``).
@@ -93,6 +101,7 @@ import sys
 import time
 import uuid
 from collections.abc import AsyncIterator
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +112,19 @@ logger = logging.getLogger(__name__)
 # rather than blipping. Better to halt and let the operator escalate
 # than to spend the next hour writing nothing.
 _MAX_CONSECUTIVE_NONES = 20
+
+
+class _Provenance(NamedTuple):
+    """Which columns carry a table's embedding provenance.
+
+    A pair rather than two optional fields on ``_TableSpec``, so "one set and
+    the other not" cannot be written down. Half a pair silently disables
+    stamping, which is the exact failure this records against — a sweep that
+    writes vectors and attests nothing. Unrepresentable beats validated.
+    """
+
+    source_hash_column: str  # read alongside the content
+    stamp_column: str  # the value read is written back here
 
 
 @dataclasses.dataclass
@@ -124,6 +146,12 @@ class _TableSpec:
     # asserts this is set so a misconfigured spec fails loudly rather
     # than emitting SQL against a nonexistent column.
     metadata_column: str | None = None
+    # Which text each stored vector was built from. ``None`` for tables that
+    # cannot record it: migration 037 added ``embedded_content_hash`` to
+    # ``memories`` alone, and ``entities`` has neither that column nor a
+    # content hash to attest — emitting the assignment there would fail with
+    # an undefined-column error on every write.
+    provenance: _Provenance | None = None
 
 
 _TARGETS: tuple[_TableSpec, ...] = (
@@ -132,7 +160,15 @@ _TARGETS: tuple[_TableSpec, ...] = (
         embedding_column="embedding",
         content_column="content",
         has_deleted_at=True,
-        metadata_column="metadata_",
+        # The DATABASE column is ``metadata``. ``metadata_`` is the Python
+        # attribute name on the ORM model — ``mapped_column("metadata", JSONB)``
+        # renames it because ``metadata`` collides with SQLAlchemy's own
+        # ``Base.metadata``. This script emits raw SQL, so it needs the
+        # database's name. Carrying the ORM's spelling here meant
+        # ``--rewrite-hint-prefixed`` raised UndefinedColumnError on its first
+        # statement and had therefore never completed a run.
+        metadata_column="metadata",
+        provenance=_Provenance("content_hash", "embedded_content_hash"),
     ),
     _TableSpec(
         table="entities",
@@ -159,8 +195,14 @@ async def _iter_rows(
     tenant_id: str | None,
     batch_size: int,
     rewrite_hint_prefixed: bool,
-) -> AsyncIterator[list[tuple[uuid.UUID, str]]]:
-    """Yield batches of (id, content) for rows that need (re-)embedding.
+) -> AsyncIterator[list[tuple[uuid.UUID, str, str | None]]]:
+    """Yield batches of (id, content, content_hash) for rows that need (re-)embedding.
+
+    ``content_hash`` is the provenance source — the hash of the text this
+    row holds — and is ``None`` for tables that don't carry it (entities).
+    It is read here, in the same statement as the content, on purpose: see
+    ``_embed_and_write`` for why the value must travel with the text rather
+    than being re-read at write time.
 
     Two scan modes:
       - Default: rows where the embedding is NULL (post-12 backfill,
@@ -187,7 +229,10 @@ async def _iter_rows(
     after: uuid.UUID | None = None
     while True:
         params: dict = {"limit": batch_size}
-        sql = f"SELECT id, {spec.content_column} FROM {spec.table} WHERE "
+        selected = f"id, {spec.content_column}"
+        if spec.provenance:
+            selected += f", {spec.provenance.source_hash_column}"
+        sql = f"SELECT {selected} FROM {spec.table} WHERE "
         if rewrite_hint_prefixed:
             # Rewrite mode: target rows that were embedded with the
             # pre-CAURA-222 hint prefix. The metadata key is preserved
@@ -198,9 +243,16 @@ async def _iter_rows(
                     f"rewrite_hint_prefixed scan requires a metadata column on "
                     f"_TableSpec.table={spec.table!r}; got metadata_column=None"
                 )
+            # No ``? 'retrieval_hint'`` existence test. ``?`` is jsonb-only and
+            # this column is ``json`` (the migration chain creates it that way
+            # regardless of the model declaring JSONB), so it raised
+            # UndefinedFunctionError: operator does not exist: json ? unknown.
+            # It was also redundant — the COALESCE below already excludes an
+            # absent key: ``->>`` yields NULL for a missing key and for a NULL
+            # metadata, which coalesces to '' and fails the ``<> ''`` test.
+            # One clause, correct on both json and jsonb.
             sql += (
                 f"{spec.embedding_column} IS NOT NULL "
-                f"AND {spec.metadata_column} ? 'retrieval_hint' "
                 f"AND COALESCE({spec.metadata_column}->>'retrieval_hint', '') <> '' "
             )
         else:
@@ -223,7 +275,7 @@ async def _iter_rows(
             rows = result.all()
         if not rows:
             return
-        yield [(row[0], row[1]) for row in rows]
+        yield [(row[0], row[1], row[2] if spec.provenance else None) for row in rows]
         after = rows[-1][0]
 
 
@@ -247,7 +299,7 @@ async def _backfill_one_table(
     consecutive_nones = 0
     none_lock = asyncio.Lock()
 
-    async def _embed_and_write(row_id: uuid.UUID, content: str | None) -> None:
+    async def _embed_and_write(row_id: uuid.UUID, content: str | None, content_hash: str | None) -> None:
         nonlocal embedded, skipped_empty, none_returns, consecutive_nones
         if not content:
             # Defensive: ``content`` is NOT NULL on memories but is
@@ -297,9 +349,46 @@ async def _backfill_one_table(
                 # PostgreSQL parses the string at server side rather
                 # than relying on implicit-cast inference, which would
                 # depend on asyncpg's chosen wire-type for the param.
+                #
+                # Provenance is written in the SAME statement as the vector.
+                # Writing the vector alone is what made this script a
+                # producer of the very rows it exists to repair: it moved
+                # them out of ``embedding IS NULL`` (which both backfills
+                # scan) and into ``embedding IS NOT NULL AND
+                # embedded_content_hash IS NULL``, which nothing scans at
+                # all. The row left every repair path and the staleness
+                # detector in one write, silently.
+                #
+                # ``:ch`` is the hash READ ALONGSIDE THE CONTENT, not a
+                # SQL-side ``= content_hash``. That distinction is the whole
+                # correctness argument. A content update landing in the
+                # fetch -> embed -> write window would leave the row's
+                # ``content_hash`` describing text this vector was not built
+                # from, and a self-referential assignment would stamp that
+                # new hash onto the old vector — recording the row as
+                # freshly embedded at the exact moment it went stale. Naming
+                # the value we embedded keeps the column's promise true:
+                # afterwards ``embedded_content_hash != content_hash``, and
+                # the staleness detector correctly picks the row up.
+                # ``memory_update_embedding`` refuses the same re-read for
+                # the same reason.
+                #
+                # A NULL ``content_hash`` writes NULL, deliberately. Unknown
+                # provenance is honest; a guessed hash reads downstream as
+                # verified freshness and is worse than the NULL it replaced.
+                # Under ``--rewrite-hint-prefixed`` this can CLEAR an
+                # existing stamp, which is also correct: that stamp
+                # described the hint-prefixed vector being overwritten here,
+                # so keeping it would assert freshness for a vector that no
+                # longer exists.
+                assignments = f"{spec.embedding_column} = (:emb)::vector"
+                params: dict = {"emb": str(vec), "id": row_id}
+                if spec.provenance:
+                    assignments += f", {spec.provenance.stamp_column} = :ch"
+                    params["ch"] = content_hash
                 await conn.execute(
-                    text(f"UPDATE {spec.table} SET {spec.embedding_column} = (:emb)::vector WHERE id = :id"),
-                    {"emb": str(vec), "id": row_id},
+                    text(f"UPDATE {spec.table} SET {assignments} WHERE id = :id"),
+                    params,
                 )
                 await conn.commit()
             embedded += 1
@@ -312,7 +401,7 @@ async def _backfill_one_table(
         rewrite_hint_prefixed=rewrite_hint_prefixed,
     ):
         scanned += len(batch)
-        await asyncio.gather(*(_embed_and_write(rid, c) for rid, c in batch))
+        await asyncio.gather(*(_embed_and_write(rid, c, ch) for rid, c, ch in batch))
         logger.info(
             "backfill[%s] progress: scanned=%d embedded=%d empty=%d none=%d",
             spec.table,

--- a/core-storage-api/tests/test_backfill_embeddings_provenance.py
+++ b/core-storage-api/tests/test_backfill_embeddings_provenance.py
@@ -1,0 +1,308 @@
+"""The embedding backfill must record which text each vector came from.
+
+Writing the vector alone does not leave the row where it was found — it moves
+it. Both embedding backfills scan ``embedding IS NULL``; a row written without
+``embedded_content_hash`` lands in ``embedding IS NOT NULL AND
+embedded_content_hash IS NULL``, and nothing anywhere scans that. So the repair
+tool's own write was what removed rows from the reach of every repair path and
+from the staleness detector, in one statement, with no error.
+
+That is not theoretical: the same omission on core-api's bulk re-embed
+fallbacks (caura#1281) put 241 production rows in that bucket before anyone
+noticed, and this script would have quietly done the same to any row it
+touched.
+
+The sharp test here is ``test_stamps_the_hash_it_embedded_not_the_row_s_current_hash``.
+Stamping provenance at all is the easy half; stamping the RIGHT hash is what
+separates this fix from the obvious one. A SQL-side ``SET embedded_content_hash
+= content_hash`` also makes the column non-NULL and also passes every other
+test in this file — while recording a row as freshly embedded at the exact
+moment it went stale.
+
+Integration: these need a real PostgreSQL with pgvector, because the defect is
+in emitted SQL and a mocked connection would assert against the mock.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from core_storage_api.scripts import backfill_embeddings as bf
+
+VECTOR_DIM_FAKE = 1024
+
+
+@pytest.fixture
+async def engine(_ensure_schema):
+    """The engine the script itself uses.
+
+    ``run_backfill`` calls ``database.init.get_engine()``, whose pool settings
+    (size, overflow, recycle, ``pool_pre_ping``) come from config. Building a
+    second engine here would test a pool the script never runs on. It is a
+    module-level singleton, so this deliberately does NOT dispose it.
+    """
+    from core_storage_api.database.init import get_engine
+
+    return get_engine()
+
+
+def _memories_spec() -> bf._TableSpec:
+    """The real production spec for ``memories``, not a hand-built stand-in.
+
+    Taken from ``_TARGETS`` so a spec that stops declaring its provenance
+    columns fails these tests rather than passing against a local copy that
+    still declares them.
+    """
+    return next(s for s in bf._TARGETS if s.table == "memories")
+
+
+def _entities_spec() -> bf._TableSpec:
+    return next(s for s in bf._TARGETS if s.table == "entities")
+
+
+async def _seed_memory(engine, tenant_id: str, *, content: str, content_hash: str | None) -> uuid.UUID:
+    mid = uuid.uuid4()
+    async with engine.connect() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO memories (id, tenant_id, agent_id, memory_type, content, content_hash, embedding) "
+                "VALUES (:id, :t, 'agent-bf', 'fact', :c, :ch, NULL)"
+            ),
+            {"id": mid, "t": tenant_id, "c": content, "ch": content_hash},
+        )
+        await conn.commit()
+    return mid
+
+
+async def _read_memory(engine, mid: uuid.UUID) -> tuple[bool, str | None, str | None]:
+    """Return (has_embedding, content_hash, embedded_content_hash)."""
+    async with engine.connect() as conn:
+        row = (
+            await conn.execute(
+                text(
+                    "SELECT embedding IS NOT NULL, content_hash, embedded_content_hash "
+                    "FROM memories WHERE id = :id"
+                ),
+                {"id": mid},
+            )
+        ).one()
+    return bool(row[0]), row[1], row[2]
+
+
+def _patch_embedding(monkeypatch, *, on_call=None):
+    """Stub the provider. ``_backfill_one_table`` imports it inside the function
+    body, so patch the module attribute the import resolves against."""
+    import common.embedding
+
+    async def _fake(content, *_a, **_kw):
+        if on_call is not None:
+            await on_call(content)
+        return [0.125] * VECTOR_DIM_FAKE
+
+    monkeypatch.setattr(common.embedding, "get_embedding", _fake)
+
+
+async def _run(engine, spec, tenant_id, *, rewrite_hint_prefixed: bool = False):
+    return await bf._backfill_one_table(
+        engine,
+        spec,
+        tenant_id=tenant_id,
+        batch_size=100,
+        max_inflight=4,
+        dry_run=False,
+        rewrite_hint_prefixed=rewrite_hint_prefixed,
+    )
+
+
+@pytest.mark.integration
+async def test_stamps_provenance_alongside_the_vector(engine, tenant_id, monkeypatch):
+    """The whole point: after the sweep, the row says which text it embedded."""
+    _patch_embedding(monkeypatch)
+    ch = "a" * 64
+    mid = await _seed_memory(engine, tenant_id, content="a body to embed", content_hash=ch)
+
+    report = await _run(engine, _memories_spec(), tenant_id)
+
+    assert report.embedded == 1
+    has_emb, content_hash, provenance = await _read_memory(engine, mid)
+    assert has_emb, "the sweep did not write a vector at all"
+    assert provenance == ch, (
+        f"vector written with embedded_content_hash={provenance!r}; a row embedded "
+        "without provenance leaves every repair path and the staleness detector"
+    )
+    assert provenance == content_hash
+
+
+@pytest.mark.integration
+async def test_row_does_not_land_in_the_unswept_population(engine, monkeypatch):
+    """Stated as the invariant that matters, and counted the way ops counts it.
+
+    ``embedding IS NOT NULL AND embedded_content_hash IS NULL`` is the
+    population no sweep selects on. Rather than re-writing that predicate here
+    — the service's own docstring already warns that its three copies must be
+    kept in step, and a fourth drifted immediately, omitting the
+    ``LIVE_MEMORY_STATUSES`` filter — this asserts through
+    ``memory_embedding_coverage_for_tenant``, whose ``unknown_provenance``
+    bucket IS that predicate and is what the operator dashboard reports. So
+    this fails if the backfill regresses, and equally if the metric stops
+    measuring what it claims.
+
+    Its own tenant, deliberately. The ``tenant_id`` fixture returns one
+    session-constant string, and ``test_null_content_hash_stays_null`` below
+    creates a row matching this very predicate under it — legitimately, since
+    a row with no content hash has nothing to attest. Sharing the tenant would
+    make this assertion depend on which test ran first.
+    """
+    from core_storage_api.services.postgres_service import PostgresService
+
+    isolated_tenant = f"test-unswept-{uuid.uuid4().hex[:8]}"
+    _patch_embedding(monkeypatch)
+    await _seed_memory(engine, isolated_tenant, content="body", content_hash="b" * 64)
+
+    await _run(engine, _memories_spec(), isolated_tenant)
+
+    _total, _missing, _stale, unknown = await PostgresService().memory_embedding_coverage_for_tenant(
+        isolated_tenant
+    )
+    assert unknown == 0, f"{unknown} row(s) moved into the population nothing sweeps"
+
+
+@pytest.mark.integration
+async def test_stamps_the_hash_it_embedded_not_the_row_s_current_hash(engine, tenant_id, monkeypatch):
+    """A content update mid-embed must not be recorded as freshly embedded.
+
+    The window is real: fetch -> embed (a network call) -> write. If the row's
+    content changes inside it, the vector describes the OLD text while
+    ``content_hash`` now describes the NEW text. Stamping the value read with
+    the content keeps the column's promise true and leaves the row visibly
+    stale. A SQL-side ``SET embedded_content_hash = content_hash`` would
+    instead stamp the NEW hash onto the OLD vector and mark the row fresh —
+    the precise failure ``memory_update_embedding`` refuses the same re-read
+    to avoid.
+
+    This is the test that distinguishes the fix from the obvious one.
+    """
+    old_hash, new_hash = "c" * 64, "d" * 64
+    mid = await _seed_memory(engine, tenant_id, content="original body", content_hash=old_hash)
+
+    async def _concurrent_content_update(_content):
+        async with engine.connect() as conn:
+            await conn.execute(
+                text("UPDATE memories SET content = :c, content_hash = :ch WHERE id = :id"),
+                {"c": "edited body", "ch": new_hash, "id": mid},
+            )
+            await conn.commit()
+
+    _patch_embedding(monkeypatch, on_call=_concurrent_content_update)
+
+    await _run(engine, _memories_spec(), tenant_id)
+
+    _has_emb, content_hash, provenance = await _read_memory(engine, mid)
+    assert content_hash == new_hash, "fixture did not actually simulate the concurrent edit"
+    assert provenance == old_hash, (
+        f"stamped {provenance!r}; the vector was built from the text hashing to "
+        f"{old_hash!r}, so recording anything else asserts a freshness that is not true"
+    )
+    assert provenance != content_hash, (
+        "row reads as freshly embedded despite its content having changed since; "
+        "the staleness detector can no longer see it"
+    )
+
+
+@pytest.mark.integration
+async def test_null_content_hash_stays_null(engine, tenant_id, monkeypatch):
+    """No hash to copy means unknown provenance, which is the honest record.
+
+    A guessed or derived value would be worse than the NULL it replaced: NULL
+    reads as "unknown", while a wrong hash reads as verified freshness. The
+    embedding is still written — the row is repaired, just not attested.
+    """
+    _patch_embedding(monkeypatch)
+    mid = await _seed_memory(engine, tenant_id, content="body without a hash", content_hash=None)
+
+    report = await _run(engine, _memories_spec(), tenant_id)
+
+    assert report.embedded == 1
+    has_emb, content_hash, provenance = await _read_memory(engine, mid)
+    assert has_emb, "the row should still get its vector"
+    assert content_hash is None
+    assert provenance is None, f"invented provenance {provenance!r} for a row with no content hash"
+
+
+@pytest.mark.integration
+async def test_entities_backfill_still_works(engine, tenant_id, monkeypatch):
+    """``entities`` has neither column, so the stamp must not be emitted there.
+
+    Migration 037 added ``embedded_content_hash`` to ``memories`` alone. A
+    table-blind fix compiles fine and fails at runtime on every entity write
+    with an undefined-column error — turning a provenance bug into an outage
+    of the other half of the same script.
+    """
+    _patch_embedding(monkeypatch)
+    eid = uuid.uuid4()
+    async with engine.connect() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO entities (id, tenant_id, entity_type, canonical_name, name_embedding) "
+                "VALUES (:id, :t, 'person', 'Ada Lovelace', NULL)"
+            ),
+            {"id": eid, "t": tenant_id},
+        )
+        await conn.commit()
+
+    report = await _run(engine, _entities_spec(), tenant_id)
+
+    assert report.embedded == 1
+    async with engine.connect() as conn:
+        has_emb = (
+            await conn.execute(
+                text("SELECT name_embedding IS NOT NULL FROM entities WHERE id = :id"), {"id": eid}
+            )
+        ).scalar()
+    assert has_emb, "entities backfill wrote no vector"
+
+
+@pytest.mark.integration
+async def test_hint_rewrite_replaces_stale_provenance(engine, tenant_id, monkeypatch):
+    """``--rewrite-hint-prefixed`` overwrites an existing vector, so it owns the stamp.
+
+    These rows already carry a vector and may already carry provenance for it.
+    The rewrite replaces the vector, which makes any existing stamp describe
+    something that no longer exists. Writing the current hash in the same
+    statement keeps the two in step.
+    """
+    _patch_embedding(monkeypatch)
+    stale_stamp, current_hash = "e" * 64, "f" * 64
+    mid = uuid.uuid4()
+    async with engine.connect() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO memories "
+                "(id, tenant_id, agent_id, memory_type, content, content_hash, "
+                " embedded_content_hash, embedding, metadata) "
+                "VALUES (:id, :t, 'agent-bf', 'fact', :c, :ch, :stale, "
+                '        (:emb)::vector, \'{"retrieval_hint": "a hint"}\'::jsonb)'
+            ),
+            {
+                "id": mid,
+                "t": tenant_id,
+                "c": "hint-prefixed body",
+                "ch": current_hash,
+                "stale": stale_stamp,
+                "emb": str([0.5] * VECTOR_DIM_FAKE),
+            },
+        )
+        await conn.commit()
+
+    report = await _run(engine, _memories_spec(), tenant_id, rewrite_hint_prefixed=True)
+
+    assert report.embedded == 1, "hint-rewrite mode did not select the seeded row"
+    _has_emb, _content_hash, provenance = await _read_memory(engine, mid)
+    assert provenance == current_hash, (
+        f"stamp is {provenance!r}; after replacing the vector the row must attest the "
+        "text the NEW vector was built from, not whatever the old one claimed"
+    )
+    assert provenance != stale_stamp

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -70,8 +70,8 @@ async def test_backfill_re_embeds_memories_and_entities(
 
     rows = {
         "from memories": [
-            (uuid.uuid4(), "memory content one"),
-            (uuid.uuid4(), "memory content two"),
+            (uuid.uuid4(), "memory content one", "hash-one"),
+            (uuid.uuid4(), "memory content two", "hash-two"),
         ],
         "from entities": [
             (uuid.uuid4(), "Acme Corp"),
@@ -113,7 +113,7 @@ async def test_backfill_dry_run_skips_provider_and_writes(
     from core_storage_api.scripts.backfill_embeddings import run_backfill
 
     rows = {
-        "from memories": [(uuid.uuid4(), "x"), (uuid.uuid4(), "y")],
+        "from memories": [(uuid.uuid4(), "x", "hx"), (uuid.uuid4(), "y", "hy")],
         "from entities": [],
     }
     monkeypatch.setattr(
@@ -145,9 +145,9 @@ async def test_backfill_skips_empty_content_rows(
 
     rows = {
         "from memories": [
-            (uuid.uuid4(), ""),
-            (uuid.uuid4(), "real content"),
-            (uuid.uuid4(), None),
+            (uuid.uuid4(), "", "h-empty"),
+            (uuid.uuid4(), "real content", "h-real"),
+            (uuid.uuid4(), None, "h-none"),
         ],
         "from entities": [],
     }
@@ -181,7 +181,9 @@ async def test_backfill_aborts_on_consecutive_provider_failures(
 
     n_rows = backfill_embeddings._MAX_CONSECUTIVE_NONES + 5
     rows = {
-        "from memories": [(uuid.uuid4(), f"content {i}") for i in range(n_rows)],
+        "from memories": [
+            (uuid.uuid4(), f"content {i}", f"h{i}") for i in range(n_rows)
+        ],
         "from entities": [],
     }
     monkeypatch.setattr(
@@ -207,7 +209,7 @@ async def test_backfill_only_table_filter(
     from core_storage_api.scripts.backfill_embeddings import run_backfill
 
     rows = {
-        "from memories": [(uuid.uuid4(), "m1")],
+        "from memories": [(uuid.uuid4(), "m1", "h-m1")],
         "from entities": [(uuid.uuid4(), "ENTITY-SHOULD-NOT-BE-PROCESSED")],
     }
     monkeypatch.setattr(
@@ -347,7 +349,7 @@ async def test_rewrite_hint_prefixed_targets_memories_with_hint_metadata(
 
     rows = {
         "from memories": [
-            (uuid.uuid4(), "memory previously embedded with a hint prefix"),
+            (uuid.uuid4(), "memory previously embedded with a hint prefix", "h-hint"),
         ],
     }
     engine, captured_sql = _capturing_engine(rows)
@@ -378,8 +380,22 @@ async def test_rewrite_hint_prefixed_targets_memories_with_hint_metadata(
     assert select_against_memories, "no SELECT against memories was emitted"
     sql = select_against_memories[0].lower()
     assert "embedding is not null" in sql
-    assert "metadata_ ? 'retrieval_hint'" in sql
-    assert "metadata_->>'retrieval_hint'" in sql
+    # MODE DISPATCH ONLY — deliberately not the SQL's exact shape.
+    #
+    # This engine is a mock; it never parses SQL, so it cannot tell a valid
+    # column name from an invalid one. That is precisely how this scan shipped
+    # naming a column that does not exist (``metadata_``, the ORM attribute,
+    # where the database column is ``metadata``) and using a jsonb-only ``?``
+    # operator against a ``json`` column — raising on its first statement, in
+    # every run, while an assertion here pinned the broken string in place and
+    # reported green.
+    #
+    # Substituting corrected strings would repeat that mistake with better
+    # spelling. SQL correctness now belongs to
+    # ``core-storage-api/tests/test_backfill_embeddings_provenance.py``, which
+    # executes against real PostgreSQL and therefore fails on SQL that cannot
+    # run. What a mock can honestly assert is which selector this mode chose.
+    assert "retrieval_hint" in sql
     # Default-mode selector must NOT be present.
     assert "embedding is null" not in sql
 
@@ -395,7 +411,7 @@ async def test_rewrite_hint_prefixed_skips_entities(
     from core_storage_api.scripts.backfill_embeddings import run_backfill
 
     rows = {
-        "from memories": [(uuid.uuid4(), "memory with hint")],
+        "from memories": [(uuid.uuid4(), "memory with hint", "h-hint")],
         "from entities": [(uuid.uuid4(), "Acme Corp")],
     }
     engine, captured_sql = _capturing_engine(rows)
@@ -428,7 +444,7 @@ async def test_default_mode_uses_null_embedding_filter(
     from core_storage_api.scripts.backfill_embeddings import run_backfill
 
     rows = {
-        "from memories": [(uuid.uuid4(), "x")],
+        "from memories": [(uuid.uuid4(), "x", "hx")],
         "from entities": [],
     }
     engine, captured_sql = _capturing_engine(rows)
@@ -573,3 +589,82 @@ async def test_amain_no_warning_on_default_mode(
     assert code == 0
     assert "NOT idempotent" not in captured.err
     assert sleeps == []
+
+
+# ---------------------------------------------------------------------------
+# Embedding provenance: which text each written vector was built from
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_production_specs_declare_provenance_where_the_columns_exist():
+    """Pins the two specs to the schema they actually run against.
+
+    ``memories`` has ``embedded_content_hash`` (migration 037) and must stamp
+    it; ``entities`` has neither that column nor a content hash and must not,
+    or every entity write fails with an undefined-column error.
+
+    Without this, a spec quietly losing its provenance columns would leave the
+    behavioural tests in ``core-storage-api/tests/`` passing against a table
+    that had stopped recording anything — the same silent-success shape the
+    provenance column exists to make impossible.
+    """
+    from core_storage_api.scripts.backfill_embeddings import _TARGETS
+
+    by_table = {s.table: s for s in _TARGETS}
+
+    memories = by_table["memories"]
+    assert memories.provenance is not None, (
+        "memories must stamp provenance; without it the sweep moves rows into "
+        "embedding IS NOT NULL AND embedded_content_hash IS NULL, which nothing scans"
+    )
+    assert memories.provenance.source_hash_column == "content_hash"
+    assert memories.provenance.stamp_column == "embedded_content_hash"
+
+    assert by_table["entities"].provenance is None, (
+        "entities has neither column; declaring provenance would emit an "
+        "undefined-column assignment on every entity write"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provenance_rides_the_same_update_as_the_vector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One statement, not two.
+
+    A follow-up UPDATE could commit the vector and then fail before the stamp,
+    leaving exactly the un-provenanced row this guards against — and leaving it
+    on the error path, where it is least likely to be noticed. Asserting on the
+    emitted SQL rather than on a written row because the coupling being pinned
+    is "same statement", which a row read cannot distinguish.
+    """
+    from core_storage_api.scripts.backfill_embeddings import (
+        _TARGETS,
+        _backfill_one_table,
+    )
+
+    rows = {"from memories": [(uuid.uuid4(), "content", "the-hash")]}
+    engine, captured_sql = _capturing_engine(rows)
+    monkeypatch.setattr(
+        "common.embedding.get_embedding", AsyncMock(return_value=[0.1] * 1024)
+    )
+
+    await _backfill_one_table(
+        engine,
+        next(s for s in _TARGETS if s.table == "memories"),
+        tenant_id=None,
+        batch_size=10,
+        max_inflight=1,
+        dry_run=False,
+        rewrite_hint_prefixed=False,
+    )
+
+    updates = [s for s in captured_sql if s.lower().startswith("update")]
+    assert len(updates) == 1, f"expected exactly one UPDATE, got {len(updates)}"
+    sql = updates[0].lower()
+    assert "embedding = (:emb)::vector" in sql
+    assert "embedded_content_hash = :ch" in sql, (
+        "provenance is not written by the same statement as the vector"
+    )


### PR DESCRIPTION
## The defect

`backfill_embeddings.py` wrote the vector and nothing else:

```sql
UPDATE memories SET embedding = (:emb)::vector WHERE id = :id
```

That does not leave a row where it found it — it **moves** it. Both embedding
backfills scan `embedding IS NULL`. A row written without
`embedded_content_hash` lands in `embedding IS NOT NULL AND
embedded_content_hash IS NULL`, and **nothing anywhere scans that**. So the
repair tool's own write removed rows from every repair path and from the
staleness detector, in one statement, with no error.

Same class as #1281, which put 241 production rows in that bucket. Per the
altitude review, this was the **last** writer to `memories` still missing
provenance — `memory_add`, `memory_add_all`, `memory_update` and
`memory_update_embedding` all record it already.

## The fix

`embedded_content_hash` is written in the same UPDATE as the vector, from the
hash **read alongside the content**.

**That bind param is the whole correctness argument, not a style choice.** A
content update landing in the `fetch → embed → write` window leaves the row's
`content_hash` describing text this vector was *not* built from. A
self-referential `SET embedded_content_hash = content_hash` would stamp that
new hash onto the old vector — recording the row as freshly embedded at the
precise moment it went stale. `memory_update_embedding` refuses the same
re-read for exactly this reason. Naming the value we embedded keeps the
column's promise true and leaves the row correctly visible as stale.

Carried on a `_Provenance` NamedTuple rather than two optional `_TableSpec`
fields, so "one column set and the other not" cannot be written down — half a
pair silently disables stamping, which is the failure being fixed.
Unrepresentable beats validated. `entities` sets it to `None`: migration 037
added the column to `memories` alone, so a blanket assignment would fail there
with an undefined-column error on **every** entity write.

A NULL `content_hash` writes NULL deliberately. Unknown provenance is honest;
a guessed hash reads downstream as verified freshness and is worse than the
NULL it replaced.

## Two pre-existing defects, found by testing the mode

`--rewrite-hint-prefixed` **had never completed a run**:

1. The spec named `metadata_` — the *ORM attribute*. The database column is
   `metadata` (`mapped_column("metadata", JSONB)` renames it away from
   `Base.metadata`). Raw SQL needs the database's name, so the scan raised
   `UndefinedColumnError` before touching a row.
2. That column is `sa.JSON()` per migration 001, not JSONB, so
   `? 'retrieval_hint'` raised `operator does not exist: json ? unknown`.
   Dropped rather than cast — the following `COALESCE(...) <> ''` already
   excludes an absent key, an empty value and a NULL metadata.

I fixed them here rather than splitting: the new stamping is untestable in a
mode that raises on its first statement, so splitting would ship this PR with
its hint-rewrite path unexercised — the same gap shape the PR exists to close.

## A test that was holding the bug in place

`tests/test_backfill_embeddings.py` asserted `"metadata_ ? 'retrieval_hint'"
in sql`. **That assertion pinned the broken SQL string**, which is how a mode
that raises on every run stayed green for its whole life. The mock never
parses SQL, so it cannot tell a valid column name from an invalid one in
either direction.

My first pass substituted corrected strings. That repeats the mistake with
better spelling, so those assertions now check only **mode dispatch** — what a
mock can honestly test — and SQL correctness moved to the new integration file
that executes against real PostgreSQL and therefore fails on SQL that cannot
run.

## Verification

Reverted two ways, because the second is the one that matters:

| Revert | Result |
|---|---|
| Stamping removed entirely | **4 of 6 integration tests red**, plus the same-statement guard |
| Naive `SET embedded_content_hash = content_hash` | **1 red** — `test_stamps_the_hash_it_embedded_not_the_row_s_current_hash` |

The naive form passes every other test in the file. That one test is the
difference between this fix and the obvious one.

core-storage-api suite **328 → 334**. Root suite: **18 known environmental
failures before and after, identical by name, zero new**, +25 passing. ruff
clean at CI's scopes, `mypy src/` clean across 85 files.

## Deliberately not done

- **No sweep for the bucket.** Nothing selects `embedding IS NOT NULL AND
  embedded_content_hash IS NULL`, and that absence — not this diff — is what
  makes each such bug permanent. A sweep needs its own index (037's partial
  index explicitly excludes the bucket, so one written today would seq-scan),
  an operator entry point, and a decision about the ~95k legitimate pre-037
  rows and their re-embed cost. Its own change.
- **No CHECK constraint.** Non-viable three ways: the ~95k pre-037 rows would
  force `NOT VALID` (unenforced for exactly the motivating population); NULL is
  the *correct* value when a row has no `content_hash`, so a constraint would
  coerce callers into inventing one; and the deferred write path legitimately
  inserts `embedding=NULL, embedded_content_hash=NULL` and fills the vector
  later.
- **`tests/test_embed_provenance_call_sites.py` unchanged.** Its
  `_EXEMPT_PARTS` includes `scripts`, but that guard checks
  `_schedule_embed_or_reembed` call sites and this file never calls it — it
  writes SQL directly. Un-exempting `scripts` would not have caught this and
  would risk false failures on diagnostic tooling. The targeted guard is
  `test_production_specs_declare_provenance_where_the_columns_exist`.
- **Still one `get_embedding` per row.** `get_embeddings_batch` exists and is
  where this script's runtime actually lives, but that is a performance change,
  not this one.

Not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
