### PR TITLE
fix(governance): remove the entity rows mined out of a dropped memory

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -948,6 +948,32 @@ class CoreStorageClient:
             "/memories/by-parent-id", read=False, tenant_id=tenant_id, parent_id=parent_id
         )
 
+    async def purge_entity_artifacts(self, tenant_id: str, memory_id: str) -> dict:
+        """H-02 — remove the graph rows mined out of a dropped memory.
+
+        Returns per-table counts (``links``, ``relations``, ``entities``) so the
+        caller can audit what a governance drop actually removed.
+
+        Un-tagged POST, so it lands on the WRITER — it deletes.
+
+        ``idempotent=True``, which this client reserves for endpoints where a
+        replay is harmless. The usual justification is a storage-side dedup key;
+        this one qualifies for a different reason — a replay finds the rows
+        already gone and deletes nothing more. Worth opting in explicitly
+        because the caller lets failures propagate: without it a transient 5xx
+        aborts a remediation whose soft-delete has ALREADY committed, leaving
+        the graph rows behind until someone notices the failed task.
+
+        The one cost of a replay is cosmetic: a lost response followed by a
+        successful retry logs zero counts for a purge that did remove rows. A
+        wrong number in an INFO line, against leaving forbidden content live.
+        """
+        return await self._post(  # type: ignore[return-value]
+            "/memories/purge-entity-artifacts",
+            {"tenant_id": tenant_id, "memory_id": memory_id},
+            idempotent=True,
+        )
+
     async def find_successors(self, data: dict) -> list[dict]:
         return await self._post("/memories/find-successors", data, read=True)  # type: ignore[return-value]
 

--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import re
+from typing import Any, Literal
 from uuid import UUID
 
 from common.embedding import get_embedding
@@ -93,6 +94,129 @@ async def _discover_cross_links_for_memory(
         )
 
 
