### PR TITLE
fix(governance): cascade a drop or keep_private to rows derived before the verdict

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -491,16 +491,28 @@ class CoreStorageClient:
         resp.raise_for_status()
         return resp.json()
 
-    async def _get_list(self, path: str, **params: Any) -> list[dict]:
-        # All current _get_list callers are pure list/stats endpoints; none
-        # sit on the write path, so no per-call opt-out is needed yet.
-        headers = await self._auth_headers(read=True)
+    async def _get_list(self, path: str, *, read: bool = True, **params: Any) -> list[dict]:
+        """List GET. ``read=False`` routes to the WRITER, same as :meth:`_get`.
+
+        This used to say "all current callers are pure list/stats endpoints;
+        none sit on the write path, so no per-call opt-out is needed yet" — true
+        when written, and falsified by the governance cascade
+        (``find_children_by_parent_id``), which reads rows it is about to delete
+        and reasons about what a retry will find. A replica read cannot support
+        that reasoning: under lag a retry sees an already-deleted child as live
+        and re-audits it. So the opt-out is here now, and the claim that it was
+        unnecessary is gone rather than left standing next to a caller that
+        needs it.
+        """
+        prefix = self._read_prefix if read else self._prefix
+        headers = await self._auth_headers(read=read)
 
         def _do() -> Awaitable[httpx.Response]:
-            return self._read_http.get(f"{self._read_prefix}{path}", params=params, headers=headers)
+            http = self._read_http if read else self._http
+            return http.get(f"{prefix}{path}", params=params, headers=headers)
 
         resp = await self._execute(_do, retry=_read_retry, label=f"GET-list {path}")
-        self._maybe_evict_on_auth_error(resp, read=True)
+        self._maybe_evict_on_auth_error(resp, read=read)
         resp.raise_for_status()
         return resp.json()
 
@@ -913,6 +925,27 @@ class CoreStorageClient:
         """
         return await self._get_list(
             "/memories/by-supersedes-id", tenant_id=tenant_id, supersedes_id=supersedes_id
+        )
+
+    async def find_children_by_parent_id(self, tenant_id: str, parent_id: str) -> list[dict]:
+        """H-10 — live rows whose ``metadata.parent_memory_id`` is ``parent_id``.
+
+        Governance-remediation-shaped: no status or visibility filter, because a
+        drop must reach every derived row whatever state it is in. Soft-deleted
+        rows are excluded storage-side — one already gone needs no second
+        remediation.
+
+        ``read=False`` — the WRITER, not the replica. This is a read-your-write:
+        the caller is about to soft-delete what comes back, and on a retry after
+        a partial failure it depends on the already-deleted rows being absent.
+        A replica cannot honour that under lag; it would hand back a child whose
+        delete has committed on the primary, and the cascade would re-audit and
+        re-delete it — putting a duplicate destructive entry in a compliance log
+        for a row that was already handled. Same reasoning ``get_memory`` records
+        for its own ``read=False``.
+        """
+        return await self._get_list(
+            "/memories/by-parent-id", read=False, tenant_id=tenant_id, parent_id=parent_id
         )
 
     async def find_successors(self, data: dict) -> list[dict]:

--- a/core-api/src/core_api/consumer.py
+++ b/core-api/src/core_api/consumer.py
@@ -38,7 +38,10 @@ from common.events.org_settings_changed_event import OrgSettingsChangedEvent
 from common.events.topics import Topics
 from core_api.clients.storage_client import get_storage_client
 from core_api.services.contradiction import Trigger, run_contradiction_detection
-from core_api.services.governance_remediation import remediate_after_enrichment
+from core_api.services.governance_remediation import (
+    GovernanceCascadeError,
+    remediate_after_enrichment,
+)
 from core_api.services.organization_settings import invalidate_cache, resolve_config
 
 logger = logging.getLogger(__name__)
@@ -104,7 +107,32 @@ async def handle_memory_enriched(event: Event) -> None:
     # counterpart to the synchronous GovernanceDecision step. ``resolve_config``
     # tolerates a None session (cache-first; cold-miss opens its own).
     gov_cfg = await resolve_config(payload.tenant_id)
-    if (await remediate_after_enrichment(memory, gov_cfg)).dropped:
+    try:
+        outcome = await remediate_after_enrichment(memory, gov_cfg)
+    except GovernanceCascadeError as exc:
+        # The parent WAS remediated; only rows derived from it could not be.
+        # Caught HERE and nowhere deeper, because the two callers of
+        # ``remediate_after_enrichment`` need opposite things from this failure:
+        #
+        #   - ``_enrich_memory_background`` is about to create MORE derived rows,
+        #     so it must abort. It does not catch this, and must not.
+        #   - this handler creates nothing. Letting the raise through would nack
+        #     the event, and the dispatcher redelivers on nack — re-running the
+        #     whole drop branch and emitting a SECOND ``critical=True`` audit for
+        #     a memory already dropped. Every redelivery. Duplicate destructive
+        #     entries in a tamper-evident log, for a row nothing further can be
+        #     done to.
+        #
+        # The outcome rides on the exception precisely so this branch can honour
+        # the parent's verdict without re-running it.
+        outcome = exc.outcome
+        logger.error(
+            "memory-enriched: governance remediated the row but could not clean up "
+            "rows derived from it; they still carry content the policy forbade",
+            exc_info=True,
+            extra={"memory_id": str(payload.memory_id), "tenant_id": payload.tenant_id},
+        )
+    if outcome.dropped:
         # Row was dropped by policy — skip contradiction detection on it.
         logger.info(
             "memory-enriched: row dropped by governance policy; ack",

--- a/core-api/src/core_api/services/governance_remediation.py
+++ b/core-api/src/core_api/services/governance_remediation.py
@@ -51,12 +51,304 @@ class RemediationOutcome:
     was left alone."""
 
 
