### PR TITLE
fix(crystallizer): stop the dedup sweep re-clustering rows it archived itself

### DIFF
--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -10,6 +10,7 @@ import httpx
 from fastapi import HTTPException
 from sqlalchemy.exc import SQLAlchemyError
 
+from common.constants import LIVE_MEMORY_STATUSES
 from common.enrichment.constants import (
     CLASSIFIER_DEPRECATED_MEMORY_TYPES,
     DEFAULT_MEMORY_TYPE,
@@ -578,7 +579,25 @@ async def _run_crystallization(
 
     # Process each cluster
     for cluster_ids in selected_clusters:
-        cluster_memories = [memories_by_id[mid] for mid in cluster_ids if mid in memories_by_id]
+        # M-61. Live rows only, checked again HERE and not only in the two
+        # queries that built the pairs. The pairs were computed at the top of
+        # this run — ``_check_near_duplicates`` runs in the checks loop, with the
+        # health, usage and issue passes in between — so a row archived by
+        # anything else in that window is still named in a cluster, and the
+        # archive step below is unconditional and irreversible in the direction
+        # that matters. ``bulk_get_memories`` cannot carry the filter itself:
+        # ``entity_service`` reads evidence rows through it and legitimately
+        # needs archived ones.
+        #
+        # This is a narrow race guard, not the fix — the two query filters are
+        # what close the reported loop. It earns its place by making the
+        # invariant checkable next to the delete instead of depending on two
+        # remote queries staying right.
+        cluster_memories = [
+            memories_by_id[mid]
+            for mid in cluster_ids
+            if mid in memories_by_id and memories_by_id[mid].get("status") in LIVE_MEMORY_STATUSES
+        ]
         if len(cluster_memories) < CRYSTALLIZER_MIN_CLUSTER_SIZE:
             continue
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -3823,6 +3823,18 @@ class PostgresService:
         batch_size: int,
         offset: int = 0,
     ) -> list[tuple]:
+        """Rows the crystallizer has not yet dedup-checked. LIVE rows only.
+
+        M-61. The status filter is half of a pair — see
+        ``memory_find_neighbors_by_embedding`` for the other half and for why
+        both ends are needed. This one keeps an archived row from entering a
+        cluster as the CANDIDATE side of a pair.
+
+        ``deleted_at IS NULL`` was the only state filter here, and soft-deletion
+        is not the state that matters: crystallization archives its sources, so
+        the rows this sweep must stop revisiting are precisely the ones it
+        archived itself.
+        """
         async with get_session() as session:
             scope, params = _scope_sql(tenant_id, fleet_id)
             result = await session.execute(
@@ -3832,11 +3844,17 @@ class PostgresService:
                 WHERE {scope}
                   AND m.embedding IS NOT NULL
                   AND m.deleted_at IS NULL
+                  AND m.status = ANY(:live_statuses)
                   AND m.last_dedup_checked_at IS NULL
                 ORDER BY m.created_at DESC
                 LIMIT :batch_size OFFSET :batch_offset
             """),
-                {**params, "batch_size": batch_size, "batch_offset": offset},
+                {
+                    **params,
+                    "batch_size": batch_size,
+                    "batch_offset": offset,
+                    "live_statuses": list(LIVE_MEMORY_STATUSES),
+                },
             )
             return result.all()  # type: ignore[return-value]
 
@@ -3849,6 +3867,28 @@ class PostgresService:
         threshold: float,
         limit: int,
     ) -> list[tuple]:
+        """Near neighbours of one embedding, for the crystallizer's dedup sweep.
+
+        M-61. LIVE rows only, and this is the half of the fix that closes the
+        reported loop. A crystallized fact stays >=0.95 similar to the sources it
+        was merged from — that is what made them a cluster — and those sources
+        are ARCHIVED by the run that created it. Returning them here re-formed
+        the cluster {F, S1, S2} on the next sweep, re-sent it to the LLM, and
+        then archived F, because the archive step takes every cluster member and
+        does not care that one of them is the crystal produced an hour earlier.
+
+        Filtering the CANDIDATE query alone would not have been enough: a pair is
+        (candidate, neighbour), so an archived row excluded from one end still
+        reaches a cluster through the other. Both queries carry the filter, and
+        neither has any caller outside this sweep — the crystallizer is the only
+        production consumer of either, which is what makes filtering safe to do
+        in the query rather than at the call site.
+
+        Deliberately ``LIVE_MEMORY_STATUSES`` rather than ``!= 'archived'``:
+        ``outdated`` and ``conflicted`` are no better as merge inputs, and naming
+        the live set means a status added later is excluded by default rather
+        than silently admitted.
+        """
         async with get_session() as session:
             scope, params = _scope_sql(tenant_id, fleet_id, table="n")
             result = await session.execute(
@@ -3859,6 +3899,7 @@ class PostgresService:
                 WHERE {scope}
                   AND n.embedding IS NOT NULL
                   AND n.deleted_at IS NULL
+                  AND n.status = ANY(:live_statuses)
                   AND n.id != :self_id
                   AND 1 - (n.embedding <=> :query_emb) >= :threshold
                 ORDER BY n.embedding <=> :query_emb
@@ -3870,6 +3911,7 @@ class PostgresService:
                     "self_id": exclude_id,
                     "threshold": threshold,
                     "k": limit,
+                    "live_statuses": list(LIVE_MEMORY_STATUSES),
                 },
             )
             return result.all()  # type: ignore[return-value]

--- a/core-storage-api/tests/test_m61_dedup_excludes_archived.py
+++ b/core-storage-api/tests/test_m61_dedup_excludes_archived.py
@@ -1,0 +1,132 @@
+"""M-61 — the crystallizer's dedup sweep must not see the rows it archived.
+
+Against real Postgres, because the finding is entirely about which rows two SQL
+predicates reach. Stubs would assert the code calls itself.
+
+The loop this closes: run 1 merges cluster {S1,S2,S3} into crystal F and archives
+the sources. F is >=0.95 similar to them — that is what made them a cluster — and
+F is written with ``last_dedup_checked_at`` NULL, so run 2 picks F as a candidate,
+finds the ARCHIVED S1/S2 as neighbours, re-forms {F,S1,S2}, re-sends it to the
+LLM, and then archives F, because the archive step takes every cluster member.
+
+A pair is (candidate, neighbour), so both queries need the filter: an archived row
+excluded from one end still reaches a cluster through the other. There is a test
+for each end.
+"""
+
+import uuid
+
+import pytest
+
+from core_storage_api.services.postgres_service import PostgresService
+
+pytestmark = pytest.mark.asyncio
+
+# 1024 is the column's dimensionality. Two vectors this close sit well past the
+# 0.95 the sweep uses, so similarity never decides these tests — status does,
+# which is the only thing they are about.
+_VEC_A = [0.1] * 1024
+_VEC_B = [0.1] * 1023 + [0.1001]
+
+
+async def _memory(svc: PostgresService, tenant: str, *, status: str, embedding=None):
+    return await svc.memory_add(
+        {
+            "tenant_id": tenant,
+            "agent_id": "m61-tester",
+            "content": f"m61 canary {uuid.uuid4()}",
+            "memory_type": "fact",
+            "weight": 0.5,
+            "status": status,
+            "visibility": "scope_team",
+            "embedding": embedding if embedding is not None else _VEC_A,
+        }
+    )
+
+
+async def test_an_archived_row_is_not_a_dedup_candidate():
+    """The candidate side of the pair.
+
+    Filtering only the neighbour query would leave this open: an archived row
+    still enters a cluster by being the row whose neighbours are scanned.
+    """
+    svc = PostgresService()
+    tenant = f"m61c-{uuid.uuid4().hex[:8]}"
+
+    live = await _memory(svc, tenant, status="active")
+    archived = await _memory(svc, tenant, status="archived")
+
+    rows = await svc.memory_find_near_duplicate_candidates(tenant_id=tenant, fleet_id=None, batch_size=50)
+    ids = {r[0] for r in rows}
+
+    assert live.id in ids, "a live unchecked row must still be swept"
+    assert archived.id not in ids, "an archived row was offered as a dedup candidate"
+
+
+async def test_an_archived_neighbour_is_not_returned():
+    """The neighbour side, and the one that closes the reported loop.
+
+    ``archived`` here stands for a source the previous run merged away; ``live``
+    stands for the crystal it produced.
+    """
+    svc = PostgresService()
+    tenant = f"m61n-{uuid.uuid4().hex[:8]}"
+
+    crystal = await _memory(svc, tenant, status="confirmed")
+    live_peer = await _memory(svc, tenant, status="active", embedding=_VEC_B)
+    archived_source = await _memory(svc, tenant, status="archived", embedding=_VEC_B)
+
+    rows = await svc.memory_find_neighbors_by_embedding(
+        tenant_id=tenant,
+        fleet_id=None,
+        query_embedding=_VEC_A,
+        exclude_id=crystal.id,
+        threshold=0.5,
+        limit=50,
+    )
+    ids = {r[0] for r in rows}
+
+    assert live_peer.id in ids, "a live neighbour must still be found"
+    assert archived_source.id not in ids, (
+        "the crystal was handed back the source it was merged from; "
+        "that re-forms the cluster and re-archives the crystal"
+    )
+
+
+async def test_confirmed_and_pending_are_live_for_this_sweep():
+    """OVER-REFUSAL GUARD, and the reason this is not ``!= 'archived'``.
+
+    A crystal is written ``confirmed``. If the filter had been the literal
+    ``active`` — the easy thing to write — the sweep would stop seeing crystals
+    entirely and never dedup-check them, which is a different bug in the
+    opposite direction and would not have failed either test above.
+    """
+    svc = PostgresService()
+    tenant = f"m61l-{uuid.uuid4().hex[:8]}"
+
+    confirmed = await _memory(svc, tenant, status="confirmed")
+    pending = await _memory(svc, tenant, status="pending")
+
+    rows = await svc.memory_find_near_duplicate_candidates(tenant_id=tenant, fleet_id=None, batch_size=50)
+    ids = {r[0] for r in rows}
+
+    assert {confirmed.id, pending.id} <= ids, f"a live status was dropped from the sweep: {ids}"
+
+
+async def test_non_live_statuses_other_than_archived_are_excluded_too():
+    """``outdated`` and ``conflicted`` are no better as merge inputs.
+
+    Naming the live set rather than excluding one status means a status added
+    later is excluded by default instead of silently admitted.
+    """
+    svc = PostgresService()
+    tenant = f"m61x-{uuid.uuid4().hex[:8]}"
+
+    outdated = await _memory(svc, tenant, status="outdated")
+    conflicted = await _memory(svc, tenant, status="conflicted")
+
+    rows = await svc.memory_find_near_duplicate_candidates(tenant_id=tenant, fleet_id=None, batch_size=50)
+    ids = {r[0] for r in rows}
+
+    assert outdated.id not in ids
+    assert conflicted.id not in ids

--- a/tests/test_p5_crystallizer_archive_sweep.py
+++ b/tests/test_p5_crystallizer_archive_sweep.py
@@ -306,3 +306,73 @@ async def test_archive_sweep_handles_none_slots_for_deleted_memories():
     assert archived_ids == {str(a), str(c), str(d)}
     assert str(b) not in archived_ids
     assert result["memories_archived"] == 3
+
+
+async def test_an_archived_row_in_a_cluster_is_never_re_archived():
+    """M-61 race guard. The pairs are computed at the top of the run.
+
+    ``_check_near_duplicates`` runs in the checks loop, with the health, usage
+    and issue passes between it and crystallization — so a row archived by
+    anything else inside that window is still named in a cluster, and the
+    archive step is unconditional.
+
+    The two SQL filters are what close the reported loop; this is the guard that
+    makes the invariant checkable next to the destructive step rather than
+    resting on two remote queries staying right. ``bulk_get_memories`` cannot
+    carry the filter itself — ``entity_service`` reads evidence rows through it
+    and legitimately needs archived ones.
+    """
+    a, b, c, d = uuid4(), uuid4(), uuid4(), uuid4()
+    rows = [_memory_row(a), _memory_row(b), _memory_row(c), _memory_row(d)]
+    # ``b`` was archived between pair computation and here.
+    rows[1]["status"] = "archived"
+
+    sc = _build_storage_mock(rows)
+    hygiene = {
+        "near_duplicates": {
+            "pairs": [
+                _pair(str(a), str(b)),
+                _pair(str(b), str(c)),
+                _pair(str(c), str(d)),
+            ]
+        }
+    }
+
+    with (
+        patch(
+            "core_api.services.crystallizer_service.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            _stub_resolve_config,
+        ),
+        patch(
+            "core_api.services.crystallizer_service._crystallize_cluster",
+            AsyncMock(
+                return_value=[
+                    {"content": "crystallized", "memory_type": "fact", "weight": 0.8}
+                ]
+            ),
+        ) as crystallize,
+        patch(
+            "core_api.services.memory_service.create_memory",
+            AsyncMock(return_value=type("_MemOut", (), {"id": uuid4()})()),
+        ),
+    ):
+        result = await _run_crystallization(
+            tenant_id="t1", fleet_id=None, hygiene=hygiene
+        )
+
+    assert sc.batch_update_status.call_count == 1
+    archived_ids = {
+        u["memory_id"] for u in sc.batch_update_status.call_args.args[0]["updates"]
+    }
+    assert str(b) not in archived_ids, "an already-archived row was archived again"
+    assert archived_ids == {str(a), str(c), str(d)}
+    assert result["memories_archived"] == 3
+
+    # And it was not handed to the LLM as a merge input either — re-merging
+    # content that was already merged away is what produces the churn.
+    merged_ids = {m["id"] for m in crystallize.call_args.args[0]}
+    assert str(b) not in merged_ids, "an archived row was re-sent to the LLM"


### PR DESCRIPTION
Closes audit finding **M-61**.

Crystallization merges a cluster into one fact and archives the sources. The crystal stays >=0.95 similar to those sources — being that similar is what made them a cluster — and it is written with `last_dedup_checked_at` NULL, so the next sweep picks it up as a candidate.

Neither of the two queries behind that sweep filtered on status. Both took `deleted_at IS NULL` and nothing else, and soft-deletion is not the state that matters here: the rows this sweep must stop revisiting are precisely the ones it archived itself.

So run 2 found the ARCHIVED sources as neighbours of the crystal, re-formed `{F,S1,S2}`, re-sent it to the LLM, and then archived F — the archive step takes every cluster member and does not care that one of them is the crystal produced an hour earlier. `create_memory` then 409s on the re-merge (same `crystallizer` agent, near-verbatim content), so `new_ids` is empty and nothing replaces what was just archived.

## Both queries carry the filter

A pair is (candidate, neighbour), and an archived row excluded from one end still reaches a cluster through the other. Filtering the neighbour query alone would have left the loop open through the candidate side. Each filter is probe-confirmed separately: removing the candidate one fails the candidate test, removing the neighbour one fails the neighbour test.

Safe to filter in the query rather than at the call site because neither query has any caller outside this sweep — the crystallizer is the only production consumer of `/memories/near-duplicate-candidates` and `/memories/neighbors-by-embedding`. That is **not** true of bulk-get, which `entity_service` also uses to read evidence rows and which legitimately needs archived ones, so the third guard below lives in the caller instead.

## Why `LIVE_MEMORY_STATUSES` rather than `!= 'archived'`

`outdated` and `conflicted` are no better as merge inputs, and naming the live set means a status added later is excluded by default rather than silently admitted.

A test pins the other direction too. A crystal is written `confirmed`, so filtering to the literal `active` would have stopped the sweep seeing crystals at all — a different bug, in the opposite direction, that neither exclusion test would have caught.

## The third change is a race guard, not part of the fix

Cluster members are re-checked for live status immediately before the LLM call and the archive. The pairs are computed at the top of the run — `_check_near_duplicates` runs in the checks loop, with the health, usage and issue passes between it and crystallization — so a row archived by anything else inside that window is still named in a cluster.

Clusters themselves are disjoint (union-find over the pairs), so this is **not** reachable from one cluster archiving another's members; the window is external writes only. It earns its place by making the invariant checkable next to the destructive step instead of resting on two remote queries staying right.

## On the reported severity

MEDIUM only because a second refuter defeated the HIGH "data loss" premise: archived rows remain fully recallable, since the recall paths exclude only `outdated`/`conflicted`. That refutation is correct and this change does not alter it. Whether archived *should* be recallable is a separate open question and is deliberately untouched here.

## Tests

Four in core-storage-api against real Postgres, because the finding is entirely about which rows two SQL predicates reach and a stub would assert the code calls itself. One in core-api for the race guard, asserting on the archive batch **and** on what was handed to the LLM, since re-merging content that was already merged away is what produces the churn.

## Verification

- Full core-api suite green (6141 passed).
- core-storage-api suite green (363 passed), on its own scratch database.
- `ruff check` and `ruff format --check` clean at CI's exact scopes, run separately.
- mypy: `core-storage-api` clean; `core-api` clean bar two pre-existing `types-python-dateutil` errors in untouched `common/enrichment/service.py`.
- Legacy-name ratchet, do-not-touch sentinel and tenant-scope gate all exit 0.
- Broker OpenAPI baseline up to date (8 operations).

### One flaky test, worth flagging rather than burying

`tests/test_unknown_field_rejection.py::test_memory_update_rejects_unknown_field` failed on one full-suite run and passed on an identical re-run. It is **not** related to this change: the 409 it fails on comes from the create-path semantic-duplicate check in `check_semantic_duplicate.py`, and the two queries this PR modifies have no caller outside the crystallizer.

The underlying cause is that `tests/conftest.py` purges only tenants matching `SWEEP_TENANT_PREFIX` on session teardown, so every other tenant's rows persist in the shared test database between runs. With `EMBEDDING_PROVIDER=fake`, an accumulated live row makes a later test's setup `POST /memories` a near-duplicate. Open PR #1140 addresses the symptom in that one file; the teardown scope is the root and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
