### PR TITLE
feat(mcp): refuse an over-plan write, behind a flag

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -416,11 +416,32 @@ class Settings(BaseSettings):
     # Crossing it bites on REST FIRST. Over-plan mode is computed from these
     # counters and stamped as ``x-org-read-only``, which core-api turns into a
     # 403 on ~22 REST write routes — while the MCP surface only OBSERVES it
-    # (see ``_observe_plan_limit``). So enabling this can refuse a tenant's
+    # (see ``_check_plan_limit``). So enabling this can refuse a tenant's
     # REST writes because of what it wrote over MCP. That is the intended end
     # state, but it is not a deploy side effect. Off = the historical (unbilled)
     # behavior. See caura-ai/caura#1220.
     meter_mcp_bulk_writes: bool = False
+    # Refuse MCP writes when the org is over its plan limit, as the ~22 REST
+    # write routes already do. Off by default, and this is the sharpest of the
+    # three flags above it: the other two change what is COUNTED, this one
+    # changes what is ALLOWED. Flipping it takes away a capability tenants have
+    # today — an over-plan org that can currently write over MCP stops being
+    # able to — so it is a deliberate, announced change, not a deploy side
+    # effect. Off = observe and log only (``_check_plan_limit``).
+    #
+    # It is a flag rather than a straight code change so the rollout is
+    # reversible without a redeploy: enable it, watch
+    # ``mcp_plan_limit_refused``, and turn it off again if the blast radius is
+    # wrong. A code-only change would need a rollback to undo.
+    #
+    # Read ``_check_plan_limit``'s docstring before enabling. A quiet
+    # observation log is NOT evidence that nothing will be refused — the
+    # counters over-plan mode is computed from barely move for MCP-first
+    # tenants while ``meter_mcp_bulk_writes`` is off, which is the population
+    # this refusal is aimed at. The two flags interact: turning THIS on while
+    # that one is off enforces a limit against counters the MCP surface hardly
+    # contributes to. See caura-ai/caura#1205.
+    enforce_mcp_plan_limits: bool = False
     stm_backend: str = "memory"  # memory | redis
     stm_notes_ttl: int = 86400  # 24h
     stm_bulletin_ttl: int = 172800  # 48h

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -40,7 +40,7 @@ from core_api.constants import (
     VALID_SCOPES,
     VERSION,
 )
