### PR TITLE
docs(core-api): finish correcting the stale MCP plan-limit claims

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -138,9 +138,10 @@ _install_uuid_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 )
 # Plan-limit read-only mode, computed by the platform from the persisted usage
 # counters and stamped as X-Org-Read-Only (see ``usage_service``'s module
-# docstring). REST reads it via ``AuthContext.is_read_only``; until now the MCP
-# middleware never read it at all, so no MCP tool could see plan-limit mode
-# (caura-ai/caura#1205).
+# docstring). REST reads it via ``AuthContext.is_read_only``. This middleware
+# reads it too, as of the commit that introduced this var — BEFORE that it did
+# not, which is the state caura-ai/caura#1205 describes and the reason that
+# issue reads as if the signal were still missing. It is not; the refusal is.
 #
 # OBSERVED, NOT ENFORCED, for now. Nothing refuses on this yet — see
 # ``_observe_plan_limit`` below for why that sequencing is deliberate.

--- a/core-api/src/core_api/services/usage_service.py
+++ b/core-api/src/core_api/services/usage_service.py
@@ -98,9 +98,12 @@ OperationType = Literal["write", "search", "recall", "insights", "evolve"]
 # would reduce usage and reactivating really would raise it, and this verb stops
 # being safe to treat as one thing — it would need to discriminate on the
 # ``old_status -> new_status`` pair. Note that such a fix is only implementable
-# on REST today: MCP cannot see plan-limit mode at all (see below), so gating
-# one direction there would rebuild the exact surface drift this table exists to
-# close.
+# on REST today — but not for the reason this comment used to give. It said MCP
+# "cannot see plan-limit mode at all"; MCP can see it now and simply does not
+# refuse on it (see below). The conclusion is unchanged and the reason is not:
+# gating one direction there would still rebuild the exact surface drift this
+# table exists to close, because a gate MCP observes but never enforces is not
+# a gate.
 #
 # ``enforce_read_only()`` is NEITHER axis. That is the demo-mode gate, a
 # separate question, and it stays on the transition route.


### PR DESCRIPTION
Follow-up to #1288. Comment-only, no behaviour change.

## Why there is a second PR

The review on #1288 raised a Medium finding I agree with: that PR corrected two comments and left two more **in the same two files** asserting the opposite. It merged before the fix landed, so this carries it.

The finding was fair. Correcting a misleading comment while leaving its twin in place is worse than not starting, because the file now contradicts itself and a reader has no way to tell which half is current.

## The two

**`usage_service.py`** — genuinely false, now fixed. It said a future status-transition fix

> is only implementable on REST today: MCP cannot see plan-limit mode at all

The conclusion is right; the stated reason is not. MCP *can* see plan-limit mode — it just never refuses on it. Restated so the conclusion no longer rests on a false premise: gating one direction there would still rebuild the surface drift the table exists to close, because **a gate MCP observes but never enforces is not a gate**.

**`mcp_server.py`** — this one was already past-tense ("until now the MCP middleware never read it at all"), so strictly speaking accurate, and I want to be straight about that rather than overclaim a bug. But it reads as a live claim at a glance, that is precisely the failure mode #1288 existed to fix, and it did mislead a reader in practice. Rewritten to say plainly that the signal is present and the missing piece is the refusal.

## Swept rather than spot-fixed

The lesson from the review finding is that I fixed what I had looked at instead of what was there. So this time I swept both files for every variant of the claim, not just the two named. No other occurrence survives.

`usage_meter.py` and `app.py` also reference `x-org-read-only` and are **deliberately left alone** — they say core-api enforces nothing and limits arrive out-of-band, which remains true.

`ruff check` / `ruff format --check core-api/src/`, `mypy src/`, and both naming gates pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)