### PR TITLE
feat(client-python): add opt-in retries for read operations

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -40,6 +40,28 @@ with Caura("standalone", tenant_id="default", base_url="http://localhost:8000") 
     ...
 ```
 
+## Retrying transient read failures
+
+Retries are disabled by default. Set `retries` to the number of additional
+attempts and `retry_backoff` to the initial delay in seconds:
+
+```python
+with Caura("mc_xxx", tenant_id="my-team", retries=2, retry_backoff=0.5) as mc:
+    memories = mc.search("Q3 revenue target")
+```
+
+Only `search`, `recall`, `health`, and `get_document` retry. `write` and
+`submit_interview` never retry, even when retries are enabled, because an
+ambiguous failure could otherwise duplicate a write. Reads retry HTTP transport
+errors and statuses 429, 502, 503, and 504. Other responses retain the existing
+error mapping immediately. After exhaustion, the final error is propagated.
+
+Delays double between retries. A valid numeric or HTTP-date `Retry-After`
+header can extend the delay; invalid values fall back to the backoff.
+`timeout` still applies per request, so the total call can take longer when
+retries are enabled. These synchronous delays block the calling thread.
+
+
 ## API
 
 | Method | Endpoint | Returns |

--- a/clients/python/src/caura_client/client.py
+++ b/clients/python/src/caura_client/client.py
@@ -6,7 +6,10 @@ A thin wrapper over the Caura REST API. Point it at a managed
 
 from __future__ import annotations
 
+import math
+import time
 import urllib.parse
+from email.utils import parsedate_to_datetime
 from typing import Any
 
 import httpx
@@ -38,12 +41,20 @@ class Caura:
         base_url: str = DEFAULT_BASE_URL,
         agent_id: str | None = None,
         timeout: float = 30.0,
+        retries: int = 0,
+        retry_backoff: float = 0.5,
         transport: httpx.BaseTransport | None = None,
     ) -> None:
         if not api_key:
             raise ValueError("api_key is required")
         if not tenant_id:
             raise ValueError("tenant_id is required")
+        if not isinstance(retries, int) or retries < 0:
+            raise ValueError("retries must be a non-negative integer")
+        if not math.isfinite(retry_backoff) or retry_backoff < 0:
+            raise ValueError("retry_backoff must be finite and non-negative")
+        self._retries = retries
+        self._retry_backoff = retry_backoff
         self.tenant_id = tenant_id
         self.agent_id = agent_id
         self._http = httpx.Client(
@@ -94,7 +105,7 @@ class Caura:
         if filter_agent_id:
             body["filter_agent_id"] = filter_agent_id
         body.update(extra)
-        data = self._post("/api/v1/search", body)
+        data = self._post("/api/v1/search", body, retry=True)
         if not isinstance(data, dict):
             raise CauraAPIError(200, "search response must be a JSON object")
         if "items" not in data:
@@ -108,11 +119,11 @@ class Caura:
         """Search + LLM summary. Returns a ``RecallResult`` context brief (POST /api/v1/recall)."""
         body: dict[str, Any] = {"tenant_id": self.tenant_id, "query": query, "top_k": top_k}
         body.update(extra)
-        return RecallResult.from_dict(self._post("/api/v1/recall", body))
+        return RecallResult.from_dict(self._post("/api/v1/recall", body, retry=True))
 
     def health(self) -> dict[str, Any]:
         """Liveness probe (GET /api/v1/health)."""
-        response = self._http.get("/api/v1/health")
+        response = self._request("GET", "/api/v1/health", retry=True)
         self._raise_for_status(response)
         return response.json()
 
@@ -132,8 +143,10 @@ class Caura:
         # paths, so a doc_id containing '/' would hit a different route and
         # '?' would inject query params.
         encoded = urllib.parse.quote(doc_id, safe="")
-        response = self._http.get(
+        response = self._request(
+            "GET",
             f"/api/v1/documents/{encoded}",
+            retry=True,
             params={"tenant_id": tenant_id or self.tenant_id, "collection": collection},
         )
         self._raise_for_status(response)
@@ -180,10 +193,42 @@ class Caura:
         return result
 
     # ------------------------------------------------------------- internals
-    def _post(self, path: str, body: dict[str, Any]) -> Any:
-        response = self._http.post(path, json=body)
+    def _post(self, path: str, body: dict[str, Any], *, retry: bool = False) -> Any:
+        response = self._request("POST", path, retry=retry, json=body)
         self._raise_for_status(response)
         return response.json()
+
+    def _request(self, method: str, path: str, *, retry: bool = False, **kwargs: Any) -> httpx.Response:
+        attempts = self._retries if retry else 0
+        delay = self._retry_backoff
+        for attempt in range(attempts + 1):
+            retry_after = None
+            try:
+                response = self._http.request(method, path, **kwargs)
+            except httpx.TransportError:
+                if attempt == attempts:
+                    raise
+            else:
+                if response.status_code not in (429, 502, 503, 504) or attempt == attempts:
+                    return response
+                retry_after = response.headers.get("Retry-After")
+                response.close()
+            time.sleep(self._retry_delay(delay, retry_after))
+            delay *= 2
+        raise AssertionError("retry loop must return or raise")
+
+    @staticmethod
+    def _retry_delay(backoff: float, retry_after: str | None) -> float:
+        if retry_after is None:
+            return backoff
+        try:
+            seconds = float(retry_after)
+        except ValueError:
+            try:
+                seconds = parsedate_to_datetime(retry_after).timestamp() - time.time()
+            except (ValueError, TypeError, OverflowError):
+                return backoff
+        return max(backoff, seconds) if math.isfinite(seconds) else backoff
 
     @staticmethod
     def _raise_for_status(response: httpx.Response) -> None:

--- a/clients/python/tests/test_retries.py
+++ b/clients/python/tests/test_retries.py
@@ -1,0 +1,127 @@
+"""Retry public reads through a real client with an offline HTTP transport."""
+
+import time
+
+import httpx
+import pytest
+
+from caura_client import Caura, CauraAPIError
+
+
+@pytest.mark.parametrize("operation", ["search", "recall", "health", "get_document"])
+@pytest.mark.parametrize("failure", [429, 502, 503, 504, "transport"])
+def test_read_retries(operation, failure, monkeypatch):
+    calls, sleeps = [], []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+
+    def handler(request):
+        calls.append((request.method, str(request.url), request.content))
+        if len(calls) < 3:
+            if failure == "transport":
+                raise httpx.ReadTimeout("transient", request=request)
+            return httpx.Response(failure)
+        return httpx.Response(200, json={"items": [], "summary": "ok"})
+
+    with Caura("key", tenant_id="tenant", retries=2, transport=httpx.MockTransport(handler)) as client:
+        if operation == "get_document":
+            client.get_document("a/b", collection="docs")
+        elif operation == "health":
+            client.health()
+        else:
+            getattr(client, operation)("query")
+    assert calls[0] == calls[1] == calls[2]
+    assert sleeps == [0.5, 1.0]
+
+
+@pytest.mark.parametrize("operation", ["health", "write", "submit_interview"])
+def test_default_and_writes_do_not_retry(operation, monkeypatch):
+    calls = []
+    monkeypatch.setattr(time, "sleep", lambda _: pytest.fail("unexpected retry"))
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(503)
+
+    kwargs = {} if operation == "health" else {"retries": 3}
+    with Caura("key", tenant_id="tenant", transport=httpx.MockTransport(handler), **kwargs) as client:
+        with pytest.raises(CauraAPIError):
+            if operation == "health":
+                client.health()
+            elif operation == "write":
+                client.write("memory")
+            else:
+                client.submit_interview(node_id="n", agent_id="a", cursor_from=0, cursor_to=1, events=[])
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 409, 422, 500])
+def test_permanent_errors_are_not_retried(status, monkeypatch):
+    calls = []
+    monkeypatch.setattr(time, "sleep", lambda _: pytest.fail("unexpected retry"))
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(status)
+
+    with Caura("key", tenant_id="tenant", retries=3, transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(CauraAPIError):
+            client.health()
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("3", 3.0),
+        ("bad", 0.5),
+        ("-1", 0.5),
+        ("inf", 0.5),
+        ("nan", 0.5),
+        ("Thu, 01 Jan 1970 00:00:03 GMT", 3.0),
+    ],
+)
+def test_retry_after_and_exhaustion(header, expected, monkeypatch):
+    calls, sleeps = [], []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+    monkeypatch.setattr(time, "time", lambda: 0)
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(429, headers={"Retry-After": header})
+
+    with Caura("key", tenant_id="tenant", retries=1, transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(CauraAPIError) as exc:
+            client.health()
+    assert exc.value.status_code == 429
+    assert len(calls) == 2
+    assert sleeps == [expected]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"retries": -1},
+        {"retries": 1.5},
+        {"retry_backoff": -1},
+        {"retry_backoff": float("nan")},
+        {"retry_backoff": float("inf")},
+    ],
+)
+def test_invalid_retry_configuration(kwargs):
+    with pytest.raises(ValueError):
+        Caura("key", tenant_id="tenant", **kwargs)
+
+
+def test_transport_exhaustion_preserves_exception(monkeypatch):
+    calls, sleeps = [], []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+
+    def handler(request):
+        calls.append(request)
+        raise httpx.ConnectError("offline", request=request)
+
+    with Caura("key", tenant_id="tenant", retries=1, transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(httpx.ConnectError, match="offline"):
+            client.health()
+    assert len(calls) == 2
+    assert sleeps == [0.5]


### PR DESCRIPTION
## Summary

Add opt-in retries to Python-client read operations. `retries=0` preserves the current default; enabled reads retry transport failures and 429/502/503/504 with exponential backoff, honoring numeric and HTTP-date Retry-After headers.

## Related Issue

Closes #551.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

From `clients/python`, using an isolated editable development install:

- `python -m pytest -q`: 181 passed, no network or real sleeps.
- The initial 23-case regression selection produced 22 failures before implementation; the default no-retry case already passed.
- New tests cover all four public reads, four retryable status codes, transport failures, request identity across attempts, default behavior, both write operations never retrying, permanent statuses, retry exhaustion, numeric/date/malformed Retry-After, and invalid configuration.
- `ruff check src tests`: passed.
- `ruff format --check src/caura_client/client.py tests/test_retries.py`: passed.
- `mypy clients/python/src/caura_client/client.py` from the repository root: passed.
- `python3 scripts/legacy_name_ratchet.py --base upstream/main` and `git diff --check`: passed.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes (or explained why none are needed)
- [x] `ruff check` and `ruff format --check` pass (scope above)
- [x] `mypy` passes (changed client source)
- [x] `pytest` passes locally (standalone Python client suite)
- [x] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing) — generated by release-please per CONTRIBUTING.md; conventional title supplied.

## Additional Notes

Only `search`, `recall`, `health`, and `get_document` enable the shared retry path. `write` and `submit_interview` remain single-attempt operations even with retries configured. Final responses use the existing error mapping; exhausted transport errors preserve their original type. This leaves #718 and the error-mapping/response-validation work in #1139 and #1243 separate.

Backoff blocks the synchronous calling thread. The existing timeout remains per request, so enabling retries extends the overall call budget. Retry-After can extend the backoff; malformed or non-finite values fall back to the configured delay. No new runtime dependency, backend/schema change, live API call, or handwritten version bump. Backend/PostgreSQL and TypeScript suites were not run because this change is confined to the standalone Python client.