+async def _pre_verdict_children(sc: Any, memory_id: str, tenant_id: str, md: dict) -> list[dict]:
+    """Rows derived from this one BEFORE any verdict existed. ``[]`` when none can.
+
+    H-10. The atomic-fact fan-out needs nothing here — it lives inside
+    ``_enrich_memory_background`` and runs remediation *before* it fans out, so
+    a drop stops it and a downgrade is carried onto the children it does create.
+    Auto-chunk is the path with no such ordering: on a deferred deployment the
+    write-time ``GovernanceDecision`` sees ``enrichment=None``, takes its
+    documented uncertain branch and enforces nothing, and the children are
+    committed immediately. The verdict arrives here minutes later, naming only
+    the parent.
+
+    Gated on ``auto_chunked`` rather than querying unconditionally. The lookup
+    filters on a JSON key with no supporting index, and a tenant configured
+    ``drop`` remediates constantly — so an ungated query would tax every
+    ordinary drop to serve the rare chunked one. The marker is safe to gate on
+    because it is stamped on the parent unconditionally, in the same function
+    that builds the children, and it is already present on the production rows
+    this fix has to reach — a NEW marker would only ever appear on rows written
+    after the deploy, leaving the existing leak in place.
+
+    Failures propagate. This module's contract is that a policy which could not
+    be applied must not be quietly treated as applied; swallowing a lookup error
+    would leave the children live, which is the leak this exists to close.
+    """
+    if not md.get("auto_chunked"):
+        return []
+    return await sc.find_children_by_parent_id(tenant_id, memory_id)
+
+
+def _child_id(child: dict) -> str | None:
+    raw = child.get("id")
+    return str(raw) if raw else None
+
+
+class GovernanceCascadeError(RuntimeError):
+    """Some derived rows could not be remediated after the parent already was.
+
+    Raised only once every child has been ATTEMPTED. The distinction matters:
+    aborting the loop on the first failure would leave the remaining children
+    live with the parent already gone — the leak this cascade exists to close,
+    reintroduced by the error handling rather than by the policy.
+
+    Still raised rather than logged, because the enclosing ``tracked_task`` is
+    what turns an unapplied policy into something a human sees; a swallowed
+    failure here is a policy silently treated as applied.
+
+    ``outcome`` carries what the PARENT's own remediation did, because that
+    part succeeded and a caller may need it. Without it this exception conflates
+    two very different states: "the parent's remediation failed, nothing
+    happened, retry from scratch" and "the parent was dropped or privatised and
+    only the derived cleanup fell short". A caller that wants to honour the
+    parent's verdict can read it; one that simply refuses to go on — which is
+    the safe default, and what every current caller does — can ignore it.
+    """
+
+    def __init__(self, message: str, outcome: RemediationOutcome | None = None) -> None:
+        super().__init__(message)
+        self.outcome = outcome or RemediationOutcome()
+
+
+def _raise_if_any_failed(
+    failed: list[str], *, parent_id: str, what: str, outcome: RemediationOutcome
+) -> None:
+    if not failed:
+        return
+    raise GovernanceCascadeError(
+        f"governance: {len(failed)} derived row(s) of {parent_id} could not be "
+        f"{what} ({', '.join(failed)}); the parent was already remediated, so these "
+        "rows still carry content the policy forbade",
+        outcome,
+    )
+
+
+async def _drop_children(
+    sc: Any,
+    children: list[dict],
+    *,
+    tenant_id: str,
+    parent_id: str,
+    action: str,
+    detail_for: Any,
+) -> None:
+    """Soft-delete each derived row, auditing before the delete as the parent does.
+
+    Per child rather than one rolled-up row: each is a separate soft-delete, and
+    an audit log that recorded one deletion while N happened would misstate the
+    compliance record in the direction that matters.
+
+    Contained PER CHILD, then raised once at the end. The parent is ALREADY
+    deleted by the time this runs, so letting the first failure abort the loop
+    would leave every later child live with the parent gone — this feature's own
+    leak, reintroduced by its error handling. One bad row must cost one row.
+
+    NOTHING RETRIES A FAILED CHILD, and this docstring used to say the opposite.
+    The retry it described was real while the raise reached the Pub/Sub
+    dispatcher and redelivered the event. It stopped being real when
+    ``handle_memory_enriched`` began catching ``GovernanceCascadeError`` and
+    acking — which it does because redelivery re-ran the parent's entire drop
+    branch and wrote another ``critical=True`` audit for an already-dropped
+    memory, on every delivery, without bound. The mechanism went; the paragraph
+    describing it did not, until this change. The parent's own remediation has
+    already succeeded by now, so no later event revisits this row either.
+
+    Recovery is therefore a person, working from the ERROR logs below, and they
+    are written to make that possible rather than merely to record that
+    something failed. The audit and the delete are attempted in SEPARATE
+    ``try`` blocks so a reader can tell the two states apart:
+
+    * ``audit_emitted=False`` — nothing happened to the row. It is live and the
+      compliance log does not claim otherwise.
+    * ``audit_emitted=True`` — the one that needs hands. The log RECORDS the row
+      as removed and the row is still live.
+
+    The audit still precedes the delete, and that ordering is what makes the
+    second state possible — deliberately, because the alternative is worse. A
+    false "dropped" entry is discoverable and the content is still there to
+    remove; auditing afterwards would turn the same failure into a deletion
+    with no record of it at all.
+    """
+    remediated = 0
+    failed: list[str] = []
+    for child in children:
+        cid = _child_id(child)
+        if not cid:
+            # Cannot delete it and cannot audit it against an id. Counted as a
+            # failure, not just logged: the row still holds content a policy
+            # forbade, and "we could not identify it" is not "it is handled".
+            # A retry will not fix this one — a person has to look.
+            logger.error(
+                "governance: derived row of %s has no usable id; it still holds "
+                "dropped content and was NOT removed",
+                parent_id,
+            )
+            failed.append("<no id>")
+            continue
+        try:
+            detail = detail_for(child.get("content") or "")
+            # Distinguishes a cascaded removal from a direct one, so a compliance
+            # review can see WHY a row with no governance signals of its own was
+            # dropped — the children are never enriched, so they carry none.
+            detail["cascaded_from"] = parent_id
+            await emit_governance_audit(
+                tenant_id=tenant_id,
+                agent_id=child.get("agent_id"),
+                action=action,
+                detail=detail,
+                resource_id=cid,
+                # Destructive, same as the parent: the audit is the only trace.
+                critical=True,
+            )
+        except Exception:
+            # Nothing was written and nothing was deleted. The row is live and
+            # the compliance log makes no claim about it.
+            logger.exception(
+                "governance: could not cascade %s to derived row %s of %s; it still holds dropped content",
+                action,
+                cid,
+                parent_id,
+                extra={
+                    "governance_cascade_needs_manual_remediation": True,
+                    "audit_emitted": False,
+                    "memory_id": cid,
+                    "parent_memory_id": parent_id,
+                    "tenant_id": tenant_id,
+                    "action": action,
+                },
+            )
+            failed.append(cid)
+            continue
+
+        # Separate block on purpose: past this point the audit EXISTS, so a
+        # failure here is a different state to report, not the same one.
+        try:
+            await sc.soft_delete_memory(cid, tenant_id)
+        except Exception:
+            logger.exception(
+                "governance: audit RECORDS derived row %s of %s as %s, but the delete "
+                "failed and the row is STILL LIVE; nothing retries this — the "
+                "compliance log is wrong about this row until someone removes it",
+                cid,
+                parent_id,
+                action,
+                extra={
+                    # The field a log-based alert keys on. Not derivable from the
+                    # message text, and it is the only signal that this row exists.
+                    "governance_cascade_needs_manual_remediation": True,
+                    "audit_emitted": True,
+                    "memory_id": cid,
+                    "parent_memory_id": parent_id,
+                    "tenant_id": tenant_id,
+                    "action": action,
+                },
+            )
+            failed.append(cid)
+            continue
+        remediated += 1
+    if remediated:
+        # ``remediated``, not ``len(children)``: rows skipped above were not
+        # remediated, and a count that includes them overstates enforcement in
+        # the compliance log.
+        logger.info(
+            "governance: cascaded %s to %d derived row(s) of %s",
+            action,
+            remediated,
+            parent_id,
+        )
+    _raise_if_any_failed(
+        failed, parent_id=parent_id, what="dropped", outcome=RemediationOutcome(dropped=True)
+    )
+
+
+async def _privatise_children(
+    sc: Any,
+    children: list[dict],
+    *,
+    tenant_id: str,
+    parent_id: str,
+    detail_for: Any,
+) -> None:
+    """Downgrade each derived row's visibility alongside the parent's.
+
+    A child left at ``scope_team`` republishes exactly the content
+    ``keep_private`` just restricted (#808). Update-then-audit, mirroring the
+    parent's non-destructive branch — nothing is lost if the audit fails after
+    a visibility narrowing.
+
+    Contained per child and raised once at the end, for the same reason as
+    :func:`_drop_children`: the parent is already downgraded, so aborting on the
+    first failure would leave the rest publishing what the policy restricted.
+
+    Nothing retries a failed child here either — see :func:`_drop_children` for
+    why the redelivery this used to rely on is gone. The consequence is milder
+    on this branch: the update runs BEFORE the audit, so a failure leaves the
+    row correctly narrowed but under-recorded, never recorded-but-unnarrowed.
+    That is why the two branches order these operations oppositely.
+    """
+    remediated = 0
+    failed: list[str] = []
+    for child in children:
+        cid = _child_id(child)
+        if not cid:
+            logger.error(
+                "governance: derived row of %s has no usable id; it still "
+                "publishes content the policy made private",
+                parent_id,
+            )
+            failed.append("<no id>")
+            continue
+        try:
+            await sc.update_memory(cid, tenant_id, {"visibility": "scope_agent"})
+            detail = detail_for(child.get("content") or "")
+            detail["cascaded_from"] = parent_id
+            await emit_governance_audit(
+                tenant_id=tenant_id,
+                agent_id=child.get("agent_id"),
+                action=ACTION_NB_KEEP_PRIVATE,
+                detail=detail,
+                resource_id=cid,
+            )
+        except Exception:
+            logger.exception(
+                "governance: could not cascade keep_private to derived row %s of %s; "
+                "it still publishes content the policy made private",
+                cid,
+                parent_id,
+            )
+            failed.append(cid)
+            continue
+        remediated += 1
+    if remediated:
+        logger.info(
+            "governance: cascaded keep_private to %d derived row(s) of %s",
+            remediated,
+            parent_id,
+        )
+    _raise_if_any_failed(
+        failed,
+        parent_id=parent_id,
+        what="made private",
+        outcome=RemediationOutcome(visibility="scope_agent"),
+    )
+
+
 async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutcome:
     """Apply LLM-signal governance to a fast-mode row after enrichment landed.
 
     Returns what was done. A caller that only needs "should I stop?" reads
     ``.dropped``; one that creates derived rows must also honour
     ``.visibility``. No-op when governance is disabled or the signals are clean.
+
+    MAY RAISE ``GovernanceCascadeError`` after the parent's own remediation has
+    already succeeded — when rows derived from it could not be cleaned up. That
+    is deliberate rather than an oversight in the return contract: a caller
+    about to create MORE derived rows must not proceed when the existing ones
+    still hold content the policy forbade, and aborting is the fail-safe answer.
+    The exception carries the parent's ``outcome`` for any caller that needs to
+    tell "nothing happened" from "the parent was handled, the cleanup was not".
     """
     pii_cfg = cfg.governance_pii
     nb_cfg = cfg.governance_non_business