-from core_api.errors import code_for_status
+from core_api.errors import AUTH_PLAN_LIMIT, code_for_status
 from core_api.pagination import decode_cursor, encode_cursor
 from core_api.schemas import (
     BulkMemoryCreate,
@@ -97,6 +97,7 @@ from core_api.services.usage_service import (
     MutatingOp,
     bulk_check_and_increment,
     charges_write_quota,
+    enforces_mcp_plan_limits,
     meters_mcp_bulk_write,
     plan_limit_gated,
     recall_operation,
@@ -141,10 +142,13 @@ _install_uuid_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 # docstring). REST reads it via ``AuthContext.is_read_only``. This middleware
 # reads it too, as of the commit that introduced this var — BEFORE that it did
 # not, which is the state caura-ai/caura#1205 describes and the reason that
-# issue reads as if the signal were still missing. It is not; the refusal is.
+# issue reads as if the signal were still missing. It never was; the refusal
+# was, and it now exists behind a flag.
 #
-# OBSERVED, NOT ENFORCED, for now. Nothing refuses on this yet — see
-# ``_observe_plan_limit`` below for why that sequencing is deliberate.
+# ENFORCED ONLY WHEN ``enforce_mcp_plan_limits`` IS ON — off by default, in
+# which case ``_check_plan_limit`` logs and lets the write through exactly as
+# before. See that function and the setting's comment for why the capability is
+# available without being automatic.
 _org_read_only_var: contextvars.ContextVar[bool] = contextvars.ContextVar("mcp_org_read_only", default=False)
 
 _UNAUTH = "__unauthenticated__"
@@ -473,15 +477,32 @@ def _is_org_read_only() -> bool:
     """True when the platform stamped this org over its plan limit.
 
     The MCP twin of ``AuthContext.is_read_only``. Read only by
-    ``_observe_plan_limit`` today — nothing refuses on it yet.
+    ``_check_plan_limit``, which refuses on it when
+    ``enforce_mcp_plan_limits`` is on and logs without refusing when it is off.
     """
     return _org_read_only_var.get(False)
 
 
-def _observe_plan_limit(op: MutatingOp, tenant_id: str) -> None:
-    """Record that ``op`` ran while the org was over its plan limit.
+def _check_plan_limit(op: MutatingOp, tenant_id: str) -> str | None:
+    """Refuse ``op`` when the org is over its plan limit — or just record it.
 
-    DELIBERATELY DOES NOT REFUSE. This is step one of caura-ai/caura#1205,
+    Returns the canonical MCP error envelope when the write must be refused,
+    and ``None`` when it may proceed. Callers MUST return the envelope rather
+    than discard it; a dropped return here is a silent un-enforcement, which is
+    the failure this whole area keeps producing.
+
+    WHICH IT DOES IS A FLAG. ``enforces_mcp_plan_limits()`` is off by default,
+    and while it is off this behaves exactly as it did before — log and let the
+    write through. That preserves the staging described below rather than
+    discarding it: enforcement becomes available without becoming automatic.
+
+    The refusal mirrors REST's ``AuthContext.enforce_usage_limits`` — same
+    error code (``PLAN_LIMIT_READ_ONLY``), same message, same carve-out that
+    deletes stay permitted so a tenant can get back under the limit. It cannot
+    reuse that method directly: it raises ``HTTPException``, and MCP tools
+    return envelopes.
+
+    Step one of caura-ai/caura#1205 was to observe rather than refuse,
     which closes a real divergence — an over-plan org is refused a write on
     REST and allowed the same write on MCP — but closes it in a direction that
     takes capability AWAY from tenants who have it today. Enforcing in the same
@@ -518,16 +539,33 @@ def _observe_plan_limit(op: MutatingOp, tenant_id: str) -> None:
 
     Logged at WARNING rather than INFO because a firing line means real money:
     a write that the plan says should not have happened.
+
+    TWO EVENT NAMES, deliberately. Observing keeps emitting
+    ``mcp_plan_limit_would_refuse``; enforcing emits
+    ``mcp_plan_limit_refused``. Reusing one name and flipping the ``enforced``
+    field would leave every existing query silently counting refusals as
+    observations, and "did we actually refuse anyone" is the question the
+    rollout turns on. The ``enforced`` field is kept on both so a query written
+    against either name still resolves it.
     """
     if not _is_org_read_only() or not plan_limit_gated(op):
-        return
+        return None
+    enforcing = enforces_mcp_plan_limits()
     logger.warning(
-        "mcp_plan_limit_would_refuse",
+        "mcp_plan_limit_refused" if enforcing else "mcp_plan_limit_would_refuse",
         extra={
             "tenant_id": tenant_id,
             "mcp_operation": op,
-            "enforced": False,
+            "enforced": enforcing,
         },
+    )
+    if not enforcing:
+        return None
+    return _error_response(
+        AUTH_PLAN_LIMIT,
+        "Organization is in read-only mode: usage exceeds plan limits. "
+        "Upgrade your plan or delete data to restore write access.",
+        remediation="Deletes stay permitted so you can get back under the limit.",
     )
 
 
@@ -1237,11 +1275,19 @@ async def caura_write(
             if not fleet_id and agent.get("fleet_id"):
                 fleet_id = agent["fleet_id"]
             if content is not None:
-                # Observation only; the write proceeds. The batch path below
-                # carries the ``bulk_create`` twin — between them they cover
-                # every op on this surface that ``PLAN_LIMIT_GATED_OPS``
-                # names (MCP exposes no ``redistribute``).
-                _observe_plan_limit("create", tenant_id)
+                # Refuses when ``enforce_mcp_plan_limits`` is on, observes
+                # otherwise. The batch path below carries the ``bulk_create``
+                # twin — between them they cover every op on this surface that
+                # ``PLAN_LIMIT_GATED_OPS`` names (MCP exposes no
+                # ``redistribute``).
+                #
+                # BEFORE the quota charge, mirroring REST: a refused write must
+                # not consume the budget it was refused for. The order matters
+                # more here than it looks, because the counter this charges is
+                # the one over-plan mode is computed FROM — charging first
+                # would let a refused write push the tenant further over.
+                if refuse := _check_plan_limit("create", tenant_id):
+                    return _with_latency(refuse, t0)
                 if charges_write_quota("create"):
                     await check_and_increment(tenant_id, "write")
                 result = await create_memory(
@@ -1295,11 +1341,18 @@ async def caura_write(
             for _idx, _item in enumerate(bulk_items):
                 if refuse := _refuse_reserved_memory_type(_item.memory_type, index=_idx):
                     return _with_latency(refuse, t0)
-            # The batch twin of the single-write observation above. This is the
-            # path where an over-plan tenant can add the most rows per call, so
+            # The batch twin of the single-write gate above. This is the path
+            # where an over-plan tenant can add the most rows per call, so
             # leaving it out would have made the numbers read low in exactly
-            # the direction that matters.
-            _observe_plan_limit("bulk_create", tenant_id)
+            # the direction that matters — and, now that it can refuse, would
+            # leave the largest writes as the ones that got through.
+            #
+            # Refuses the WHOLE batch rather than trimming it to what fits.
+            # A partial batch would report success for a call that did not do
+            # what it was asked, and the caller has no way to tell which items
+            # landed; REST's bulk route refuses whole for the same reason.
+            if refuse := _check_plan_limit("bulk_create", tenant_id):
+                return _with_latency(refuse, t0)
             # One unit per item, mirroring REST's ``POST /memories/bulk``, which
             # charges ``len(body.items)`` before the write. Before this the path
             # charged nothing at all (caura-ai/caura#1220).
@@ -1312,10 +1365,15 @@ async def caura_write(
             #
             # ``meters_mcp_bulk_write()`` is off by default. It is a billing
             # switch, not a correctness one — see its docstring. While it is
-            # off, the caveat on ``_observe_plan_limit`` still stands: the
+            # off, the caveat on ``_check_plan_limit`` still stands: the
             # counters this would move are the ones over-plan mode is computed
             # from, so a quiet observation log is not evidence that nothing
-            # would be refused.
+            # would be refused — and now not evidence that nothing WILL be,
+            # since the gate above can refuse on a verdict this path never
+            # contributed to.
+            #
+            # Unreachable while the plan-limit gate refuses, which is the point:
+            # a refused batch charges nothing.
             if charges_write_quota("bulk_create") and meters_mcp_bulk_write():
                 await bulk_check_and_increment(tenant_id, len(bulk_items))
             bulk_data = BulkMemoryCreate(

--- a/core-api/src/core_api/services/usage_service.py
+++ b/core-api/src/core_api/services/usage_service.py
@@ -98,12 +98,14 @@ OperationType = Literal["write", "search", "recall", "insights", "evolve"]
 # would reduce usage and reactivating really would raise it, and this verb stops
 # being safe to treat as one thing — it would need to discriminate on the
 # ``old_status -> new_status`` pair. Note that such a fix is only implementable
-# on REST today — but not for the reason this comment used to give. It said MCP
-# "cannot see plan-limit mode at all"; MCP can see it now and simply does not
-# refuse on it (see below). The conclusion is unchanged and the reason is not:
-# gating one direction there would still rebuild the exact surface drift this
-# table exists to close, because a gate MCP observes but never enforces is not
-# a gate.
+# on REST today, and the reason has now moved twice. It first said MCP "cannot
+# see plan-limit mode at all" (false since the middleware started reading the
+# header), then that MCP sees it but never refuses (false since
+# ``enforce_mcp_plan_limits`` landed). What is left is narrower and flag-shaped:
+# MCP refuses only when that setting is ON, so a direction-discriminating gate
+# added here would hold on both surfaces with it on, and rebuild the exact
+# surface drift this table exists to close with it off. Until the flag is the
+# default, treat such a gate as REST-only.
 #
 # ``enforce_read_only()`` is NEITHER axis. That is the demo-mode gate, a
 # separate question, and it stays on the transition route.
@@ -121,25 +123,26 @@ WRITE_QUOTA_OPS: frozenset[str] = frozenset({"create", "bulk_create", "update", 
 # Ops refused when the org is over its plan limit. A subset of the above minus
 # ``update`` — see the note on it.
 #
-# STILL REST-ONLY IN PRACTICE, BUT NO LONGER FOR THE REASON THIS COMMENT USED TO
-# GIVE. It said the MCP surface "has no read-only signal at all — the MCP
-# middleware never reads the gateway's ``x-org-read-only`` header". That was
-# true when written and is now false: ``MCPAuthMiddleware`` reads the header on
-# the gateway-verified path and ``mcp_server._is_org_read_only()`` exposes it.
+# ENFORCED ON BOTH SURFACES NOW, BUT NOT BY DEFAULT ON MCP. This comment has
+# been wrong twice in the same direction, so it is worth stating the history:
+# it first said MCP "has no read-only signal at all" (false once
+# ``MCPAuthMiddleware`` started reading ``x-org-read-only``), then that MCP sees
+# the signal but never refuses (false once ``enforce_mcp_plan_limits`` landed).
 #
-# What remains true is the part that matters for this table: no MCP tool
-# REFUSES on the signal yet. ``_observe_plan_limit`` consults this set and logs
-# ``mcp_plan_limit_would_refuse`` at WARNING without blocking, which is step one
-# of caura-ai/caura#1205 — deliberately staged that way, because enforcing takes
-# capability away from tenants who have it today and the blast radius should be
-# read off the logs rather than the support queue. So an op listed here is still
-# gated on REST and ungated on MCP, and ``transition`` is still deliberately NOT
-# listed.
+# Current state: ``mcp_server._check_plan_limit`` consults this set and returns
+# a refusal envelope when ``enforces_mcp_plan_limits()`` is on, or logs
+# ``mcp_plan_limit_would_refuse`` and allows the write when it is off — the
+# default. So an op listed here is gated on REST unconditionally and on MCP only
+# where that setting is enabled. ``transition`` is still deliberately NOT
+# listed, and while the flag is off the old asymmetry is still the shipped
+# behaviour for everything that is.
 #
-# The distinction is worth keeping straight because the stale version of this
-# comment is what #1205 was written from: it describes a missing signal, and the
-# work left is a missing refusal. ``redistribute`` is not exposed as an MCP tool,
-# so the observation covers every op on this list that MCP can actually reach.
+# ``redistribute`` is not exposed as an MCP tool, so this list's MCP-reachable
+# members are ``create`` and ``bulk_create``; both are wired.
+#
+# IF YOU EDIT THIS SET, the MCP side follows automatically — the call sites
+# consult ``plan_limit_gated`` rather than naming ops, so this stays the single
+# policy record.
 PLAN_LIMIT_GATED_OPS: frozenset[str] = frozenset({"create", "bulk_create", "redistribute"})
 
 # Typed so a mistyped verb is a mypy error at the call site rather than a
@@ -264,6 +267,36 @@ def recall_operation() -> OperationType:
     from core_api.config import settings
 
     return "recall" if settings.meter_recall_as_recall else "search"
+
+
+def enforces_mcp_plan_limits() -> bool:
+    """Whether the MCP surface REFUSES an over-plan write (caura-ai/caura#1205).
+
+    The signal has been readable on this surface since the middleware started
+    honouring ``x-org-read-only``; what was missing is the refusal.
+    ``_check_plan_limit`` logs what it would have refused and lets the write
+    through. This flag turns that observation into enforcement.
+
+    Gated for the same reason as the two flags above, and more sharply: those
+    change what is COUNTED, this changes what is ALLOWED. An over-plan tenant
+    that can write over MCP today stops being able to. That is the intended end
+    state — the same tenant is already refused on REST, and answering
+    differently per transport is the drift #1205 exists to close — but it takes
+    capability away, so it is a decision rather than a deploy side effect.
+
+    ``plan_limit_gated(op)`` is still consulted at the call site. This flag is
+    the deploy-time gate; that table remains the policy record.
+
+    INTERACTS WITH ``meters_mcp_bulk_write``. Over-plan mode is computed from
+    counters the MCP batch path does not move while that flag is off, so
+    enabling this one alone enforces a limit against counters this surface
+    barely contributes to. Enforcement will still fire — the counters are
+    per-org and REST moves them — but a quiet ``mcp_plan_limit_would_refuse``
+    log beforehand is not evidence the blast radius is small.
+    """
+    from core_api.config import settings
+
+    return settings.enforce_mcp_plan_limits
 
 
 def meters_mcp_bulk_write() -> bool:

--- a/tests/test_mcp_gateway_secret.py
+++ b/tests/test_mcp_gateway_secret.py
@@ -212,8 +212,11 @@ async def test_identity_headers_ignored_without_tenant_header(monkeypatch):
 #
 # The gateway computes "over plan" from the persisted counters and stamps this
 # header; REST turns it into a 403 via ``AuthContext.is_read_only``. The MCP
-# middleware never read it, so no MCP tool could see plan-limit mode at all
-# (caura-ai/caura#1205).
+# middleware did not read it at all before caura-ai/caura#1205, which is why
+# these tests exist; it does now, and refuses on it when
+# ``enforce_mcp_plan_limits`` is on. What is tested HERE is only that the value
+# is trusted on the gateway path and not off it — the refusal itself lives in
+# ``test_mcp_plan_limit_enforcement.py``.
 #
 # The risk here runs the OPPOSITE way to the identity headers above. There,
 # self-assertion buys access; here, a direct caller simply OMITTING the header

--- a/tests/test_mcp_plan_limit_enforcement.py
+++ b/tests/test_mcp_plan_limit_enforcement.py
@@ -1,0 +1,195 @@
+"""MCP refuses an over-plan write, flag-gated (caura-ai/caura#1205).
+
+An org over its plan limit is refused a write on REST and was allowed the same
+write on MCP. The signal has been readable on this surface since the middleware
+started honouring ``x-org-read-only``; what was missing was the refusal. This
+supplies it, behind ``settings.enforce_mcp_plan_limits``, default OFF.
+
+Gated rather than switched on, because this is sharper than the two flags it
+mirrors: ``meter_recall_as_recall`` and ``meter_mcp_bulk_writes`` change what is
+COUNTED, this changes what is ALLOWED. An over-plan tenant that can write over
+MCP today stops being able to.
+
+The OFF case stays pinned in ``test_mcp_plan_limit_observation.py``, which is
+not redundant with this file — while the flag is off, observe-and-allow IS the
+shipped behaviour, and that file fails if a refusal ever appears by accident.
+This file pins what happens when someone chooses it on purpose.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core_api import mcp_server
+from core_api.config import settings
+from tests._mcp_test_helpers import parse_envelope
+
+pytestmark = pytest.mark.unit
+
+_PLAN_LIMIT_CODE = "PLAN_LIMIT_READ_ONLY"
+
+
+class _OutStub:
+    def model_dump(self, mode: str = "python"):
+        return {"id": "m-1", "status": "created"}
+
+
+@pytest.fixture(autouse=True)
+def _reset_org_read_only():
+    """The context var is shared across the session; leave it clean."""
+    yield
+    mcp_server._org_read_only_var.set(False)
+
+
+@pytest.fixture
+def enforcing(monkeypatch):
+    monkeypatch.setattr(settings, "enforce_mcp_plan_limits", True)
+
+
+def _refusals(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.message == "mcp_plan_limit_refused"]
+
+
+# --- the helper -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op", ["create", "bulk_create"])
+def test_a_gated_op_over_plan_is_refused(caplog, enforcing, op):
+    mcp_server._org_read_only_var.set(True)
+
+    with caplog.at_level(logging.WARNING, logger="core_api.mcp_server"):
+        envelope = mcp_server._check_plan_limit(op, "tenant-over-plan")
+
+    assert envelope is not None, "an over-plan gated op must be refused"
+    assert json.loads(envelope)["error"]["code"] == _PLAN_LIMIT_CODE
+    records = _refusals(caplog)
+    assert len(records) == 1
+    assert records[0].enforced is True
+    assert records[0].mcp_operation == op
+
+
+def test_the_refusal_uses_a_distinct_event_name(caplog, enforcing):
+    """An enforced refusal must not land under the observation's event name.
+
+    Reusing one name and flipping ``enforced`` would leave every existing query
+    counting refusals as observations, and "did we actually refuse anyone" is
+    the question the rollout turns on.
+    """
+    mcp_server._org_read_only_var.set(True)
+
+    with caplog.at_level(logging.WARNING, logger="core_api.mcp_server"):
+        mcp_server._check_plan_limit("create", "tenant-over-plan")
+
+    assert [
+        r for r in caplog.records if r.message == "mcp_plan_limit_would_refuse"
+    ] == []
+    assert len(_refusals(caplog)) == 1
+
+
+@pytest.mark.parametrize("op", ["transition", "delete", "update", "bulk_delete"])
+def test_an_ungated_op_is_allowed_even_when_enforcing(enforcing, op):
+    """Enforcement reads the same table REST gates on, so it cannot refuse what
+    REST permits. The deletes above all must stay open — an over-plan org gets
+    back under the limit by deleting, and refusing that traps it there."""
+    mcp_server._org_read_only_var.set(True)
+
+    assert mcp_server._check_plan_limit(op, "tenant-over-plan") is None
+
+
+def test_a_within_plan_org_is_not_refused(enforcing):
+    mcp_server._org_read_only_var.set(False)
+
+    assert mcp_server._check_plan_limit("create", "tenant-ok") is None
+
+
+# --- end to end through the tool -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_over_plan_single_write_is_refused(mcp_env, enforcing):
+    svc = mcp_env["service"]("create_memory")
+    svc.return_value = _OutStub()
+    mcp_server._org_read_only_var.set(True)
+
+    out = await mcp_server.caura_write(content="written while over plan")
+
+    assert parse_envelope(out)["error"]["code"] == _PLAN_LIMIT_CODE
+    # Refused means not written. Returning an error while still persisting the
+    # row would be the worst of both.
+    svc.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_over_plan_batch_write_is_refused_whole(mcp_env, enforcing):
+    """No partial batches. A trimmed batch reports success for a call that did
+    not do what it was asked, and the caller cannot tell which items landed."""
+    svc = mcp_env["service"]("create_memories_bulk")
+    svc.return_value = _OutStub()
+    mcp_server._org_read_only_var.set(True)
+
+    out = await mcp_server.caura_write(
+        items=[{"content": "one"}, {"content": "two"}, {"content": "three"}]
+    )
+
+    assert parse_envelope(out)["error"]["code"] == _PLAN_LIMIT_CODE
+    svc.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_refused_write_does_not_charge_quota(mcp_env, enforcing, monkeypatch):
+    """The gate runs BEFORE the meter, and the ordering is load-bearing.
+
+    The counter this would charge is the one over-plan mode is computed FROM, so
+    charging a refused write would push the tenant further over the limit it was
+    just refused for — the org digs deeper by being told no.
+    """
+    meter = AsyncMock(return_value=None)
+    monkeypatch.setattr(mcp_server, "check_and_increment", meter)
+    mcp_env["service"]("create_memory").return_value = _OutStub()
+    mcp_server._org_read_only_var.set(True)
+
+    await mcp_server.caura_write(content="written while over plan")
+
+    meter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_refused_batch_does_not_charge_quota(mcp_env, enforcing, monkeypatch):
+    """Same property on the batch path, where the charge is per item and the
+    over-charge would therefore scale with batch size."""
+    meter = AsyncMock(return_value=None)
+    monkeypatch.setattr(mcp_server, "bulk_check_and_increment", meter)
+    monkeypatch.setattr(settings, "meter_mcp_bulk_writes", True)
+    mcp_env["service"]("create_memories_bulk").return_value = _OutStub()
+    mcp_server._org_read_only_var.set(True)
+
+    await mcp_server.caura_write(items=[{"content": "one"}, {"content": "two"}])
+
+    meter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_within_plan_write_still_succeeds_while_enforcing(mcp_env, enforcing):
+    """The guard against over-reach: enabling enforcement must refuse the
+    over-plan case and nothing else."""
+    mcp_env["service"]("create_memory").return_value = _OutStub()
+    mcp_server._org_read_only_var.set(False)
+
+    out = await mcp_server.caura_write(content="a normal write")
+
+    assert "error" not in parse_envelope(out)
+
+
+# --- the default ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_flag_defaults_off():
+    """A rebuilt image with no env change must refuse exactly as before: not at
+    all. This is the difference between shipping a capability and shipping a
+    behaviour change."""
+    assert settings.enforce_mcp_plan_limits is False

--- a/tests/test_mcp_plan_limit_observation.py
+++ b/tests/test_mcp_plan_limit_observation.py
@@ -1,14 +1,18 @@
-"""MCP plan-limit observation — step one of caura-ai/caura#1205.
+"""MCP plan-limit observation — the DEFAULT half of caura-ai/caura#1205.
 
 An org over its plan limit is refused a write on REST and allowed the same
-write on MCP, because the MCP middleware never read ``x-org-read-only``. This
-change plumbs the signal and reports what WOULD be refused; it deliberately
-does not refuse yet.
+write on MCP, because the MCP middleware never read ``x-org-read-only``. Step
+one plumbed the signal and reported what WOULD be refused without refusing.
 
-The tests below pin both halves of that, and the second half is the one that
-matters most right now: **the write must still succeed**. A test suite that
-only proved the logging works would go green on an accidental enforcement,
-which is precisely the outcome the observe-first sequencing exists to avoid.
+The refusal now exists, behind ``settings.enforce_mcp_plan_limits`` — see
+``test_mcp_plan_limit_enforcement.py``. This file did NOT become historical
+when that landed: the flag is off by default, so observe-and-allow is still the
+SHIPPED behaviour, and these tests are what stop it changing by accident.
+
+The second half below is the load-bearing one: **the write must still
+succeed**. A suite that only proved the logging works would go green on an
+accidental enforcement — including one caused by flipping the flag's default,
+which is exactly what it catches.
 """
 
 from __future__ import annotations
@@ -48,7 +52,7 @@ def _warnings(caplog) -> list[logging.LogRecord]:
 def test_a_gated_op_over_plan_is_reported(caplog, op):
     mcp_server._org_read_only_var.set(True)
     with caplog.at_level(logging.WARNING, logger="core_api.mcp_server"):
-        mcp_server._observe_plan_limit(op, "tenant-over-plan")
+        mcp_server._check_plan_limit(op, "tenant-over-plan")
     records = _warnings(caplog)
     assert len(records) == 1
     assert records[0].tenant_id == "tenant-over-plan"
@@ -61,7 +65,7 @@ def test_a_gated_op_over_plan_is_reported(caplog, op):
 def test_nothing_is_reported_when_the_org_is_within_plan(caplog):
     mcp_server._org_read_only_var.set(False)
     with caplog.at_level(logging.WARNING, logger="core_api.mcp_server"):
-        mcp_server._observe_plan_limit("create", "tenant-ok")
+        mcp_server._check_plan_limit("create", "tenant-ok")
     assert _warnings(caplog) == []
 
 
@@ -73,7 +77,7 @@ def test_an_ungated_op_is_not_reported_even_over_plan(caplog, op):
     ``update`` rewrites a row rather than adding one."""
     mcp_server._org_read_only_var.set(True)
     with caplog.at_level(logging.WARNING, logger="core_api.mcp_server"):
-        mcp_server._observe_plan_limit(op, "tenant-over-plan")
+        mcp_server._check_plan_limit(op, "tenant-over-plan")
     assert _warnings(caplog) == []
 
 


### PR DESCRIPTION
Closes the refusal half of #1205. **Behaviour change, flag-gated, default OFF** — a rebuilt image with no env change behaves exactly as it does today.

## What was missing

An org over its plan limit is refused a write on REST and allowed the same write on MCP. Same tenant, same operation, different answer per transport.

The signal has been readable on this surface since `MCPAuthMiddleware` started honouring `x-org-read-only` — the issue's step 1, already merged. What was missing was the refusal. `_check_plan_limit` now returns the canonical MCP error envelope when the org is over plan, and both gated call sites return it.

`create` and `bulk_create` are full coverage: `redistribute` is the third member of `PLAN_LIMIT_GATED_OPS` and is not exposed as an MCP tool.

Renamed from `_observe_plan_limit`, which stopped describing what the function does.

## Why a flag rather than just enforcing

It mirrors `meter_recall_as_recall` and `meter_mcp_bulk_writes`, and it is sharper than either: **those change what is COUNTED, this changes what is ALLOWED.** An over-plan tenant that can write over MCP today stops being able to.

The flag makes the rollout reversible without a redeploy — enable it, watch `mcp_plan_limit_refused`, turn it off if the blast radius is wrong. A code-only change would need a rollback to undo. #1205's own "Blast radius — read before doing this" section asks for exactly this kind of sequencing.

## I could not confirm the log has fired, and I am not claiming otherwise

The staging exists so this gets enforced "with the number in hand", so I went looking for the number. `mcp_plan_limit_would_refuse` returns **zero results over 30 days**. That is *not* evidence that nothing would be refused, and I checked far enough to know I cannot use it:

- The pipeline is healthy — 3.69M `service:core-api` logs over 7 days, and `message` carries the structlog event name, so the query shape was right.
- But prod core-api runs `version:90b75a65…`, which is a **caura-enterprise** commit, not an OSS one. Enterprise `core-api/` contains only `helm`, so that tag is the deploy commit, not the core-api source revision — and I could not establish from here whether the deployed image predates #1221 (which landed the observation on 2026-09-01, four days ago).

So the empty log is **inconclusive**, and the flag is doing the job the log was supposed to. The remaining known cause of silence is unchanged and still open: over-plan mode is computed from counters the MCP batch path does not move while `meter_mcp_bulk_writes` is off, so enabling this flag alone enforces against counters this surface barely contributes to. The counters are per-org and REST moves them, so enforcement *will* fire — but do not read a quiet observation log as a small blast radius. That interaction is written into both settings' comments.

## Two details that are easy to get backwards

- **The gate runs BEFORE the meter.** The counter it would charge is the one over-plan mode is computed *from*, so charging a refused write would push the tenant further over the limit it was just refused for — the org digs deeper by being told no. Pinned by a test.
- **A refused batch is refused WHOLE.** Trimming it to what fits would report success for a call that did not do what it was asked, with no way for the caller to tell which items landed. REST's bulk route refuses whole for the same reason.

The refusal mirrors REST's `AuthContext.enforce_usage_limits`: same `PLAN_LIMIT_READ_ONLY` code, same message, same carve-out that deletes stay permitted. It cannot reuse that method — it raises `HTTPException`, and MCP tools return envelopes.

Enforcing emits `mcp_plan_limit_refused`; observing keeps emitting `mcp_plan_limit_would_refuse`. Reusing one name and flipping `enforced` would leave every existing query counting refusals as observations.

## Tests

14 new, and the 9 existing observation tests pass **unchanged** — which is the design working: flag off means the shipped behaviour is untouched, so the guard that says *"if someone later adds the refusal without meaning to, this fails"* still guards.

Every new test confirmed to fail under the mutation it exists to catch:

| Mutation | Fails |
|---|---|
| helper never returns an envelope | 6 |
| call sites discard the envelope | 4 (end-to-end only — helper tests still pass, which is why the end-to-end ones exist) |
| gate moved after the meter | 1 (the ordering test, precisely) |
| one event name for both modes | 3 |
| `plan_limit_gated` check dropped | 4 (the ungated ops) |
| refuse regardless of read-only | 2 (the over-reach guards) |
| **flag default flipped to True** | 4 — including the **pre-existing** `test_an_over_plan_write_still_succeeds` |

That last row is the one I would look at first: an accidental default flip is caught by the guard the previous author left behind, not only by my own test.

796 passed across `-k "mcp or usage or plan or quota or write"`. `ruff check` / `ruff format --check` at CI's scopes, `mypy src/`, both naming gates.

## Stale comments swept, not spot-fixed

This change falsified several comments — including ones #1288 and #1290 had just corrected. I swept for every variant rather than fixing the ones I happened to look at, having had that exact lesson twice this week. `usage_service`'s policy note now records the history explicitly, because it has been wrong in the same direction twice.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)