### PR TITLE
fix(events): stop the malformed-message drop leaking its payload

### DIFF
--- a/common/events/pubsub.py
+++ b/common/events/pubsub.py
@@ -1106,7 +1106,11 @@ class PubSubEventBus(EventBus):
                 ack_ids: list[str] = []
                 nack_ids: list[str] = []
                 for received in response.received_messages:
-                    foreign_env = self._foreign_source_env(received.message)
+                    # Hoisted: proto-plus re-wraps the nested message on every
+                    # ``.message`` access, so reading it three times costs
+                    # three wrapper allocations per message on the hot path.
+                    msg = received.message
+                    foreign_env = self._foreign_source_env(msg)
                     if foreign_env is not None:
                         # Fan-out copy from a sibling environment sharing
                         # this project's topics. Ack-drop *before* decode
@@ -1127,10 +1131,16 @@ class PubSubEventBus(EventBus):
                             },
                         )
                         continue
-                    event = self._decode(received.message.data)
+                    event = self._decode(
+                        msg.data,
+                        subscription=subscription_name,
+                        message_id=msg.message_id,
+                    )
                     if event is None:
                         # Malformed message — ack so we don't redeliver
-                        # forever, log for alerting.
+                        # forever, log for alerting. The log is ``_decode``'s,
+                        # not this branch's: adding one here would double-count
+                        # the drop in any alert that counts occurrences.
                         ack_ids.append(received.ack_id)
                         continue
                     success = await self._dispatch_all(handlers, event)
@@ -1240,7 +1250,7 @@ class PubSubEventBus(EventBus):
                 continue
 
     @staticmethod
-    def _decode(data: bytes) -> Event | None:
+    def _decode(data: bytes, *, subscription: str, message_id: str) -> Event | None:
         # Pydantic shifted `ValidationError`'s base across v2 minors
         # (v1 + current ≥2.4 inherit from ValueError, 2.0-2.3 did not),
         # so we catch both explicitly rather than assume either. A
@@ -1250,11 +1260,69 @@ class PubSubEventBus(EventBus):
         # `json.JSONDecodeError` already inherits from ValueError since
         # Python 3.5, so ValueError covers it — listed explicitly would
         # be redundant.
+        #
+        # ``subscription`` / ``message_id`` are required keyword args: they
+        # exist only to be logged, so a default would let a caller drop the
+        # context and leave the log as unusable as it was before. They go in
+        # ``extra=`` rather than ``bind_contextvars`` (which this repo does
+        # configure, via ``merge_contextvars`` in ``structlog_config``) because
+        # contextvars are merged at emit time inside ``ProcessorFormatter`` and
+        # never reach the ``LogRecord`` — so ``caplog`` cannot see them, and
+        # every other drop site in the estate is asserted through the record.
+        #
+        # The two failure modes are caught SEPARATELY, and not for tidiness:
+        # only one of them can be logged with a traceback.
         try:
             parsed: dict[str, Any] = json.loads(data.decode("utf-8"))
             return Event.model_validate(parsed)
-        except (ValueError, ValidationError):
-            logger.exception("failed to decode pubsub message; acking to drop")
+        except ValidationError as exc:
+            # MUST precede the ValueError arm: pydantic ≥2.4 makes
+            # ValidationError a ValueError subclass, so the order is what
+            # selects this branch at all.
+            #
+            # No ``exc_info`` here, deliberately. Pydantic renders the
+            # offending input into ``str(exc)`` as ``input_value=...`` — the
+            # whole decoded document when a required field is missing — and
+            # ``structlog_config``'s ``format_exc_info`` ships the rendered
+            # traceback to Cloud Logging and Datadog. That payload is tenant-
+            # or attacker-supplied and may carry personal data, so a
+            # ``logger.exception`` here silently exfiltrates it on every
+            # malformed message. ``errors(include_input=False)`` keeps the
+            # part that aids triage — which field failed and why — and drops
+            # the value. Verified against pydantic 2.13.4; the
+            # ``include_input`` kwarg is what the guarantee rests on.
+            logger.error(
+                "failed to decode pubsub message; acking to drop",
+                extra={
+                    "subscription": subscription,
+                    "message_id": message_id,
+                    "dropped": True,
+                    "validation_errors": exc.errors(
+                        include_input=False, include_url=False
+                    ),
+                },
+            )
+            return None
+        except ValueError:
+            # Malformed bytes/JSON. ``json.JSONDecodeError.__str__`` carries
+            # only a position ("Expecting value: line 1 column 1"), never the
+            # document — it hangs off ``.doc``, which is never rendered — so
+            # this arm keeps its traceback safely.
+            #
+            # Context matters most here: the traceback names the syntax fault
+            # but not WHICH message or subscription produced it, and a payload
+            # this broken yields no event_type or tenant_id to identify it by.
+            # ``message_id`` is what makes the dropped message findable after
+            # the fact, across ~60 prod subscriptions spanning two topic
+            # families mid-rename.
+            logger.exception(
+                "failed to decode pubsub message; acking to drop",
+                extra={
+                    "subscription": subscription,
+                    "message_id": message_id,
+                    "dropped": True,
+                },
+            )
             return None
 
     async def _dispatch_all(self, handlers: list[EventHandler], event: Event) -> bool:

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -106,10 +106,20 @@ def test_topic_name_prefix_and_no_op() -> None:
     assert noop._topic_name(EMBEDDED_TOPIC) == EMBEDDED_TOPIC
 
 