@@ -80,6 +372,10 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutco
     if pii_cfg.enabled and md.get("contains_pii"):
         pii_types = md.get("pii_types") or []
         if pii_cfg.action == "drop":
+            # Resolved BEFORE the parent's audit and delete: a lookup failure
+            # then leaves everything intact and remediable, rather than a
+            # dropped parent whose children were never found (H-10).
+            children = await _pre_verdict_children(sc, memory_id, tenant_id, md)
             # Audit BEFORE the destructive delete (mirrors GovernanceScanContent's
             # audit-before-mutate): a delete that succeeds before a failing audit
             # would leave an untracked deletion in the tamper-evident log, whereas
@@ -96,6 +392,14 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutco
             )
             await sc.soft_delete_memory(memory_id, tenant_id)
             logger.info("governance: dropped fast-mode memory %s (pii)", memory_id)
+            await _drop_children(
+                sc,
+                children,
+                tenant_id=tenant_id,
+                parent_id=memory_id,
+                action=ACTION_PII_DROP,
+                detail_for=lambda c: llm_pii_audit_detail(ACTION_PII_DROP, pii_types, c, "fast"),
+            )
             return RemediationOutcome(dropped=True)
         # mask/flag: the LLM gives no offsets to redact a free-form span, and in
         # fast mode the row is already persisted — so a "mask"-configured tenant
@@ -119,6 +423,8 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutco
     # ── Business-vs-personal disposition ──
     if nb_cfg.enabled and md.get("business_relevance") == "personal":
         if nb_cfg.disposition == "drop":
+            # Before the parent's audit and delete — see the PII-drop branch.
+            children = await _pre_verdict_children(sc, memory_id, tenant_id, md)
             # Audit before the destructive delete (see the PII-drop branch above).
             await emit_governance_audit(
                 tenant_id=tenant_id,
@@ -131,15 +437,43 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutco
             )
             await sc.soft_delete_memory(memory_id, tenant_id)
             logger.info("governance: dropped fast-mode memory %s (non-business)", memory_id)
+            await _drop_children(
+                sc,
+                children,
+                tenant_id=tenant_id,
+                parent_id=memory_id,
+                action=ACTION_NB_DROP,
+                detail_for=lambda c: nonbusiness_audit_detail(ACTION_NB_DROP, c, "fast"),
+            )
             return RemediationOutcome(dropped=True)
         if nb_cfg.disposition == "keep_private":
+            children = await _pre_verdict_children(sc, memory_id, tenant_id, md)
             await sc.update_memory(memory_id, tenant_id, {"visibility": "scope_agent"})
