### PR TITLE
fix(health): give the storage probe a budget bigger than one connect

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -18,6 +18,7 @@ from common.storage_auth import is_storage_shared_secret_rejection
 from core_api.clients.identity_token import evict as _evict_id_token
 from core_api.clients.identity_token import fetch_auth_header
 from core_api.config import settings
+from core_api.constants import STORAGE_CONNECT_TIMEOUT_SECONDS
 
 logger = logging.getLogger(__name__)
 
@@ -295,7 +296,7 @@ class CoreStorageClient:
         fallback for the remaining 1%.
         """
         return httpx.AsyncClient(
-            timeout=httpx.Timeout(connect=5.0, read=120.0, write=120.0, pool=5.0),
+            timeout=httpx.Timeout(connect=STORAGE_CONNECT_TIMEOUT_SECONDS, read=120.0, write=120.0, pool=5.0),
             # CAURA-682: pre-fix values 100/50 caused TCP ConnectTimeout
             # retries (3x 5s ~= 13s tail per affected request) during
             # noisy-neighbor write storms — concurrent core-api → storage
@@ -439,11 +440,19 @@ class CoreStorageClient:
         plain HTTP — Cloud Run ``--no-allow-unauthenticated`` always
         uses TLS, so an ``http://`` audience is by definition local
         or in-cluster and never needs an ID token. Without this guard,
-        the metadata-server fetch's 5 s timeout races the health
-        probe's own 5 s budget; a lost race surfaces ``CancelledError``
+        the metadata-server fetch's 5 s timeout competes with the health
+        probe's own budget; a lost race surfaces ``CancelledError``
         (not ``Exception``) which the inner catch misses, and the
         health endpoint flips to ``storage: unreachable`` for the
-        duration of the failure-cache TTL."""
+        duration of the failure-cache TTL.
+
+        The two budgets are no longer equal — ``PROBE_TIMEOUT_SECONDS`` is
+        12 s against this 5 s — so on an HTTPS audience a cold token fetch
+        and a connect attempt can now both fit inside one probe rather than
+        the fetch alone consuming it. That is headroom, not a guarantee: the
+        ID token is cached for 50 min, so this cost lands only on a cache
+        miss, and the guard above still matters because it removes the race
+        entirely for HTTP audiences."""
         headers: dict[str, str] = {}
         shared_secret = settings.core_storage_shared_secret.get_secret_value()
         if shared_secret:

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -506,6 +506,8 @@ class Settings(BaseSettings):
             BULK_EMBEDDING_TIMEOUT_SECONDS,
             BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS,
             BULK_STRONG_EMBED_TIMEOUT_SECONDS,
+            PROBE_TIMEOUT_SECONDS,
+            STORAGE_CONNECT_TIMEOUT_SECONDS,
         )
 
         if self.request_timeout_seconds < BULK_ENRICHMENT_TOTAL_TIMEOUT_SECONDS:
@@ -622,6 +624,29 @@ class Settings(BaseSettings):
                 f"BULK_EMBEDDING_TIMEOUT_SECONDS ({BULK_EMBEDDING_TIMEOUT_SECONDS}s): the "
                 "opportunistic bulk strong-embed budget cannot exceed the required embed cap, "
                 "which the storage-phase ordering check above is proved against."
+            )
+        if PROBE_TIMEOUT_SECONDS <= STORAGE_CONNECT_TIMEOUT_SECONDS:
+            # A dependency probe must outlive ONE attempt of the call it makes,
+            # or it reports a healthy dependency as unreachable. These were both
+            # 5.0: equal, so the probe's ``wait_for`` and the transport's connect
+            # ceiling raced, and the probe could absorb none of the five connect
+            # retries ``CONNECT_PHASE_MAX_ATTEMPTS`` grants it. In prod that
+            # returned ``storage: unreachable`` on ~0.8% of probes while storage
+            # was answering the very same call in ~30ms — the abandoned request,
+            # shielded by ``_cancel_safe``, completed 200 about 10ms after the
+            # probe had already given up. A third party (Better Stack Uptime)
+            # polls this endpoint, so the false alarms left the estate.
+            #
+            # Checked here rather than only in a test because the probe's callers
+            # are operator-facing surfaces and this ordering is the kind that gets
+            # broken by tuning one number in isolation — the same rationale as the
+            # gate ordering above.
+            raise ValueError(
+                f"PROBE_TIMEOUT_SECONDS ({PROBE_TIMEOUT_SECONDS}s) must be > "
+                f"STORAGE_CONNECT_TIMEOUT_SECONDS ({STORAGE_CONNECT_TIMEOUT_SECONDS}s), or the "
+                "/health storage probe times out before its own transport has finished a "
+                "single connect attempt and reports a healthy dependency as unreachable. "
+                "Raise PROBE_TIMEOUT_SECONDS, or lower the storage connect ceiling."
             )
         return self
 

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -146,13 +146,47 @@ MEMORY_STATUSES_PATTERN = (
 )
 
 # ── Health / status probe timeouts ──
+# The storage pool's per-attempt connect ceiling (``storage_client._make_pool``
+# reads it from here). Named rather than inlined because PROBE_TIMEOUT_SECONDS
+# below has to stay ordered against it, and an ordering between two literals in
+# different modules is one nobody can see. It lives in this file, not beside the
+# pool, because ``storage_client`` imports ``config.settings`` at module scope —
+# so the validator that enforces the ordering cannot import from there without a
+# cycle (``config`` builds ``Settings()`` at import).
+#
+# NB both sibling HTTP clients sit at 15.0 (``OPENAI_HTTPX_CONNECT_TIMEOUT_SECONDS``,
+# ``EMBEDDING_HTTPX_CONNECT_TIMEOUT_SECONDS``), each raised from 5.0 after Cloud Run
+# VPC-connector cold connects overran it — the same failure class as the probe
+# flapping below. Whether storage should follow is deliberately NOT settled here:
+# this value governs every storage call, not just the probe.
+STORAGE_CONNECT_TIMEOUT_SECONDS = 5.0
+
 # Upper bound on a single dependency probe (storage / redis / event_bus).
-# Cloud Run typically gives health checks 10-30s before marking a revision
-# unhealthy; we want to fail-fast well before that so a stalled backend
-# can't hang the whole probe. Shared between ``/health`` (binary 503 deploy
-# gate) and ``/stats`` / ``/status`` (public endpoints with the same posture
-# — return ``0`` / "unreachable" rather than block landing-page hits).
-PROBE_TIMEOUT_SECONDS = 5.0
+# Shared between ``/health`` (binary 503 deploy gate) and ``/stats`` /
+# ``/status`` (public endpoints with the same posture — return ``0`` /
+# "unreachable" rather than block landing-page hits).
+#
+# MUST stay strictly above STORAGE_CONNECT_TIMEOUT_SECONDS, enforced at startup
+# by ``Settings._validate_timeout_ordering``. At 5.0 the two were EQUAL, so the
+# probe could absorb none of the five connect retries ``CONNECT_PHASE_MAX_ATTEMPTS``
+# deliberately grants — one slow connection setup and ``wait_for`` lost the race
+# by construction. In prod that reported ``storage: unreachable`` on ~0.8% of
+# probes while storage was healthy: the abandoned request, kept alive by
+# ``_cancel_safe``'s shield, completed 200 in ~30ms about 10ms after the probe
+# had already given up.
+#
+# 12.0 clears one connect attempt, a backoff and a second attempt (5.0 + ~0.22
+# + 5.0), so the probe reflects the resilience the client actually has instead
+# of failing ahead of its own first retry. That is above the 10s edge of the
+# "Cloud Run gives health checks 10-30s" window this comment used to cite as a
+# reason to stay well below it — which was never the operative constraint here:
+# this deployment configures no Cloud Run liveness or readiness probe at all
+# (TCP startupProbe only), so the consumers are the deploy gate, the compose
+# healthcheck (whose own ``timeout`` must exceed this — see docker-compose.yml)
+# and an external uptime monitor. The two I/O probes run concurrently, so this
+# is the ceiling for the whole call rather than a per-dependency budget to be
+# summed.
+PROBE_TIMEOUT_SECONDS = 12.0
 
 # Probe route paths, declared here rather than inline in ``routes/health.py``
 # so that exactly one string backs both the route decorator and the

--- a/core-api/src/core_api/routes/health.py
+++ b/core-api/src/core_api/routes/health.py
@@ -254,6 +254,43 @@ async def tool_descriptions(enriched: bool = False):
     return {spec.name: spec.description for spec in REGISTRY.values()}
 
 
+async def _probe_storage() -> tuple[str, bool]:
+    """Probe storage; return ``(reported_status, is_healthy)``.
+
+    Never raises: every failure mode is reported through the return value,
+    which is what lets :func:`_probe_dependencies` gather this with
+    :func:`_probe_redis` under a plain ``asyncio.gather``.
+    """
+    try:
+        sc = get_storage_client()
+        await asyncio.wait_for(
+            sc.count_all(tenant_id="__health_check__"),
+            timeout=PROBE_TIMEOUT_SECONDS,
+        )
+        return "connected", True
+    except Exception:
+        # Never surface str(exc) — httpx errors embed the target URL
+        # (and any basic-auth creds in it) into the response body.
+        logger.exception("Storage health check failed")
+        return "unreachable", False
+
+
+async def _probe_redis() -> tuple[str, bool]:
+    """Probe redis; return ``(reported_status, is_healthy)``.
+
+    An unset ``redis_url`` is the OSS in-memory-fallback default, not a
+    failure — it reports "not configured" and counts as healthy. Never
+    raises, for the same reason as :func:`_probe_storage`.
+    """
+    if not settings.redis_url:
+        return "not configured", True
+    try:
+        redis_ok = await asyncio.wait_for(redis_healthy(), timeout=PROBE_TIMEOUT_SECONDS)
+    except Exception:
+        redis_ok = False
+    return ("connected", True) if redis_ok else ("unavailable", False)
+
+
 async def _probe_dependencies() -> tuple[dict[str, Any], list[str]]:
     """Probe storage / redis / event_bus and return ``(result, unhealthy)``.
 
