### PR TITLE
test(recall): stop the identity fixture drawing its own retrievability

### DIFF
--- a/tests/test_h06_m30_recall_identity.py
+++ b/tests/test_h06_m30_recall_identity.py
@@ -101,9 +101,22 @@ async def _write_private(client, headers, tenant_id, *, content, agent_id, fleet
 
 
 async def _setup(client, sc):
-    """Peer B holds a private memory; attacker A is trust-1 in another fleet."""
+    """Peer B holds a private memory; attacker A is trust-1 in another fleet.
+
+    Returns the seeded content as the query, NOT the bare nonce. Under the fake
+    embedding provider a vector is the sum of its words' hashes, so a one-word
+    query against six-word content scores a fresh random cosine on every
+    ``uuid4()`` — spanning -0.25 to 0.73, with 35% of draws below the 0.3
+    relevance floor. That made the row unretrievable at random and the parity
+    test below a coin flip (#1301). Querying the whole content pins the cosine
+    at 1.0; the nonce still isolates the row within the shared tenant.
+
+    These tests are about WHO may read a row, so retrieval must not be the
+    variable. Anything asserting a rank or a floor belongs in a search test.
+    """
     tenant_id, headers = get_test_auth()
     nonce = f"h06-{uuid.uuid4().hex}"
+    content = f"{nonce} peer B private scope_agent memory"
     peer = f"peer-b-{_uid()}"
     attacker = f"agent-a-{_uid()}"
     await _seed_agent(sc, tenant_id, peer, fleet_id=f"fleet-f2-{_uid()}", trust=3)
@@ -112,11 +125,11 @@ async def _setup(client, sc):
         client,
         headers,
         tenant_id,
-        content=f"{nonce} peer B private scope_agent memory",
+        content=content,
         agent_id=peer,
         fleet_id=None,
     )
-    return tenant_id, headers, nonce, peer, attacker
+    return tenant_id, headers, content, peer, attacker
 
 
 # ---------------------------------------------------------------------------