+            # The parent's OWN audit comes before the cascade, and the ordering
+            # is load-bearing rather than tidy. ``_privatise_children`` raises
+            # when a child fails, so with the cascade in between, one failed
+            # child left the parent durably narrowed with NO audit row at all —
+            # an untracked mutation, which this module's own docstrings forbid.
+            #
+            # The drop branches never had that exposure: they audit the parent
+            # before the destructive delete, so the cascade is already the last
+            # thing they do. This branch mutates first (nothing is lost if a
+            # non-destructive audit fails after), which put the natural place
+            # for the audit AFTER the mutation — and dropping the cascade in
+            # between quietly moved it behind a raise.
             await emit_governance_audit(
                 tenant_id=tenant_id,
                 agent_id=agent_id,
                 action=ACTION_NB_KEEP_PRIVATE,
                 detail=nonbusiness_audit_detail(ACTION_NB_KEEP_PRIVATE, content, "fast"),
                 resource_id=memory_id,
+            )
+            await _privatise_children(
+                sc,
+                children,
+                tenant_id=tenant_id,
+                parent_id=memory_id,
+                detail_for=lambda c: nonbusiness_audit_detail(ACTION_NB_KEEP_PRIVATE, c, "fast"),
             )
             # Reported so a caller creating derived rows can carry the
             # downgrade to them instead of publishing the same content wider.

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -385,6 +385,19 @@ async def find_by_supersedes_id(tenant_id: str, supersedes_id: str) -> list[dict
     return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
 
 
+@router.get("/by-parent-id")
+async def find_children_by_parent_id(tenant_id: str, parent_id: str) -> list[dict]:
+    """H-10 — live rows derived from a parent, for governance cascade.
+
+    ``parent_id`` is matched against child ``metadata.parent_memory_id`` and is
+    NOT parsed as a UUID here: it is compared as the string the writer stored,
+    so a malformed value matches nothing instead of 500ing the remediation that
+    is trying to enforce a drop.
+    """
+    memories = await _svc.memory_find_children_by_parent_id(tenant_id=tenant_id, parent_id=parent_id)
+    return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
+
+
 @router.post("/find-successors")
 async def find_successors(request: Request) -> list[dict]:
     body: dict = await request.json()

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2798,6 +2798,39 @@ class PostgresService:
             )
             return list((await session.execute(stmt)).scalars().all())
 
