### PR TITLE
feat(ops): alert on embeddings written without provenance

### DIFF
--- a/core-api/src/core_api/routes/lifecycle.py
+++ b/core-api/src/core_api/routes/lifecycle.py
@@ -310,6 +310,8 @@ async def embedding_coverage_all_tenants(
             "tenants_with_missing": coverage.get("tenants_with_missing"),
             "stale_embeddings": coverage.get("stale_embeddings"),
             "unknown_provenance": coverage.get("unknown_provenance"),
+            # Should be 0. See ``run_embedding_coverage_tick``, which alerts.
+            "missing_provenance": coverage.get("missing_provenance"),
         },
     )
     return coverage

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -156,12 +156,20 @@ def _alert_on_missing_provenance(coverage: dict, tenants: list[dict]) -> None:
                 {"tenant_id": t.get("tenant_id"), "missing_provenance": t.get("missing_provenance")}
                 for t in worst
             ],
-            # Names the query an operator should run, since these rows are
-            # reachable by no existing sweep or endpoint.
-            "predicate": (
-                "embedding IS NOT NULL AND embedded_content_hash IS NULL "
-                "AND content_hash IS NOT NULL AND created_at >= '2026-08-17'"
-            ),
+            # The query an operator should run — these rows are reachable by no
+            # existing sweep or endpoint, so the count alone is unactionable.
+            #
+            # Echoed from the response, never composed here. This service is a
+            # separate deployable with no import path into core-storage-api, so
+            # a literal would be kept honest by nothing: it would drift the
+            # first time the cutoff date moved, and the alert would then name a
+            # query that does not reproduce the number printed beside it.
+            #
+            # ``None`` if the storage service predates the field — which is the
+            # honest degradation during a rolling deploy. A missing hint costs
+            # an operator one lookup; a confidently wrong one costs them the
+            # investigation.
+            "predicate": coverage.get("missing_provenance_predicate"),
         },
     )
 

--- a/core-operations/src/core_operations/tasks.py
+++ b/core-operations/src/core_operations/tasks.py
@@ -117,6 +117,55 @@ async def run_embed_backfill_tick() -> None:
     await _fire_fanout("embed-backfill")
 
 