@@ -132,12 +145,12 @@ async def test_recall_refuses_a_filter_agent_id_that_is_not_the_caller(
     Agent A names peer B. Pre-fix that made B the visibility identity, so B's
     ``scope_agent`` content came back to A.
     """
-    tenant_id, _, nonce, peer, attacker = await _setup(client, sc)
+    tenant_id, _, query, peer, attacker = await _setup(client, sc)
     as_auth(tenant_id, attacker)
 
     resp = await client.post(
         "/api/v1/recall",
-        json={"tenant_id": tenant_id, "query": nonce, "filter_agent_id": peer},
+        json={"tenant_id": tenant_id, "query": query, "filter_agent_id": peer},
     )
     assert resp.status_code == 403, (
         f"recall let an agent name a peer; body={resp.text[:400]}"
@@ -157,12 +170,12 @@ async def test_recall_refuses_a_caller_agent_id_that_is_not_the_caller(
     ``filter_agent_id`` would have left the hole open under a different field
     name. Fails without the fix.
     """
-    tenant_id, _, nonce, peer, attacker = await _setup(client, sc)
+    tenant_id, _, query, peer, attacker = await _setup(client, sc)
     as_auth(tenant_id, attacker)
 
     resp = await client.post(
         "/api/v1/recall",
-        json={"tenant_id": tenant_id, "query": nonce, "caller_agent_id": peer},
+        json={"tenant_id": tenant_id, "query": query, "caller_agent_id": peer},
     )
     assert resp.status_code == 403, resp.text
     assert "does not match the authenticated agent identity" in resp.text
@@ -170,12 +183,12 @@ async def test_recall_refuses_a_caller_agent_id_that_is_not_the_caller(
 
 async def test_recall_allows_an_agent_naming_itself(client, sc, as_auth):
     """The gate must not over-refuse: naming yourself is the normal case."""
-    tenant_id, _, nonce, _peer, attacker = await _setup(client, sc)
+    tenant_id, _, query, _peer, attacker = await _setup(client, sc)
     as_auth(tenant_id, attacker)
 
     resp = await client.post(
         "/api/v1/recall",
-        json={"tenant_id": tenant_id, "query": nonce, "filter_agent_id": attacker},
+        json={"tenant_id": tenant_id, "query": query, "filter_agent_id": attacker},
     )
     assert resp.status_code == 200, resp.text
 
@@ -186,12 +199,12 @@ async def test_recall_tenant_key_may_still_name_any_agent(client, sc, as_auth):
     Pins the scope of the guard. Closing the hole by refusing every named agent
     would break the dashboard and every tenant-key integration.
     """
-    tenant_id, _, nonce, peer, _attacker = await _setup(client, sc)
+    tenant_id, _, query, peer, _attacker = await _setup(client, sc)
     as_auth(tenant_id, None)  # tenant-scoped: no agent identity
 
     resp = await client.post(
         "/api/v1/recall",
-        json={"tenant_id": tenant_id, "query": nonce, "filter_agent_id": peer},
+        json={"tenant_id": tenant_id, "query": query, "filter_agent_id": peer},
     )
     assert resp.status_code == 200, resp.text
 
@@ -230,7 +243,7 @@ async def test_recall_binds_an_omitted_filter_to_the_authenticated_agent(
     # call happened to leave. #995 patched this seam for this reason.
     from core_api.services import memory_service
 
-    tenant_id, _, nonce, _peer, attacker = await _setup(client, sc)
+    tenant_id, _, query, _peer, attacker = await _setup(client, sc)
     as_auth(tenant_id, attacker)
 
     seen: dict = {}
@@ -243,7 +256,7 @@ async def test_recall_binds_an_omitted_filter_to_the_authenticated_agent(
 
     resp = await client.post(
         "/api/v1/recall",
-        json={"tenant_id": tenant_id, "query": nonce},  # no filter, no caller
+        json={"tenant_id": tenant_id, "query": query},  # no filter, no caller
     )
     assert resp.status_code == 200, resp.text
     assert seen, "search_memories was never reached — test is vacuous"
@@ -277,10 +290,10 @@ async def test_recall_honours_caller_agent_id_as_the_visibility_identity(
     hardcoded expectation, so the test states the contract the findings are
     actually about.
     """
-    tenant_id, _headers, nonce, peer, _attacker = await _setup(client, sc)
+    tenant_id, _headers, query, peer, _attacker = await _setup(client, sc)
     as_auth(tenant_id, None)
 
-    body = {"tenant_id": tenant_id, "query": nonce, "caller_agent_id": peer}
+    body = {"tenant_id": tenant_id, "query": query, "caller_agent_id": peer}
 
     search = await client.post("/api/v1/search", json=body)
     assert search.status_code == 200, search.text


### PR DESCRIPTION
Fixes #1301.

`test_recall_honours_caller_agent_id_as_the_visibility_identity` failed **6 of 10 runs when run
on its own**, on unchanged `main`, pristine database each time. The fixture decided the outcome,
not the route.

## The cause

`_setup` seeded six-word content and queried one word of it:

```python
nonce   = f"h06-{uuid.uuid4().hex}"                      # the query
content = f"{nonce} peer B private scope_agent memory"   # the row
```

`FakeEmbeddingProvider` sums a **per-word** hash vector, so the cosine between a one-word query
and that content is a fresh draw on every `uuid4()`. Over 2000 nonces:

| min | p05 | median | p95 | max | σ |
|---|---|---|---|---|---|
| −0.248 | 0.081 | 0.361 | 0.581 | 0.727 | 0.150 |

`MIN_SEARCH_SIMILARITY = 0.3`, so **35% of draws put the row under the relevance floor**, where
`post_filter_results` dropped it. The captured log shows storage returning it and the floor
taking it away: `scored-search row_count: 1` → `memory-search row_count: 0`.

Confirmed by pinning four nonces around the floor and running them together:

| cosine | −0.033 | +0.284 | +0.317 | +0.660 |
|---|---|---|---|---|
| | **FAIL** | **FAIL** | pass | pass |

The split is exactly `MIN_SEARCH_SIMILARITY`. Repeated, the outer two are 3/3 fail and 3/3 pass —
a pinned nonce is fully deterministic, so the draw is the only variance.

## The fix

Query the whole seeded content. Cosine is 1.0 by construction; the nonce still isolates the row
inside the shared `default` tenant, so nothing these tests assert changes. They are about **who
may read a row** — retrieval should never have been a variable in them.

Every query site moves, not only the failing one. The negative assertion the file carries against
a possible future 200-with-filtering behaviour ("must still not surface the peer's private row")
was vacuous on the same 35% of runs: a row under the floor is absent whether the gate works or
not. The 403 detail carries only agent ids, never the query, so passing the content as the query
cannot satisfy those assertions by echo — verified by running the file.

## Verification

- **0/15** failures on the exact condition that failed 6/10. If the draw were still live, 0.65¹⁵ ≈ 0.16%.
- **12/12** across this file and its H-05 sibling, which uses the same fixture shape.
- **Still catches the defect it guards.** Reverting the `/recall` call site to the pre-fix
  `eff_agent_id = body.filter_agent_id` fails it on the parity claim rather than the vacuity
  guard: `/recall dropped caller_agent_id: same body, different rows. search=['ab69f265-…'] recall=[]`.
  Three H-06 spoof tests go red with it, as they should.
- `ruff check tests/` clean.

## Scope note

This never turned CI red — 0 failures in the 30 CI runs whose head commit contains the test (the
one red in that window failed on Ruff). The rate falls as more of the suite runs first: 6/10
alone, 2/10 for the file, 0/30 for the full suite. **I did not establish what suppresses it in
the full suite** — most likely an earlier test setting a tenant-level `min_similarity` on
`default`, which moves both the floor and the FTS bypass. #1301 records that as open. It is worth
someone's attention separately, because CI's green here currently depends on whatever it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