+    async def memory_find_children_by_parent_id(
+        self,
+        tenant_id: str,
+        parent_id: str,
+    ) -> list[Memory]:
+        """Live rows derived from ``parent_id`` via ``metadata.parent_memory_id``.
+
+        H-10. Governance remediation lands on the PARENT — the row the enriched
+        event names — but on a deferred deployment the auto-chunk children were
+        already committed before any verdict existed. Without this the drop
+        reached one row and left N carrying the same content live and
+        team-visible, permanently: children are never enriched, so nothing
+        revisits them.
+
+        Filtered on the JSON key rather than a column because that is where the
+        link lives — ``parent_memory_id`` has only ever been written into child
+        metadata. A column would be better and is not what production rows
+        carry, so the fix has to read what is actually there.
+
+        Tenant-scoped, which is the filter that is a boundary rather than a
+        preference; ``deleted_at IS NULL`` because a row already gone needs no
+        second remediation. No visibility or status scoping: remediation must
+        reach every derived row whatever state it is in, the same reasoning
+        ``memory_find_by_supersedes_id`` above records for retraction.
+        """
+        async with get_session() as session:
+            stmt = select(Memory).where(
+                Memory.tenant_id == tenant_id,
+                Memory.metadata_["parent_memory_id"].astext == parent_id,
+                Memory.deleted_at.is_(None),
+            )
+            return list((await session.execute(stmt)).scalars().all())
+
     async def memory_find_successors(
         self,
         supersedes_ids: list[UUID],

--- a/core-storage-api/tests/test_h10_children_by_parent_id.py
+++ b/core-storage-api/tests/test_h10_children_by_parent_id.py
@@ -1,0 +1,111 @@
+"""H-10 — the parent→child lookup governance remediation cascades through.
+
+Runs against the real Postgres fixture, because the thing under test is a JSONB
+key comparison (``metadata->>'parent_memory_id'``) and a stub would assert only
+that the code calls itself. The core-api side stubs storage entirely, so without
+these the cascade could ship with a query that matches nothing and every test
+above it would still pass.
+
+The rows this finds are ones a governance verdict is about to soft-delete, so
+the two negative cases matter as much as the positive one: a query that reaches
+across tenants would delete another tenant's rows on a drop.
+"""
+
+import uuid
+
+import pytest
+
+from core_storage_api.services.postgres_service import PostgresService
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _insert(svc: PostgresService, tenant: str, metadata: dict, content: str | None = None):
+    return await svc.memory_add(
+        {
+            "tenant_id": tenant,
+            "agent_id": "h10-tester",
+            "content": content or f"h10 canary {uuid.uuid4()}",
+            "memory_type": "fact",
+            "weight": 0.5,
+            "metadata_": metadata,
+            "status": "active",
+            "visibility": "scope_team",
+        }
+    )
+
+
+async def test_finds_every_child_of_the_parent():
+    svc = PostgresService()
+    tenant = f"h10-{uuid.uuid4().hex[:8]}"
+    parent = await _insert(svc, tenant, {"auto_chunked": True, "child_count": 2})
+    pid = str(parent.id)
+
+    c1 = await _insert(svc, tenant, {"parent_memory_id": pid, "source": "auto_chunk"})
+    c2 = await _insert(svc, tenant, {"parent_memory_id": pid, "source": "auto_chunk"})
+    # An unrelated row in the same tenant must not be swept up — on a drop this
+    # query decides what gets soft-deleted.
+    await _insert(svc, tenant, {"source": "ordinary write"})
+
+    found = await svc.memory_find_children_by_parent_id(tenant_id=tenant, parent_id=pid)
+
+    assert {str(m.id) for m in found} == {str(c1.id), str(c2.id)}
+
+
+async def test_does_not_cross_tenants():
+    """The one filter that is a boundary rather than a preference.
+
+    A child id is a UUID, so a collision is not the worry — a query that
+    forgot the tenant filter is, and it would soft-delete a stranger's rows the
+    moment one tenant's governance policy fired.
+    """
+    svc = PostgresService()
+    tenant_a = f"h10a-{uuid.uuid4().hex[:8]}"
+    tenant_b = f"h10b-{uuid.uuid4().hex[:8]}"
+    parent = await _insert(svc, tenant_a, {"auto_chunked": True})
+    pid = str(parent.id)
+
+    await _insert(svc, tenant_a, {"parent_memory_id": pid})
+    # Same parent id, different tenant. Contrived on purpose: it isolates the
+    # tenant predicate from the metadata predicate.
+    await _insert(svc, tenant_b, {"parent_memory_id": pid})
+
+    found_a = await svc.memory_find_children_by_parent_id(tenant_id=tenant_a, parent_id=pid)
+    found_b = await svc.memory_find_children_by_parent_id(tenant_id=tenant_b, parent_id=pid)
+
+    assert len(found_a) == 1
+    assert len(found_b) == 1
+    assert {m.tenant_id for m in found_a} == {tenant_a}
+    assert {m.tenant_id for m in found_b} == {tenant_b}
+
+
+async def test_skips_rows_already_soft_deleted():
+    """A row already gone needs no second remediation, and re-deleting it would
+    put a duplicate destructive audit row in the compliance log."""
+    svc = PostgresService()
+    tenant = f"h10-{uuid.uuid4().hex[:8]}"
+    parent = await _insert(svc, tenant, {"auto_chunked": True})
+    pid = str(parent.id)
+
+    live = await _insert(svc, tenant, {"parent_memory_id": pid})
+    gone = await _insert(svc, tenant, {"parent_memory_id": pid})
+    assert await svc.memory_soft_delete_by_ids(tenant, [gone.id]) == 1
+
+    found = await svc.memory_find_children_by_parent_id(tenant_id=tenant, parent_id=pid)
+
+    assert [str(m.id) for m in found] == [str(live.id)]
+
+
+async def test_a_parent_with_no_children_finds_nothing():
+    """Not a tautology: ``metadata->>'key'`` on rows lacking the key yields NULL,
+    and a predicate written against the wrong operator can match those instead of
+    skipping them — which would hand a drop every row in the tenant."""
+    svc = PostgresService()
+    tenant = f"h10-{uuid.uuid4().hex[:8]}"
+    parent = await _insert(svc, tenant, {"auto_chunked": True})
+    await _insert(svc, tenant, {"source": "no parent link"})
+    await _insert(svc, tenant, {})
+
+    found = await svc.memory_find_children_by_parent_id(tenant_id=tenant, parent_id=str(parent.id))
+
+    assert found == []

--- a/tests/test_governance_consumer.py
+++ b/tests/test_governance_consumer.py
@@ -20,6 +20,7 @@ import pytest
 from common.events.base import Event
 from common.events.topics import Topics
 from core_api import consumer
+from core_api.services import governance_remediation
 from core_api.services.organization_settings import ResolvedConfig
 
 pytestmark = pytest.mark.asyncio
@@ -144,3 +145,32 @@ async def test_clean_signal_runs_detection_with_no_governance_action(
     sc.soft_delete_memory.assert_not_awaited()
     sc.update_memory.assert_not_awaited()
     detect.assert_awaited_once()
+
+
+async def test_a_failed_child_cascade_does_not_nack_the_event(sc, detect, monkeypatch):
+    """A raise out of this handler nacks, and the dispatcher redelivers on nack.
+
+    Redelivery re-runs the whole drop branch and emits a SECOND
+    ``critical=True`` audit for a memory that was already dropped — every
+    redelivery, forever, for a row nothing further can be done to.
+
+    The parent's verdict still has to be honoured, which is why the outcome
+    rides on the exception rather than being lost with it. Contradiction
+    detection stays skipped: the row IS dropped.
+    """
+    mid = uuid.uuid4()
+    sc.get_memory.return_value = _memory(mid, business_relevance="personal")
+    _patch_config(monkeypatch, non_business={"enabled": True, "disposition": "drop"})
+
+    async def _boom(*_a, **_k):
+        raise governance_remediation.GovernanceCascadeError(
+            "one child could not be dropped",
+            governance_remediation.RemediationOutcome(dropped=True),
+        )
+
+    monkeypatch.setattr(consumer, "remediate_after_enrichment", _boom)
+
+    # Must not raise — a raise here is the nack.
+    await consumer.handle_memory_enriched(_event(mid))
+
+    detect.assert_not_awaited()

--- a/tests/test_governance_remediation.py
+++ b/tests/test_governance_remediation.py
@@ -30,8 +30,20 @@ def emitted(monkeypatch):
 
 @pytest.fixture
 def storage(monkeypatch):
-    """Stub the storage client; record soft-delete / update calls."""
-    actions: list[tuple] = []
+    """Stub the storage client; record soft-delete / update calls.
+
+    ``actions.children`` seeds what ``find_children_by_parent_id`` returns, so a
+    test can put derived rows behind a parent without a database. Empty by
+    default, which keeps every pre-H-10 test on its original path.
+    """
+
+    class _Actions(list):
+        """A list that also carries the seeded children (a bare list cannot)."""
+
+        children: list[dict] = []
+
+    actions = _Actions()
+    actions.children = []
 
     class _SC:
         async def soft_delete_memory(self, mid, tenant_id):
@@ -39,6 +51,10 @@ def storage(monkeypatch):
 
         async def update_memory(self, mid, tenant_id, patch):
             actions.append(("update", mid, tenant_id, patch))
+
+        async def find_children_by_parent_id(self, tenant_id, parent_id):
+            actions.append(("find_children", parent_id, tenant_id))
+            return list(actions.children)
 
     monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
     return actions
@@ -88,6 +104,387 @@ async def test_pii_drop_soft_deletes_and_audits(emitted, storage):
     assert outcome.dropped is True
     assert ("soft_delete", "m1", "t1") in storage
     assert any(c["action"] == "pii_drop" for c in emitted)
+
+
+# ---------------------------------------------------------------------------
+# H-10 — derived rows that already exist when the verdict lands
+# ---------------------------------------------------------------------------
+#
+# The atomic-fact fan-out is safe by ORDERING: it lives inside
+# ``_enrich_memory_background``, runs remediation first, and early-returns on a
+# drop — "a policy that could not be applied must not be followed by rows it
+# might have forbidden". Auto-chunk children get no such protection on a
+# deferred deployment. There the write-time ``GovernanceDecision`` runs with
+# ``enrichment=None``, takes its uncertain branch and enforces NOTHING, and the
+# children are built and committed immediately. The parent's real verdict
+# arrives minutes later, through here — and remediated only the row the event
+# named. ``parent_memory_id`` was written on every child and queried nowhere.
+#
+# So a tenant configured ``non_business.disposition=drop`` had its parent
+# dropped and audited while N children carrying the same content stayed live at
+# ``scope_team``, with no governance metadata and no audit row tying them to the
+# drop. Permanently: children are never enriched, so no later pass revisits them.
+
+
+def _child(mid: str) -> dict:
+    return {
+        "id": mid,
+        "tenant_id": "t1",
+        "agent_id": "a1",
+        "content": "a fact",
+        "metadata": {},
+    }
+
+
+async def test_a_drop_cascades_to_the_children_that_already_exist(emitted, storage):
+    """The parent's drop must reach rows derived from it before the verdict."""
+    storage.children = [_child("c1"), _child("c2")]
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 2,
+        }
+    )
+
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    assert outcome.dropped is True
+    deleted = {mid for kind, mid, *_ in storage if kind == "soft_delete"}
+    assert deleted == {"m1", "c1", "c2"}, (
+        f"the dropped content survives in the children: {deleted}"
+    )
+
+
+async def test_the_cascaded_children_are_audited_not_deleted_silently(emitted, storage):
+    """A destructive action with no audit row is exactly what compliance cannot have.
+
+    The parent's drop is already audited ``critical=True`` because the
+    soft-delete leaves the audit as the only trace. The children carry the same
+    content, so deleting them off the back of the parent's verdict with no
+    record of their own would leave the compliance log claiming one row was
+    dropped when N+1 were.
+    """
+    storage.children = [_child("c1"), _child("c2")]
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 2,
+        }
+    )
+
+    await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    audited = {c.get("resource_id") for c in emitted}
+    assert {"c1", "c2"} <= audited, f"children dropped without an audit row: {audited}"
+
+
+async def test_keep_private_cascades_the_downgrade_to_the_children(emitted, storage):
+    """``keep_private`` downgrades the parent; a child left at ``scope_team``
+    re-publishes exactly the content the policy just made private (#808)."""
+    storage.children = [_child("c1")]
+    cfg = _cfg(nb={"enabled": True, "disposition": "keep_private"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 1,
+        }
+    )
+
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    assert outcome.visibility == "scope_agent"
+    downgraded = {mid for kind, mid, *_ in storage if kind == "update"}
+    assert downgraded == {"m1", "c1"}, (
+        f"a child still publishes the privatised content: {downgraded}"
+    )
+
+
+async def test_a_row_with_no_children_never_runs_the_lookup(emitted, storage):
+    """OVER-REFUSAL GUARD. The common path must not pay for the rare one.
+
+    The cascade query filters on a JSON key with no supporting index, and a
+    compliance tenant configured ``drop`` remediates constantly. Gating on the
+    parent's own record of having children keeps that query off every ordinary
+    drop — and the marker is set unconditionally beside the children it
+    describes, which ``test_the_auto_chunk_parent_records_that_it_has_children``
+    pins.
+    """
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(metadata={"business_relevance": "personal"})
+
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    assert outcome.dropped is True
+    assert not any(kind == "find_children" for kind, *_ in storage), (
+        "the child lookup fired for a row that has no children"
+    )
+
+
+async def test_pii_drop_cascades_too(emitted, storage):
+    """Both destructive dispositions reach the children, not just the non-business one.
+
+    They are separate branches with separate configs; a tenant on a PII drop
+    policy leaks identically if only the non-business branch cascades.
+    """
+    storage.children = [_child("c1")]
+    cfg = _cfg(pii={"enabled": True, "action": "drop"})
+    mem = _mem(
+        metadata={"contains_pii": True, "pii_types": ["health"], "auto_chunked": True}
+    )
+
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    assert outcome.dropped is True
+    deleted = {mid for kind, mid, *_ in storage if kind == "soft_delete"}
+    assert deleted == {"m1", "c1"}, deleted
+
+
+async def test_one_failing_child_does_not_abandon_the_rest(
+    emitted, storage, monkeypatch, caplog
+):
+    """The parent is already gone by the time this loop runs.
+
+    So aborting on the first failure would leave every later child live with the
+    parent deleted — this feature's own leak, reintroduced by its error
+    handling. One bad row must cost one row.
+
+    The failure still surfaces: it is raised once, after every child has been
+    ATTEMPTED, so ``tracked_task`` records an unapplied policy rather than the
+    cascade swallowing it.
+    """
+    storage.children = [_child("c1"), _child("c2"), _child("c3")]
+
+    class _SC:
+        async def soft_delete_memory(self, mid, tenant_id):
+            if mid == "c1":
+                raise RuntimeError("storage blipped on the first child")
+            storage.append(("soft_delete", mid, tenant_id))
+
+        async def update_memory(self, mid, tenant_id, patch):
+            storage.append(("update", mid, tenant_id, patch))
+
+        async def find_children_by_parent_id(self, tenant_id, parent_id):
+            return list(storage.children)
+
+    monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
+
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 3,
+        }
+    )
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(governance_remediation.GovernanceCascadeError) as exc:
+            await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    # The exception carries what the PARENT's remediation did. Without it a
+    # caller cannot tell "nothing happened, retry from scratch" from "the parent
+    # was dropped and only the derived cleanup fell short" — two states that
+    # want opposite follow-up.
+    assert exc.value.outcome.dropped is True
+
+    deleted = {mid for kind, mid, *_ in storage if kind == "soft_delete"}
+    # c1 failed; c2 and c3 must still have been remediated, and so must the parent.
+    assert deleted == {"m1", "c2", "c3"}, (
+        f"a failure on one child abandoned the others: {deleted}"
+    )
+    assert any("c1" in r.getMessage() for r in caplog.records)
+
+
+async def test_a_child_whose_delete_failed_after_its_audit_is_logged_as_such(
+    emitted, storage, caplog, monkeypatch
+):
+    """The audit says "dropped" and the row is live. Nothing retries it.
+
+    That combination used to be indistinguishable in the logs from "nothing
+    happened to this row", and the docstring claimed a redelivery would clean it
+    up — which stopped being true once ``handle_memory_enriched`` began acking
+    on ``GovernanceCascadeError``. A person is the recovery path now, so the log
+    has to say WHICH state the row is in and carry a field an alert can key on.
+
+    Asserts the structured field, not the prose: the message can be reworded,
+    but a monitor keyed on ``governance_cascade_needs_manual_remediation``
+    breaking silently is the whole failure mode this guards.
+    """
+    storage.children = [_child("c1")]
+
+    class _SC:
+        async def soft_delete_memory(self, mid, tenant_id):
+            if mid == "c1":
+                raise RuntimeError("delete failed AFTER the audit landed")
+            storage.append(("soft_delete", mid, tenant_id))
+
+        async def update_memory(self, mid, tenant_id, patch):
+            storage.append(("update", mid, tenant_id, patch))
+
+        async def find_children_by_parent_id(self, tenant_id, parent_id):
+            return list(storage.children)
+
+    monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
+
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 1,
+        }
+    )
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(governance_remediation.GovernanceCascadeError):
+            await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    # The audit for c1 DID land — which is exactly what makes this state bad.
+    assert any(a.get("resource_id") == "c1" for a in emitted), (
+        "precondition: the child's audit must have been emitted before the delete"
+    )
+
+    flagged = [
+        r
+        for r in caplog.records
+        if getattr(r, "governance_cascade_needs_manual_remediation", False)
+    ]
+    assert flagged, "the failure carried no field an alert could key on"
+    assert flagged[0].audit_emitted is True, (
+        "an audit-emitted-then-delete-failed row must not be reported as if "
+        "nothing had been written about it"
+    )
+    assert flagged[0].memory_id == "c1"
+    assert flagged[0].parent_memory_id == "m1"
+
+
+async def test_a_child_whose_audit_failed_is_reported_as_untouched(
+    emitted, storage, caplog, monkeypatch
+):
+    """The other state, and the one that must NOT claim an audit exists.
+
+    Pairs with the test above: same failure surface, opposite value of
+    ``audit_emitted``. Without the split ``try`` blocks both states produced the
+    same log line, so a responder could not tell a live row the log misdescribes
+    from a live row it says nothing about.
+    """
+    storage.children = [_child("c1")]
+
+    async def _boom(*args, **kwargs):
+        # Only the CHILD's audit fails. The parent's has to succeed or
+        # remediation never reaches the cascade and this tests nothing.
+        if kwargs.get("resource_id") == "c1":
+            raise RuntimeError("audit queue rejected the entry")
+        emitted.append(kwargs)
+
+    monkeypatch.setattr(governance_remediation, "emit_governance_audit", _boom)
+
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 1,
+        }
+    )
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(governance_remediation.GovernanceCascadeError):
+            await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    flagged = [
+        r
+        for r in caplog.records
+        if getattr(r, "governance_cascade_needs_manual_remediation", False)
+    ]
+    assert flagged, "the failure carried no field an alert could key on"
+    assert flagged[0].audit_emitted is False
+    # And the delete was never attempted for it.
+    assert not [a for a in storage if a[0] == "soft_delete" and a[1] == "c1"]
+
+
+async def test_the_cascade_count_does_not_include_rows_it_skipped(
+    emitted, storage, caplog
+):
+    """A summary log that overstates enforcement is worse than no summary.
+
+    ``len(children)`` counted rows the loop skipped for a missing id — so the
+    line claimed N remediated while N-1 were, in a log a compliance review
+    reads.
+    """
+    storage.children = [_child("c1"), {"id": None, "content": "unidentifiable"}]
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 2,
+        }
+    )
+
+    with caplog.at_level("INFO"):
+        with pytest.raises(governance_remediation.GovernanceCascadeError):
+            await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    summary = [r.getMessage() for r in caplog.records if "cascaded" in r.getMessage()]
+    assert summary, "no summary line was logged"
+    assert "to 1 derived row(s)" in summary[0], summary
+
+
+async def test_a_failed_cascade_never_erases_the_parents_own_audit(
+    emitted, storage, monkeypatch
+):
+    """The parent's mutation is durable; its audit must be too.
+
+    ``keep_private`` narrows the parent BEFORE auditing it — correct on its own,
+    because nothing is lost if a non-destructive audit fails after the change.
+    But the cascade raises when a child fails, so putting the cascade between
+    the two left the parent durably narrowed with NO audit row at all. An
+    untracked mutation is precisely what this module's ordering rules exist to
+    prevent.
+
+    The drop branches never had this exposure: they audit before the destructive
+    delete, so the cascade is already the last thing they do.
+    """
+    storage.children = [_child("c1")]
+
+    class _SC:
+        async def update_memory(self, mid, tenant_id, patch):
+            if mid == "c1":
+                raise RuntimeError("storage blipped on the child")
+            storage.append(("update", mid, tenant_id, patch))
+
+        async def soft_delete_memory(self, mid, tenant_id):
+            storage.append(("soft_delete", mid, tenant_id))
+
+        async def find_children_by_parent_id(self, tenant_id, parent_id):
+            return list(storage.children)
+
+    monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
+
+    cfg = _cfg(nb={"enabled": True, "disposition": "keep_private"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 1,
+        }
+    )
+
+    with pytest.raises(governance_remediation.GovernanceCascadeError):
+        await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    # The parent WAS narrowed...
+    assert ("update", "m1", "t1", {"visibility": "scope_agent"}) in storage
+    # ...so the record of that narrowing must exist.
+    assert any(c.get("resource_id") == "m1" for c in emitted), (
+        f"the parent's visibility changed with no audit row: {emitted}"
+    )
 
 
 async def test_pii_mask_config_flags_but_records_intent(emitted, storage):

