### PR TITLE
docs(env): add JWT_SECRET and SETTINGS_ENCRYPTION_KEY to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -225,6 +225,24 @@ CRYSTALLIZER_ENABLED=true
 CRYSTALLIZER_STALE_DAYS=180
 CRYSTALLIZER_DEDUP_THRESHOLD=0.95
 
+# -- Security (required in production) ---------------------------------------
+# Both are declared in core-api/src/core_api/config.py with insecure defaults,
+# and _validate_startup_settings refuses to boot a non-standalone production
+# environment without them:
+#
+#   SETTINGS_ENCRYPTION_KEY unset  ->  "SETTINGS_ENCRYPTION_KEY must be set"
+#   JWT_SECRET left at the default ->  "JWT_SECRET must be changed"
+#
+# Leaving them out of this file is what makes that a surprise at deploy time
+# rather than a decision at copy time.
+#
+# SETTINGS_ENCRYPTION_KEY is a Fernet key. Generate one with:
+#     python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+SETTINGS_ENCRYPTION_KEY=
+# JWT_SECRET signs API tokens. Any long random string; generate one with:
+#     python -c "import secrets; print(secrets.token_urlsafe(64))"
+JWT_SECRET=change-me-in-production
+
 # -- CORS -------------------------------------------------------------------
 CORS_ORIGINS=http://localhost:3000
 


### PR DESCRIPTION
## Summary

Adds the two variables `_validate_startup_settings` refuses to boot production without. Both are declared in `core-api/src/core_api/config.py` with insecure defaults and neither appeared in `.env.example`, so copying that file gave no signal either existed.

## Related Issue

Closes #717

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

No code path changes; `.env.example` is not read by the test suite. Checked against the guard in `core-api/src/core_api/app.py:142-162` and the cases in `tests/test_production_startup_guards.py`.

## Additional Notes

`JWT_SECRET` is written as the literal default rather than left empty on purpose. The guard is `if val == bad_val` against `"change-me-in-production"`, so an empty `JWT_SECRET=` would pass it and boot production with an empty signing secret. `SETTINGS_ENCRYPTION_KEY` is empty because its own guard is `if not app_settings.settings_encryption_key`, which an empty value trips correctly.

That asymmetry may itself be worth a look — an operator who deletes the value rather than replacing it currently gets past the JWT check — but that is a behaviour change and not this PR.

`CHANGELOG.md` is left alone: it is generated by release-please from the commit subject.