+async def _purge_written_artifacts_if_dropped(
+    sc: Any, memory_id: UUID, tenant_id: str
+) -> Literal["live", "dropped", "unknown"]:
+    """Undo our own graph writes when the memory died while we were making them.
+
+    Reports WHAT IT FOUND and leaves the policy to the caller, because the two
+    call sites want different things from the same answer. An earlier revision
+    returned a bool meaning "you must stop", which forced the indeterminate case
+    to pick one of the two real answers and pretend — it chose "stop", and that
+    silently discarded the audit-log entry, the contradiction trigger and
+    cross-link discovery for a memory that a transient read timeout had said
+    nothing bad about. Three states, named:
+
+    ``dropped``
+        The row is gone or soft-deleted, and its graph rows have been purged
+        (or the purge failed, loudly — either way it is not coming back).
+    ``live``
+        The row is there. Nothing was purged and nothing should stop.
+    ``unknown``
+        The read itself failed. Nothing is known and nothing was purged.
+
+    Purging is only half of the job at the first call site: everything after the
+    link upsert — relation upserts carrying ``evidence_memory_id``, the subject
+    write-back, cross-link discovery — writes MORE graph rows for this memory. A
+    version that purged and fell through cleaned the table and then immediately
+    refilled it, moving the leak from the link table to the relation table rather
+    than closing it.
+
+    H-02. The liveness check before the persistence block narrows the window; it
+    cannot close it. Between that check and the links landing there are embedding
+    round-trips and three storage calls, and a governance drop can complete
+    inside them — including its own purge, which finds nothing because these rows
+    do not exist yet. The entities then land moments later and nothing ever
+    revisits them: the memory is gone, so no verdict names it again.
+
+    Re-checking AFTER the writes closes it, and the argument is about what is
+    observable rather than about timing:
+
+    * the drop committed before our writes — its purge found nothing, but this
+      check sees the row deleted, and we purge what we just wrote,
+    * the drop commits after our writes — its own purge sees our rows and takes
+      them,
+    * the drop commits between the two — whichever purge runs later sees the
+      rows, and both are keyed on the same ``memory_id``.
+
+    That argument only holds for rows written BEFORE the call, which is why
+    ``process_entity_extraction`` calls this THREE times rather than once. An
+    earlier revision called it once, after the link upsert, and claimed "there is
+    no ordering left in which the rows survive" — untrue of everything written
+    afterwards: the subject write-back, the relation upserts, the links
+    cross-link discovery creates. The call sites, and what each is for:
+
+    * after the link upsert — an optimisation. It saves the relation upserts and
+      a cross-link pass when the row is already gone, and is allowed to fall
+      through on anything short of ``dropped``.
+    * at the end of the ``try`` — the guarantee for the path that completes. It
+      sits after every graph-mutating write, so the rows it can find are all of
+      them.
+    * in the ``except`` — the same guarantee for the path that leaves by
+      raising, which the previous one cannot reach.
+
+    Both of the trailing two are guarded on ``wrote_graph_rows``, so a run that
+    wrote nothing does not pay for a read, and the ``except`` one also runs on
+    failures early enough that ``sc`` does not exist yet.
+
+    The WRITER read is load-bearing at every site for the same reason as the
+    pre-write check: the whole question is whether a delete that just committed
+    is visible.
+
+    A failed PURGE still reports ``dropped``: the memory is gone whether or not
+    the cleanup worked, and the caller's decision does not change. Only a failed
+    READ is ``unknown``.
+    """
+    try:
+        live = await sc.get_memory(str(memory_id), tenant_id, read=False)
+    except Exception:
+        logger.exception(
+            "entity extraction: could not establish whether memory %s survived its own "
+            "extraction; nothing purged and nothing concluded",
+            memory_id,
+            extra={"liveness_check": "unknown", "memory_id": str(memory_id)},
+        )
+        return "unknown"
+
+    if live is not None and live.get("deleted_at") is None:
+        return "live"
+
+    try:
+        counts = await sc.purge_entity_artifacts(tenant_id, str(memory_id))
+    except Exception:
+        logger.exception(
+            "entity extraction: memory %s was dropped while its entities were being "
+            "written, and the rows just written could NOT be purged; they are live in "
+            "the graph for content the policy removed",
+            memory_id,
+        )
+        return "dropped"
+    if not isinstance(counts, dict):
+        # Same gap as the governance-side purge: reading ``counts`` as a dict
+        # would raise from outside the try above. Lower stakes at two of this
+        # function's three call sites, which sit inside the worker's catch-all —
+        # but NOT at the one in the ``except`` handler, where a raise escapes
+        # ``process_entity_extraction`` entirely and surfaces as an unhandled
+        # task exception. The purge still happened as far as anything here can
+        # tell; only the counts are unreadable.
+        logger.warning(
+            "entity extraction: memory %s was dropped mid-extraction and the purge "
+            "answered with %s rather than an object, so what it removed is unknown",
+            memory_id,
+            type(counts).__name__,
+        )
+        return "dropped"
+    logger.warning(
+        "entity extraction: memory %s was dropped mid-extraction; purged the graph "
+        "rows just written for it (links=%s relations=%s entities=%s)",
+        memory_id,
+        counts.get("links"),
+        counts.get("relations"),
+        counts.get("entities"),
+    )
+    return "dropped"
+
+
 async def process_entity_extraction(
     memory_id: UUID,
     tenant_id: str,
@@ -109,6 +233,18 @@ async def process_entity_extraction(
     # calls. Full migration: CAURA-593 lands Pub/Sub first, then a new
     # worker service subscribes to ``Topics.Pipeline.ENTITY_EXTRACT_REQUESTED``
     # and this function becomes its handler body.
+    #
+    # H-02. Guards both of the trailing liveness checks — the one at the end of
+    # the ``try`` and the one in the ``except``. It means "this memory MAY have
+    # graph rows", not "the persistence block ran": there are two independent
+    # writers below (the entity/link upserts, and cross-link discovery, which
+    # runs even when every extracted name was filtered out), and both set it.
+    #
+    # False means nothing was written, so there is nothing to purge and no reason
+    # to spend a writer read. That matters because the early exits above the
+    # persistence block — no entities extracted, row already gone — are the
+    # common case, and because ``sc`` is not yet bound on the first of them.
+    wrote_graph_rows = False
     try:
         # A5c: resolve tenant_config BEFORE the extraction call so the
         # tenant-level ``entity_extraction.provider`` / ``.model``
@@ -124,6 +260,33 @@ async def process_entity_extraction(
             return
 
         sc = get_storage_client()
+
+        # H-02: is the memory still there? This is scheduled fire-and-forget at
+        # write time on both non-inline paths, in parallel with the enrichment
+        # that carries the governance verdict — so by the time the LLM call above
+        # returns, the policy may already have dropped the row. Writing entities
+        # for it would re-create the leak the drop exists to close, in a table
+        # the drop does not reach.
+        #
+        # ``read=False`` — the WRITER. The whole point is to observe a delete
+        # that just committed; a replica under lag would report the row live and
+        # this check would pass exactly when it most needed to fail.
+        #
+        # This check alone does NOT close the window, and it is not claimed to:
+        # the writes below are several round-trips away, so a drop can land after
+        # it passes. ``_purge_written_artifacts_if_dropped`` at the end of the
+        # persistence block is what closes that; this one is here to avoid doing
+        # the work at all in the common case where the row is already gone.
+        live = await sc.get_memory(str(memory_id), tenant_id, read=False)
+        if live is None or live.get("deleted_at") is not None:
+            logger.info(
+                "entity extraction: memory %s is gone by the time extraction finished; "
+                "discarding %d extracted entit(ies) rather than writing them to a "
+                "dropped row's graph",
+                memory_id,
+                len(graph.entities),
+            )
+            return
 
         blocklist = tenant_cfg.entity_blocklist
 
@@ -342,6 +505,18 @@ async def process_entity_extraction(
             # the TOCTOU race where another writer created the natural-
             # key match between our resolve and our upsert — semantically
             # equivalent to ``updated`` for the worker.
+            # H-02. From here this memory MAY have graph rows, so every exit
+            # from this function owes it a liveness check — including the ones
+            # that leave by raising.
+            #
+            # Set BEFORE the await, not after. "The call raised" does not mean
+            # "nothing was written": a timeout can land on a request the storage
+            # side already committed, and a malformed response does not un-write
+            # rows either. The flag has to mean "might have written", because
+            # the only failure it is allowed to make is the cheap one — a wasted
+            # writer read on a call that never landed, on a path that is already
+            # an error. Getting it wrong the other way leaks the rows.
+            wrote_graph_rows = True
             upserted = await sc.bulk_upsert_entities(items=upsert_items)
             # Explicit loop (not a comprehension) so an out-of-range
             # ``input_idx`` from a misbehaving storage response surfaces
@@ -349,6 +524,12 @@ async def process_entity_extraction(
             # length-mismatch warning above on ``bulk_resolve_entities``
             # — same "treat malformed responses defensively" pattern.
             name_to_id: dict[str, UUID] = {}
+            # H-02. Only the rows THIS run brought into existence. An entity that
+            # already existed is reachable through whatever linked it before and
+            # is nobody's orphan; a created one is reachable only through the link
+            # we are about to write. See the link upsert below for why that
+            # distinction is worth carrying.
+            created_entity_ids: list[str] = []
             for r in upserted:
                 if not r.get("entity_id"):
                     continue
@@ -361,6 +542,8 @@ async def process_entity_extraction(
                     )
                     continue
                 name_to_id[filtered[idx][0]] = UUID(r["entity_id"])
+                if r.get("action") == "created":
+                    created_entity_ids.append(str(r["entity_id"]))
 
             # ---- Step 3: bulk entity-link upsert ----
             #
@@ -401,7 +584,74 @@ async def process_entity_extraction(
                 )
                 link_idx += 1
             if link_items:
-                link_result = await sc.bulk_upsert_entity_links(tenant_id, items=link_items)
+                try:
+                    link_result = await sc.bulk_upsert_entity_links(tenant_id, items=link_items)
+                except Exception:
+                    # H-02, and this is the one gap the purge cannot close from
+                    # its own side. ``memory_purge_entity_artifacts`` finds
+                    # entities THROUGH the memory's links — deliberately, because
+                    # the first draft swept every unlinked entity in the tenant
+                    # and would have raced a concurrent writer that had created
+                    # an entity but not yet linked it. Over-deleting is the
+                    # direction that does not come back.
+                    #
+                    # The cost of that bounding is exactly here: entities
+                    # committed a moment ago whose links never landed are
+                    # reachable by nothing, so a purge for this memory runs,
+                    # finds no links, and honestly reports zero. Indistinguishable
+                    # in the audit trail from "there was nothing to purge" —
+                    # which is what makes it worth a log rather than nothing.
+                    #
+                    # Widening the candidate set instead was considered and not
+                    # done: passing these ids to the purge re-introduces the same
+                    # race the bounding exists to prevent, since an id we upserted
+                    # may be a row another writer created and is about to link.
+                    # A person with a concrete list can check that; a query
+                    # cannot.
+                    #
+                    # Re-raised, so the except handler below still runs its
+                    # liveness check and purges whatever IS reachable.
+                    if created_entity_ids:
+                        logger.exception(
+                            "entity extraction: entity rows for memory %s were committed but "
+                            "their links were not, so a governance purge for this memory will "
+                            "find and report nothing while these rows survive; entity ids "
+                            "created by this run: %s",
+                            memory_id,
+                            ", ".join(created_entity_ids),
+                            extra={
+                                "unlinked_entity_ids": created_entity_ids,
+                                "memory_id": str(memory_id),
+                                "tenant_id": tenant_id,
+                            },
+                        )
+                    raise
+                # H-02: the rows exist NOW, so from here the leak is recoverable
+                # by the same purge governance uses. See the helper for why this
+                # is where the window actually closes.
+                #
+                # The RETURN has to be honoured, not just the purge. Everything
+                # below writes more graph rows for this memory — relations
+                # carrying ``evidence_memory_id``, the subject write-back,
+                # cross-link discovery. Purging and then falling through refills
+                # the table we just cleaned.
+                #
+                # ``dropped`` ONLY. This site is an optimisation — it saves the
+                # relation upserts and a cross-link discovery pass — so it must
+                # not act on ``unknown``. Stopping here also skips the audit-log
+                # entry below, and losing an audit record to a read timeout is a
+                # real cost with no later repair.
+                #
+                # Falling through on ``unknown`` is safe because a later check
+                # covers every remaining exit: the one at the end of the ``try``
+                # if the rest of the run succeeds, the one in the ``except`` if
+                # it raises. Neither is a guarantee that the rows are cleaned —
+                # both call the same read, and a read that failed once will
+                # likely fail again — but the failure is a bounded leak that
+                # governance's purge can still reach, and the alternative was
+                # destroying an audit record nothing rebuilds.
+                if await _purge_written_artifacts_if_dropped(sc, memory_id, tenant_id) == "dropped":
+                    return
                 # Surface any FK violations from the per-item path
                 # (storage-side reports ``error="fk_violation"`` for rows
                 # whose memory_id or entity_id no longer exists). Same
@@ -520,6 +770,17 @@ async def process_entity_extraction(
 
         # Cross-link discovery (non-fatal)
         if tenant_cfg.auto_entity_linking_enabled:
+            # H-02. This writes ``memory_entity_links`` rows for THIS memory —
+            # storage-side it is an ON CONFLICT DO NOTHING insert into exactly
+            # the table the purge deletes from — and it does not go through the
+            # persistence block above, so it is a second, independent way for
+            # this memory to acquire graph rows. It runs even when every
+            # extracted name was filtered out and ``bulk_upsert_entities`` was
+            # never called.
+            #
+            # Before the await, for the same reason as the upsert: a call that
+            # raised may still have committed.
+            wrote_graph_rows = True
             try:
                 await _discover_cross_links_for_memory(memory_id, tenant_id, fleet_id)
             except Exception:
@@ -529,5 +790,63 @@ async def process_entity_extraction(
                     exc_info=True,
                 )
 
+        # H-02, and this is the call that actually closes the window. The check
+        # after the link upsert only covers rows written UP TO it; everything
+        # between the two — the subject write-back, the relation upserts carrying
+        # ``evidence_memory_id``, the links cross-link discovery creates — is
+        # written after it has already passed. A drop landing in that stretch
+        # runs its own purge against rows that do not exist yet, and nothing
+        # revisits them.
+        #
+        # This one runs after every graph-mutating write for this memory, so the
+        # rows it finds are all of them. The earlier check is kept as an early
+        # exit: it saves the relation upserts and a cross-link discovery pass in
+        # the common case where the row was already gone.
+        #
+        # It covers the SUCCESSFUL path only. The ``except`` handler carries the
+        # same check for the path where something in between raised.
+        #
+        # Contradiction detection above is deliberately not covered here. It is
+        # spawned via ``track_task`` and writes conflict rows rather than graph
+        # rows, and it re-checks ``deleted_at`` itself for exactly this race.
+        #
+        # Guarded on the flag, so a run that reached here having written nothing
+        # — every extracted name filtered out AND cross-link discovery disabled —
+        # does not pay for a writer read to find nothing. Note what the flag has
+        # to mean for that to be safe: "this memory may have graph rows", not
+        # "the persistence block ran". Cross-link discovery sets it too, and
+        # gating on the narrower reading would leak exactly the links it creates.
+        #
+        # The result is not branched on: nothing follows this, so ``live`` and
+        # ``unknown`` are the same instruction — do nothing — and ``dropped`` has
+        # already purged by the time it returns.
+        if wrote_graph_rows:
+            await _purge_written_artifacts_if_dropped(sc, memory_id, tenant_id)
+
     except Exception:
         logger.exception("Entity extraction failed for memory %s (non-fatal)", memory_id)
+        # H-02, and the reason the check below is duplicated rather than moved
+        # into a ``finally``. The normal-path call at the end of the ``try`` is
+        # unreachable once anything between the link upsert and it raises — the
+        # relation upserts, the subject write-back, the audit log — and the rows
+        # already written stay behind for a memory that may have been dropped.
+        # That is the leak this PR exists to close, arriving by a different door.
+        #
+        # A ``finally`` would cover this in one place, but it also fires on the
+        # three early ``return``s in the ``try``, and all three are wrong for it:
+        # the no-entities exit happens before ``sc`` is even bound, so an
+        # unguarded ``finally`` raises ``NameError`` out of a fire-and-forget
+        # task; the already-dropped exit would spend a writer read to learn what
+        # it just learned; and the ``dropped`` exit would repeat a purge that had
+        # just run. Those are the common paths, not the rare ones. The flag would
+        # have to gate a ``finally`` anyway, so all ``finally`` buys is one fewer
+        # call site.
+        #
+        # Nothing is branched on. ``dropped`` has purged by the time it returns;
+        # ``live`` and ``unknown`` both mean leave it alone. ``unknown`` is the
+        # likely answer when the storage failure that landed us here is still
+        # going, and the rows do leak in that case — bounded to what was written
+        # before the raise, and reachable by governance's own purge later. The
+        # alternative was losing the audit record outright.
+        if wrote_graph_rows:
+            await _purge_written_artifacts_if_dropped(sc, memory_id, tenant_id)

--- a/core-api/src/core_api/services/governance_remediation.py
+++ b/core-api/src/core_api/services/governance_remediation.py
@@ -247,6 +247,22 @@ async def _drop_children(
             )
             failed.append(cid)
             continue
+
+        # A child is an ordinary memory, so the invariant the parent's purge
+        # enforces — a dropped row leaves no graph rows behind — has to hold for
+        # it too. Never counted as a cascade failure: the helper logs and
+        # swallows, matching how the parent's own purge failure is treated one
+        # level up.
+        #
+        # Narrow in practice, and worth being accurate about rather than selling:
+        # auto-chunk children are written through ``sc.create_memories`` directly
+        # and get NO extraction of their own — the parent is what gets extracted,
+        # over the full document, so the names mined from chunked content hang off
+        # the PARENT and its purge already takes them. A child acquires graph rows
+        # only if something later rewrites its content, since ``update_memory``
+        # re-extracts. This closes that case, and keeps the invariant true of the
+        # cascade regardless of which paths populate children in future.
+        await _purge_entity_artifacts(sc, cid, tenant_id, action)
         remediated += 1
     if remediated:
         # ``remediated``, not ``len(children)``: rows skipped above were not
@@ -335,6 +351,93 @@ async def _privatise_children(
     )
 
 
+async def _purge_entity_artifacts(sc: Any, memory_id: str, tenant_id: str, action: str) -> None:
+    """Remove the graph rows mined out of a memory the policy just dropped.
+
+    H-02. #808 established that a drop must stop the derived rows too, and
+    named this case explicitly — "entities mined out of dropped content are the
+    same leak in another table". It fixed the INLINE path, by ordering:
+    ``_enrich_memory_background`` runs remediation first and its early return
+    skips the entity extraction scheduled below it.
+
+    Both non-inline paths schedule extraction independently, at write time, as
+    a task that races the verdict — and extraction is one LLM call while the
+    verdict needs enrichment plus an event round-trip, so extraction usually
+    wins. ``process_entity_extraction`` never re-checked the row, and a
+    soft-deleted memory still satisfies the link and relation foreign keys. So
+    the names survived, listable tenant-wide through ``/entities`` and
+    ``/graph``, with nothing tying them to the drop.
+
+    Not guarded by a marker, unlike the child cascade: any dropped memory may
+    have been extracted from, there is no flag on the row saying so, and the
+    purge is three targeted deletes keyed on ``memory_id`` — cheap enough to
+    run unconditionally rather than gate on something that could drift.
+
+    Failures are LOGGED, not raised, and that is the opposite of what the rest
+    of this module does — so it needs its reason stated.
+
+    An earlier draft let this propagate "matching every other unapplied-policy
+    path in this module". That was wrong about the caller. The other paths run
+    under ``_enrich_memory_background``, where a raise becomes a
+    ``BackgroundTaskLog`` row. This one also runs under
+    ``consumer.handle_memory_enriched``, which has no guard around it, and the
+    Pub/Sub dispatcher NACKS on a handler exception — a documented, load-bearing
+    invariant. So a raise here redelivers the same event, re-runs the whole drop
+    branch, and emits a SECOND ``critical=True`` audit for a memory that was
+    already dropped. Repeatedly. Duplicate destructive entries in a
+    tamper-evident log, for a row nothing further can be done to.
+
+    The trade the other way is bounded: the memory itself is already gone, so
+    the content is not live. What remains is graph rows, and an ERROR naming the
+    memory is enough to purge them by hand. A transient failure does not even
+    reach here — ``purge_entity_artifacts`` is marked idempotent, so the client
+    retries 5xx and timeouts on its own.
+    """
+    try:
+        counts = await sc.purge_entity_artifacts(tenant_id, memory_id)
+    except Exception:
+        logger.exception(
+            "governance: %s dropped memory %s but its entity/relation rows were NOT "
+            "removed; the names mined from that content are still listable and need "
+            "purging by hand",
+            action,
+            memory_id,
+        )
+        return
+    if not isinstance(counts, dict):
+        # ``_post`` is declared ``dict | list`` and the client silences the
+        # mismatch with a ``type: ignore``, so nothing between here and the wire
+        # enforces the shape. A 2xx carrying something other than an object means
+        # we are not talking to the endpoint we think we are — a version-skewed
+        # storage, or something in front of it answering instead. The status says
+        # the call succeeded and the body says we cannot read what it did, so
+        # neither "purged" nor "failed" is a claim worth making.
+        #
+        # What matters is that ``counts.get`` would raise ``AttributeError`` from
+        # OUTSIDE the try above, and this function has one hard requirement: it
+        # must not raise. See the docstring — the caller is an unguarded Pub/Sub
+        # handler that catches only ``GovernanceCascadeError``, and the dispatcher
+        # nacks on anything else.
+        logger.error(
+            "governance: %s asked storage to purge the graph rows for %s and got a "
+            "success carrying %s rather than an object; the purge cannot be "
+            "confirmed and the rows may still be listable",
+            action,
+            memory_id,
+            type(counts).__name__,
+        )
+        return
+    if any(counts.get(k) for k in ("links", "relations", "entities")):
+        logger.info(
+            "governance: %s purged graph rows for %s (links=%s relations=%s entities=%s)",
+            action,
+            memory_id,
+            counts.get("links"),
+            counts.get("relations"),
+            counts.get("entities"),
+        )
+
+
 async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutcome:
     """Apply LLM-signal governance to a fast-mode row after enrichment landed.
 
@@ -392,6 +495,11 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutco
             )
             await sc.soft_delete_memory(memory_id, tenant_id)
             logger.info("governance: dropped fast-mode memory %s (pii)", memory_id)
+            # Purge BEFORE the cascade, not after. ``_drop_children`` raises once
+            # any child fails, so ordering it first would skip this parent's own
+            # graph rows on exactly the runs where something already went wrong.
+            # The purge cannot raise (it logs), so it never blocks the cascade.
+            await _purge_entity_artifacts(sc, memory_id, tenant_id, ACTION_PII_DROP)
             await _drop_children(
                 sc,
                 children,
@@ -437,6 +545,8 @@ async def remediate_after_enrichment(memory: dict, cfg: Any) -> RemediationOutco
             )
             await sc.soft_delete_memory(memory_id, tenant_id)
             logger.info("governance: dropped fast-mode memory %s (non-business)", memory_id)
+            # Purge before the cascade — see the PII-drop branch above.
+            await _purge_entity_artifacts(sc, memory_id, tenant_id, ACTION_NB_DROP)
             await _drop_children(
                 sc,
                 children,

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -398,6 +398,32 @@ async def find_children_by_parent_id(tenant_id: str, parent_id: str) -> list[dic
     return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
 
 
+@router.post("/purge-entity-artifacts")
+async def purge_entity_artifacts(request: Request) -> dict:
+    """H-02 — drop the graph rows mined out of a governance-dropped memory.
+
+    POST, not DELETE: it removes rows across three tables and returns per-table
+    counts the caller audits. Body carries ``tenant_id`` and ``memory_id``.
+    """
+    body: dict = await request.json()
+    tenant_id = body.get("tenant_id")
+    memory_id = body.get("memory_id")
+    if not tenant_id or not memory_id:
+        # 4xx at the edge, same convention as the bulk route above: a missing
+        # scope here would be a delete with no tenant, which must never be a
+        # thing this endpoint attempts.
+        raise HTTPException(status_code=422, detail="tenant_id and memory_id are both required")
+    try:
+        parsed = UUID(str(memory_id))
+    except (ValueError, TypeError) as exc:
+        # Same shape as every sibling route that parses a UUID out of the body.
+        # Unguarded this surfaced as a 500, which reads as "the purge broke" when
+        # the truth is the caller sent something that was never an id — and the
+        # caller in question lets failures propagate out of a remediation.
+        raise HTTPException(status_code=422, detail="memory_id must be a UUID") from exc
+    return await _svc.memory_purge_entity_artifacts(tenant_id=tenant_id, memory_id=parsed)
+
+
 @router.post("/find-successors")
 async def find_successors(request: Request) -> list[dict]:
     body: dict = await request.json()

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -6337,6 +6337,186 @@ class PostgresService:
             )
             return dict(result.all())  # type: ignore[arg-type]
 
+    async def memory_purge_entity_artifacts(self, tenant_id: str, memory_id: UUID) -> dict:
+        """Remove the graph rows mined out of one memory. Returns per-table counts.
+
+        H-02. The schema already says these rows must not outlive the memory:
+        ``memory_entity_links.memory_id`` is ``ON DELETE CASCADE`` and
+        ``relations.evidence_memory_id`` is ``ON DELETE SET NULL``. Both fire on
+        a HARD delete. Governance does a SOFT delete — it sets ``deleted_at`` —
+        so neither ever fires, and the entity names mined from dropped content
+        (person names, under a PII policy) stay listable tenant-wide through
+        ``/entities`` and ``/graph``.
+
+        The entity row itself has no FK to the memory at all, so nothing would
+        remove it even on a hard delete. That is why this is three statements
+        and not one.
+
+        Every statement is confined to ``tenant_id``. The link rows need that
+        said out loud because ``memory_entity_links`` carries no ``tenant_id``
+        column, so ``memory_id`` alone is an identifier and not an
+        authorisation — see the comment on ``owned`` below.
+
+        REFUSES TO RUN unless the memory is present, in this tenant, and already
+        soft-deleted; otherwise it is a no-op returning zero counts. Both callers
+        check that themselves, so this changes nothing today — it is here because
+        the method deletes across three tables and cannot be undone, and "only
+        purge what governance actually dropped" should not be an invariant that
+        lives only in the callers' heads.
+
+        Order matters and is not arbitrary:
+
+        0. note which entities THIS memory linked to, before the links go,
+        1. delete those links,
+        2. delete relations whose evidence IS this memory — one row carries one
+           evidence id, so a relation attributed to dropped content has no
+           other justification,
+        3. delete, FROM THE NOTED SET ONLY, entities now left with no links and
+           no relations.
+
+        Step 0 is what keeps step 3 honest. Deleting every entity in the tenant
+        that happens to have no links would be a far larger blast radius than
+        this function's job: it would sweep entities orphaned for unrelated
+        reasons, and race an entity that a concurrent write has created but not
+        yet linked. The candidate set is bounded to what this memory touched,
+        so an unrelated orphan is left alone. Under-deleting is recoverable;
+        over-deleting another caller's rows is not.
+
+        An entity still referenced by another live memory is likewise kept — the
+        name is not this memory's to remove once something else asserts it.
+
+        One transaction: a partial purge would leave the graph half-cleaned with
+        nothing recording which half.
+        """
+        async with get_session() as session:
+            # ``memory_entity_links`` has no ``tenant_id`` of its own, so keying on
+            # ``memory_id`` alone authorises nothing: a caller passing a memory_id
+            # this tenant does not own would delete the OWNING tenant's link rows,
+            # silently and with a success response. The guard below is what makes
+            # a mismatched tenant/memory pairing a no-op; once it passes, the
+            # statements can key on ``memory_id`` alone because the pairing has
+            # already been established.
+            #
+            # The tenant half is deliberately the memory end only, NOT
+            # ``_link_within_tenant`` (which the readers just above use). That
+            # helper requires BOTH ends in the tenant because a read that returns
+            # a straddling row hands back the other tenant's UUID. The question
+            # here is different and is purely about authority to delete: this row
+            # references a memory we own and are dropping, so a foreign entity on
+            # the far end is a reason to keep the ENTITY (the tenant-scoped delete
+            # below already does) — never a reason to keep a link pointing at
+            # dropped content. Requiring both ends would leave exactly those
+            # historical straddling links behind, which is the leak this function
+            # exists to close.
+            #
+            # One guard, checked before anything is deleted, rather than a
+            # predicate threaded through each statement. It answers the only
+            # question that authorises this call at all: is there a row with this
+            # id, in this tenant, that is ACTUALLY DROPPED?
+            #
+            # ``deleted_at IS NOT NULL`` is the half that does not merely restate
+            # the caller. Both callers check liveness before calling — but this
+            # deletes across three tables and cannot be undone, so it should not
+            # be the caller's job to remember. A stale call, a reordering, or a
+            # future caller written from the method name alone would otherwise
+            # wipe the entity graph of a live, fully visible memory.
+            #
+            # An early return rather than narrowing each delete, because the
+            # relation delete never took the ownership subquery: it keyed on
+            # ``evidence_memory_id`` and the tenant alone, so guarding only the
+            # link path would have left a live memory losing its RELATIONS while
+            # its links and entities survived — partial destruction, which is
+            # worse to diagnose than either outcome.
+            eligible = (
+                await session.execute(
+                    select(Memory.id).where(
+                        Memory.id == memory_id,
+                        Memory.tenant_id == tenant_id,
+                        Memory.deleted_at.isnot(None),
+                    )
+                )
+            ).scalar_one_or_none()
+            if eligible is None:
+                return {"links": 0, "relations": 0, "entities": 0}
+
+            candidates = (
+                (
+                    await session.execute(
+                        select(MemoryEntityLink.entity_id).where(
+                            MemoryEntityLink.memory_id == memory_id,
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+            link_rows = await session.execute(
+                delete(MemoryEntityLink).where(MemoryEntityLink.memory_id == memory_id)
+            )
+            relation_rows = await session.execute(
+                delete(Relation).where(
+                    Relation.tenant_id == tenant_id,
+                    Relation.evidence_memory_id == memory_id,
+                )
+            )
+
+            entity_count = 0
+            if candidates:
+                # "Is this entity still referenced by anything?" Narrowed to the
+                # tenant so the anti-joins do not scan every install's links and
+                # relations on a path a drop-configured tenant runs constantly.
+                #
+                # Narrowed by the ENTITY's tenant, never by the referencing row's
+                # own tenant_id — and the difference is not stylistic. Scoping
+                # relations on ``Relation.tenant_id`` would drop a historical
+                # straddling row (a relation in another tenant pointing at an
+                # entity here) out of the anti-join, and this entity would then be
+                # deleted while something still referenced it. Keying on the
+                # entity's tenant narrows the scan just as much and cannot lose a
+                # reference: every row that could name a candidate names an entity
+                # in THIS tenant, because that is what a candidate is.
+                #
+                # Erring wide here is free — an extra reference only keeps an
+                # entity alive, and under-deleting is recoverable where
+                # over-deleting is not.
+                still_linked = (
+                    select(MemoryEntityLink.entity_id)
+                    .join(Entity, Entity.id == MemoryEntityLink.entity_id)
+                    .where(Entity.tenant_id == tenant_id)
+                )
+                rel_from = (
+                    select(Relation.from_entity_id)
+                    .join(Entity, Entity.id == Relation.from_entity_id)
+                    .where(Entity.tenant_id == tenant_id)
+                )
+                rel_to = (
+                    select(Relation.to_entity_id)
+                    .join(Entity, Entity.id == Relation.to_entity_id)
+                    .where(Entity.tenant_id == tenant_id)
+                )
+                entity_rows = await session.execute(
+                    delete(Entity).where(
+                        # Tenant-scoped like everything else here. Not about id
+                        # collisions — about never letting one tenant's
+                        # remediation reach another tenant's rows.
+                        Entity.tenant_id == tenant_id,
+                        Entity.id.in_(candidates),
+                        Entity.id.not_in(still_linked),
+                        Entity.id.not_in(rel_from),
+                        Entity.id.not_in(rel_to),
+                    )
+                )
+                entity_count = entity_rows.rowcount or 0  # type: ignore[attr-defined]
+
+            # ``rowcount`` is untyped on ``Result`` — same ignore as
+            # ``memory_soft_delete_by_ids`` above, for the same reason.
+            return {
+                "links": link_rows.rowcount or 0,  # type: ignore[attr-defined]
+                "relations": relation_rows.rowcount or 0,  # type: ignore[attr-defined]
+                "entities": entity_count,
+            }
+
     async def entity_get_linked_memories(
         self,
         entity_id: UUID,

--- a/core-storage-api/tests/test_h02_purge_entity_artifacts.py
+++ b/core-storage-api/tests/test_h02_purge_entity_artifacts.py
@@ -1,0 +1,300 @@
+"""H-02 — removing the graph rows mined out of a governance-dropped memory.
+
+Against real Postgres, because the thing under test is a three-statement delete
+whose correctness is entirely about what it does and does NOT reach. A stub
+would assert the code calls itself.
+
+The schema already says these rows must not outlive the memory:
+``memory_entity_links.memory_id`` is ``ON DELETE CASCADE`` and
+``relations.evidence_memory_id`` is ``ON DELETE SET NULL``. Both fire on a HARD
+delete only. Governance soft-deletes, so neither ever fires — and the entity
+names mined from dropped content stay listable tenant-wide.
+
+The negative cases carry the weight here. This deletes rows, so a query that
+reaches one row too far is worse than the leak it closes.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from common.models import Entity, MemoryEntityLink, Relation
+from core_storage_api.services.postgres_service import PostgresService, get_session
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _memory(svc: PostgresService, tenant: str):
+    return await svc.memory_add(
+        {
+            "tenant_id": tenant,
+            "agent_id": "h02-tester",
+            "content": f"h02 canary {uuid.uuid4()}",
+            "memory_type": "fact",
+            "weight": 0.5,
+            "status": "active",
+            "visibility": "scope_team",
+        }
+    )
+
+
+async def _dropped_memory(svc: PostgresService, tenant: str):
+    """A memory in the state the purge actually runs against.
+
+    Governance soft-deletes and THEN purges, and the purge now refuses to run
+    against a live row. Tests that skipped the delete were exercising a state no
+    caller produces.
+    """
+    mem = await _memory(svc, tenant)
+    await svc.memory_soft_delete_by_ids(tenant, [mem.id])
+    return mem
+
+
+async def _entity(svc: PostgresService, tenant: str, name: str):
+    return await svc.entity_add({"tenant_id": tenant, "entity_type": "person", "canonical_name": name})
+
+
+async def _link(memory_id, entity_id, role: str = "subject"):
+    async with get_session() as s:
+        s.add(MemoryEntityLink(memory_id=memory_id, entity_id=entity_id, role=role))
+
+
+async def _relation(tenant: str, frm, to, evidence):
+    async with get_session() as s:
+        rel = Relation(
+            tenant_id=tenant,
+            from_entity_id=frm,
+            relation_type="knows",
+            to_entity_id=to,
+            evidence_memory_id=evidence,
+        )
+        s.add(rel)
+
+
+async def _entity_names(tenant: str) -> set[str]:
+    async with get_session() as s:
+        rows = await s.execute(select(Entity.canonical_name).where(Entity.tenant_id == tenant))
+        return set(rows.scalars().all())
+
+
+async def _link_entity_ids(memory_id) -> set:
+    async with get_session() as s:
+        rows = await s.execute(
+            select(MemoryEntityLink.entity_id).where(MemoryEntityLink.memory_id == memory_id)
+        )
+        return set(rows.scalars().all())
+
+
+async def test_purges_links_relations_and_the_orphaned_entity():
+    """The whole point: the PII name must stop being listable."""
+    svc = PostgresService()
+    tenant = f"h02-{uuid.uuid4().hex[:8]}"
+    mem = await _dropped_memory(svc, tenant)
+    alice = await _entity(svc, tenant, f"Alice {uuid.uuid4().hex[:6]}")
+    bob = await _entity(svc, tenant, f"Bob {uuid.uuid4().hex[:6]}")
+    await _link(mem.id, alice.id)
+    await _link(mem.id, bob.id)
+    await _relation(tenant, alice.id, bob.id, mem.id)
+
+    counts = await svc.memory_purge_entity_artifacts(tenant_id=tenant, memory_id=mem.id)
+
+    assert counts == {"links": 2, "relations": 1, "entities": 2}, counts
+    assert await _entity_names(tenant) == set()
+
+
+async def test_keeps_an_entity_another_live_memory_still_asserts():
+    """The name is not this memory's to remove once something else asserts it.
+
+    This is the assertion that separates a targeted purge from a graph wipe.
+    """
+    svc = PostgresService()
+    tenant = f"h02-{uuid.uuid4().hex[:8]}"
+    dropped = await _dropped_memory(svc, tenant)
+    survivor = await _memory(svc, tenant)
+    shared = await _entity(svc, tenant, f"Shared {uuid.uuid4().hex[:6]}")
+    await _link(dropped.id, shared.id)
+    await _link(survivor.id, shared.id)
+
+    counts = await svc.memory_purge_entity_artifacts(tenant_id=tenant, memory_id=dropped.id)
+
+    assert counts["links"] == 1
+    assert counts["entities"] == 0, "an entity another memory still links to was deleted"
+    assert len(await _entity_names(tenant)) == 1
+
+
+async def test_leaves_unrelated_orphans_alone():
+    """OVER-DELETION GUARD, and the reason the candidate set is bounded.
+
+    A first draft of this deleted every entity in the tenant with no links —
+    which would sweep entities orphaned for unrelated reasons and race an entity
+    a concurrent write had created but not yet linked. The purge must only
+    consider entities THIS memory touched.
+    """
+    svc = PostgresService()
+    tenant = f"h02-{uuid.uuid4().hex[:8]}"
+    mem = await _dropped_memory(svc, tenant)
+    mine = await _entity(svc, tenant, f"Mine {uuid.uuid4().hex[:6]}")
+    await _link(mem.id, mine.id)
+    # Linked to nothing, touched by nobody — exactly the shape a broad
+    # "delete orphans" query would take with it.
+    stranger_name = f"Stranger {uuid.uuid4().hex[:6]}"
+    await _entity(svc, tenant, stranger_name)
+
+    counts = await svc.memory_purge_entity_artifacts(tenant_id=tenant, memory_id=mem.id)
+
+    assert counts["entities"] == 1
+    assert await _entity_names(tenant) == {stranger_name}
+
+
+async def test_does_not_cross_tenants():
+    """One tenant's drop must not reach another tenant's graph."""
+    svc = PostgresService()
+    tenant_a = f"h02a-{uuid.uuid4().hex[:8]}"
+    tenant_b = f"h02b-{uuid.uuid4().hex[:8]}"
+    mem_a = await _dropped_memory(svc, tenant_a)
+    ent_a = await _entity(svc, tenant_a, f"A {uuid.uuid4().hex[:6]}")
+    await _link(mem_a.id, ent_a.id)
+
+    b_name = f"B {uuid.uuid4().hex[:6]}"
+    ent_b = await _entity(svc, tenant_b, b_name)
+    mem_b = await _memory(svc, tenant_b)
+    await _link(mem_b.id, ent_b.id)
+    await _relation(tenant_b, ent_b.id, ent_b.id, mem_b.id)
+
+    await svc.memory_purge_entity_artifacts(tenant_id=tenant_a, memory_id=mem_a.id)
+
+    assert await _entity_names(tenant_b) == {b_name}
+
+
+async def test_a_live_memory_is_never_purged():
+    """The invariant enforced where the deleting happens, not in the callers.
+
+    Both callers check that the memory is dropped before calling. This asserts
+    the method does not TRUST them: it deletes across three tables and cannot be
+    undone, so a stale call, a reordering, or a future caller written from the
+    method name alone must not be able to wipe a live memory's graph.
+
+    Covers all three deletes, not just the links — the relation delete never took
+    the ownership subquery, so guarding only the link path would have left a live
+    memory losing its relations while its links and entities survived.
+    """
+    svc = PostgresService()
+    tenant = f"h02live-{uuid.uuid4().hex[:8]}"
+
+    mem = await _memory(svc, tenant)  # LIVE — deliberately not dropped
+    name = f"Live {uuid.uuid4().hex[:6]}"
+    ent = await _entity(svc, tenant, name)
+    await _link(mem.id, ent.id)
+    await _relation(tenant, ent.id, ent.id, mem.id)
+
+    counts = await svc.memory_purge_entity_artifacts(tenant_id=tenant, memory_id=mem.id)
+
+    assert counts == {"links": 0, "relations": 0, "entities": 0}
+    assert await _link_entity_ids(mem.id) == {ent.id}
+    assert await _entity_names(tenant) == {name}
+    async with get_session() as s:
+        rels = await s.execute(select(Relation.id).where(Relation.evidence_memory_id == mem.id))
+        assert len(list(rels.scalars().all())) == 1, "a live memory's relation was purged"
+
+
+async def test_a_tenant_that_does_not_own_the_memory_deletes_nothing():
+    """The pairing is an authorisation, not just an identifier.
+
+    ``test_does_not_cross_tenants`` above passes a MATCHED tenant/memory pair, so
+    it never exercised this: keyed on ``memory_id`` alone, the link delete removed
+    the owning tenant's rows for any memory_id a caller could name, and returned a
+    success response saying so. ``memory_entity_links`` has no ``tenant_id`` column
+    to make that visible, which is exactly why it has to be joined for.
+    """
+    svc = PostgresService()
+    owner = f"h02own-{uuid.uuid4().hex[:8]}"
+    other = f"h02oth-{uuid.uuid4().hex[:8]}"
+
+    mem = await _dropped_memory(svc, owner)
+    name = f"Owned {uuid.uuid4().hex[:6]}"
+    ent = await _entity(svc, owner, name)
+    await _link(mem.id, ent.id)
+    await _relation(owner, ent.id, ent.id, mem.id)
+
+    # ``other`` names a memory it does not own.
+    counts = await svc.memory_purge_entity_artifacts(tenant_id=other, memory_id=mem.id)
+
+    assert counts == {"links": 0, "relations": 0, "entities": 0}
+    assert await _link_entity_ids(mem.id) == {ent.id}
+    assert await _entity_names(owner) == {name}
+
+
+async def test_a_link_to_another_tenants_entity_is_still_removed():
+    """Pins the deliberate choice of the memory end over ``_link_within_tenant``.
+
+    That helper requires BOTH ends in the tenant, because a read returning a
+    straddling row hands back the other tenant's UUID. Deleting is a different
+    question: this link points at content we are dropping, so it goes. The
+    foreign ENTITY stays — the tenant-scoped entity delete never reaches it.
+
+    Such rows are historical (the write path has refused to create them since
+    #1085/#1124), which is precisely why requiring both ends would strand them.
+    """
+    svc = PostgresService()
+    owner = f"h02str-{uuid.uuid4().hex[:8]}"
+    other = f"h02frn-{uuid.uuid4().hex[:8]}"
+
+    mem = await _dropped_memory(svc, owner)
+    foreign_name = f"Foreign {uuid.uuid4().hex[:6]}"
+    foreign_ent = await _entity(svc, other, foreign_name)
+    await _link(mem.id, foreign_ent.id)
+
+    counts = await svc.memory_purge_entity_artifacts(tenant_id=owner, memory_id=mem.id)
+
+    assert counts["links"] == 1
+    assert await _link_entity_ids(mem.id) == set()
+    # Not ours to delete, and it is still listable in the tenant that owns it.
+    assert counts["entities"] == 0
+    assert await _entity_names(other) == {foreign_name}
+
+
+async def test_a_relation_in_another_tenant_still_protects_the_entity():
+    """The reference survives even when the row asserting it lives elsewhere.
+
+    The "still referenced?" anti-joins are narrowed by the ENTITY's tenant, not
+    by the referencing row's own ``tenant_id``. Scoping relations on
+    ``Relation.tenant_id`` instead — the obvious narrowing, since the column is
+    right there — would drop this straddling row out of the anti-join and delete
+    an entity something still points at. Over-deleting is the direction that does
+    not come back.
+    """
+    svc = PostgresService()
+    owner = f"h02rel-{uuid.uuid4().hex[:8]}"
+    other = f"h02out-{uuid.uuid4().hex[:8]}"
+
+    mem = await _dropped_memory(svc, owner)
+    name = f"Cited {uuid.uuid4().hex[:6]}"
+    ent = await _entity(svc, owner, name)
+    await _link(mem.id, ent.id)
+
+    # A relation in ANOTHER tenant naming this tenant's entity. Historical shape:
+    # the write path guards endpoints now, but old rows can still straddle.
+    other_mem = await _memory(svc, other)
+    await _relation(other, ent.id, ent.id, other_mem.id)
+
+    counts = await svc.memory_purge_entity_artifacts(tenant_id=owner, memory_id=mem.id)
+
+    assert counts["links"] == 1
+    # The link went; the entity stayed, because something still asserts it.
+    assert counts["entities"] == 0
+    assert await _entity_names(owner) == {name}
+
+
+async def test_a_memory_with_no_graph_rows_is_a_no_op():
+    """The common case. Most dropped memories were never extracted from."""
+    svc = PostgresService()
+    tenant = f"h02-{uuid.uuid4().hex[:8]}"
+    mem = await _dropped_memory(svc, tenant)
+    kept = f"Untouched {uuid.uuid4().hex[:6]}"
+    await _entity(svc, tenant, kept)
+
+    counts = await svc.memory_purge_entity_artifacts(tenant_id=tenant, memory_id=mem.id)
+
+    assert counts == {"links": 0, "relations": 0, "entities": 0}
+    assert await _entity_names(tenant) == {kept}

--- a/tests/test_a63_subject_writeback.py
+++ b/tests/test_a63_subject_writeback.py
@@ -58,6 +58,10 @@ def _sc(entity_ids: list[str]) -> MagicMock:
     """Storage mock where entity i resolves as a fresh create with
     ``entity_ids[i]``."""
     sc = MagicMock()
+    # H-02: the worker re-reads the memory before persisting, so nothing is
+    # written to the graph of a row governance dropped mid-extraction. These
+    # tests exercise a live row.
+    sc.get_memory = AsyncMock(return_value={"id": "m", "deleted_at": None})
     sc.bulk_resolve_entities = AsyncMock(return_value=[None] * len(entity_ids))
     sc.bulk_upsert_entities = AsyncMock(
         return_value=[
@@ -150,6 +154,10 @@ async def test_no_subject_role_skips() -> None:
 async def test_two_surface_forms_same_entity_count_as_one_subject() -> None:
     shared_id = str(uuid4())
     sc = MagicMock()
+    # H-02: the worker re-reads the memory before persisting, so nothing is
+    # written to the graph of a row governance dropped mid-extraction. These
+    # tests exercise a live row.
+    sc.get_memory = AsyncMock(return_value={"id": "m", "deleted_at": None})
     sc.bulk_resolve_entities = AsyncMock(return_value=[None, None])
     # Both surface forms upsert to the SAME entity row.
     sc.bulk_upsert_entities = AsyncMock(

--- a/tests/test_entity_linking_wiring.py
+++ b/tests/test_entity_linking_wiring.py
@@ -74,6 +74,10 @@ async def test_extraction_triggers_cross_links_when_enabled(
     mock_extract.return_value = graph
 
     sc = MagicMock()
+    # H-02: the worker re-reads the memory before persisting, so nothing is
+    # written to the graph of a row governance dropped mid-extraction. These
+    # tests exercise a live row.
+    sc.get_memory = AsyncMock(return_value={"id": "m", "deleted_at": None})
     sc.find_entity_link = AsyncMock(return_value=None)
     sc.create_entity_link = AsyncMock()
     mock_sc_factory.return_value = sc
@@ -149,6 +153,10 @@ async def test_extraction_skips_cross_links_when_disabled(
     mock_extract.return_value = graph
 
     sc = MagicMock()
+    # H-02: the worker re-reads the memory before persisting, so nothing is
+    # written to the graph of a row governance dropped mid-extraction. These
+    # tests exercise a live row.
+    sc.get_memory = AsyncMock(return_value={"id": "m", "deleted_at": None})
     sc.find_entity_link = AsyncMock(return_value=None)
     sc.create_entity_link = AsyncMock()
     mock_sc_factory.return_value = sc
@@ -224,6 +232,10 @@ async def test_extraction_cross_link_failure_is_nonfatal(
     mock_extract.return_value = graph
 
     sc = MagicMock()
+    # H-02: the worker re-reads the memory before persisting, so nothing is
+    # written to the graph of a row governance dropped mid-extraction. These
+    # tests exercise a live row.
+    sc.get_memory = AsyncMock(return_value={"id": "m", "deleted_at": None})
     sc.find_entity_link = AsyncMock(return_value=None)
     sc.create_entity_link = AsyncMock()
     mock_sc_factory.return_value = sc
@@ -260,3 +272,896 @@ async def test_extraction_cross_link_failure_is_nonfatal(
         )
 
     mock_discover.assert_awaited_once()
+
+
+# ── H-02: a row governance dropped mid-extraction gets no graph rows ──
+
+
+def _one_entity_graph():
+    entity = MagicMock()
+    entity.canonical_name = "Alice"
+    entity.entity_type = "person"
+    entity.role = "subject"
+    graph = MagicMock()
+    graph.entities = [entity]
+    graph.relations = []
+    return graph
+
+
+def _graph_with_relation():
+    """Like ``_one_entity_graph`` but the LLM also proposed a relation.
+
+    ``graph.relations = []`` everywhere else in this file is what hid the
+    post-purge fall-through: the relation upsert loop had nothing to iterate, so
+    no test noticed the function carrying on writing after a detected drop.
+    """
+    graph = _one_entity_graph()
+    rel = MagicMock()
+    rel.from_entity = "Alice"
+    rel.to_entity = "Alice"
+    rel.relation_type = "knows"
+    graph.relations = [rel]
+    return graph
+
+
+def _graph_sc(*, deleted_at):
+    sc = MagicMock()
+    sc.get_memory = AsyncMock(return_value={"id": "m", "deleted_at": deleted_at})
+    sc.bulk_resolve_entities = AsyncMock(return_value=[None])
+    # ``entity_id`` + ``input_idx`` is the shape the worker actually reads; a bare
+    # ``id`` leaves name_to_id empty, so no links are built and the write path
+    # quietly ends early.
+    sc.bulk_upsert_entities = AsyncMock(
+        return_value=[
+            {"entity_id": str(uuid.uuid4()), "input_idx": 0, "action": "created"}
+        ]
+    )
+    sc.bulk_upsert_entity_links = AsyncMock(
+        return_value=[{"input_idx": 0, "created": True}]
+    )
+    sc.find_entity_link = AsyncMock(return_value=None)
+    sc.create_entity_link = AsyncMock()
+    sc.purge_entity_artifacts = AsyncMock(
+        return_value={"links": 1, "relations": 0, "entities": 1}
+    )
+    # Reached only by the tests that run the write path to completion — the
+    # dropped-before-extraction case returns before it.
+    sc.discover_cross_links = AsyncMock(return_value={"links_created": 0})
+    sc.update_memory = AsyncMock()
+    return sc
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_a_memory_dropped_during_extraction_gets_no_entities(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, mock_log
+):
+    """H-02. Extraction is scheduled at write time, in parallel with the
+    enrichment that carries the governance verdict — so the row can already be
+    gone by the time the LLM call returns.
+
+    Writing entities for it would put the dropped content's names into a table
+    the drop does not reach, listable tenant-wide through ``/entities`` and
+    ``/graph``.
+
+    This is the cheap case: the row was already gone when the LLM call returned,
+    so no work is done at all. It does NOT close the window on its own — a drop
+    landing during the writes is covered by the post-write purge, pinned below.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _one_entity_graph()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at="2026-09-05T00:00:00Z")
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    # Asserted on the WRITES, not on the early return, so a refactor that keeps
+    # the check but persists anyway still fails.
+    sc.bulk_upsert_entities.assert_not_awaited()
+    sc.bulk_upsert_entity_links.assert_not_awaited()
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_the_liveness_check_reads_the_writer(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, mock_log
+):
+    """The check exists to observe a delete that just committed.
+
+    A replica under lag would report the row live, so the check would pass
+    exactly when it most needed to fail.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _one_entity_graph()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    assert sc.get_memory.await_args.kwargs.get("read") is False, (
+        sc.get_memory.await_args
+    )
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_a_drop_landing_during_the_writes_purges_what_was_just_written(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, mock_log
+):
+    """The window the pre-write check cannot close.
+
+    The row is live when extraction finishes, so the early check passes and the
+    writes proceed. Governance drops it during those writes — its own purge runs
+    while these rows do not exist yet and finds nothing. Without the post-write
+    re-check the entities land afterwards and nothing ever revisits them: the
+    memory is gone, so no later verdict names it.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _one_entity_graph()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    # Live at the pre-write check, dropped by the post-write one.
+    sc.get_memory = AsyncMock(
+        side_effect=[
+            {"id": "m", "deleted_at": None},
+            {"id": "m", "deleted_at": "2026-09-05T00:00:00Z"},
+        ]
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    # The writes DID happen — that is the premise, not a failure.
+    sc.bulk_upsert_entity_links.assert_awaited()
+    # And they were taken back.
+    sc.purge_entity_artifacts.assert_awaited_once()
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_a_row_still_live_after_the_writes_is_not_purged(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, mock_log
+):
+    """OVER-REFUSAL GUARD, and the one that matters most here.
+
+    The ordinary path writes entities for a live memory. A post-write purge that
+    fired on it would delete the graph rows of every successfully extracted
+    memory in the install — the failure mode of this fix is far worse than the
+    leak it closes, so it gets its own test rather than riding on the one above.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _one_entity_graph()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    sc.bulk_upsert_entity_links.assert_awaited()
+    sc.purge_entity_artifacts.assert_not_awaited()
+
+
+@patch(
+    "core_api.services.entity_extraction_worker._discover_cross_links_for_memory",
+    new_callable=AsyncMock,
+)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_a_detected_drop_stops_the_writes_that_come_after_the_purge(
+    mock_resolve,
+    mock_extract,
+    mock_sc_factory,
+    mock_embed,
+    mock_log,
+    mock_upsert_relation,
+    mock_discover,
+):
+    """Purging is only half of it — the function must also STOP.
+
+    Everything after the link upsert writes more graph rows for this memory: a
+    relation carrying ``evidence_memory_id``, the subject write-back, cross-link
+    discovery. Purging and then falling through cleans the link table and
+    immediately refills the relation table, which moves the leak rather than
+    closing it.
+
+    Every other test in this file leaves ``graph.relations`` empty, so the
+    relation loop had nothing to iterate and none of them could have caught it.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _graph_with_relation()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    sc.get_memory = AsyncMock(
+        side_effect=[
+            {"id": "m", "deleted_at": None},
+            {"id": "m", "deleted_at": "2026-09-05T00:00:00Z"},
+        ]
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    sc.purge_entity_artifacts.assert_awaited_once()
+    # The rows the purge would NOT have covered, because they did not exist yet.
+    mock_upsert_relation.assert_not_awaited()
+    mock_discover.assert_not_awaited()
+
+
+@patch(
+    "core_api.services.entity_extraction_worker._discover_cross_links_for_memory",
+    new_callable=AsyncMock,
+)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_a_live_row_still_gets_its_relations_written(
+    mock_resolve,
+    mock_extract,
+    mock_sc_factory,
+    mock_embed,
+    mock_log,
+    mock_upsert_relation,
+    mock_discover,
+):
+    """The other half of the guard above: stopping must be conditional.
+
+    A short-circuit that fired on live rows would silently stop writing relations
+    and cross-links for every extracted memory in the install.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _graph_with_relation()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    sc.purge_entity_artifacts.assert_not_awaited()
+    mock_upsert_relation.assert_awaited()
+    mock_discover.assert_awaited()
+
+
+@patch(
+    "core_api.services.entity_extraction_worker._discover_cross_links_for_memory",
+    new_callable=AsyncMock,
+)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_a_drop_landing_after_the_relation_write_is_still_purged(
+    mock_resolve,
+    mock_extract,
+    mock_sc_factory,
+    mock_embed,
+    mock_log,
+    mock_upsert_relation,
+    mock_discover,
+):
+    """The window the post-link check does NOT cover.
+
+    The row is live at the link check, so the function proceeds — and writes the
+    subject pointer, the relations carrying ``evidence_memory_id``, and whatever
+    cross-link discovery creates. A drop landing across THAT stretch runs its own
+    purge against rows that do not exist yet, and nothing revisits them.
+
+    Only a check after every graph-mutating write catches it. A single check
+    after the link upsert reports success on this case while leaving the relation
+    row live for dropped content.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _graph_with_relation()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    # Live at the pre-write check AND at the post-link check; dropped only by the
+    # final one, after the relation and cross-link writes.
+    sc.get_memory = AsyncMock(
+        side_effect=[
+            {"id": "m", "deleted_at": None},
+            {"id": "m", "deleted_at": None},
+            {"id": "m", "deleted_at": "2026-09-05T00:00:00Z"},
+        ]
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    # The relation WAS written — that is the premise of this race, not a failure.
+    mock_upsert_relation.assert_awaited()
+    # And the rows it left behind were taken back.
+    sc.purge_entity_artifacts.assert_awaited_once()
+
+
+@patch(
+    "core_api.services.entity_extraction_worker._discover_cross_links_for_memory",
+    new_callable=AsyncMock,
+)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_a_transient_liveness_read_failure_does_not_discard_the_audit_work(
+    mock_resolve,
+    mock_extract,
+    mock_sc_factory,
+    mock_embed,
+    mock_log,
+    mock_upsert_relation,
+    mock_discover,
+):
+    """A read timeout says nothing about whether the memory was dropped.
+
+    An earlier revision returned a bool meaning "you must stop", which forced the
+    indeterminate case to pick one of the two real answers. It picked "stop", and
+    a transient storage blip then silently discarded the audit-log entry, the
+    contradiction trigger and cross-link discovery for a memory that was almost
+    certainly still live — with nothing to repair it, since the task is
+    fire-and-forget.
+
+    ``unknown`` is now its own answer and this call site acts only on ``dropped``.
+    The final check is the leak guarantee; this one is only an optimisation, so
+    it has no business destroying work on a non-answer.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _graph_with_relation()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    sc.get_memory = AsyncMock(
+        side_effect=[
+            {"id": "m", "deleted_at": None},  # pre-write check: live
+            RuntimeError("storage read timed out"),  # post-link check: indeterminate
+            {"id": "m", "deleted_at": None},  # final check: live after all
+        ]
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    # Nothing was concluded, so nothing was destroyed.
+    sc.purge_entity_artifacts.assert_not_awaited()
+    assert mock_log.await_count == 1, "the audit entry was discarded on a non-answer"
+    mock_upsert_relation.assert_awaited()
+    mock_discover.assert_awaited()
+
+
+@patch(
+    "core_api.services.entity_extraction_worker._discover_cross_links_for_memory",
+    new_callable=AsyncMock,
+)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_a_crash_after_the_writes_still_purges_a_dropped_row(
+    mock_resolve,
+    mock_extract,
+    mock_sc_factory,
+    mock_embed,
+    mock_log,
+    mock_upsert_relation,
+    mock_discover,
+):
+    """The exit the final check does not cover: leaving by raising.
+
+    The check at the end of the ``try`` is the leak guarantee for the path that
+    finishes. It is unreachable on the path that does not — anything between the
+    link upsert and it that raises (a relation upsert, the subject write-back,
+    the audit call) jumps straight to ``except``, and the entities and links
+    already committed stay behind for a memory that may have been dropped. That
+    is the H-02 leak itself, arriving through a door the fix had left open.
+
+    The post-link check does not save this case either: it is allowed to fall
+    through on ``unknown``, and here it is answered ``live`` — the drop lands
+    afterwards, which is the whole reason a later check exists.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _graph_with_relation()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    sc.get_memory = AsyncMock(
+        side_effect=[
+            {"id": "m", "deleted_at": None},  # pre-write check: live
+            {"id": "m", "deleted_at": None},  # post-link check: still live
+            {"id": "m", "deleted_at": "2026-09-06T00:00:00Z"},  # except path: dropped
+        ]
+    )
+    mock_sc_factory.return_value = sc
+    # Raised after the links are committed and before the audit call, so the
+    # function leaves with graph rows written and no normal-path check run.
+    mock_upsert_relation.side_effect = RuntimeError("storage went away mid-write")
+
+    with patch("core_api.tasks.track_task"):
+        # Extraction is fire-and-forget; swallowing is the established contract
+        # and not what this test is about.
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    # It really did leave by raising — otherwise this passes for the wrong reason.
+    mock_log.assert_not_awaited()
+    assert sc.get_memory.await_count == 3, (
+        "the except path never asked whether the memory survived"
+    )
+    sc.purge_entity_artifacts.assert_awaited_once()
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_a_crash_before_any_write_costs_no_extra_liveness_read(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, mock_log
+):
+    """Guard on the FIX, not a reproducer for the bug — it passes either way.
+
+    The obvious form of the fix is an unconditional check in ``except``. That
+    spends a writer read on every failed extraction, including the failures that
+    wrote nothing at all, on a path that runs for essentially every memory. The
+    flag is what keeps the cost proportional to what is actually at risk.
+
+    Here the resolve step fails, so no entity or link row was ever written and
+    there is nothing to purge. The only liveness read should be the pre-write
+    check that already ran.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _one_entity_graph()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    sc.bulk_resolve_entities = AsyncMock(side_effect=RuntimeError("resolve failed"))
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    sc.bulk_upsert_entities.assert_not_awaited()
+    assert sc.get_memory.await_count == 1, (
+        "a failure that wrote nothing still paid for a writer read"
+    )
+    sc.purge_entity_artifacts.assert_not_awaited()
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_a_crash_before_the_storage_client_exists_does_not_raise(
+    mock_resolve, mock_extract, mock_sc_factory, mock_log
+):
+    """The other reason the ``except`` check is guarded: ``sc`` may not exist.
+
+    ``get_storage_client`` is called after extraction, so a failure in the LLM
+    call leaves the name unbound. An unguarded check in the handler raises
+    ``NameError`` out of a fire-and-forget task, turning a logged non-fatal
+    failure into an unhandled task exception. Also passes without the fix.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.side_effect = RuntimeError("extraction provider is down")
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    mock_sc_factory.assert_not_called()
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_an_entity_upsert_that_raises_is_still_treated_as_maybe_written(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, mock_log
+):
+    """Pins WHERE the flag is set: before the upsert await, not after.
+
+    "The call raised" is not "nothing was written". A timeout can land on a
+    request storage already committed, and then the rows exist while the caller
+    only ever saw an exception. Setting the flag after the await would skip the
+    liveness check on exactly that case and leak the rows — the H-02 bug again,
+    through the narrowest door yet.
+
+    The cost of being wrong the other way is one writer read on a call that
+    never landed, on a path that is already failing. That asymmetry is the whole
+    argument for the ordering, and moving the assignment one line down is an
+    easy, invisible way to undo it.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _one_entity_graph()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    sc.bulk_upsert_entities = AsyncMock(
+        side_effect=RuntimeError("timed out waiting for the upsert response")
+    )
+    sc.get_memory = AsyncMock(
+        side_effect=[
+            {"id": "m", "deleted_at": None},  # pre-write check: live
+            {"id": "m", "deleted_at": "2026-09-06T00:00:00Z"},  # except path: dropped
+        ]
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    assert sc.get_memory.await_count == 2, (
+        "a write that may have committed was treated as certainly not written"
+    )
+    sc.purge_entity_artifacts.assert_awaited_once()
+
+
+@patch(
+    "core_api.services.entity_extraction_worker._discover_cross_links_for_memory",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_cross_link_discovery_alone_still_owes_the_memory_a_liveness_check(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, mock_log, mock_discover
+):
+    """The persistence block is not the only thing that writes graph rows.
+
+    Cross-link discovery inserts ``memory_entity_links`` rows for this memory —
+    storage-side it is an ON CONFLICT DO NOTHING insert into exactly the table
+    the purge deletes from — and it is gated on ``auto_entity_linking_enabled``
+    alone. It runs when every extracted name was filtered out and
+    ``bulk_upsert_entities`` was therefore never called.
+
+    So ``wrote_graph_rows`` has to mean "this memory may have graph rows", not
+    "the persistence block ran". Gating the final check on the narrower reading
+    skips the purge on this path and leaks the links discovery just created for
+    a dropped memory — H-02 again, through the fix's own guard.
+    """
+    # Every extracted name is blocklisted, so ``filtered`` ends up empty and the
+    # whole persistence branch is skipped.
+    mock_resolve.return_value = _fake_config(entity_blocklist=frozenset({"alice"}))
+    mock_extract.return_value = _one_entity_graph()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    sc.get_memory = AsyncMock(
+        side_effect=[
+            {"id": "m", "deleted_at": None},  # pre-write check: live
+            {"id": "m", "deleted_at": "2026-09-06T00:00:00Z"},  # final check: dropped
+        ]
+    )
+    mock_sc_factory.return_value = sc
+
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    # The premise: nothing went through the persistence block, and discovery ran.
+    sc.bulk_upsert_entities.assert_not_awaited()
+    mock_discover.assert_awaited_once()
+    sc.purge_entity_artifacts.assert_awaited_once()
+
+
+@patch(
+    "core_api.services.entity_extraction_worker._discover_cross_links_for_memory",
+    new_callable=AsyncMock,
+)
+@patch(
+    "core_api.services.entity_extraction_worker.upsert_relation", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_an_unreadable_purge_response_does_not_escape_the_except_handler(
+    mock_resolve,
+    mock_extract,
+    mock_sc_factory,
+    mock_embed,
+    mock_log,
+    mock_upsert_relation,
+    mock_discover,
+):
+    """The purge response shape is not guaranteed, and one call site is exposed.
+
+    ``_post`` is typed ``dict | list`` with a ``type: ignore`` at the call, so a
+    2xx carrying a list reaches ``counts.get`` — outside the try that wraps the
+    purge — and raises ``AttributeError``.
+
+    Two of this helper's three call sites sit inside ``process_entity_extraction``'s
+    catch-all, which would absorb that. The third does not: it IS the catch-all,
+    and an exception raised inside an ``except`` block propagates out of the
+    function, surfacing as an unhandled exception on a fire-and-forget task.
+
+    So this drives the except-handler site specifically — a relation upsert fails
+    after the links are committed, the memory turns out to be dropped, and the
+    purge answers with a list.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _graph_with_relation()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    sc.get_memory = AsyncMock(
+        side_effect=[
+            {"id": "m", "deleted_at": None},  # pre-write check: live
+            {"id": "m", "deleted_at": None},  # post-link check: still live
+            {"id": "m", "deleted_at": "2026-09-06T00:00:00Z"},  # except path: dropped
+        ]
+    )
+    sc.purge_entity_artifacts = AsyncMock(return_value=["unexpected", "shape"])
+    mock_sc_factory.return_value = sc
+    mock_upsert_relation.side_effect = RuntimeError("storage went away mid-write")
+
+    # The assertion IS that this returns rather than raising.
+    with patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    # And it really did take the except-handler path with the purge attempted.
+    assert sc.get_memory.await_count == 3
+    sc.purge_entity_artifacts.assert_awaited_once()
+
+
+@patch("core_api.services.entity_extraction_worker.log_action", new_callable=AsyncMock)
+@patch(
+    "core_api.services.entity_extraction_worker.get_embedding", new_callable=AsyncMock
+)
+@patch("core_api.services.entity_extraction_worker.get_storage_client")
+@patch(
+    "core_api.services.entity_extraction_worker.extract_entities_from_content",
+    new_callable=AsyncMock,
+)
+@patch("core_api.services.organization_settings.resolve_config", new_callable=AsyncMock)
+async def test_entities_committed_without_their_links_are_named_in_the_log(
+    mock_resolve, mock_extract, mock_sc_factory, mock_embed, mock_log, caplog
+):
+    """The one gap the purge cannot close from its own side.
+
+    ``memory_purge_entity_artifacts`` finds entities THROUGH the memory's links,
+    deliberately: the first draft swept every unlinked entity in the tenant, which
+    over-deletes and races a concurrent writer that has created an entity but not
+    yet linked it.
+
+    The cost of that bounding lands exactly here. If the entity upsert commits and
+    the link upsert then raises, those rows are reachable by nothing — so a purge
+    for this memory runs, finds no links, and reports ``{0, 0, 0}``. That is
+    indistinguishable in the audit trail from "there was nothing to purge", which
+    is what makes it a silent miss rather than a loud one.
+
+    It stays a miss; what changes is that a person is handed the ids. Widening the
+    purge's candidate set instead would re-introduce the race the bounding exists
+    to prevent.
+
+    Only entities this run CREATED are named. One that already existed is
+    reachable through whatever linked it before and is nobody's orphan.
+    """
+    mock_resolve.return_value = _fake_config()
+    mock_extract.return_value = _one_entity_graph()
+    mock_embed.return_value = None
+    sc = _graph_sc(deleted_at=None)
+    fresh = str(uuid.uuid4())
+    sc.bulk_upsert_entities = AsyncMock(
+        return_value=[{"entity_id": fresh, "input_idx": 0, "action": "created"}]
+    )
+    sc.bulk_upsert_entity_links = AsyncMock(
+        side_effect=RuntimeError("link upsert never landed")
+    )
+    mock_sc_factory.return_value = sc
+
+    with caplog.at_level("ERROR"), patch("core_api.tasks.track_task"):
+        await process_entity_extraction(
+            memory_id=uuid.uuid4(),
+            tenant_id="test-tenant",
+            fleet_id=None,
+            agent_id="test-agent",
+            content="Alice loves coffee",
+            memory_type="episodic",
+        )
+
+    assert any(fresh in r.getMessage() for r in caplog.records), (
+        "an entity row that no link and no purge can reach went unnamed in the log"
+    )

--- a/tests/test_governance_consumer.py
+++ b/tests/test_governance_consumer.py
@@ -47,6 +47,12 @@ def sc(monkeypatch):
     c.get_memory = AsyncMock()
     c.soft_delete_memory = AsyncMock()
     c.update_memory = AsyncMock()
+    # H-02: a drop now also purges the graph rows mined from the row. Returns
+    # explicit zero counts rather than a bare AsyncMock so the caller's log
+    # branch reads real numbers instead of a truthy mock.
+    c.purge_entity_artifacts = AsyncMock(
+        return_value={"links": 0, "relations": 0, "entities": 0}
+    )
     monkeypatch.setattr("core_api.consumer.get_storage_client", lambda: c)
     monkeypatch.setattr(
         "core_api.services.governance_remediation.get_storage_client", lambda: c

--- a/tests/test_governance_remediation.py
+++ b/tests/test_governance_remediation.py
@@ -56,6 +56,10 @@ def storage(monkeypatch):
             actions.append(("find_children", parent_id, tenant_id))
             return list(actions.children)
 
+        async def purge_entity_artifacts(self, tenant_id, memory_id):
+            actions.append(("purge_entities", memory_id, tenant_id))
+            return {"links": 0, "relations": 0, "entities": 0}
+
     monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
     return actions
 
@@ -104,6 +108,95 @@ async def test_pii_drop_soft_deletes_and_audits(emitted, storage):
     assert outcome.dropped is True
     assert ("soft_delete", "m1", "t1") in storage
     assert any(c["action"] == "pii_drop" for c in emitted)
+
+
+# ---------------------------------------------------------------------------
+# H-02 — entity rows mined out of dropped content
+# ---------------------------------------------------------------------------
+#
+# #808 named this case when it fixed the inline path: "entities mined out of
+# dropped content are the same leak in another table". Both non-inline paths
+# schedule extraction at write time, racing the verdict, and a soft-deleted
+# memory still satisfies the link/relation foreign keys — so the names survived,
+# listable tenant-wide, with nothing tying them to the drop.
+
+
+async def test_a_pii_drop_purges_the_graph_rows(emitted, storage):
+    cfg = _cfg(pii={"enabled": True, "action": "drop"})
+    mem = _mem(metadata={"contains_pii": True, "pii_types": ["health"]})
+
+    outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    assert outcome.dropped is True
+    assert ("purge_entities", "m1", "t1") in storage, storage
+
+
+async def test_a_nonbusiness_drop_purges_the_graph_rows(emitted, storage):
+    """Both destructive dispositions, not just one — separate branches, separate
+    configs, and a tenant on either policy leaks identically without this."""
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(metadata={"business_relevance": "personal"})
+
+    await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    assert ("purge_entities", "m1", "t1") in storage, storage
+
+
+async def test_a_failed_purge_does_not_abort_the_handler(
+    emitted, storage, monkeypatch, caplog
+):
+    """A raise here would nack the Pub/Sub event and redeliver it forever.
+
+    ``consumer.handle_memory_enriched`` has no guard around remediation, and the
+    dispatcher nacks on a handler exception. Redelivery re-runs the whole drop
+    branch, emitting a SECOND ``critical=True`` audit for a memory that was
+    already dropped — duplicate destructive entries in a tamper-evident log, for
+    a row nothing further can be done to.
+
+    The trade is bounded the other way: the memory is already gone, so the
+    content is not live. What remains is graph rows, and the ERROR names the
+    memory so they can be purged by hand.
+    """
+
+    class _SC:
+        async def soft_delete_memory(self, mid, tenant_id):
+            storage.append(("soft_delete", mid, tenant_id))
+
+        async def purge_entity_artifacts(self, tenant_id, memory_id):
+            raise RuntimeError("storage refused the purge")
+
+    monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
+
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(metadata={"business_relevance": "personal"})
+
+    with caplog.at_level("ERROR"):
+        outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    # The parent's verdict still reaches the caller.
+    assert outcome.dropped is True
+    assert ("soft_delete", "m1", "t1") in storage
+    # And the failure is not silent.
+    assert any("were NOT" in r.getMessage() for r in caplog.records), [
+        r.getMessage()[:80] for r in caplog.records
+    ]
+
+
+async def test_a_non_destructive_verdict_purges_nothing(emitted, storage):
+    """OVER-REFUSAL GUARD. ``flag`` and ``keep_private`` leave the row readable.
+
+    The graph rows describe content that is still there and still allowed, so
+    removing them would destroy data no policy asked to remove.
+    """
+    cfg = _cfg(
+        pii={"enabled": True, "action": "flag"},
+        nb={"enabled": True, "disposition": "keep_private"},
+    )
+    mem = _mem(metadata={"contains_pii": True, "business_relevance": "personal"})
+
+    await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    assert not any(kind == "purge_entities" for kind, *_ in storage), storage
 
 
 # ---------------------------------------------------------------------------
@@ -271,6 +364,10 @@ async def test_one_failing_child_does_not_abandon_the_rest(
         async def find_children_by_parent_id(self, tenant_id, parent_id):
             return list(storage.children)
 
+        async def purge_entity_artifacts(self, tenant_id, memory_id):
+            storage.append(("purge_entities", memory_id, tenant_id))
+            return {"links": 0, "relations": 0, "entities": 0}
+
     monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
 
     cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
@@ -328,6 +425,10 @@ async def test_a_child_whose_delete_failed_after_its_audit_is_logged_as_such(
 
         async def find_children_by_parent_id(self, tenant_id, parent_id):
             return list(storage.children)
+
+        async def purge_entity_artifacts(self, tenant_id, memory_id):
+            storage.append(("purge_entities", memory_id, tenant_id))
+            return {"links": 0, "relations": 0, "entities": 0}
 
     monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
 
@@ -408,6 +509,92 @@ async def test_a_child_whose_audit_failed_is_reported_as_untouched(
     assert not [a for a in storage if a[0] == "soft_delete" and a[1] == "c1"]
 
 
+async def test_a_cascaded_child_has_its_own_graph_rows_purged(emitted, storage):
+    """The invariant has to hold for the children, not just the row the event named.
+
+    A child is an ordinary memory. Narrow in practice — auto-chunk children get no
+    extraction of their own, so the names mined from chunked content hang off the
+    PARENT — but a child whose content was later rewritten has its own graph rows,
+    because ``update_memory`` re-extracts.
+    """
+    storage.children = [_child("c1"), _child("c2")]
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 2,
+        }
+    )
+
+    await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    purged = {mid for kind, mid, *_ in storage if kind == "purge_entities"}
+    assert purged == {"m1", "c1", "c2"}, f"a dropped row kept its graph rows: {purged}"
+
+
+async def test_a_child_that_could_not_be_deleted_is_not_purged(
+    emitted, storage, monkeypatch, caplog
+):
+    """OVER-REFUSAL GUARD. The row is STILL LIVE, so its graph rows describe
+    content that is still there — removing them would destroy the graph of a
+    memory no policy managed to drop."""
+    storage.children = [_child("c1")]
+
+    class _SC:
+        async def soft_delete_memory(self, mid, tenant_id):
+            if mid == "c1":
+                raise RuntimeError("delete refused")
+            storage.append(("soft_delete", mid, tenant_id))
+
+        async def find_children_by_parent_id(self, tenant_id, parent_id):
+            return list(storage.children)
+
+        async def purge_entity_artifacts(self, tenant_id, memory_id):
+            storage.append(("purge_entities", memory_id, tenant_id))
+            return {"links": 0, "relations": 0, "entities": 0}
+
+    monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
+
+    cfg = _cfg(nb={"enabled": True, "disposition": "drop"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 1,
+        }
+    )
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(governance_remediation.GovernanceCascadeError):
+            await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    purged = {mid for kind, mid, *_ in storage if kind == "purge_entities"}
+    assert "c1" not in purged, (
+        "the child is still live; purging its graph rows destroys data no policy removed"
+    )
+    # The parent's own purge still ran — it WAS dropped.
+    assert "m1" in purged
+
+
+async def test_privatised_children_keep_their_graph_rows(emitted, storage):
+    """OVER-REFUSAL GUARD. ``keep_private`` narrows visibility; nothing is removed,
+    so the graph rows still describe content that is there and still allowed."""
+    storage.children = [_child("c1")]
+    cfg = _cfg(nb={"enabled": True, "disposition": "keep_private"})
+    mem = _mem(
+        metadata={
+            "business_relevance": "personal",
+            "auto_chunked": True,
+            "child_count": 1,
+        }
+    )
+
+    await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    assert not any(kind == "purge_entities" for kind, *_ in storage), storage
+
+
 async def test_the_cascade_count_does_not_include_rows_it_skipped(
     emitted, storage, caplog
 ):
@@ -465,6 +652,10 @@ async def test_a_failed_cascade_never_erases_the_parents_own_audit(
         async def find_children_by_parent_id(self, tenant_id, parent_id):
             return list(storage.children)
 
+        async def purge_entity_artifacts(self, tenant_id, memory_id):
+            storage.append(("purge_entities", memory_id, tenant_id))
+            return {"links": 0, "relations": 0, "entities": 0}
+
     monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
 
     cfg = _cfg(nb={"enabled": True, "disposition": "keep_private"})
@@ -505,6 +696,57 @@ async def test_pii_flag_config_records_no_configured_action(emitted, storage):
     await governance_remediation.remediate_after_enrichment(mem, cfg)
     flag = next(c for c in emitted if c["action"] == "pii_flag")
     assert "configured_action" not in flag["detail"]
+
+
+async def test_a_purge_response_that_is_not_an_object_does_not_raise(
+    emitted, monkeypatch, caplog
+):
+    """This function's one hard requirement is that it must not raise.
+
+    ``_post`` is declared ``dict | list`` and the storage client silences the
+    mismatch with a ``type: ignore``, so nothing between the caller and the wire
+    enforces the shape. A 2xx carrying a list satisfies ``raise_for_status`` and
+    never reaches the ``except`` around the call — and reading ``.get`` on it
+    then raises ``AttributeError`` from OUTSIDE that guard.
+
+    The consequence is not a stray log line. ``remediate_after_enrichment`` runs
+    under ``consumer.handle_memory_enriched``, which catches
+    ``GovernanceCascadeError`` and nothing else, and the dispatcher nacks on any
+    other exception: redelivery, the whole drop branch re-run, and a SECOND
+    ``critical=True`` audit for a memory already dropped. Every redelivery. That
+    is the exact failure mode round 2 of this PR fixed, arriving back through a
+    type nobody checked.
+    """
+
+    class _SC:
+        async def soft_delete_memory(self, mid, tenant_id):
+            pass
+
+        async def find_children_by_parent_id(self, tenant_id, parent_id):
+            return []
+
+        async def purge_entity_artifacts(self, tenant_id, memory_id):
+            # A success whose body is not an object.
+            return ["unexpected", "shape"]
+
+    monkeypatch.setattr(governance_remediation, "get_storage_client", lambda: _SC())
+
+    # ``action`` on the PII branch — ``disposition`` is the non-business key, and
+    # passing the wrong one here silently lands on ``flag``, which never purges.
+    cfg = _cfg(pii={"enabled": True, "action": "drop"})
+    mem = _mem(metadata={"contains_pii": True, "pii_types": ["health"]})
+
+    with caplog.at_level("ERROR"):
+        outcome = await governance_remediation.remediate_after_enrichment(mem, cfg)
+
+    # The parent's own verdict still stands; only the cleanup is unconfirmable.
+    assert outcome.dropped is True
+    assert any(c["action"] == "pii_drop" for c in emitted), (
+        "the drop branch never ran, so the purge was never reached"
+    )
+    assert any("m1" in r.getMessage() for r in caplog.records), (
+        "an unreadable purge response went by without a word in the log"
+    )
 
 
 async def test_nonbusiness_keep_private_updates_visibility(emitted, storage):

--- a/tests/test_p1_entity_extraction_bulk.py
+++ b/tests/test_p1_entity_extraction_bulk.py
@@ -74,6 +74,10 @@ def _build_sc_mock(
     links_returns: list[dict] | None = None,
 ) -> MagicMock:
     sc = MagicMock()
+    # H-02: the worker re-reads the memory before persisting, so nothing is
+    # written to the graph of a row governance dropped mid-extraction. These
+    # tests exercise a live row.
+    sc.get_memory = AsyncMock(return_value={"id": "m", "deleted_at": None})
     sc.bulk_resolve_entities = AsyncMock(return_value=resolve_returns)
     sc.bulk_upsert_entities = AsyncMock(return_value=upsert_returns)
     sc.bulk_upsert_entity_links = AsyncMock(

--- a/tests/test_wt2_entity_canonicalisation.py
+++ b/tests/test_wt2_entity_canonicalisation.py
@@ -82,6 +82,10 @@ def _build_sc_mock(
     upsert_returns: list[dict],
 ) -> MagicMock:
     sc = MagicMock()
+    # H-02: the worker re-reads the memory before persisting, so a row dropped
+    # by governance while extraction was running gets nothing written to its
+    # graph. These tests are about canonicalisation, so the row is live.
+    sc.get_memory = AsyncMock(return_value={"id": "m", "deleted_at": None})
     sc.bulk_resolve_entities = AsyncMock(return_value=resolve_returns)
     sc.bulk_upsert_entities = AsyncMock(return_value=upsert_returns)
     sc.bulk_upsert_entity_links = AsyncMock(


### PR DESCRIPTION
Closes audit finding **H-02**.

#808 named this case when it fixed the inline path: "entities mined out of
dropped content are the same leak in another table". It fixed that path by
ordering — _enrich_memory_background runs remediation first, and its early
return on a drop skips the entity extraction scheduled below it.

Both non-inline paths schedule extraction independently, at write time, as a
fire-and-forget task that races the verdict. ScheduleBackgroundTasks fires it
alongside the enrichment carrying run_governance_remediation=True in the fast
branch, and at write time in strong+deferred. process_entity_extraction never
re-checked the row.

And the schema's own expression of "these rows must not outlive the memory"
never fires: memory_entity_links.memory_id is ON DELETE CASCADE and
relations.evidence_memory_id is ON DELETE SET NULL, both on a HARD delete.
Governance soft-deletes — it sets deleted_at — so neither ever runs. The entity
row itself has no FK to the memory at all, so nothing would remove it even on a
hard delete.

Result: a tenant configured to drop had the memory removed and audited while the
names mined from it (person names, under a PII policy) stayed listable
tenant-wide through /entities and /graph, with nothing tying them to the drop.

Verified from the code rather than reproduced as one failing assertion, and the
distinction is worth being straight about: unlike the earlier findings in this
series there was no existing code path to make fail, because nothing could reach
these rows at all. What IS probe-confirmed is each guard added here — reverting
the candidate bounding fails the over-deletion test with 2 == 1, and neutering
the liveness check fails the dropped-row test.

Two halves, and they are not alternatives.

1. A purge on the drop path. New storage call, one transaction: delete the
   memory's entity links, then relations whose evidence IS this memory (one row
   carries one evidence id, so a relation attributed to dropped content has no
   other justification), then — from the entities this memory linked to and only
   those — the ones now left with no links and no relations. Both destructive
   dispositions cascade, not just the non-business one the finding described:
   they are separate branches reading separate configs, and a PII drop policy
   leaked identically.

   The candidate set is bounded on purpose. A first draft deleted every entity in
   the tenant with no links, which would sweep entities orphaned for unrelated
   reasons and race an entity a concurrent write had created but not yet linked.
   Under-deleting is recoverable; over-deleting another caller's rows is not. A
   test pins it: the unbounded version fails with 2 == 1.

2. A liveness re-check in the worker, immediately before persisting, reading the
   WRITER — the whole point is to observe a delete that just committed, and a
   replica under lag would report the row live exactly when the check most needed
   to fail.

Half 1 covers the common ordering: extraction is one LLM call while the verdict
needs enrichment plus an event round-trip, so extraction usually finishes first
and its rows are there to purge. Half 2 covers the tail where it does not — the
purge has already run by then and would miss what lands afterwards. Neither half
covers the other's case.

The purge is deliberately NOT gated on a marker, unlike H-10's child cascade: any
dropped memory may have been extracted from, no flag on the row says so, and the
purge is three targeted deletes keyed on memory_id.

The purge runs AFTER the soft-delete, and that ordering is pinned. Purging first
would destroy graph rows for a memory that is still live if the delete then
failed, and nothing would put them back.

Tests. Five in core-storage-api against real Postgres, because the query's
correctness is entirely about what it does and does not reach and a stub would
assert the code calls itself — including the over-deletion guard, the
still-asserted-by-another-memory case, and the tenant boundary. Three in
core-api for the wiring, one of them an over-refusal guard that flag and
keep_private purge nothing (those rows describe content that is still there and
still allowed). Two for the worker guard, asserting on the WRITES rather than
the early return so a refactor that keeps the check and persists anyway fails,
plus one that the check reads the writer.

Four existing entity-extraction test files gained a get_memory stub. That is the
honest cost of the worker now depending on a storage read it did not before, not
churn to hide a problem.

Overlaps #1292 (H-10), which is in review and adds its own cascade to the same
two drop branches. Whichever lands second needs a mechanical rebase; the two
mechanisms are independent — one covers rows derived into the memories table,
this one covers rows derived into the graph.

## Verification

- Full root suite: **6077 passed, 5 skipped, 1 xfailed, 0 failed**.
- `core-storage-api/tests/`: **343 passed**, on its own scratch database.
- `ruff check` and `ruff format --check` run separately at CI's exact scopes — clean.
- `mypy` clean on both packages (`core-api` keeps its 2 pre-existing `types-python-dateutil` errors in an untouched file). The three new `rowcount` ignores match `memory_soft_delete_by_ids`' existing pattern.
- ratchet *No new lines.* · sentinel *All 35 protected strings survive.* · tenant-scope gate exit 0 · broker OpenAPI baseline current. All after `git add`.
- Checked for open PRs on this subsystem before starting; only #1292, noted above.
- Branched from `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