+def _decode_any(data: bytes) -> Event | None:
+    """``_decode`` with throwaway log context.
+
+    Only ``test_decode_failure_logs_subscription_and_message_id`` asserts on
+    the context, so every other call site passes placeholders through here
+    rather than restating the signature five times.
+    """
+    return PubSubEventBus._decode(data, subscription="sub-a", message_id="m-1")
+
+
 async def test_decode_accepts_well_formed_envelope() -> None:
     src = Event(event_type=Topics.Memory.ENRICHED, tenant_id="t1", payload={"k": "v"})
     bytes_ = src.model_dump_json().encode("utf-8")
-    decoded = PubSubEventBus._decode(bytes_)
+    decoded = _decode_any(bytes_)
     assert decoded is not None
     assert decoded.event_type == src.event_type
     assert decoded.tenant_id == "t1"
@@ -117,8 +127,82 @@ async def test_decode_accepts_well_formed_envelope() -> None:
 
 
 async def test_decode_returns_none_on_garbage() -> None:
-    assert PubSubEventBus._decode(b"not json at all") is None
-    assert PubSubEventBus._decode(b'{"missing": "event_type"}') is None
+    assert _decode_any(b"not json at all") is None
+    assert _decode_any(b'{"missing": "event_type"}') is None
+
+
+async def test_decode_failure_logs_subscription_and_message_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A dropped malformed message must be traceable to its source.
+
+    The traceback names the syntax fault but not WHICH message or subscription
+    produced it, and a payload this broken yields no event_type or tenant_id to
+    identify it by. The sibling foreign-env drop branch in ``_pull_loop``
+    already logs structured context; this is the same guarantee for the other
+    drop path.
+    """
+    with caplog.at_level("ERROR"):
+        _decode_any(b"not json at all")
+
+    # ``is None`` is already covered by test_decode_returns_none_on_garbage.
+    recs = [r for r in caplog.records if "failed to decode" in r.getMessage()]
+    assert len(recs) == 1, "exactly one record, so recs[0] below is unambiguous"
+    rec = recs[0]
+    # The JSON arm keeps its traceback — it is safe to render and it names the
+    # syntax fault. Breaks if someone downgrades it to logger.error.
+    assert rec.exc_info is not None
+    assert rec.subscription == "sub-a"
+    assert rec.message_id == "m-1"
+    # ``dropped`` is the estate-wide marker for a silent discard; core-api and
+    # core-worker consumers set it on their own ack-drops and assert on it.
+    assert rec.dropped is True
+
+
+async def test_decode_validation_failure_never_logs_the_payload() -> None:
+    """A schema-invalid payload must not reach the log. This one can leak.
+
+    Pydantic renders the offending input into ``str(exc)`` as
+    ``input_value=...`` — the whole decoded document when a required field is
+    missing — so a ``logger.exception`` on this arm ships tenant data into
+    Cloud Logging and Datadog on every malformed message.
+
+    Asserted against the FULLY FORMATTED record, not ``getMessage()``:
+    ``LogRecord.getMessage()`` renders only ``msg % args`` and structurally
+    excludes ``exc_info``, so a test written against it passes while the
+    payload ships. That is not a hypothetical — it is the first version of
+    this test, and it stayed green against a leaking implementation.
+    """
+    import json as _json
+    import logging
+
+    secret = "ssn-123-45-6789"
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Capture()
+    bus_logger = logging.getLogger("common.events.pubsub")
+    bus_logger.addHandler(handler)
+    try:
+        # Valid JSON, invalid Event: takes the pydantic arm, not the JSON one.
+        assert _decode_any(_json.dumps({"note": secret}).encode()) is None
+    finally:
+        bus_logger.removeHandler(handler)
+
+    assert len(records) == 1
+    rec = records[0]
+    rendered = logging.Formatter().format(rec)
+    assert secret not in rendered, "tenant payload reached the log"
+    assert "input_value" not in rendered, "pydantic echoed the input document"
+    # The diagnostic that makes the drop actionable must survive the scrubbing:
+    # which field failed, and why.
+    errors = rec.validation_errors
+    assert [e["loc"] for e in errors] == [("event_type",)]
+    assert errors[0]["type"] == "missing"
+    assert all("input" not in e for e in errors)
 
 
 async def test_dispatch_all_returns_true_when_all_handlers_succeed(
@@ -996,13 +1080,13 @@ async def test_decode_handles_pydantic_validation_error() -> None:
 
     # Missing the required `event_type` field.
     bad_payload = _json.dumps({"tenant_id": "t1", "payload": {}}).encode()
-    assert PubSubEventBus._decode(bad_payload) is None
+    assert _decode_any(bad_payload) is None
 
     # Wrong type for `occurred_at` — invalid datetime string.
     bad_ts = _json.dumps(
         {"event_type": "memclaw.memory.enriched", "occurred_at": "not-a-date"}  # legacy-name-ok: rule 3 — pins the wire format a live subscriber must still decode
     ).encode()
-    assert PubSubEventBus._decode(bad_ts) is None
+    assert _decode_any(bad_ts) is None
 
 
 # ---------------------------------------------------------------------------
@@ -1015,17 +1099,25 @@ async def test_decode_handles_pydantic_validation_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_received(data: bytes, ack_id: str, attributes: dict[str, str]) -> Any:
+def _make_received(
+    data: bytes,
+    ack_id: str,
+    attributes: dict[str, str],
+    message_id: str = "msg-default",
+) -> Any:
     """Build a fake Pub/Sub ReceivedMessage with real-dict attributes.
 
     A bare ``MagicMock`` would make ``message.attributes.get(...)`` return a
     truthy mock, defeating the guard's "attribute absent" branch — so the
