### PR TITLE
feat(storage): add a repair sweep for un-provenanced embeddings

### DIFF
--- a/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
+++ b/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
@@ -265,6 +265,16 @@ async def _iter_rows(
     """
     from sqlalchemy import text
 
+    # Deferred like every other import in this module — the CLI keeps its
+    # startup light and avoids importing the service layer it deliberately
+    # does not depend on — but hoisted out of the pagination loop below, which
+    # would otherwise re-resolve it once per page.
+    #
+    # Imported rather than restated: the alert in core-operations counts the
+    # population this sweep repairs, and a second copy of the cutoff would let
+    # the two disagree about which rows are a defect.
+    from core_storage_api.services.postgres_service import PROVENANCE_REQUIRED_FROM
+
     after: uuid.UUID | None = None
     while True:
         params: dict = {"limit": batch_size}
@@ -315,10 +325,6 @@ async def _iter_rows(
                 # predate provenance entirely: repairing them is a provider
                 # spend decision about tens of thousands of rows, not a defect
                 # being cleaned up, so it takes an explicit flag.
-                from core_storage_api.services.postgres_service import (
-                    PROVENANCE_REQUIRED_FROM,
-                )
-
                 sql += "AND created_at >= :provenance_cutoff "
                 params["provenance_cutoff"] = PROVENANCE_REQUIRED_FROM
         else:
@@ -501,7 +507,7 @@ async def run_backfill(
 ) -> list[BackfillReport]:
     """Walk targeted rows and (re-)embed them according to the selected scan mode.
 
-    Two modes:
+    Three modes:
 
     - ``NULL_EMBEDDING`` (default): rows where ``embedding IS NULL``,
       embedded from ``content`` / ``canonical_name``. The

--- a/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
+++ b/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
@@ -14,7 +14,10 @@ backfill task in core-worker (see ``local_emb_res/specs/C-backfill-task-pr.md``)
 
 Idempotent and restartable: the WHERE clauses filter to rows with NULL
 embeddings, so a partial run can be resumed by simply re-running the
-command — already-embedded rows are skipped naturally.
+command — already-embedded rows are skipped naturally. ``--repair-provenance``
+is idempotent for the same reason: its own write flips
+``embedded_content_hash`` out of the selector. ``--rewrite-hint-prefixed`` is
+the exception, and says so at the point of use.
 
 ⚠ **Single-provider only — does NOT honour per-tenant embedding configs.**
 
@@ -65,6 +68,20 @@ Usage:
     python -m core_storage_api.scripts.backfill_embeddings \\
         --rewrite-hint-prefixed --tenant-id tenant-abc --dry-run
 
+    # Repair rows that carry a vector but record nothing about the text it
+    # came from. NO OTHER SWEEP CAN REACH THESE: every other backfill,
+    # core-worker's included, selects ``embedding IS NULL`` and these rows
+    # have one. Defaults to rows created after provenance existed, which is
+    # the population that should always be empty.
+    python -m core_storage_api.scripts.backfill_embeddings \\
+        --repair-provenance --dry-run
+
+    # Widen to rows predating migration 037: tens of thousands of them, one
+    # provider call each, undetermined rather than known-damaged. Size it
+    # with --dry-run before spending it.
+    python -m core_storage_api.scripts.backfill_embeddings \\
+        --repair-provenance --include-legacy --dry-run
+
 Scope:
 - ``memories.embedding`` — re-embedded from ``memories.content``, and
   ``memories.embedded_content_hash`` stamped in the same statement with the
@@ -95,6 +112,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import dataclasses
+import enum
 import logging
 import os
 import sys
@@ -112,6 +130,26 @@ logger = logging.getLogger(__name__)
 # rather than blipping. Better to halt and let the operator escalate
 # than to spend the next hour writing nothing.
 _MAX_CONSECUTIVE_NONES = 20
+
+
+class _ScanMode(enum.StrEnum):
+    """Which population a run targets. Exactly one, by construction.
+
+    A pair of booleans once the third mode arrived, and that admits a state
+    ("rewrite the hint prefix AND repair provenance") with no meaning and no
+    branch. The values double as the log and CLI spelling, which is what the
+    mode was already being rendered as by hand.
+    """
+
+    #: Rows with no vector. The post-migration-012 recovery path, and the
+    #: catch-all for any other source of missing embeddings.
+    NULL_EMBEDDING = "null-embedding"
+    #: Rows embedded under the pre-CAURA-222 hint-prefixed write path.
+    REWRITE_HINT_PREFIXED = "rewrite-hint-prefixed"
+    #: Rows carrying a vector that records nothing about the text it came
+    #: from. Invisible to every other sweep precisely because they HAVE an
+    #: embedding, which is what makes this mode the only way to reach them.
+    REPAIR_PROVENANCE = "repair-provenance"
 
 
 class _Provenance(NamedTuple):
@@ -194,7 +232,8 @@ async def _iter_rows(
     *,
     tenant_id: str | None,
     batch_size: int,
-    rewrite_hint_prefixed: bool,
+    mode: _ScanMode,
+    include_legacy: bool = False,
 ) -> AsyncIterator[list[tuple[uuid.UUID, str, str | None]]]:
     """Yield batches of (id, content, content_hash) for rows that need (re-)embedding.
 
@@ -204,15 +243,15 @@ async def _iter_rows(
     ``_embed_and_write`` for why the value must travel with the text rather
     than being re-read at write time.
 
-    Two scan modes:
-      - Default: rows where the embedding is NULL (post-12 backfill,
-        also covers any other source of missing vectors).
-      - ``rewrite_hint_prefixed=True``: rows whose stored vector was
-        produced under the pre-CAURA-222 hint-prefixed write path
-        (``"[Retrieval hint]: <hint>\\n\\n<content>"``). Selector is
-        ``embedding IS NOT NULL AND metadata_->>'retrieval_hint'`` is
-        non-empty. Only ``memories`` carries hint metadata; the
-        ``entities`` table is skipped at the call site.
+    Three scan modes, one selector each — see :class:`_ScanMode`.
+
+    ``REPAIR_PROVENANCE`` requires ``content_hash IS NOT NULL``, and that term
+    is load-bearing rather than tidy. The repair writes
+    ``embedded_content_hash`` FROM the row's ``content_hash``, so a row without
+    one is stamped NULL again and still matches the selector on the next run —
+    the sweep would re-embed it forever, spending a provider call each time to
+    change nothing. Every other mode is self-terminating because its own write
+    flips the row out of its predicate; this is the one that has to be told.
 
     Cursor-style pagination on ``id`` for stable resumability — the
     consumer's writes flip the row's match condition (NULL → non-NULL,
@@ -233,7 +272,7 @@ async def _iter_rows(
         if spec.provenance:
             selected += f", {spec.provenance.source_hash_column}"
         sql = f"SELECT {selected} FROM {spec.table} WHERE "
-        if rewrite_hint_prefixed:
+        if mode is _ScanMode.REWRITE_HINT_PREFIXED:
             # Rewrite mode: target rows that were embedded with the
             # pre-CAURA-222 hint prefix. The metadata key is preserved
             # as auditability ground truth — we use it as the selector
@@ -255,6 +294,33 @@ async def _iter_rows(
                 f"{spec.embedding_column} IS NOT NULL "
                 f"AND COALESCE({spec.metadata_column}->>'retrieval_hint', '') <> '' "
             )
+        elif mode is _ScanMode.REPAIR_PROVENANCE:
+            # Reachable by no other sweep: both embedding backfills and
+            # core-worker's event-driven task select ``embedding IS NULL``,
+            # and these rows have one. That is why 241 of them sat unrepaired
+            # for a week while three repair paths ran over the same table.
+            if spec.provenance is None:
+                raise ValueError(
+                    f"repair_provenance scan requires provenance columns on "
+                    f"_TableSpec.table={spec.table!r}; got provenance=None"
+                )
+            sql += (
+                f"{spec.embedding_column} IS NOT NULL "
+                f"AND {spec.provenance.stamp_column} IS NULL "
+                # Idempotency, not tidiness — see the docstring.
+                f"AND {spec.provenance.source_hash_column} IS NOT NULL "
+            )
+            if not include_legacy:
+                # Default to the population that should be empty. Older rows
+                # predate provenance entirely: repairing them is a provider
+                # spend decision about tens of thousands of rows, not a defect
+                # being cleaned up, so it takes an explicit flag.
+                from core_storage_api.services.postgres_service import (
+                    PROVENANCE_REQUIRED_FROM,
+                )
+
+                sql += "AND created_at >= :provenance_cutoff "
+                params["provenance_cutoff"] = PROVENANCE_REQUIRED_FROM
         else:
             sql += f"{spec.embedding_column} IS NULL "
         # Skip soft-deleted rows on tables that have ``deleted_at`` —
@@ -287,7 +353,8 @@ async def _backfill_one_table(
     batch_size: int,
     max_inflight: int,
     dry_run: bool,
-    rewrite_hint_prefixed: bool,
+    mode: _ScanMode,
+    include_legacy: bool = False,
 ) -> BackfillReport:
     from sqlalchemy import text
 
@@ -398,7 +465,8 @@ async def _backfill_one_table(
         spec,
         tenant_id=tenant_id,
         batch_size=batch_size,
-        rewrite_hint_prefixed=rewrite_hint_prefixed,
+        mode=mode,
+        include_legacy=include_legacy,
     ):
         scanned += len(batch)
         await asyncio.gather(*(_embed_and_write(rid, c, ch) for rid, c, ch in batch))
@@ -428,26 +496,44 @@ async def run_backfill(
     max_inflight: int,
     dry_run: bool,
     only_table: str | None = None,
-    rewrite_hint_prefixed: bool = False,
+    mode: _ScanMode = _ScanMode.NULL_EMBEDDING,
+    include_legacy: bool = False,
 ) -> list[BackfillReport]:
     """Walk targeted rows and (re-)embed them according to the selected scan mode.
 
     Two modes:
 
-    - Default (``rewrite_hint_prefixed=False``): scan rows where
-      ``embedding IS NULL`` and embed them from ``content`` /
-      ``canonical_name``. This is the post-migration-012 recovery
-      path for OSS docker-compose users, and also covers any other
-      source of missing vectors (failed inline embeds, etc.).
+    - ``NULL_EMBEDDING`` (default): rows where ``embedding IS NULL``,
+      embedded from ``content`` / ``canonical_name``. The
+      post-migration-012 recovery path, and the catch-all for any other
+      source of missing vectors.
 
-    - Hint-prefixed rewrite (``rewrite_hint_prefixed=True``): scan
-      rows where ``embedding IS NOT NULL`` AND
-      ``metadata.retrieval_hint`` is non-empty — rows written under
-      the pre-CAURA-222 hint-prefixed write path — and re-embed them
-      from raw ``content`` to align with the search-side surface.
-      One-off recall recovery after CAURA-222 has deployed; new
-      writes already land on the raw-content surface. Entities are
-      skipped in this mode (no hint metadata exists there).
+    - ``REWRITE_HINT_PREFIXED``: rows where ``embedding IS NOT NULL`` AND
+      ``metadata.retrieval_hint`` is non-empty — written under the
+      pre-CAURA-222 hint-prefixed path — re-embedded from raw ``content``
+      to match the search-side surface. Entities are skipped (no hint
+      metadata there).
+
+    - ``REPAIR_PROVENANCE``: rows carrying a vector that records nothing
+      about the text it came from. **The only sweep that can see them.**
+      The other two, and core-worker's event-driven backfill, all select
+      ``embedding IS NULL``; these rows have an embedding, which is why 241
+      of them sat unrepaired for a week in 2026-09 while three separate
+      repair paths ran over the same table.
+
+      The repair is a genuine re-embed, never a stamp. Writing
+      ``embedded_content_hash = content_hash`` here would assert that the
+      EXISTING vector describes the current text — which is exactly what
+      nothing knows, because that is the state being repaired. It happened
+      to be true for those 241 rows (each verified first against a
+      recomputed hash) and is not true in general; a wrong hash reads
+      downstream as verified freshness, worse than the NULL it replaced.
+      Re-embedding makes the assertion true rather than assuming it.
+
+      ``include_legacy`` widens the scan past ``PROVENANCE_REQUIRED_FROM``
+      to rows predating provenance entirely. Off by default: those are
+      undetermined rather than damaged, there are tens of thousands of
+      them, and each costs a provider call.
 
     Returns one ``BackfillReport`` per table processed.
 
@@ -465,7 +551,16 @@ async def run_backfill(
     for spec in _TARGETS:
         if only_table is not None and spec.table != only_table:
             continue
-        if rewrite_hint_prefixed and spec.table != "memories":
+        if mode is _ScanMode.REPAIR_PROVENANCE and spec.provenance is None:
+            # Nothing to repair where nothing can be recorded: migration 037
+            # gave ``embedded_content_hash`` to ``memories`` alone. Skipped
+            # rather than raised so the CLI stays one command over both tables.
+            logger.info(
+                "backfill[%s] skipped under --repair-provenance (table records no provenance)",
+                spec.table,
+            )
+            continue
+        if mode is _ScanMode.REWRITE_HINT_PREFIXED and spec.table != "memories":
             # Only memories carry ``metadata.retrieval_hint``; skip
             # other tables silently to keep the CLI a single command.
             logger.info(
@@ -480,7 +575,7 @@ async def run_backfill(
             batch_size,
             max_inflight,
             dry_run,
-            "rewrite-hint-prefixed" if rewrite_hint_prefixed else "null-embedding",
+            mode.value,
         )
         report = await _backfill_one_table(
             engine,
@@ -489,7 +584,8 @@ async def run_backfill(
             batch_size=batch_size,
             max_inflight=max_inflight,
             dry_run=dry_run,
-            rewrite_hint_prefixed=rewrite_hint_prefixed,
+            mode=mode,
+            include_legacy=include_legacy,
         )
         reports.append(report)
         logger.info(
@@ -535,7 +631,8 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Count rows that would be re-embedded; don't call the embedding provider or write to the DB.",
     )
-    p.add_argument(
+    modes = p.add_mutually_exclusive_group()
+    modes.add_argument(
         "--rewrite-hint-prefixed",
         action="store_true",
         help=(
@@ -546,6 +643,32 @@ def _build_parser() -> argparse.ArgumentParser:
             "the CAURA-222 fix has deployed to recover recall on existing "
             "rows. Combine with --tenant-id and --dry-run for a phased "
             "rollout."
+        ),
+    )
+    modes.add_argument(
+        "--repair-provenance",
+        action="store_true",
+        help=(
+            "Re-embed memories that carry a vector but record nothing about "
+            "the text it came from (embedding IS NOT NULL AND "
+            "embedded_content_hash IS NULL). No other sweep can reach these "
+            "rows: every other backfill selects embedding IS NULL and these "
+            "have one. Entities are skipped (no provenance columns). Rows with "
+            "no content_hash are skipped too — there is nothing to record for "
+            "them, and including them would re-embed the same rows on every "
+            "run forever. Defaults to rows created after provenance existed; "
+            "see --include-legacy."
+        ),
+    )
+    p.add_argument(
+        "--include-legacy",
+        action="store_true",
+        help=(
+            "With --repair-provenance, also scan rows predating migration 037 "
+            "(2026-08-16). Those are undetermined rather than damaged, there "
+            "are tens of thousands of them, and each costs a provider call to "
+            "re-embed — so widening the scan is a spend decision. Size it with "
+            "--dry-run first."
         ),
     )
     p.add_argument(
@@ -584,6 +707,33 @@ async def _amain(argv: list[str]) -> int:
     # so an operator who re-invokes the command doesn't silently burn
     # provider quota on a no-op rewrite. Dry-run is fine — no provider
     # call, no DB write.
+    if args.rewrite_hint_prefixed:
+        mode = _ScanMode.REWRITE_HINT_PREFIXED
+    elif args.repair_provenance:
+        mode = _ScanMode.REPAIR_PROVENANCE
+    else:
+        mode = _ScanMode.NULL_EMBEDDING
+
+    if args.include_legacy and mode is not _ScanMode.REPAIR_PROVENANCE:
+        # Ignoring it silently would let an operator believe they had widened
+        # a scan that never reads the flag.
+        logger.error("--include-legacy only applies to --repair-provenance")
+        return 1
+
+    # Widening past migration 037 is a spend decision, not a bug fix: those
+    # rows are undetermined rather than damaged, there are tens of thousands
+    # of them, and each costs a provider call. Say so before spending it.
+    if args.repair_provenance and args.include_legacy and not args.dry_run:
+        print(
+            "WARNING: --include-legacy re-embeds rows that predate provenance "
+            "(migration 037, 2026-08-16). These are UNDETERMINED, not known to "
+            "be damaged, and there are tens of thousands of them — one provider "
+            "call each. Run with --dry-run first to size it.",
+            file=sys.stderr,
+        )
+        print("Starting in 5 s — press Ctrl-C to abort.", file=sys.stderr)
+        await asyncio.sleep(5)
+
     if args.rewrite_hint_prefixed and not args.dry_run:
         print(
             "WARNING: --rewrite-hint-prefixed is NOT idempotent. "
@@ -608,7 +758,8 @@ async def _amain(argv: list[str]) -> int:
             max_inflight=args.max_inflight,
             dry_run=args.dry_run,
             only_table=args.only_table,
-            rewrite_hint_prefixed=args.rewrite_hint_prefixed,
+            mode=mode,
+            include_legacy=args.include_legacy,
         )
     except RuntimeError as e:
         # Reserved for the "degraded provider" abort path (20 consecutive

--- a/core-storage-api/tests/test_backfill_embeddings_provenance.py
+++ b/core-storage-api/tests/test_backfill_embeddings_provenance.py
@@ -105,7 +105,7 @@ def _patch_embedding(monkeypatch, *, on_call=None):
     monkeypatch.setattr(common.embedding, "get_embedding", _fake)
 
 
-async def _run(engine, spec, tenant_id, *, rewrite_hint_prefixed: bool = False):
+async def _run(engine, spec, tenant_id, *, mode: bf._ScanMode = bf._ScanMode.NULL_EMBEDDING):
     return await bf._backfill_one_table(
         engine,
         spec,
@@ -113,7 +113,7 @@ async def _run(engine, spec, tenant_id, *, rewrite_hint_prefixed: bool = False):
         batch_size=100,
         max_inflight=4,
         dry_run=False,
-        rewrite_hint_prefixed=rewrite_hint_prefixed,
+        mode=mode,
     )
 
 
@@ -301,7 +301,7 @@ async def test_hint_rewrite_replaces_stale_provenance(engine, tenant_id, monkeyp
         )
         await conn.commit()
 
-    report = await _run(engine, _memories_spec(), tenant_id, rewrite_hint_prefixed=True)
+    report = await _run(engine, _memories_spec(), tenant_id, mode=bf._ScanMode.REWRITE_HINT_PREFIXED)
 
     assert report.embedded == 1, "hint-rewrite mode did not select the seeded row"
     _has_emb, _content_hash, provenance = await _read_memory(engine, mid)
@@ -409,3 +409,225 @@ def test_predicate_string_is_derived_from_the_constant():
         "created_at >=",
     ):
         assert term in ps.MISSING_PROVENANCE_PREDICATE_SQL, f"predicate omits {term!r}"
+
+
+# ---------------------------------------------------------------------------
+# --repair-provenance: the only sweep that can see these rows
+# ---------------------------------------------------------------------------
+
+
+async def _seed_embedded(
+    engine,
+    tenant_id: str,
+    *,
+    content: str,
+    content_hash: str | None,
+    created_at,
+    stamp: str | None = None,
+) -> uuid.UUID:
+    """A row that already carries a vector — the population under repair."""
+    mid = uuid.uuid4()
+    async with engine.connect() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO memories (id, tenant_id, agent_id, memory_type, content, "
+                " content_hash, embedded_content_hash, embedding, created_at) "
+                "VALUES (:id, :t, 'agent-bf', 'fact', :c, :ch, :stamp, (:emb)::vector, :ts)"
+            ),
+            {
+                "id": mid,
+                "t": tenant_id,
+                "c": content,
+                "ch": content_hash,
+                "stamp": stamp,
+                "emb": str([0.9] * VECTOR_DIM_FAKE),
+                "ts": created_at,
+            },
+        )
+        await conn.commit()
+    return mid
+
+
+@pytest.mark.integration
+async def test_repair_provenance_reaches_rows_no_other_sweep_can(engine, monkeypatch):
+    """The point of the mode: these rows are invisible to every other scan.
+
+    Both embedding backfills and core-worker's event-driven task select
+    ``embedding IS NULL``. These rows HAVE an embedding, which is exactly why
+    241 of them sat unrepaired for a week while three separate repair paths ran
+    over the same table.
+    """
+    from datetime import UTC, datetime
+
+    _patch_embedding(monkeypatch)
+    t = f"test-repair-{uuid.uuid4().hex[:8]}"
+    ch = "a" * 64
+    mid = await _seed_embedded(
+        engine, t, content="body", content_hash=ch, created_at=datetime(2026, 9, 1, tzinfo=UTC)
+    )
+
+    # The default mode cannot see it — that is the gap being closed.
+    before = await _run(engine, _memories_spec(), t)
+    assert before.scanned == 0, "default mode should not match an already-embedded row"
+
+    report = await _run(engine, _memories_spec(), t, mode=bf._ScanMode.REPAIR_PROVENANCE)
+
+    assert report.embedded == 1
+    _has_emb, content_hash, provenance = await _read_memory(engine, mid)
+    assert provenance == ch
+    assert provenance == content_hash
+
+
+@pytest.mark.integration
+async def test_repair_provenance_is_idempotent(engine, monkeypatch):
+    """A second pass must find nothing.
+
+    The repair flips ``embedded_content_hash`` from NULL to non-NULL, which
+    takes the row out of its own selector. Worth pinning: the hint-rewrite mode
+    next door is deliberately NOT idempotent, so "re-running is safe" is not a
+    property this file can assume.
+    """
+    from datetime import UTC, datetime
+
+    _patch_embedding(monkeypatch)
+    t = f"test-repair-idem-{uuid.uuid4().hex[:8]}"
+    await _seed_embedded(
+        engine, t, content="body", content_hash="b" * 64, created_at=datetime(2026, 9, 1, tzinfo=UTC)
+    )
+
+    first = await _run(engine, _memories_spec(), t, mode=bf._ScanMode.REPAIR_PROVENANCE)
+    second = await _run(engine, _memories_spec(), t, mode=bf._ScanMode.REPAIR_PROVENANCE)
+
+    assert first.embedded == 1
+    assert second.scanned == 0, "the repair did not take the row out of its own selector"
+
+
+@pytest.mark.integration
+async def test_repair_provenance_skips_rows_with_no_content_hash(engine, monkeypatch):
+    """A row with nothing to attest to must not be scanned at all.
+
+    Not a tidiness filter — an infinite-work guard. The repair stamps
+    ``embedded_content_hash`` FROM ``content_hash``, so a row without one is
+    stamped NULL again and still matches the selector. Including it would spend
+    one provider call per row per run, forever, changing nothing.
+    """
+    from datetime import UTC, datetime
+
+    _patch_embedding(monkeypatch)
+    t = f"test-repair-nohash-{uuid.uuid4().hex[:8]}"
+    await _seed_embedded(
+        engine, t, content="body", content_hash=None, created_at=datetime(2026, 9, 1, tzinfo=UTC)
+    )
+
+    report = await _run(engine, _memories_spec(), t, mode=bf._ScanMode.REPAIR_PROVENANCE)
+
+    assert report.scanned == 0, (
+        "a row with no content_hash was scanned; the repair cannot make progress "
+        "on it, so every run would re-embed it and change nothing"
+    )
+
+
+@pytest.mark.integration
+async def test_repair_provenance_leaves_legacy_rows_alone_by_default(engine, monkeypatch):
+    """Pre-037 rows cost money and are not known to be damaged.
+
+    ``unknown_provenance`` holds tens of thousands of them. Sweeping them by
+    default would turn a defect cleanup into an unbounded provider spend that
+    nobody approved, so the default scan stops at the cutoff and
+    ``--include-legacy`` opts in.
+    """
+    from datetime import UTC, datetime
+
+    _patch_embedding(monkeypatch)
+    t = f"test-repair-legacy-{uuid.uuid4().hex[:8]}"
+    legacy = await _seed_embedded(
+        engine, t, content="old", content_hash="c" * 64, created_at=datetime(2026, 8, 1, tzinfo=UTC)
+    )
+
+    default_run = await _run(engine, _memories_spec(), t, mode=bf._ScanMode.REPAIR_PROVENANCE)
+    assert default_run.scanned == 0, "a pre-037 row was swept without --include-legacy"
+    _e, _ch, provenance = await _read_memory(engine, legacy)
+    assert provenance is None
+
+    widened = await bf._backfill_one_table(
+        engine,
+        _memories_spec(),
+        tenant_id=t,
+        batch_size=100,
+        max_inflight=4,
+        dry_run=False,
+        mode=bf._ScanMode.REPAIR_PROVENANCE,
+        include_legacy=True,
+    )
+    assert widened.embedded == 1
+    _e2, _ch2, provenance2 = await _read_memory(engine, legacy)
+    assert provenance2 == "c" * 64
+
+
+@pytest.mark.integration
+async def test_repair_provenance_re_embeds_rather_than_stamping(engine, monkeypatch):
+    """The vector must be recomputed, not just attested.
+
+    Stamping ``embedded_content_hash = content_hash`` on the existing vector
+    would assert that vector describes the current text — which is precisely
+    what nothing knows here, since that is the state being repaired. It happened
+    to hold for the 241 production rows (each verified first against a
+    recomputed hash) and does not hold in general; a wrong hash reads downstream
+    as verified freshness, worse than the NULL it replaced.
+
+    The seeded vector is all 0.9 and the provider returns all 0.125, so a
+    changed vector proves a real embed rather than a bare UPDATE of the hash.
+    """
+    from datetime import UTC, datetime
+
+    _patch_embedding(monkeypatch)
+    t = f"test-repair-reembed-{uuid.uuid4().hex[:8]}"
+    mid = await _seed_embedded(
+        engine, t, content="body", content_hash="d" * 64, created_at=datetime(2026, 9, 1, tzinfo=UTC)
+    )
+
+    await _run(engine, _memories_spec(), t, mode=bf._ScanMode.REPAIR_PROVENANCE)
+
+    async with engine.connect() as conn:
+        vec = (
+            await conn.execute(text("SELECT embedding::text FROM memories WHERE id = :id"), {"id": mid})
+        ).scalar()
+    assert vec is not None
+    assert vec.startswith("[0.125"), (
+        "the stored vector was not recomputed; the repair stamped provenance onto "
+        "whatever was already there, asserting a freshness it never verified"
+    )
+
+
+@pytest.mark.integration
+async def test_repair_provenance_drives_the_alert_metric_to_zero(engine, monkeypatch):
+    """End to end: the sweep empties the bucket the alert fires on.
+
+    Asserted through ``memory_embedding_coverage_for_tenant`` rather than a
+    hand-written predicate, so this fails if the sweep regresses OR if the
+    metric stops measuring the population the sweep targets. Those two must
+    agree, and nothing but this ties them together.
+    """
+    from datetime import UTC, datetime
+
+    from core_storage_api.services.postgres_service import PostgresService
+
+    _patch_embedding(monkeypatch)
+    t = f"test-repair-metric-{uuid.uuid4().hex[:8]}"
+    for i in range(3):
+        await _seed_embedded(
+            engine,
+            t,
+            content=f"body-{i}",
+            content_hash=f"{i}" * 64,
+            created_at=datetime(2026, 9, 1, tzinfo=UTC),
+        )
+
+    svc = PostgresService()
+    *_, before = await svc.memory_embedding_coverage_for_tenant(t)
+    assert before == 3, "fixture did not create the alertable population"
+
+    await _run(engine, _memories_spec(), t, mode=bf._ScanMode.REPAIR_PROVENANCE)
+
+    *_, after = await svc.memory_embedding_coverage_for_tenant(t)
+    assert after == 0, f"sweep left {after} row(s) in the population the alert fires on"

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -345,7 +345,7 @@ async def test_rewrite_hint_prefixed_targets_memories_with_hint_metadata(
     """--rewrite-hint-prefixed scans rows where embedding IS NOT NULL
     and metadata.retrieval_hint is non-empty. The default mode's
     embedding-IS-NULL filter must NOT appear in this scan."""
-    from core_storage_api.scripts.backfill_embeddings import run_backfill
+    from core_storage_api.scripts.backfill_embeddings import _ScanMode, run_backfill
 
     rows = {
         "from memories": [
@@ -362,7 +362,7 @@ async def test_rewrite_hint_prefixed_targets_memories_with_hint_metadata(
         batch_size=500,
         max_inflight=10,
         dry_run=False,
-        rewrite_hint_prefixed=True,
+        mode=_ScanMode.REWRITE_HINT_PREFIXED,
     )
 
     by_table = {r.table: r for r in reports}
@@ -408,7 +408,7 @@ async def test_rewrite_hint_prefixed_skips_entities(
     """Entities don't carry retrieval_hint metadata, so the hint-rewrite
     mode skips them — even if rows exist on that table, they shouldn't
     produce a report or burn embed calls."""
-    from core_storage_api.scripts.backfill_embeddings import run_backfill
+    from core_storage_api.scripts.backfill_embeddings import _ScanMode, run_backfill
 
     rows = {
         "from memories": [(uuid.uuid4(), "memory with hint", "h-hint")],
@@ -424,7 +424,7 @@ async def test_rewrite_hint_prefixed_skips_entities(
         batch_size=500,
         max_inflight=10,
         dry_run=False,
-        rewrite_hint_prefixed=True,
+        mode=_ScanMode.REWRITE_HINT_PREFIXED,
     )
 
     by_table = {r.table: r for r in reports}
@@ -643,6 +643,7 @@ async def test_provenance_rides_the_same_update_as_the_vector(
     from core_storage_api.scripts.backfill_embeddings import (
         _TARGETS,
         _backfill_one_table,
+        _ScanMode,
     )
 
     rows = {"from memories": [(uuid.uuid4(), "content", "the-hash")]}
@@ -658,7 +659,7 @@ async def test_provenance_rides_the_same_update_as_the_vector(
         batch_size=10,
         max_inflight=1,
         dry_run=False,
-        rewrite_hint_prefixed=False,
+        mode=_ScanMode.NULL_EMBEDDING,
     )
 
     updates = [s for s in captured_sql if s.lower().startswith("update")]


### PR DESCRIPTION
## The gap this closes

Rows with `embedding IS NOT NULL AND embedded_content_hash IS NULL` were
reachable by nothing. Every existing repair path — both modes of this CLI, and
core-worker's event-driven task — selects `embedding IS NULL`, and these rows
**have** an embedding. That is why 241 of them sat unrepaired for a week in
2026-09 while three separate repair paths ran over the same table.

#1281 and #1289 stopped the writers producing them. #1294 made them visible.
This is the part that gets them back.

## Re-embed, not stamp

The cheap repair is `SET embedded_content_hash = content_hash`. **It is not
correct**, and the distinction is the whole design.

That statement asserts the vector already on the row describes the row's
current text — which is exactly what nothing here knows, because that is the
state being repaired. It happened to hold for the 241 production rows, each
verified first against a recomputed `sha256(tenant_id || ':' ||
coalesce(fleet_id,'') || ':' || content)`, and it does not hold in general. A
wrong hash reads downstream as verified freshness, which is worse than the NULL
it replaced.

So the sweep re-embeds and stamps the hash read alongside that content — making
the assertion true rather than assuming it. `test_repair_provenance_re_embeds_
rather_than_stamping` seeds a `0.9` vector and asserts a `0.125` one afterwards,
so a stamp-only implementation cannot pass.

## Three scope terms, each load-bearing

- **`content_hash IS NOT NULL`** — an infinite-work guard, not tidiness. The
  repair stamps *from* `content_hash`, so a row without one is stamped NULL
  again and still matches the selector: one provider call per row per run,
  forever, changing nothing. Every other mode is self-terminating because its
  own write flips the row out of its predicate; this one has to be told.
- **`created_at >= PROVENANCE_REQUIRED_FROM`** by default — imported from
  core-storage-api rather than restated, so the sweep and #1294's alert cannot
  disagree about which population is a defect. `--include-legacy` widens to the
  ~95k pre-037 rows behind an explicit flag, a warning and a 5s pause: those are
  undetermined rather than damaged, and one provider call each makes it a spend
  decision rather than a bug fix.
- **Entities skipped** — migration 037 gave `embedded_content_hash` to
  `memories` alone.

## Why no index

Migration 037's partial index carries `AND embedded_content_hash IS NOT NULL`,
so it deliberately **excludes** this population. I did not add one:

- Pagination is `ORDER BY id` with `id > :after`, which walks the primary key
  and filters rather than re-scanning per page — adequate for an operator-run,
  resumable batch job.
- An index for a population that should be *permanently empty* is a cost paid on
  every write forever, in exchange for speed on a job that should find nothing.
- If the legacy sweep is ever run at scale, the index belongs with **that**
  decision, sized against that population, rather than shipped ahead of it.

Happy to add it if you'd rather; it is a migration plus a `CONCURRENTLY` build.

## The mode flags became an enum

Three mutually exclusive modes on two booleans admits a state ("rewrite the hint
prefix AND repair provenance") with no meaning and no branch — the same shape as
the `_Provenance` pair in #1289. The code was already rendering the mode as one
of these exact strings by hand, so `_ScanMode` is what it was half-expressing.
argparse enforces the same exclusivity at the CLI.

## Verification

Each guard reverted independently:

| Revert | Fails |
|---|---|
| Drop `content_hash IS NOT NULL` | the idempotency test |
| Drop the `created_at` bound | the legacy test |
| Replace re-embed with a bare stamp | **10 of 14**, including the one written for it |

Plus an end-to-end dry run against a seeded database, and CLI smoke tests
covering both rejections (`--repair-provenance --rewrite-hint-prefixed`, and
`--include-legacy` without its mode).

core-storage-api **339 → 346**. core-operations 55, unchanged.

**On the root suite** — a note worth having. My stored baseline was captured
hours ago against an older main on a database since deleted, and it is no longer
a comparator: it disagreed with itself twice. I re-ran both arms in one session,
pristine database each, and diffed by name:

```
origin/main : 26 failed, 13 errored
my branch   : 19 failed, 13 errored
FAILURES introduced: NONE      ERRORS introduced: NONE
```

Fewer failures on my branch only because `test_mcp_plan_limit_observation.py`
happens to be unstable and landed differently on the two arms.

Separately, `test_h06_m30_recall_identity.py::test_recall_honours_caller_agent_
id_as_the_visibility_identity` is **flaky**: 1 failure in 5 identical runs, same
code, pristine database each. I twice reached a confident wrong conclusion about
it — first "environmental", then "mine" — before running arms that were actually
comparable. Worth its own issue; it is not touched here.

Not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