--- a/tests/test_h09_autochunk_embed_degrade.py
+++ b/tests/test_h09_autochunk_embed_degrade.py
@@ -87,6 +87,7 @@ async def _noop() -> None:
 class _Run:
     def __init__(self) -> None:
         self.parent_id = ""
+        self.parent_payload: dict = {}
         self.children: list[dict] = []
         self.tasks: list[tuple[str, str]] = []
         self.raised: BaseException | None = None
@@ -273,6 +274,8 @@ async def _run(
 
     if sc.create_memories.await_args_list:
         run.children = sc.create_memories.await_args_list[0].args[0]
+    if sc.create_memory.await_args_list:
+        run.parent_payload = sc.create_memory.await_args_list[0].args[0]
     return run
 
 
@@ -588,3 +591,40 @@ async def test_the_no_id_log_carries_no_memory_content(caplog) -> None:
     joined = " ".join(r.getMessage() for r in caplog.records)
     for chunk in CHUNKS:
         assert chunk not in joined, f"memory content leaked into a log: {chunk!r}"
+
+
+# ---------------------------------------------------------------------------
+# The two markers H-10's governance cascade reads
+# ---------------------------------------------------------------------------
+
+
+async def test_the_auto_chunk_write_records_the_parent_child_link() -> None:
+    """Pins the contract ``governance_remediation`` depends on (H-10).
+
+    On a deferred deployment these children are committed before any governance
+    verdict exists, so the verdict — which arrives later naming only the parent
+    — has to find them afterwards. It does that with exactly two things written
+    here:
+
+    * ``auto_chunked`` on the PARENT, which gates the lookup. Gating keeps a
+      JSON-key query with no supporting index off every ordinary drop, and a
+      compliance tenant configured ``drop`` remediates constantly. If this
+      marker ever stops being written, the cascade silently stops running and
+      the leak returns with no test failing anywhere near it — which is why the
+      assertion lives here, beside the write, rather than only in the
+      remediation tests where it would be a stub asserting itself.
+    * ``parent_memory_id`` on each CHILD, which is what the lookup matches on.
+
+    Deliberately asserted on the payloads sent to storage, not on a return
+    value: what the row carries is what a later remediation can read.
+    """
+    run = await _run(embed_raises=False)
+
+    assert run.parent_payload, "no parent was written — the test is vacuous"
+    parent_meta = run.parent_payload.get("metadata_") or {}
+    assert parent_meta.get("auto_chunked") is True, parent_meta
+    assert parent_meta.get("child_count") == len(CHUNKS), parent_meta
+
+    assert len(run.children) == len(CHUNKS)
+    for child in run.children:
+        assert (child.get("metadata_") or {}).get("parent_memory_id") == run.parent_id

--- a/tests/test_storage_client_routing.py
+++ b/tests/test_storage_client_routing.py
@@ -91,6 +91,48 @@ async def test_find_duplicate_hash_stays_on_writer() -> None:
     assert len(reader.requests) == 0
 
 
+async def test_governance_child_lookup_stays_on_writer() -> None:
+    """H-10 — the cascade reads rows it is about to soft-delete.
+
+    A read-your-write, and the FIRST ``_get_list`` caller that is one: the
+    method's own comment used to say no caller sat on a write path, which is
+    why it had no opt-out. On a retry after a partial cascade failure this
+    lookup must not return children whose delete already committed — a replica
+    under lag would hand them back, and the cascade would re-audit and
+    re-soft-delete a row it had already handled, putting a duplicate
+    destructive entry in a compliance log.
+    """
+    client, writer, reader = await _fresh_client(
+        writer_url="http://writer:8002", reader_url="http://reader:8002"
+    )
+
+    await client.find_children_by_parent_id(
+        "t1", "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert len(writer.requests) == 1
+    assert len(reader.requests) == 0
+    assert writer.requests[0].url.path.endswith("/memories/by-parent-id")
+
+
+async def test_get_list_still_defaults_to_the_reader() -> None:
+    """OVER-CORRECTION GUARD. The opt-out must stay opt-IN.
+
+    Adding a ``read`` parameter to ``_get_list`` must not change where its
+    existing callers go. This pins that for one of them rather than asserting
+    anything about whether the replica is the right home for each — that is a
+    per-caller question this change does not reopen.
+    """
+    client, writer, reader = await _fresh_client(
+        writer_url="http://writer:8002", reader_url="http://reader:8002"
+    )
+
+    await client.find_by_supersedes_id("t1", "11111111-1111-1111-1111-111111111111")
+
+    assert len(reader.requests) == 1
+    assert len(writer.requests) == 0
+
+
 async def test_exact_lifecycle_audit_read_stays_on_writer() -> None:
     """A just-created canary audit must not transiently 404 on a replica."""
     client, writer, reader = await _fresh_client(


### PR DESCRIPTION
Closes audit finding **H-10**.

## The defect

On a **deferred deployment — the production SaaS write path** — the auto-chunk branch's `GovernanceDecision` runs with `enrichment=None`, takes its documented uncertain branch and **enforces nothing**. The children are built and committed immediately, at `scope_team`, with no governance metadata of their own.

The parent's real verdict arrives minutes later (`ENRICH_REQUESTED` → worker PATCH → `ENRICHED` → `remediate_after_enrichment`) and soft-deleted or downgraded **only the row the event named**. `parent_memory_id` was written onto every child and **queried nowhere** — five sites in production code, all writes.

So a tenant configured `non_business.disposition=drop` had its parent dropped and audited while **N children carrying the same content stayed live and team-visible**. Permanently: children are never enriched, so nothing revisits them, and they carry clean metadata so any future sweep reads them as fine. No audit row tied them to the drop either — the compliance log recorded one deletion where one row was removed and N were not.

## Reproduced before fixing

```
AssertionError: the dropped content survives in the children: {'m1'}
```

## Why this is the #808 shape, and why ordering can't fix it here

The codebase documents #808 as fixed, and it **is** fixed for the atomic-fact fan-out — by ordering. That path lives inside `_enrich_memory_background`, runs remediation **before** it fans out, early-returns on a drop, and carries a downgrade onto the children via `effective_visibility`. Its own comment states the rule:

> a policy that could not be applied must not be followed by rows it might have forbidden

Auto-chunk in deferred mode is the path where **the derived rows already exist when the verdict lands**. Ordering cannot save it; a cascade is the missing half.

## The fix

`remediate_after_enrichment` now resolves the derived rows and applies the same action: soft-delete on either drop disposition, visibility downgrade on `keep_private`.

**Both destructive branches, not just the one the finding described.** PII-drop and non-business-drop are separate branches reading separate configs; a tenant on a PII drop policy leaked identically.

**The lookup runs before the parent's audit and delete**, so a lookup failure leaves everything intact and remediable rather than a dropped parent whose children were never found. **Failures propagate** rather than being swallowed — this module's contract is that a policy which could not be applied must not be quietly treated as applied, and the enclosing `tracked_task` surfaces it.

**Each cascaded row gets its own audit row**, carrying `cascaded_from` so a review can see why a row with no governance signals of its own was removed. Per child rather than one rolled-up entry: each is a separate soft-delete, and a log recording one deletion while N happened misstates the record in the direction that matters.

### The new storage query

The parent→child link lives in child metadata JSON and nothing could read it. Tenant-scoped, live rows only, **no status or visibility filter** — remediation must reach every derived row whatever state it is in, the same reasoning `memory_find_by_supersedes_id` records for retraction.

### Why it is gated on `auto_chunked`

The query filters a JSON key with no supporting index, and a tenant configured `drop` remediates constantly — an ungated version would tax every ordinary drop to serve the rare chunked one.

`auto_chunked` is safe to gate on for a reason worth stating: it is stamped **unconditionally in the same function that builds the children**, and it is **already on the production rows this has to reach**. A new marker would only appear on rows written after the deploy and would leave the existing leak in place.

## Tests

**Five in core-api**, four confirmed failing without the fix. The fifth is an over-refusal guard: an ordinary row must not run the lookup at all.

**Four in core-storage-api against real Postgres**, because the core-api side stubs storage entirely — without them the cascade could ship with a query that matches nothing and every test above it would still pass. The tenant-boundary one is probe-confirmed: removing the tenant predicate fails it with `2 == 1`, which on a drop would mean deleting **another tenant's** rows.

**One test lives beside the write rather than the remediation.** The gate depends on `auto_chunked` being stamped on the parent and `parent_memory_id` on each child; if either stops being written the cascade silently stops running with nothing failing near it. Asserting that in the remediation tests would be a stub asserting itself.

## Verification

- Full root suite: **6076 passed, 5 skipped, 1 xfailed, 0 failed**.
- `core-storage-api/tests/`: **336 passed**, on its own scratch database.
- `ruff check` and `ruff format --check` run **separately** at CI's exact scopes — clean.
- `mypy` clean on `core-storage-api/src/`; `core-api/src/` clean apart from 2 pre-existing `types-python-dateutil` stub errors in an untouched file.
- Broker OpenAPI baseline — current. (The new endpoint is on core-storage-api, which the broker contract does not cover.)
- `legacy_name_ratchet.py` → *No new lines.* · `do_not_touch_sentinel.py` → *All 35 protected strings survive* (the 39→35 change came from #1284 on main, confirmed against a clean tree, not from this branch) · `tenant_scope_gate.py` → exit 0, no allowlist movement, and the new route is counted as tenant-bound.
- Checked for an open PR on this subsystem before starting; none.
- Branched from `origin/main`, rebased onto `4c9cef2a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