-    attributes must be a real mapping.
+    attributes must be a real mapping. ``message_id`` is real for the same
+    reason: ``_pull_loop`` forwards it to ``_decode`` for the drop log, and a
+    MagicMock there would satisfy any assertion.
     """
     received = MagicMock()
     received.ack_id = ack_id
     received.message.data = data
     received.message.attributes = attributes
+    received.message.message_id = message_id
     return received
 
 
@@ -1183,6 +1275,56 @@ async def test_pull_loop_drops_foreign_env_message_before_dispatch() -> None:
     assert result["dispatched"] == []
     assert result["acked"] == ["ack-foreign"]
     assert result["nacked"] == []
+
+
+async def test_pull_loop_malformed_message_acks_and_logs_real_context() -> None:
+    """Pin the ONLY production call site of ``_decode``.
+
+    The unit test above proves ``_decode`` logs what it is handed. This proves
+    ``_pull_loop`` hands it the right things — the short ``subscription_name``
+    rather than ``sub_path`` (``projects/proj/subscriptions/test-sub``), and
+    the message's real id. Both are plausible to get wrong and neither is
+    caught by a test that calls ``_decode`` directly with literals.
+    """
+    import logging
+
+    bus = PubSubEventBus(
+        project_id="proj",
+        subscription_prefix="test",
+        env="production",
+        dual_subscribe=True,
+    )
+    junk = _make_received(
+        b"not a valid envelope",
+        "ack-junk",
+        {"source_env": "production"},
+        message_id="msg-from-the-wire",
+    )
+
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Capture()
+    bus_logger = logging.getLogger("common.events.pubsub")
+    bus_logger.addHandler(handler)
+    try:
+        result = await _drive_one_batch(bus, [junk])
+    finally:
+        bus_logger.removeHandler(handler)
+
+    # Ack-dropped, never dispatched, never nacked — a poison payload must not
+    # loop the subscription.
+    assert result["dispatched"] == []
+    assert result["acked"] == ["ack-junk"]
+    assert result["nacked"] == []
+
+    drops = [r for r in records if "failed to decode" in r.getMessage()]
+    assert len(drops) == 1, "exactly one drop log per malformed message"
+    assert drops[0].subscription == "test-sub"
+    assert drops[0].message_id == "msg-from-the-wire"
 
 
 async def test_pull_loop_processes_same_env_message() -> None:


### PR DESCRIPTION
## What I went looking for, and what I found instead

`_decode` ack-drops a message the bus cannot parse. It logged that at ERROR with **no context** — no subscription, no message id — and a malformed payload has no `event_type` or `tenant_id` to identify it by either. So the line said only that *something undecodable arrived somewhere*, across ~60 prod subscriptions spanning two topic families mid-rename. The sibling foreign-env drop branch in the same loop already logs `subscription`, `source_env` and `env`.

Threading the context in surfaced a worse problem on the same line.

## The leak

**Pydantic renders the offending input into `str(exc)` as `input_value=...`** — the *whole decoded document* when a required field is missing — and `structlog_config`'s `format_exc_info` ships the rendered traceback into the `exception` field sent to Cloud Logging and Datadog. So `logger.exception` on the schema-invalid path exfiltrated tenant payload on **every malformed message**.

Verified end to end against the repo's own `Event` model:

```
Field required [type=missing, input_value={'note': 'ssn-123-45-6789'}, input_type=dict]
```

Two leak shapes: a missing required field puts the entire document in `input_value`; a wrong-typed field puts that field's value there. Pydantic truncates the repr at ~50 chars head+tail, so long payloads leak head and tail — a display limit, not a privacy control. Anything short leaks whole.

`json.JSONDecodeError` is clean: `__str__` is only a position, and the document hangs off `.doc`, which is never rendered.

## The change

The two failure modes are now caught **separately**, because only one can carry a traceback safely:

| Arm | `exc_info` | Why |
|---|---|---|
| `ValidationError` | **no** | carries `errors(include_input=False, include_url=False)` — keeps *which field failed and why*, drops the value |
| `ValueError` | yes | `JSONDecodeError` cannot carry the document |

`ValidationError` **must** precede the `ValueError` arm: pydantic ≥2.4 makes it a subclass, so the ordering is what selects the branch at all. The existing comment about that base-class shift across pydantic minors is now load-bearing rather than informational.

Both arms set **`dropped: True`** — the marker twelve other drop sites across `common/`, `core-api` and `core-worker` already use, and which `tests/test_consumer_enriched.py` already asserts on. The one drop whose entire purpose is making a silent discard findable was the one not setting it. Deliberately **not** added to the foreign-env branch: that drop is routine, per-message and logged at INFO, and marking it would swamp any `dropped:true` query.

`subscription`/`message_id` are **required** keyword args — they exist only to be logged, so a default would let a caller drop the context and restore the original blindness. They go in `extra=` rather than `bind_contextvars` (which this repo does configure): contextvars merge at emit time inside `ProcessorFormatter` and never reach the `LogRecord`, so `caplog` cannot see them, and every other drop site in the estate is asserted through the record.

Also hoists `msg = received.message` in the pull loop. proto-plus re-wraps the nested message on **every** `.message` access, so reading it three times allocated three wrappers per message on the hot path (measured +1.72 µs/msg, ~88% of the successful-decode body). The hoist also removes a pre-existing redundant wrap, leaving the path cheaper than before this change.

## Verification

Every test confirmed **red** against the implementation it guards:

| Test | Against | Failure |
|---|---|---|
| `..._never_logs_the_payload` | single combined arm with `exc_info` | `tenant payload reached the log` — shows `{'note': 'ssn-123-45-6789'}` |
| `..._acks_and_logs_real_context` | call site passing `sub_path` | `'projects/.../test-sub' == 'test-sub'` |
| `..._acks_and_logs_real_context` | call site dropping the real id | `'unknown' == 'msg-from-the-wire'` |
| `..._logs_subscription_and_message_id` | signature reverted to `main`'s | `TypeError: unexpected keyword argument` |

**The privacy test asserts against the fully formatted record, not `getMessage()`.** `LogRecord.getMessage()` renders only `msg % args` and structurally excludes `exc_info` — so a test written against it passes while the payload ships. That was this test's first version, and it stayed green against the leaking code. Worth stating because the mistake is invisible: the test *looks* like it checks the payload isn't logged, and checks the one surface the payload could never be on.

The second new test drives a malformed message through `_pull_loop` via the existing `_drive_one_batch` harness, so the **only production call site** is pinned — that it passes the short `subscription_name` rather than `sub_path`, and the message's real id. `_make_received` gained a real `message_id` for the same reason: a `MagicMock` there satisfies any assertion.

Gates at CI's exact separate scopes: `ruff check common/` and `ruff check tests/` clean, `ruff format --check tests/` clean, `mypy --config-file common/mypy.ini common/` clean, legacy-name ratchet and do-not-touch sentinel clean. Full root suite **6,071 passed**; 18 failures, identical set to a baseline I ran on clean `origin/main` in a separate worktree, zero unique to this branch.

## Required follow-up — enterprise CI will go red

`caura-enterprise@dev` carries its own `common/events/pubsub.py` with the identical pre-fix code (bare `logger.exception` at its line 1179), and `scripts/vendored_manual_baselines.json` records the OSS sha it was last reconciled against — currently exactly OSS `main`. `scripts/check_vendored_drift.py` gates on the OSS side holding still, so **this merge breaks that check** until the change is ported and the baseline re-approved (`--approve-manual --only common/events/pubsub.py`).

That is a firing gate with documented remediation, not optional drift — and the enterprise copy has the same payload leak, which is the more important reason to port it promptly. Flagging rather than bundling: it is a separate repo with a separate base branch (`dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