@@ -261,53 +298,48 @@ async def _probe_dependencies() -> tuple[dict[str, Any], list[str]]:
     ``GET /status`` (which surfaces the same shape but never fails the
     response code on it). Each probe is bounded by ``PROBE_TIMEOUT_SECONDS``
     so a stalled backend can't hang the whole call.
+
+    The two I/O probes run CONCURRENTLY, so the wall-clock ceiling for the
+    whole call is one ``PROBE_TIMEOUT_SECONDS`` rather than the sum — which is
+    what makes that budget affordable at 12s. Neither caller depends on probe
+    ordering or on partial results (both await the complete tuple), so the only
+    order that matters is the key order of ``result``: both splat it into their
+    response body, so it is the response shape.
     """
-    result: dict[str, Any] = {}
-    unhealthy: list[str] = []
-
+    # Event bus first: ``is_healthy`` is sync (no I/O) and ``get_event_bus()``
+    # is a cached singleton, so this costs nothing and must not sit behind a
+    # stalled storage probe waiting out the full budget. It can still raise
+    # (Pub/Sub env vars missing, unknown backend); catch so that surfaces as
+    # 503-shaped output rather than a bare 500.
     try:
-        sc = get_storage_client()
-        await asyncio.wait_for(
-            sc.count_all(tenant_id="__health_check__"),
-            timeout=PROBE_TIMEOUT_SECONDS,
-        )
-        result["storage"] = "connected"
-    except Exception:
-        # Never surface str(exc) — httpx errors embed the target URL
-        # (and any basic-auth creds in it) into the response body.
-        logger.exception("Storage health check failed")
-        result["storage"] = "unreachable"
-        unhealthy.append("storage")
-
-    if settings.redis_url:
-        try:
-            redis_ok = await asyncio.wait_for(redis_healthy(), timeout=PROBE_TIMEOUT_SECONDS)
-        except Exception:
-            redis_ok = False
-        if redis_ok:
-            result["redis"] = "connected"
-        else:
-            result["redis"] = "unavailable"
-            unhealthy.append("redis")
-    else:
-        result["redis"] = "not configured"
-
-    # Event bus: ``is_healthy`` is sync (no I/O), no timeout wrapper.
-    # ``get_event_bus()`` itself can raise (Pub/Sub env vars missing,
-    # unknown backend); wrap consistently so those surface as 503-shaped
-    # output rather than a bare 500.
-    try:
-        bus = get_event_bus()
-        if bus.is_healthy:
-            result["event_bus"] = "ok"
-        else:
-            result["event_bus"] = "unhealthy"
-            unhealthy.append("event_bus")
+        bus_status = "ok" if get_event_bus().is_healthy else "unhealthy"
     except Exception:
         logger.exception("Event bus health check failed")
-        result["event_bus"] = "error"
-        unhealthy.append("event_bus")
+        bus_status = "error"
 
+    # gather without ``return_exceptions``: both helpers are total, catching
+    # ``Exception`` and reporting through their return value. A ``BaseException``
+    # (the request being cancelled) should still cancel the sibling and
+    # propagate, which is the default.
+    (storage_status, storage_ok), (redis_status, redis_ok) = await asyncio.gather(
+        _probe_storage(),
+        _probe_redis(),
+    )
+
+    result: dict[str, Any] = {
+        "storage": storage_status,
+        "redis": redis_status,
+        "event_bus": bus_status,
+    }
+    unhealthy = [
+        dep
+        for dep, ok in (
+            ("storage", storage_ok),
+            ("redis", redis_ok),
+            ("event_bus", bus_status == "ok"),
+        )
+        if not ok
+    ]
     return result, unhealthy
 
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -165,7 +165,12 @@ services:
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]
       interval: 15s
-      timeout: 5s
+      # Must stay above core-api's PROBE_TIMEOUT_SECONDS (12s): the probe is
+      # allowed to spend that long bounding a stalled dependency, and a shorter
+      # timeout here severs the check and scores a failure before the probe can
+      # answer — the same inverted-budget defect, one layer out. At 5s a slow
+      # storage connect read as an unhealthy container.
+      timeout: 15s
       retries: 3
       start_period: 15s
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,12 @@ services:
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')"]
       interval: 15s
-      timeout: 5s
+      # Must stay above core-api's PROBE_TIMEOUT_SECONDS (12s): the probe is
+      # allowed to spend that long bounding a stalled dependency, and a shorter
+      # timeout here severs the check and scores a failure before the probe can
+      # answer — the same inverted-budget defect, one layer out. At 5s a slow
+      # storage connect read as an unhealthy container.
+      timeout: 15s
       retries: 3
       start_period: 15s
 

--- a/tests/test_health_gate.py
+++ b/tests/test_health_gate.py
@@ -125,3 +125,98 @@ async def test_health_503_when_event_bus_factory_raises(client):
     assert data["status"] == "unhealthy"
     assert data["event_bus"] == "error"
     assert "event_bus" in data["unhealthy_dependencies"]
+
+
+# ── Probe budget vs. the storage client's own retry policy ──
+
+
+async def test_probe_timeout_clears_storage_connect_ceiling():
+    """``PROBE_TIMEOUT_SECONDS`` must outlive ONE storage connect attempt.
+
+    Asserted as a RELATION against the client's own configuration, never
+    against the literal ``12.0``. Both numbers are legitimately tunable; the
+    property that has to survive any retune is that the probe does not give
+    up before the transport it is measuring has finished a single attempt.
+
+    This was ``5.0 > 5.0`` → False. Equal budgets meant the probe could
+    absorb none of the five connect retries ``CONNECT_PHASE_MAX_ATTEMPTS``
+    grants, so one slow connection setup reported ``storage: unreachable``
+    while storage was in fact answering the very same call in ~30ms.
+    """
+    from core_api.clients.storage_client import CoreStorageClient
+    from core_api.constants import (
+        PROBE_TIMEOUT_SECONDS,
+        STORAGE_CONNECT_TIMEOUT_SECONDS,
+    )
+
+    assert STORAGE_CONNECT_TIMEOUT_SECONDS < PROBE_TIMEOUT_SECONDS, (
+        f"probe budget {PROBE_TIMEOUT_SECONDS}s must exceed the storage client's "
+        f"per-attempt connect ceiling {STORAGE_CONNECT_TIMEOUT_SECONDS}s, or the probe "
+        f"times out first and reports a healthy dependency as unreachable"
+    )
+
+    # The constant is only meaningful if the pool actually uses it — otherwise
+    # the ordering above guards a number nothing reads. Assert the wiring, not
+    # a second copy of the value.
+    pool = CoreStorageClient._make_pool()
+    try:
+        assert pool.timeout.connect == STORAGE_CONNECT_TIMEOUT_SECONDS
+    finally:
+        await pool.aclose()
+
+
+async def test_dependency_probes_run_concurrently():
+    """Storage and redis must be in flight together, not one after the other.
+
+    Concurrency is what keeps the wall-clock ceiling at ONE
+    ``PROBE_TIMEOUT_SECONDS`` after that budget was raised; run sequentially
+    they add up. Asserted by observing overlap rather than by timing the
+    call — a wall-clock threshold measures runner contention, not the
+    implementation (see the benchmark note in ``pytest.ini``).
+    """
+    import asyncio
+
+    from core_api.config import settings
+    from core_api.routes.health import _probe_dependencies
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _enter_and_yield():
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.01)  # yield so a sibling probe can start
+        in_flight -= 1
+
+    async def _slow_count(*_args, **_kwargs):
+        await _enter_and_yield()
+        return 0
+
+    async def _slow_redis():
+        await _enter_and_yield()
+        return True
+
+    with (
+        patch.object(settings, "redis_url", "redis://phantom:6379/0"),
+        patch(
+            "core_api.clients.storage_client.CoreStorageClient.count_all",
+            AsyncMock(side_effect=_slow_count),
+        ),
+        patch("core_api.routes.health.redis_healthy", _slow_redis),
+    ):
+        deps, unhealthy = await _probe_dependencies()
+
+    assert max_in_flight == 2, (
+        f"expected storage and redis probes to overlap, saw at most "
+        f"{max_in_flight} in flight — probes are running sequentially"
+    )
+    # The refactor must not change what the probes report, nor the key order:
+    # ``/health`` and ``/status`` both splat ``deps`` into their response body,
+    # so that order IS the response shape. Checked on the ``deps`` this test
+    # already holds rather than in a separate test, which would pay another
+    # storage round trip to re-assert a dict literal.
+    assert unhealthy == []
+    assert list(deps) == ["storage", "redis", "event_bus"]
+    assert deps["storage"] == "connected"
+    assert deps["redis"] == "connected"


### PR DESCRIPTION
## The defect

`PROBE_TIMEOUT_SECONDS = 5.0`. The storage pool's per-attempt connect ceiling is also `5.0`. **Equal**, so `asyncio.wait_for` and the transport raced, and the probe could absorb none of the five connect retries `CONNECT_PHASE_MAX_ATTEMPTS` deliberately grants it — whose own comment says they exist to "ride out a Cloud Run cold start". One slow connection setup and the probe lost by construction.

`5.0 > 5.0 → False` is the whole bug.

## What it did in production

`GET /api/v1/health` returned 503 `storage: unreachable` on **23 of ~3,000 probes (~0.8%)** over ten hours while storage was healthy. At each failure the reader served the very same `/memories/count` call:

```
probe gives up          reader serves the same call
00:08:38.002  TimeoutError    00:08:38.012   200 in 34 ms
00:16:40.775  TimeoutError    00:16:38.121   200 in 28 ms
```

The abandoned request completes because `_cancel_safe` shields it (from the 2026-06-16 pool-leak incident), so both halves are in the logs: the probe calling a dependency unreachable, and that dependency answering ~10ms later.

**It is not a slow-count problem.** `/v1/storage/memories/count` measured p50 28ms, p95 96ms, max 1.658s across 2,000 requests — nothing crossed 5s. The probe passes a truthy tenant (`__health_check__`), so it takes `memory_count_active`'s tenant-scoped branch, not the whole-corpus counter. **Nor is it pool exhaustion** — the call succeeds, immediately.

**This has an external audience.** `Better Stack Better Uptime Bot` polls `prod-memclaw-core-api` directly — found independently while enumerating external referrers of the prod service URLs, and absent from the Datadog section of the rename runbook. So a third-party uptime service has been receiving false alarms from us for an unknown period. That is why this lands on its own rather than batched.

## The change

**`STORAGE_CONNECT_TIMEOUT_SECONDS`** names a ceiling that was a bare literal plus three separate prose copies. It lives in `constants.py` rather than beside the pool because `storage_client` imports `config.settings` at module scope and `config` builds `Settings()` at import — putting it in `storage_client.py` is a circular import (verified, not assumed).

**The ordering is enforced at startup**, in `Settings._validate_timeout_ordering` alongside the orderings already there, so it fails the process rather than only a test run. That matters more than a test: the probe's consumers are operator-facing, and this is the kind of ordering broken by tuning one number in isolation.

**The two I/O probes run concurrently.** Raising a per-dependency budget awaited in series would have taken the worst case from 10s to 24s; gathering keeps it at 12s. The event-bus check is sync (`bus.is_healthy`, no I/O) and moves *above* the gather so a free check no longer waits out a stalled probe. Result-dict key order is unchanged — both callers splat it into their response body, so that order is the response shape.

**Both compose healthchecks go `timeout: 5s → 15s`.** They call this endpoint. Leaving them at 5s would have recreated the identical inverted-budget defect one layer out — the review caught this, and it is the reason the diff touches compose at all.

## On failure semantics

`_probe_dependencies` has exactly two callers, `health` and `status_`, both in `routes/health.py`. Both `await` the complete tuple; neither short-circuits, inspects which probe failed first, or consumes partial results. `health` uses `unhealthy` only as a truthiness test plus a verbatim dump into `unhealthy_dependencies`. Stating that explicitly rather than leaving it implied: **nothing depends on probe ordering.**

## Verification

Tests confirmed **red before the fix**, each against the specific change it guards:

| Test | Without its fix |
|---|---|
| `test_probe_timeout_clears_storage_connect_ceiling` | `AssertionError: assert 5.0 > 5.0` |
| `test_dependency_probes_run_concurrently` | `assert 1 == 2` — probes sequential |
| `_validate_timeout_ordering` (startup) | `ValidationError` — process refuses to boot |

The ordering test asserts the **relation**, never the literal `12.0`: both numbers are legitimately tunable, and the property that must survive a retune is that the probe outlives one attempt. A literal would pass forever while the invariant silently broke.

The concurrency test asserts **overlap** (max probes in flight `== 2`), not elapsed time — a wall-clock threshold measures runner contention, which is the trap `pytest.ini`'s own benchmark note documents. The key-order assertion rides on the concurrency test's existing call rather than paying a second storage round trip to re-check a dict literal.

Gates at CI's exact separate scopes: `ruff check core-api/src/` and `ruff check tests/` clean; `ruff format --check` clean on both; `mypy` clean (203 files).

Full root suite: **6,071 passed**. 18 failures, all pre-existing — verified against a baseline I ran myself on clean `origin/main` in a separate worktree, diffed by sorted test name, with zero failures unique to this branch. Worth recording that the environmental failure count is ~18–19 and its *membership varies between runs*: the two names that differed across my runs both pass in isolation on this branch, and the one unique to a branch run also fails on clean main.

## Deliberately not done

Deriving the probe budget arithmetically from the connect ceiling, and making that ceiling env-overridable to match `OPENAI_HTTPX_CONNECT_TIMEOUT_SECONDS` / `EMBEDDING_HTTPX_CONNECT_TIMEOUT_SECONDS`.

Both siblings sit at **15.0**, each raised from 5.0 after Cloud Run VPC-connector cold connects overran it — the same failure class that produced this flapping, which makes storage the holdout on the old default. Whether it should follow them is a real question and worth a follow-up, but that value governs **every** storage call, not just the probe, and it is not this change's to settle. Flagging rather than silently changing production storage behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