+def _alert_on_missing_provenance(coverage: dict, tenants: list[dict]) -> None:
+    """Escalate rows that record no provenance and have no excuse for it.
+
+    Alerting on a LEVEL is what the other buckets cannot do.
+    ``unknown_provenance`` sits in the tens of thousands of legitimate pre-037
+    rows, so a threshold on it is either permanently breached or useless — and
+    the conclusion drawn from that was to stop watching the number entirely,
+    on the premise that it only ever drains. In 2026-09 a defect grew it by 241
+    rows over a week inside that blind spot.
+
+    ``missing_provenance`` is the same predicate with the innocent explanations
+    removed: written after migration 037, holding a content hash to attest,
+    with a vector that something computed. Its correct value is zero, so this
+    needs no stored history, no baseline and no tuned threshold — the three
+    things a delta-based alert would need, in a service that keeps no state
+    between ticks.
+
+    ERROR rather than WARNING: every such row is invisible to both embedding
+    backfills (they select ``embedding IS NULL``) and to the staleness detector
+    (which needs a hash to compare), so it is permanent until someone
+    intervenes. Nothing drains this on its own.
+    """
+    total = coverage.get("missing_provenance") or 0
+    if not total:
+        return
+    worst = sorted(
+        (t for t in tenants if t.get("missing_provenance")),
+        key=lambda t: t.get("missing_provenance") or 0,
+        reverse=True,
+    )[:_COVERAGE_TENANT_LOG_CAP]
+    logger.error(
+        "memories embedded without provenance; a writer is dropping content_hash",
+        extra={
+            "missing_provenance": total,
+            "tenants_affected": coverage.get("tenants_with_missing_provenance"),
+            "worst_tenants": [
+                {"tenant_id": t.get("tenant_id"), "missing_provenance": t.get("missing_provenance")}
+                for t in worst
+            ],
+            # Names the query an operator should run, since these rows are
+            # reachable by no existing sweep or endpoint.
+            "predicate": (
+                "embedding IS NOT NULL AND embedded_content_hash IS NULL "
+                "AND content_hash IS NOT NULL AND created_at >= '2026-08-17'"
+            ),
+        },
+    )
+
+
 async def run_embedding_coverage_tick() -> None:
     """Log embedding coverage per tenant so the backlog is observable.
 
@@ -182,18 +231,33 @@ async def run_embedding_coverage_tick() -> None:
             "stale_embeddings": coverage.get("stale_embeddings"),
             "tenants_with_stale": coverage.get("tenants_with_stale"),
             # Embedded before provenance existed: undetermined, not damaged.
-            # Expected to fall over time; it is a measurement gap closing, so
-            # do not alert on it.
+            # Still not alertable — it legitimately holds tens of thousands of
+            # pre-037 rows, so any threshold on its LEVEL is either permanently
+            # breached or meaningless. What was wrong was concluding from that
+            # that the number needs no watching at all: the old note here said
+            # it was "a measurement gap closing", which assumed it only ever
+            # drains. See ``missing_provenance`` below for what replaced that
+            # assumption with a measurement.
             "unknown_provenance": coverage.get("unknown_provenance"),
+            # The alertable subset, and the one number here with a correct
+            # value: zero. Rows written after migration 037, carrying a content
+            # hash, that record no provenance — so NULL has no innocent reading
+            # and some live writer dropped it.
+            "missing_provenance": coverage.get("missing_provenance"),
             "tenant_count": len(tenants),
         },
     )
-    # A tenant is worth a line if it has EITHER defect. Filtering on missing
-    # alone would hide a tenant whose rows are all embedded but wrong — the
-    # exact case this release makes visible.
-    reported = [t for t in tenants if t.get("missing_embeddings") or t.get("stale_embeddings")][
-        :_COVERAGE_TENANT_LOG_CAP
-    ]
+    _alert_on_missing_provenance(coverage, tenants)
+    # A tenant is worth a line if it has ANY defect. Filtering on missing alone
+    # would hide a tenant whose rows are all embedded but wrong — the exact case
+    # this release makes visible — and omitting ``missing_provenance`` would hide
+    # the tenant the alert above just fired for, leaving an alert with no
+    # per-tenant line to act on.
+    reported = [
+        t
+        for t in tenants
+        if t.get("missing_embeddings") or t.get("stale_embeddings") or t.get("missing_provenance")
+    ][:_COVERAGE_TENANT_LOG_CAP]
     for tenant in reported:
         logger.info(
             "embedding coverage tenant",
@@ -203,10 +267,15 @@ async def run_embedding_coverage_tick() -> None:
                 "missing_embeddings": tenant.get("missing_embeddings"),
                 "stale_embeddings": tenant.get("stale_embeddings"),
                 "unknown_provenance": tenant.get("unknown_provenance"),
+                "missing_provenance": tenant.get("missing_provenance"),
                 "coverage_pct": tenant.get("coverage_pct"),
             },
         )
-    affected = sum(1 for t in tenants if t.get("missing_embeddings") or t.get("stale_embeddings"))
+    affected = sum(
+        1
+        for t in tenants
+        if t.get("missing_embeddings") or t.get("stale_embeddings") or t.get("missing_provenance")
+    )
     if affected > len(reported):
         logger.info(
             "embedding coverage per-tenant lines truncated",

--- a/core-operations/tests/test_tasks.py
+++ b/core-operations/tests/test_tasks.py
@@ -248,6 +248,12 @@ def _coverage_body(tenants: list[dict]) -> dict:
         "tenants_with_missing": sum(1 for t in tenants if t["missing_embeddings"]),
         "missing_provenance": sum(t.get("missing_provenance", 0) for t in tenants),
         "tenants_with_missing_provenance": sum(1 for t in tenants if t.get("missing_provenance", 0)),
+        # The real endpoint always serves this. Tests that care about its
+        # absence pop it explicitly rather than relying on a default.
+        "missing_provenance_predicate": (
+            "embedding IS NOT NULL AND embedded_content_hash IS NULL "
+            "AND content_hash IS NOT NULL AND created_at >= '2026-08-17'"
+        ),
     }
 
 
@@ -523,3 +529,73 @@ async def test_missing_provenance_tenant_gets_a_per_tenant_line(monkeypatch, cap
     per_tenant = _records(caplog, "embedding coverage tenant")
     assert [r.tenant_id for r in per_tenant] == ["t-prov-only"]
     assert per_tenant[0].missing_provenance == 3
+
+
+@pytest.mark.asyncio
+async def test_alert_echoes_the_served_predicate_rather_than_a_local_literal(monkeypatch, caplog):
+    """The query in the alert must come from whoever ran it.
+
+    core-operations is a separate deployable with no import path into
+    core-storage-api, so a predicate literal here would be kept honest by
+    nothing — it would drift silently the first time the cutoff date moved, and
+    the alert would name a query that does not reproduce the count beside it.
+
+    Asserted with a deliberately unreal predicate: a hardcoded implementation
+    would emit its own plausible-looking string and pass a laxer check.
+    """
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    served = "SERVED BY STORAGE: created_at >= '2099-01-01'"
+    body = _coverage_body(
+        [
+            {
+                "tenant_id": "t-x",
+                "total_active": 5,
+                "missing_embeddings": 0,
+                "missing_provenance": 2,
+                "coverage_pct": 100.0,
+            },
+        ]
+    )
+    body["missing_provenance_predicate"] = served
+    caplog.set_level("INFO", logger=tasks.logger.name)
+    async with _patch_client(monkeypatch, response=_StubResponse(200, body)):
+        await tasks.run_embedding_coverage_tick()
+
+    alerts = _records(caplog, "memories embedded without provenance; a writer is dropping content_hash")
+    assert alerts[0].predicate == served
+
+
+@pytest.mark.asyncio
+async def test_alert_survives_a_storage_service_without_the_predicate(monkeypatch, caplog):
+    """A rolling deploy must not cost the alert.
+
+    An older storage service omits the field. The count is still correct and
+    still worth escalating, so the alert fires with no query attached rather
+    than being suppressed or crashing the tick. A missing hint costs an
+    operator one lookup; suppressing the alert costs them the incident.
+    """
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    body = _coverage_body(
+        [
+            {
+                "tenant_id": "t-x",
+                "total_active": 5,
+                "missing_embeddings": 0,
+                "missing_provenance": 2,
+                "coverage_pct": 100.0,
+            },
+        ]
+    )
+    body.pop("missing_provenance_predicate", None)
+    caplog.set_level("INFO", logger=tasks.logger.name)
+    async with _patch_client(monkeypatch, response=_StubResponse(200, body)):
+        await tasks.run_embedding_coverage_tick()
+
+    alerts = _records(caplog, "memories embedded without provenance; a writer is dropping content_hash")
+    assert len(alerts) == 1, "the alert must still fire without the predicate field"
+    assert alerts[0].missing_provenance == 2
+    assert alerts[0].predicate is None

--- a/core-operations/tests/test_tasks.py
+++ b/core-operations/tests/test_tasks.py
@@ -234,11 +234,20 @@ async def test_embed_backfill_tick_posts_to_fanout(monkeypatch: pytest.MonkeyPat
 
 
 def _coverage_body(tenants: list[dict]) -> dict:
+    """Mirror the aggregate endpoint's shape, including the derived totals.
+
+    Summed here rather than passed in so a test cannot state a total that
+    disagrees with its own per-tenant rows — the endpoint derives both from one
+    query, and a fixture that let them diverge could assert behaviour the
+    service can never actually see.
+    """
     return {
         "tenants": tenants,
         "total_active": sum(t["total_active"] for t in tenants),
         "missing_embeddings": sum(t["missing_embeddings"] for t in tenants),
         "tenants_with_missing": sum(1 for t in tenants if t["missing_embeddings"]),
+        "missing_provenance": sum(t.get("missing_provenance", 0) for t in tenants),
+        "tenants_with_missing_provenance": sum(1 for t in tenants if t.get("missing_provenance", 0)),
     }
 
 
@@ -394,3 +403,123 @@ async def test_embedding_coverage_tick_reports_stale_separately(monkeypatch, cap
     per_tenant = _records(caplog, "embedding coverage tenant")
     assert [r.tenant_id for r in per_tenant] == ["t-stale"]
     assert per_tenant[0].stale_embeddings == 7
+
+
+# ---------------------------------------------------------------------------
+# missing_provenance — the one coverage bucket with a correct value (zero)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_provenance_raises_an_error_line(monkeypatch, caplog):
+    """A single un-provenanced row must escalate, with no threshold to cross.
+
+    This is the signal that was absent when 241 production rows accumulated
+    over a week in 2026-09. The bucket that held them was logged at INFO and
+    explicitly documented as not worth alerting on, because its level
+    legitimately sits in the tens of thousands of pre-037 rows.
+    ``missing_provenance`` removes the innocent explanations, so its correct
+    value is zero and one row is already a defect.
+
+    ERROR, not WARNING: no sweep can reach these rows — both embedding
+    backfills select ``embedding IS NULL`` and these have a vector — so nothing
+    drains them without a person.
+    """
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    body = _coverage_body(
+        [
+            {
+                "tenant_id": "t-dropping",
+                "total_active": 100,
+                "missing_embeddings": 0,
+                "missing_provenance": 1,
+                "coverage_pct": 100.0,
+            },
+        ]
+    )
+    caplog.set_level("INFO", logger=tasks.logger.name)
+    async with _patch_client(monkeypatch, response=_StubResponse(200, body)):
+        await tasks.run_embedding_coverage_tick()
+
+    alerts = _records(caplog, "memories embedded without provenance; a writer is dropping content_hash")
+    assert len(alerts) == 1, "one un-provenanced row must raise an alert"
+    assert alerts[0].levelname == "ERROR"
+    assert alerts[0].missing_provenance == 1
+    assert alerts[0].tenants_affected == 1
+    assert alerts[0].worst_tenants == [{"tenant_id": "t-dropping", "missing_provenance": 1}]
+    # The rows are reachable by no sweep or endpoint, so the alert has to carry
+    # the query an operator would otherwise have to reconstruct.
+    assert "embedded_content_hash IS NULL" in alerts[0].predicate
+
+
+@pytest.mark.asyncio
+async def test_no_alert_when_provenance_is_complete(monkeypatch, caplog):
+    """A deployment full of legitimate pre-037 rows must stay quiet.
+
+    The distinction the whole change rests on: ``unknown_provenance`` in the
+    tens of thousands is normal and must not alert, while ``missing_provenance``
+    of one must. A fixture with a large ``unknown_provenance`` and zero
+    ``missing_provenance`` is exactly the shape of a healthy production
+    deployment today, and an alert here would be the false positive that gets
+    the alert switched off.
+    """
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    body = _coverage_body(
+        [
+            {
+                "tenant_id": "t-legacy",
+                "total_active": 100_000,
+                "missing_embeddings": 0,
+                "missing_provenance": 0,
+                "coverage_pct": 100.0,
+            },
+        ]
+    )
+    body["unknown_provenance"] = 95_070
+    caplog.set_level("INFO", logger=tasks.logger.name)
+    async with _patch_client(monkeypatch, response=_StubResponse(200, body)):
+        await tasks.run_embedding_coverage_tick()
+
+    assert not _records(caplog, "memories embedded without provenance; a writer is dropping content_hash"), (
+        "95k legitimate pre-037 rows must not alert"
+    )
+    total = _records(caplog, "embedding coverage total")
+    assert total[0].unknown_provenance == 95_070
+    assert total[0].missing_provenance == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_provenance_tenant_gets_a_per_tenant_line(monkeypatch, caplog):
+    """An alert with no per-tenant line would name a number and no owner.
+
+    The per-tenant filter previously keyed on ``missing_embeddings or
+    stale_embeddings``. A tenant whose only defect is dropped provenance has
+    neither, so it would have been filtered out — leaving the alert above
+    firing with nothing underneath it to act on.
+    """
+    settings.core_api_url = "http://core-api"
+    settings.core_api_admin_api_key = "admin-key-xyz"
+
+    body = _coverage_body(
+        [
+            {
+                "tenant_id": "t-prov-only",
+                "total_active": 10,
+                "missing_embeddings": 0,
+                "stale_embeddings": 0,
+                "missing_provenance": 3,
+                "coverage_pct": 100.0,
+            },
+        ]
+    )
+    caplog.set_level("INFO", logger=tasks.logger.name)
+    async with _patch_client(monkeypatch, response=_StubResponse(200, body)):
+        await tasks.run_embedding_coverage_tick()
+
+    per_tenant = _records(caplog, "embedding coverage tenant")
+    assert [r.tenant_id for r in per_tenant] == ["t-prov-only"]
+    assert per_tenant[0].missing_provenance == 3

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -23,6 +23,7 @@ from core_storage_api.observability import bind_timer, log_request
 from core_storage_api.routers._validation import _require, _require_dict
 from core_storage_api.schemas import MEMORY_FIELDS, MEMORY_LIST_FIELDS, orm_to_dict
 from core_storage_api.services.postgres_service import (
+    MISSING_PROVENANCE_PREDICATE_SQL,
     BulkValidationError,
     PostgresService,
 )
@@ -894,6 +895,12 @@ async def get_embedding_coverage_all() -> dict:
         # can be alerted on directly instead of trended.
         "missing_provenance": sum(r["missing_provenance"] for r in rows),
         "tenants_with_missing_provenance": sum(1 for r in rows if r["missing_provenance"]),
+        # The query that reproduces the count above. Served rather than
+        # composed by the caller: core-operations, which alerts on this, is a
+        # separate deployable and a literal there would drift the first time
+        # the cutoff moved — naming a query that no longer matches the number
+        # beside it.
+        "missing_provenance_predicate": MISSING_PROVENANCE_PREDICATE_SQL,
     }
 
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -846,12 +846,18 @@ async def get_embedding_coverage(
     # The provenance counts are reported here as well as in the cross-tenant
     # view: omitting them would make this route read as "no stale rows" for a
     # tenant the aggregate flags, and absence is indistinguishable from zero.
-    total, missing, stale, unknown = await _svc.memory_embedding_coverage_for_tenant(tenant_id, fleet_id)
+    total, missing, stale, unknown, missing_prov = await _svc.memory_embedding_coverage_for_tenant(
+        tenant_id, fleet_id
+    )
     return {
         "total_active": total,
         "missing_embeddings": missing,
         "stale_embeddings": stale,
         "unknown_provenance": unknown,
+        # The alertable subset of ``unknown_provenance``: rows written after
+        # provenance existed, with a hash to attest, that attest nothing.
+        # Expected to be 0; any other value names a live writer dropping it.
+        "missing_provenance": missing_prov,
         "coverage_pct": round((total - missing) / total * 100, 1) if total > 0 else 0.0,
     }
 
@@ -882,6 +888,12 @@ async def get_embedding_coverage_all() -> dict:
         "tenants_with_stale": sum(1 for r in rows if r["stale_embeddings"]),
         # Embedded before provenance was recorded — undetermined, not damaged.
         "unknown_provenance": sum(r["unknown_provenance"] for r in rows),
+        # The subset of the above with no innocent explanation: written after
+        # migration 037, carrying a content hash, yet attesting nothing. Unlike
+        # every other bucket here this one has a correct value — zero — so it
+        # can be alerted on directly instead of trended.
+        "missing_provenance": sum(r["missing_provenance"] for r in rows),
+        "tenants_with_missing_provenance": sum(1 for r in rows if r["missing_provenance"]),
     }
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -382,6 +382,24 @@ _LINK_REJECTED = "entity link rejected: memory_id or entity_id does not exist, o
 # that HAS a hash to attest, it means a writer dropped it.
 PROVENANCE_REQUIRED_FROM = datetime(2026, 8, 17, tzinfo=UTC)
 
+# The same rule as SQL, for an operator to paste. These rows are reachable by
+# no sweep and no endpoint, so whatever alerts on the count has to hand over a
+# query or the number is unactionable.
+#
+# Built from the constant above rather than written out, and shipped in the
+# coverage response rather than composed by the consumer. core-operations is a
+# separate deployable with no import path into this module, so a literal there
+# could not be kept honest by anything: the date would drift the first time
+# this constant moved, and the alert would name a query that no longer matches
+# what it counted. Deriving it here means there is one date in one place, and
+# ``test_predicate_string_is_derived_from_the_constant`` fails if this string
+# stops agreeing with the filter it describes.
+MISSING_PROVENANCE_PREDICATE_SQL = (
+    "embedding IS NOT NULL AND embedded_content_hash IS NULL "
+    "AND content_hash IS NOT NULL "
+    f"AND created_at >= '{PROVENANCE_REQUIRED_FROM.date().isoformat()}'"
+)
+
 
 class _CoverageCounts(NamedTuple):
     """The four embedding-coverage buckets, as FILTER'd count expressions.

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -18,7 +18,7 @@ from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from sqlalchemy import (
@@ -371,6 +371,87 @@ _ENTITY_UPDATABLE_FIELDS = frozenset({"canonical_name", "entity_type", "attribut
 # wire — two copies could drift apart and reintroduce the existence oracle one
 # word at a time. The true cause is logged, never returned.
 _LINK_REJECTED = "entity link rejected: memory_id or entity_id does not exist, or the link already exists"
+
+
+# Migration 037 added ``embedded_content_hash`` on 2026-08-16, and every writer
+# has recorded provenance since. Dated a day later so a row written during the
+# deploy itself is not held to a guarantee that was still rolling out.
+#
+# This is what separates a live defect from historical silence: before this
+# instant a NULL means "written before provenance existed"; after it, on a row
+# that HAS a hash to attest, it means a writer dropped it.
+PROVENANCE_REQUIRED_FROM = datetime(2026, 8, 17, tzinfo=UTC)
+
+
+class _CoverageCounts(NamedTuple):
+    """The four embedding-coverage buckets, as FILTER'd count expressions.
+
+    Built once and used by both coverage queries. They previously inlined the
+    same predicates separately, under a docstring warning to "keep the three in
+    sync" — a warning is not a mechanism, and the buckets disagreeing is
+    precisely what sends someone hunting a phantom bug when the aggregate and
+    the per-tenant route report different numbers for one tenant.
+    """
+
+    missing: ColumnElement[int]
+    stale: ColumnElement[int]
+    unknown: ColumnElement[int]
+    missing_provenance: ColumnElement[int]
+
+
+def _coverage_counts() -> _CoverageCounts:
+    """The four buckets. See ``memory_embedding_coverage_by_tenant`` for meaning."""
+    return _CoverageCounts(
+        missing=func.count().filter(Memory.embedding.is_(None)),
+        stale=func.count().filter(
+            Memory.embedding.isnot(None),
+            Memory.embedded_content_hash.isnot(None),
+            # ``is_distinct_from``, NOT ``!=``. SQLAlchemy's ``!=`` compiles to
+            # plain ``<>``, which yields NULL when ``content_hash`` is NULL (it
+            # is a nullable column) — and ``COUNT(*) FILTER`` drops NULL. Such a
+            # row has a KNOWN provenance hash, so it is not ``unknown``; it has
+            # an embedding, so it is not ``missing``; and the NULL comparison
+            # kept it out of ``stale``. It counted in ``total_active`` and in no
+            # defect bucket at all — silently unaccounted for by the very
+            # detector this column exists to provide.
+            #
+            # This also keeps the ORM in step with the migration's partial index
+            # predicate, which uses IS DISTINCT FROM. The two encode one rule in
+            # two languages and nothing checks they agree, so they must be read
+            # together whenever either changes.
+            Memory.embedded_content_hash.is_distinct_from(Memory.content_hash),
+        ),
+        unknown=func.count().filter(
+            Memory.embedding.isnot(None),
+            Memory.embedded_content_hash.is_(None),
+        ),
+        # A STRICT SUBSET of ``unknown``, and the only one of the four that
+        # should ever be zero.
+        #
+        # ``unknown`` cannot be alerted on: it legitimately holds ~95,000
+        # pre-037 rows that will never acquire provenance, so any threshold on
+        # its level is either always breached or useless. That is why the
+        # operations tick was told not to alert on it — on the premise that it
+        # only ever drains. A defect that GROWS it falsifies that premise, and
+        # in 2026-09 one did: 241 rows accumulated for over a week inside a
+        # number nobody was watching, because the only signal was a level that
+        # legitimately sat in the tens of thousands.
+        #
+        # These three extra terms carve out the population where NULL has no
+        # innocent explanation, so the alertable quantity is an exact invariant
+        # rather than a tuned threshold, and needs no stored history to compare
+        # against:
+        #   created_at        — after provenance existed, so not pre-037 silence
+        #   content_hash NOT NULL — something to attest TO; a row without one
+        #                     honestly records NULL, per core-worker's backfill
+        #   embedding NOT NULL    — a vector exists, so something did embed it
+        missing_provenance=func.count().filter(
+            Memory.embedding.isnot(None),
+            Memory.embedded_content_hash.is_(None),
+            Memory.content_hash.isnot(None),
+            Memory.created_at >= PROVENANCE_REQUIRED_FROM,
+        ),
+    )
 
 
 def _link_within_tenant(tenant_id: str) -> ColumnElement[bool]:
@@ -3353,8 +3434,8 @@ class PostgresService:
         self,
         tenant_id: str,
         fleet_id: str | None = None,
-    ) -> tuple[int, int, int, int]:
-        """``(total_active, missing, stale, unknown_provenance)`` for one tenant.
+    ) -> tuple[int, int, int, int, int]:
+        """``(total_active, missing, stale, unknown_provenance, missing_provenance)``.
 
         The per-tenant twin of ``memory_embedding_coverage_by_tenant``, and the
         single source for ``GET /embedding-coverage``. Without the provenance
@@ -3371,20 +3452,15 @@ class PostgresService:
         Same population predicate and the same ``is_distinct_from`` NULL
         handling as the aggregate; keep the two in step.
         """
+        counts = _coverage_counts()
         async with get_read_session() as session:
             stmt = (
                 select(
                     func.count(),
-                    func.count().filter(Memory.embedding.is_(None)),
-                    func.count().filter(
-                        Memory.embedding.isnot(None),
-                        Memory.embedded_content_hash.isnot(None),
-                        Memory.embedded_content_hash.is_distinct_from(Memory.content_hash),
-                    ),
-                    func.count().filter(
-                        Memory.embedding.isnot(None),
-                        Memory.embedded_content_hash.is_(None),
-                    ),
+                    counts.missing,
+                    counts.stale,
+                    counts.unknown,
+                    counts.missing_provenance,
                 )
                 .select_from(Memory)
                 .where(
@@ -3396,7 +3472,13 @@ class PostgresService:
             if fleet_id:
                 stmt = stmt.where(Memory.fleet_id == fleet_id)
             row = (await session.execute(stmt)).one()
-        return int(row[0] or 0), int(row[1] or 0), int(row[2] or 0), int(row[3] or 0)
+        return (
+            int(row[0] or 0),
+            int(row[1] or 0),
+            int(row[2] or 0),
+            int(row[3] or 0),
+            int(row[4] or 0),
+        )
 
     async def memory_embedding_coverage_by_tenant(self) -> list[dict]:
         """Embedding coverage for EVERY tenant, in one pass.
@@ -3434,37 +3516,16 @@ class PostgresService:
           damaged; reporting it as fresh would assert a correctness nobody
           verified. It drains as rows are rewritten or re-embedded.
         """
-        missing = func.count().filter(Memory.embedding.is_(None))
-        stale = func.count().filter(
-            Memory.embedding.isnot(None),
-            Memory.embedded_content_hash.isnot(None),
-            # ``is_distinct_from``, NOT ``!=``. SQLAlchemy's ``!=`` compiles to
-            # plain ``<>``, which yields NULL when ``content_hash`` is NULL (it
-            # is a nullable column) — and ``COUNT(*) FILTER`` drops NULL. Such a
-            # row has a KNOWN provenance hash, so it is not ``unknown``; it has
-            # an embedding, so it is not ``missing``; and the NULL comparison
-            # kept it out of ``stale``. It counted in ``total_active`` and in no
-            # defect bucket at all — silently unaccounted for by the very
-            # detector this column exists to provide.
-            #
-            # This also keeps the ORM in step with the migration's partial index
-            # predicate, which uses IS DISTINCT FROM. The two encode one rule in
-            # two languages and nothing checks they agree, so they must be read
-            # together whenever either changes.
-            Memory.embedded_content_hash.is_distinct_from(Memory.content_hash),
-        )
-        unknown = func.count().filter(
-            Memory.embedding.isnot(None),
-            Memory.embedded_content_hash.is_(None),
-        )
+        counts = _coverage_counts()
         async with get_read_session() as session:
             stmt = (
                 select(
                     Memory.tenant_id,
                     func.count().label("total_active"),
-                    missing.label("missing_embeddings"),
-                    stale.label("stale_embeddings"),
-                    unknown.label("unknown_provenance"),
+                    counts.missing.label("missing_embeddings"),
+                    counts.stale.label("stale_embeddings"),
+                    counts.unknown.label("unknown_provenance"),
+                    counts.missing_provenance.label("missing_provenance"),
                 )
                 .select_from(Memory)
                 .where(
@@ -3477,7 +3538,7 @@ class PostgresService:
                 # leads. Unknown is not ranked — it is a measurement gap, not
                 # a defect, and letting it sort the list would bury real
                 # damage under untriaged history.
-                .order_by((stale + missing).desc())
+                .order_by((counts.stale + counts.missing).desc())
             )
             rows = (await session.execute(stmt)).all()
         return [
@@ -3487,6 +3548,7 @@ class PostgresService:
                 "missing_embeddings": int(row.missing_embeddings or 0),
                 "stale_embeddings": int(row.stale_embeddings or 0),
                 "unknown_provenance": int(row.unknown_provenance or 0),
+                "missing_provenance": int(row.missing_provenance or 0),
                 "coverage_pct": (
                     round((row.total_active - row.missing_embeddings) / row.total_active * 100, 1)
                     if row.total_active

--- a/core-storage-api/tests/test_backfill_embeddings_provenance.py
+++ b/core-storage-api/tests/test_backfill_embeddings_provenance.py
@@ -164,9 +164,13 @@ async def test_row_does_not_land_in_the_unswept_population(engine, monkeypatch):
 
     await _run(engine, _memories_spec(), isolated_tenant)
 
-    _total, _missing, _stale, unknown = await PostgresService().memory_embedding_coverage_for_tenant(
-        isolated_tenant
-    )
+    (
+        _total,
+        _missing,
+        _stale,
+        unknown,
+        _missing_prov,
+    ) = await PostgresService().memory_embedding_coverage_for_tenant(isolated_tenant)
     assert unknown == 0, f"{unknown} row(s) moved into the population nothing sweeps"
 
 
@@ -306,3 +310,72 @@ async def test_hint_rewrite_replaces_stale_provenance(engine, tenant_id, monkeyp
         "text the NEW vector was built from, not whatever the old one claimed"
     )
     assert provenance != stale_stamp
+
+
+@pytest.mark.integration
+async def test_missing_provenance_excludes_the_innocent_cases(engine):
+    """The alertable bucket must hold only rows with no honest explanation.
+
+    ``unknown_provenance`` cannot be alerted on: its level legitimately sits in
+    the tens of thousands of pre-037 rows. ``missing_provenance`` is the same
+    predicate with three carve-outs, and every one has to hold or the alert
+    becomes a false positive on a healthy deployment — which is how an alert
+    gets switched off and the next defect goes unseen.
+
+    * a row created BEFORE migration 037 predates provenance entirely
+    * a row with no ``content_hash`` has nothing to attest TO, so NULL is the
+      honest value — core-worker's backfill legitimately publishes None
+    * a row with no embedding has nothing to attest ABOUT
+
+    Seeds one of each beside a genuine defect and asserts the buckets split.
+    """
+    from datetime import UTC, datetime
+
+    from core_storage_api.services.postgres_service import PostgresService
+
+    t = f"test-prov-buckets-{uuid.uuid4().hex[:8]}"
+    async with engine.connect() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO memories "
+                "(id, tenant_id, agent_id, memory_type, content, content_hash, "
+                " embedded_content_hash, embedding, created_at) VALUES "
+                # 1. genuine defect: post-037, has a hash, has a vector, attests nothing
+                "(:i1, :t, 'a', 'fact', 'defect', 'h1', NULL, (:emb)::vector, :recent), "
+                # 2. pre-037: provenance did not exist yet
+                "(:i2, :t, 'a', 'fact', 'legacy', 'h2', NULL, (:emb)::vector, :old), "
+                # 3. no content_hash: nothing to attest TO
+                "(:i3, :t, 'a', 'fact', 'nohash', NULL, NULL, (:emb)::vector, :recent), "
+                # 4. no embedding: nothing to attest ABOUT
+                "(:i4, :t, 'a', 'fact', 'novec', 'h4', NULL, NULL, :recent)"
+            ),
+            {
+                "i1": uuid.uuid4(),
+                "i2": uuid.uuid4(),
+                "i3": uuid.uuid4(),
+                "i4": uuid.uuid4(),
+                "t": t,
+                "emb": str([0.3] * VECTOR_DIM_FAKE),
+                "recent": datetime(2026, 9, 1, tzinfo=UTC),
+                "old": datetime(2026, 8, 1, tzinfo=UTC),
+            },
+        )
+        await conn.commit()
+
+    (
+        _total,
+        missing,
+        _stale,
+        unknown,
+        missing_prov,
+    ) = await PostgresService().memory_embedding_coverage_for_tenant(t)
+
+    # All three embedded-but-unattested rows land in ``unknown`` — that bucket
+    # is deliberately broad, which is exactly why it cannot be alerted on.
+    assert unknown == 3, f"expected rows 1-3 in unknown_provenance, got {unknown}"
+    # Only row 1 has no innocent reading.
+    assert missing_prov == 1, (
+        f"missing_provenance={missing_prov}; it must exclude pre-037 rows and rows "
+        "with no content_hash, or the alert fires on a healthy deployment"
+    )
+    assert missing == 1, "row 4 has no vector at all"

--- a/core-storage-api/tests/test_backfill_embeddings_provenance.py
+++ b/core-storage-api/tests/test_backfill_embeddings_provenance.py
@@ -379,3 +379,33 @@ async def test_missing_provenance_excludes_the_innocent_cases(engine):
         "with no content_hash, or the alert fires on a healthy deployment"
     )
     assert missing == 1, "row 4 has no vector at all"
+
+
+def test_predicate_string_is_derived_from_the_constant():
+    """The operator-facing query must describe the filter that produced the count.
+
+    ``MISSING_PROVENANCE_PREDICATE_SQL`` is handed to whoever alerts on
+    ``missing_provenance`` so a human can reproduce the number. It is a string,
+    so nothing makes it agree with the ORM filter beside it — and the two live
+    ten lines apart today but are consumed by different services.
+
+    No database: this asserts the string is built FROM the constant rather than
+    restating it, which is the only property that keeps them from drifting when
+    the cutoff moves.
+    """
+    from core_storage_api.services import postgres_service as ps
+
+    assert ps.PROVENANCE_REQUIRED_FROM.date().isoformat() in ps.MISSING_PROVENANCE_PREDICATE_SQL, (
+        "the predicate string does not name the cutoff it is built from; an "
+        "operator pasting it would count a different population than the alert did"
+    )
+    # The three carve-outs that make this bucket alertable at all must each be
+    # visible in the query an operator is handed, or they will reproduce the
+    # broad ``unknown_provenance`` count and conclude the alert was wrong.
+    for term in (
+        "embedding IS NOT NULL",
+        "embedded_content_hash IS NULL",
+        "content_hash IS NOT NULL",
+        "created_at >=",
+    ):
+        assert term in ps.MISSING_PROVENANCE_PREDICATE_SQL, f"predicate omits {term!r}"


### PR DESCRIPTION
## Why nobody noticed

241 production rows accumulated over a week. **The number that would have shown
them was already being computed** — logged at INFO every tick, and explicitly
documented as not worth alerting on:

```python
# Embedded before provenance existed: undetermined, not damaged.
# Expected to fall over time; it is a measurement gap closing, so
# do not alert on it.
```

That reasoning is sound about what it describes and wrong about what it
assumes. `unknown_provenance` genuinely **cannot** be alerted on: it holds
~95,000 legitimate pre-037 rows, so any threshold on its level is either
permanently breached or meaningless. But "do not alert" was justified by
*"expected to fall over time"* — which assumes the population only ever drains.
A defect that grows it falsifies that premise, and #1281's did, inside the one
number nobody was watching.

The premise has since been restored (that writer and the backfill in #1289 are
both fixed), but it is only ever as good as the last writer. This replaces the
assumption with a measurement.

## What this adds

`missing_provenance` — the same predicate with every innocent explanation
removed:

```sql
embedding IS NOT NULL              -- something embedded it
AND embedded_content_hash IS NULL  -- and recorded nothing
AND content_hash IS NOT NULL       -- with a hash it could have recorded
AND created_at >= '2026-08-17'     -- after provenance existed
```

**Its correct value is zero, always.** That is the whole design. It needs no
stored history, no baseline, and no tuned threshold.

### Why not the delta

The obvious answer is to alert on the *change* in `unknown_provenance`. I chose
against it:

- **It needs state.** core-operations is a stateless tick runner — it POSTs an
  endpoint and logs. Persisting a previous level for one metric means giving
  this service a store it does not otherwise have.
- **It still needs a threshold**, and the bucket legitimately moves as rows are
  rewritten, so the threshold is a tuning problem with no correct answer.
- **It only fires once a trend establishes.** The scoped invariant fires on the
  **first** bad row.

An exact invariant beats a tuned threshold whenever one is available, and here
one is.

## The alert

ERROR, not WARNING, and it carries the predicate:

```
memories embedded without provenance; a writer is dropping content_hash
  missing_provenance=241 tenants_affected=1
  worst_tenants=[{tenant_id: ..., missing_provenance: 241}]
  predicate="embedding IS NOT NULL AND embedded_content_hash IS NULL
             AND content_hash IS NOT NULL AND created_at >= '2026-08-17'"
```

ERROR because these rows are reachable by **no sweep and no endpoint** — both
embedding backfills select `embedding IS NULL` and these have a vector; the
staleness detector needs a hash to compare. Nothing drains them without a
person. The predicate rides along because an operator who sees this has no
query to run otherwise.

The per-tenant filter now includes the new bucket. It keyed on
`missing_embeddings or stale_embeddings`, and a tenant whose *only* defect is
dropped provenance has neither — so the alert would have fired with no
per-tenant line beneath it naming who to look at.

## Also: one definition instead of three

The coverage predicates were inlined separately in both queries, under a
docstring warning to *"keep the three in sync"*. A warning is not a mechanism —
and a fourth copy, in a test I wrote last week, had already drifted by omitting
the `LIVE_MEMORY_STATUSES` filter. They now come from one `_coverage_counts()`.
This is the change I'd most want a second opinion on, since it touches working
production query code in a PR about alerting.

## Verification

Reverted three ways:

| Revert | Fails |
|---|---|
| Drop the alert call | `test_missing_provenance_raises_an_error_line` |
| Revert the per-tenant filter | `test_missing_provenance_tenant_gets_a_per_tenant_line` |
| Remove the three carve-outs (new bucket ≡ `unknown`) | `test_missing_provenance_excludes_the_innocent_cases` |

The third is the one that matters. It seeds four rows — a genuine defect, a
pre-037 row, a row with no `content_hash`, and a row with no embedding — and
asserts `unknown == 3` while `missing_provenance == 1`. **That is what keeps
the alert quiet on a healthy deployment holding 95k legacy rows**, which is the
difference between an alert people act on and one they switch off.

core-operations **50 → 53**, core-storage-api **334 → 339**, root suite
unchanged at 18 known environmental failures, zero new by name. ruff clean at
CI's scopes; `mypy src/` clean in all three packages.

## Not included: the repair sweep

The task's part 2 asked whether a sweep for this population belongs here. I
left it out deliberately — it is a materially different change:

- **It needs an index.** Migration 037's partial index carries `AND
  embedded_content_hash IS NOT NULL`, so it deliberately excludes this bucket.
  A sweep written today would sequential-scan `memories`.
- **It needs a policy decision.** ~95,000 legitimate pre-037 rows are in scope
  for any such sweep, and re-embedding them costs real provider spend. Whether
  to repair them, and at what rate, is not a code question.
- **The safe repair is a re-embed, not a stamp.** `embedded_content_hash =
  content_hash` is true only for a row whose content has not changed since its
  vector was written. It held for the 241 rows repaired this week — each
  verified first against a recomputed `sha256(tenant_id || ':' ||
  coalesce(fleet_id,'') || ':' || content)` — but it must not be assumed in
  general. A wrong hash reads downstream as verified freshness and is worse
  than the NULL it replaces.

Detection is the half that pays for itself immediately and is safe to ship
alone. Happy to take the sweep as a follow-up.

Not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
