### PR TITLE
fix(storage): scope a relation's ENDPOINTS to the tenant, not just the edge

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -346,7 +346,15 @@ async def get_full_graph(
 @router.post("/relations")
 async def create_relation(request: Request) -> dict:
     body: dict = await request.json()
-    relation = await _svc.relation_add(body)
+    try:
+        relation = await _svc.relation_add(body)
+    except ValueError as e:
+        # M-64. Without this the service's endpoint-ownership refusal would
+        # surface as a 500 — indistinguishable from storage being broken, which
+        # is the same conflation ``entity_add`` and ``create_memory_entity_link``
+        # already resolved as 409. A caller naming an entity it does not own is
+        # a client error.
+        raise HTTPException(status_code=409, detail=str(e))
     return orm_to_dict(relation, RELATION_FIELDS)
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -371,6 +371,11 @@ _ENTITY_UPDATABLE_FIELDS = frozenset({"canonical_name", "entity_type", "attribut
 # wire — two copies could drift apart and reintroduce the existence oracle one
 # word at a time. The true cause is logged, never returned.
 _LINK_REJECTED = "entity link rejected: memory_id or entity_id does not exist, or the link already exists"
+# M-64. One answer for "no such entity" and "that entity is another tenant's",
+# for the reason ``_LINK_REJECTED`` already carries: this service authenticates
+# no request, so a distinguishable refusal turns the route into an existence
+# oracle over the whole entity id space (GHSA-wgvw-28pq-jc36).
+_RELATION_REJECTED = "relation rejected: from_entity_id or to_entity_id does not exist"
 
 
 # Migration 037 added ``embedded_content_hash`` on 2026-08-16, and every writer
@@ -4643,8 +4648,27 @@ class PostgresService:
 
             link_rows = (
                 await session.execute(
+                    # M-64, and not part of that finding's text — the same
+                    # disclosure through a second door. The MEMORY is
+                    # tenant-checked above, the link row has no tenant column of
+                    # its own, and the entity was joined on id alone: a
+                    # straddling link (this tenant's memory, another tenant's
+                    # entity) handed back that entity's ``canonical_name`` and
+                    # ``attributes`` below. The write path has refused to create
+                    # those since #1085/#1124, which is exactly why the ones that
+                    # remain are historical and unreachable by any later guard.
+                    #
+                    # Stays an OUTER join, so the entry keeps its ``entity_id``
+                    # and ``role`` and simply loses the fields it should never
+                    # have carried — the None branch below already handles it.
                     select(MemoryEntityLink, Entity)
-                    .outerjoin(Entity, MemoryEntityLink.entity_id == Entity.id)
+                    .outerjoin(
+                        Entity,
+                        and_(
+                            MemoryEntityLink.entity_id == Entity.id,
+                            Entity.tenant_id == tenant_id,
+                        ),
+                    )
                     .where(MemoryEntityLink.memory_id == memory_id)
                 )
             ).all()
@@ -6116,8 +6140,40 @@ class PostgresService:
         the response to clients should treat the returned fleet_id as
         authoritative. The row id is preserved across upserts so
         callers reading by id still find the relation.
+
+        M-64. Both entity ends must belong to ``data["tenant_id"]``, and this is
+        the only place that can enforce it. The FKs require the rows to exist in
+        SOME tenant, not this one; ``Relation.tenant_id`` describes the edge, not
+        its endpoints; and upstream ``core-api`` (``entity_service.upsert_relation``)
+        only calls ``enforce_tenant`` on the body before forwarding the raw ids.
+
+        Unenforced, a write key for tenant T could point an edge at a victim
+        entity UUID in tenant U and then read U's ``canonical_name`` and
+        ``attributes`` straight back out of ``relation_get_outgoing``. Refusing
+        the write is the half that stops new ones being created; the tenant
+        predicate added to that reader is what closes the rows already there.
+
+        Raises ``ValueError`` — which the router maps to 409 — with the same
+        message whichever end is at fault, and the same message a nonexistent id
+        gets. See ``_RELATION_REJECTED``.
         """
         async with get_session() as session:
+            from_id, to_id = data["from_entity_id"], data["to_entity_id"]
+            if not isinstance(from_id, UUID):
+                from_id = UUID(str(from_id))
+            if not isinstance(to_id, UUID):
+                to_id = UUID(str(to_id))
+            owned = await self._owned_entities(session, data["tenant_id"], {from_id, to_id})
+            if from_id not in owned or to_id not in owned:
+                # The distinct log line is what keeps the real cause available to
+                # an operator while the wire answer stays uniform.
+                logger.info(
+                    "Relation rejected for %s → %s: an endpoint is not in tenant %s",
+                    from_id,
+                    to_id,
+                    data["tenant_id"],
+                )
+                raise ValueError(_RELATION_REJECTED)
             insert_stmt = pg_insert(Relation).values(**data)
             upsert_stmt = insert_stmt.on_conflict_do_update(
                 constraint="uq_relations_natural_key",
@@ -6179,11 +6235,27 @@ class PostgresService:
         entity_id: UUID,
         tenant_id: str,
     ) -> list[tuple[Relation, Entity]]:
-        """Return outgoing relations with their target entities."""
+        """Return outgoing relations with their target entities.
+
+        M-64. The join carries ``Entity.tenant_id`` as well, not just
+        ``Relation.tenant_id``. The edge belonging to this tenant says nothing
+        about where its TARGET lives: an edge written before the write-side
+        guard (or by any caller reaching storage directly) can name an entity in
+        another tenant, and this method hands the row's ``canonical_name`` and
+        ``attributes`` back to whoever asked.
+
+        An INNER join, so such an edge disappears from this endpoint entirely
+        rather than returning with a hollow target. That is a visible change for
+        any tenant holding one — but every row it hides is an edge into somebody
+        else's data, and there is no version of showing it that is safe.
+        """
         async with get_session() as session:
             stmt = (
                 select(Relation, Entity)
-                .join(Entity, Entity.id == Relation.to_entity_id)
+                .join(
+                    Entity,
+                    and_(Entity.id == Relation.to_entity_id, Entity.tenant_id == tenant_id),
+                )
                 .where(
                     Relation.from_entity_id == entity_id,
                     Relation.tenant_id == tenant_id,
@@ -6631,14 +6703,28 @@ class PostgresService:
                 )
             ).all()
         )
-        owned_entities = set(
+        return owned_memories, await self._owned_entities(session, tenant_id, entity_ids)
+
+    async def _owned_entities(
+        self,
+        session: AsyncSession,
+        tenant_id: str,
+        entity_ids: set[UUID],
+    ) -> set[UUID]:
+        """Which of these entity ids belong to ``tenant_id``.
+
+        Split out of :meth:`_owned_link_endpoints` so "an entity this tenant
+        owns" has ONE definition. M-64 needed the same test for relation
+        endpoints, where there is no memory side to check, and a second inline
+        copy is how the two drift apart.
+        """
+        return set(
             (
                 await session.scalars(
                     select(Entity.id).where(Entity.id.in_(entity_ids), Entity.tenant_id == tenant_id)
                 )
             ).all()
         )
-        return owned_memories, owned_entities
 
     async def entity_add_entity_link(self, tenant_id: str, data: dict) -> MemoryEntityLink:
         """Create one memory→entity link, both ends scoped to ``tenant_id``.

--- a/core-storage-api/tests/test_relation_tenant_scope.py
+++ b/core-storage-api/tests/test_relation_tenant_scope.py
@@ -1,0 +1,257 @@
+"""M-64 — a relation's ENDPOINTS must belong to the tenant, not just the edge.
+
+``Relation`` has a ``tenant_id``, which is what made this easy to miss: the edge
+carried a predicate, so the queries looked scoped. But the column describes the
+edge, not the two entities it names, and the FKs only require those rows to exist
+in SOME tenant. Three surfaces, and they fail independently:
+
+* ``relation_add`` accepted any entity UUID, so a write key for tenant T could
+  point an edge at a victim entity in tenant U.
+* ``relation_get_outgoing`` joined the TARGET entity on id alone, so reading that
+  edge back handed over U's ``canonical_name`` and ``attributes``.
+* ``memory_get_detail`` joined the linked entity on id alone — the same
+  disclosure through ``memory_entity_links``, which is NOT part of the reported
+  finding and was found by auditing every ``join(Entity`` in the service.
+
+The write guard stops new straddling rows. It does nothing for the ones already
+there, which is why each reader is fixed and tested separately: reverting either
+predicate leaves a live disclosure that the other test still passes over.
+
+Straddling rows are created here with raw SQL on purpose. Both write paths refuse
+them now, so going through the API would test the guard instead of the reader and
+every assertion below would hold with the bug reintroduced — the failure mode
+``test_memory_entity_links_tenant_scope._links`` documents for the same reason.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from core_storage_api.services.postgres_service import get_session
+from tests.test_integration import PREFIX, _memory_payload
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _tenant() -> str:
+    """See ``test_memory_entity_links_tenant_scope._tenant`` — same prefix contract."""
+    return f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+
+async def _entity(client: AsyncClient, tenant_id: str, name: str | None = None) -> str:
+    resp = await client.post(
+        f"{PREFIX}/entities",
+        json={
+            "tenant_id": tenant_id,
+            "entity_type": "person",
+            "canonical_name": name or f"RelScope-{uuid.uuid4().hex[:8]}",
+            "attributes": {"secret": "victim-only"},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _memory(client: AsyncClient, tenant_id: str) -> str:
+    fleet_id = f"test-fleet-{uuid.uuid4().hex[:8]}"
+    resp = await client.post(f"{PREFIX}/memories", json=_memory_payload(tenant_id, fleet_id))
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _straddling_relation(tenant_id: str, from_id: str, to_id: str) -> None:
+    """Insert the row the write path now refuses, as history already holds it."""
+    async with get_session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO relations (id, tenant_id, from_entity_id, relation_type, "
+                "to_entity_id, weight) VALUES (gen_random_uuid(), :t, CAST(:f AS uuid), "
+                "'knows', CAST(:o AS uuid), 0.5)"
+            ),
+            {"t": tenant_id, "f": from_id, "o": to_id},
+        )
+        await session.commit()
+
+
+async def _straddling_link(memory_id: str, entity_id: str) -> None:
+    """Same, for ``memory_entity_links`` — refused since #1085/#1124."""
+    async with get_session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO memory_entity_links (memory_id, entity_id, role) "
+                "VALUES (CAST(:m AS uuid), CAST(:e AS uuid), 'subject')"
+            ),
+            {"m": memory_id, "e": entity_id},
+        )
+        await session.commit()
+
+
+class TestRelationWriteTenantScope:
+    async def test_a_foreign_to_entity_is_refused(self, client: AsyncClient) -> None:
+        attacker, victim = _tenant(), _tenant()
+        mine = await _entity(client, attacker)
+        theirs = await _entity(client, victim)
+
+        resp = await client.post(
+            f"{PREFIX}/entities/relations",
+            json={
+                "tenant_id": attacker,
+                "from_entity_id": mine,
+                "relation_type": "knows",
+                "to_entity_id": theirs,
+            },
+        )
+        assert resp.status_code == 409, resp.text
+
+    async def test_a_foreign_from_entity_is_refused(self, client: AsyncClient) -> None:
+        """The other end, separately — the two failures are independent.
+
+        Guarding only ``to_entity_id`` still lets an attacker hang an edge off a
+        victim's entity, which ``relation_get_outgoing`` then serves to anyone
+        who can name it.
+        """
+        attacker, victim = _tenant(), _tenant()
+        mine = await _entity(client, attacker)
+        theirs = await _entity(client, victim)
+
+        resp = await client.post(
+            f"{PREFIX}/entities/relations",
+            json={
+                "tenant_id": attacker,
+                "from_entity_id": theirs,
+                "relation_type": "knows",
+                "to_entity_id": mine,
+            },
+        )
+        assert resp.status_code == 409, resp.text
+
+    async def test_own_relation_is_created(self, client: AsyncClient) -> None:
+        """OVER-REFUSAL GUARD. A guard that refused everything passes every test above."""
+        tenant = _tenant()
+        a, b = await _entity(client, tenant), await _entity(client, tenant)
+
+        resp = await client.post(
+            f"{PREFIX}/entities/relations",
+            json={
+                "tenant_id": tenant,
+                "from_entity_id": a,
+                "relation_type": "knows",
+                "to_entity_id": b,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["from_entity_id"] == a
+
+    async def test_a_foreign_id_is_indistinguishable_from_a_missing_one(self, client: AsyncClient) -> None:
+        """No existence oracle. This service authenticates nothing.
+
+        If "that entity is another tenant's" answered differently from "no such
+        entity", the route would confirm the existence of any UUID a caller cared
+        to guess — the reason ``_LINK_REJECTED`` is one message for both, per
+        GHSA-wgvw-28pq-jc36.
+        """
+        attacker, victim = _tenant(), _tenant()
+        mine = await _entity(client, attacker)
+        theirs = await _entity(client, victim)
+        nonexistent = str(uuid.uuid4())
+
+        foreign = await client.post(
+            f"{PREFIX}/entities/relations",
+            json={
+                "tenant_id": attacker,
+                "from_entity_id": mine,
+                "relation_type": "knows",
+                "to_entity_id": theirs,
+            },
+        )
+        missing = await client.post(
+            f"{PREFIX}/entities/relations",
+            json={
+                "tenant_id": attacker,
+                "from_entity_id": mine,
+                "relation_type": "knows",
+                "to_entity_id": nonexistent,
+            },
+        )
+        assert foreign.status_code == missing.status_code
+        assert foreign.json() == missing.json(), (
+            "a foreign entity answers differently from a missing one; the route "
+            "is an existence oracle over the whole entity id space"
+        )
+
+
+class TestRelationReadTenantScope:
+    async def test_a_straddling_relation_does_not_disclose_its_target(self, client: AsyncClient) -> None:
+        """The row the write guard cannot reach: one that already exists."""
+        attacker, victim = _tenant(), _tenant()
+        mine = await _entity(client, attacker)
+        theirs = await _entity(client, victim, name="Victim-Confidential")
+        await _straddling_relation(attacker, mine, theirs)
+
+        resp = await client.get(f"{PREFIX}/entities/{mine}/relations", params={"tenant_id": attacker})
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == [], f"another tenant's entity was served as a relation target: {resp.text}"
+
+    async def test_own_relations_are_still_returned(self, client: AsyncClient) -> None:
+        """OVER-REFUSAL GUARD on the join predicate."""
+        tenant = _tenant()
+        a, b = await _entity(client, tenant), await _entity(client, tenant)
+        created = await client.post(
+            f"{PREFIX}/entities/relations",
+            json={
+                "tenant_id": tenant,
+                "from_entity_id": a,
+                "relation_type": "knows",
+                "to_entity_id": b,
+            },
+        )
+        assert created.status_code == 200, created.text
+
+        resp = await client.get(f"{PREFIX}/entities/{a}/relations", params={"tenant_id": tenant})
+        assert resp.status_code == 200, resp.text
+        targets = [row["target"]["id"] for row in resp.json()]
+        assert targets == [b], f"a same-tenant relation was dropped by the join: {resp.text}"
+
+
+class TestMemoryDetailEntityTenantScope:
+    async def test_a_straddling_link_does_not_disclose_the_entity(self, client: AsyncClient) -> None:
+        """Surface #3, absent from the finding's text.
+
+        The memory is tenant-checked; the entity joined onto it was not. The link
+        row itself has no tenant column, so nothing else stood between a
+        historical straddling row and the victim's name.
+        """
+        attacker, victim = _tenant(), _tenant()
+        memory_id = await _memory(client, attacker)
+        theirs = await _entity(client, victim, name="Victim-Confidential")
+        await _straddling_link(memory_id, theirs)
+
+        resp = await client.get(f"{PREFIX}/memories/{memory_id}/detail", params={"tenant_id": attacker})
+        assert resp.status_code == 200, resp.text
+        links = resp.json()["entity_links"]
+        assert len(links) == 1, links
+        # The link is still reported — it is this tenant's row and hiding it
+        # would misrepresent the memory. Only the foreign entity's fields go.
+        assert links[0]["entity_id"] == theirs
+        assert links[0]["role"] == "subject"
+        assert "canonical_name" not in links[0], f"the victim's entity name leaked: {links[0]}"
+        assert "attributes" not in links[0], f"the victim's attributes leaked: {links[0]}"
+
+    async def test_own_link_still_carries_the_entity_name(self, client: AsyncClient) -> None:
+        """OVER-REFUSAL GUARD. The outer join must still populate same-tenant rows."""
+        tenant = _tenant()
+        memory_id = await _memory(client, tenant)
+        mine = await _entity(client, tenant, name="Mine-Visible")
+        await _straddling_link(memory_id, mine)
+
+        resp = await client.get(f"{PREFIX}/memories/{memory_id}/detail", params={"tenant_id": tenant})
+        assert resp.status_code == 200, resp.text
+        links = resp.json()["entity_links"]
+        assert len(links) == 1, links
+        assert links[0]["canonical_name"] == "Mine-Visible", (
+            f"a same-tenant entity lost its fields to the new predicate: {links[0]}"
+        )


### PR DESCRIPTION
Closes audit finding **M-64**. Cross-tenant disclosure.

`Relation` carries a `tenant_id`, which is what made this easy to miss: the edge had a predicate, so the queries looked scoped. But that column describes the **edge**, not the two entities it names, and the entity FKs only require those rows to exist in *some* tenant.

So a write key for tenant T could post:

```json
{"tenant_id": "T", "from_entity_id": "<own>", "to_entity_id": "<a victim UUID in tenant U>"}
```

…then `GET /entities/<own>/relations` and read U's `canonical_name` and `attributes` straight out of the response. Upstream core-api only calls `enforce_tenant` on the body and forwards the raw ids, so storage is the sole line of defence and it had none.

## Three surfaces, fixed and tested separately

They fail independently, so each has its own test and its own probe.

| | where | what |
|---|---|---|
| 1 | `relation_add` | refuses an endpoint the tenant does not own — stops **new** straddling rows |
| 2 | `relation_get_outgoing` | carries `Entity.tenant_id` on the join — closes the rows **already there** |
| 3 | `memory_get_detail` | same disclosure via `memory_entity_links` — **not in the finding** |

Surface 3 was found by auditing every `join(Entity` in the service rather than only the two locations the finding cites. The write guard cannot reach history, and any caller reaching storage directly bypasses core-api entirely — which is why fixing the write side alone would have left a live leak.

**`entity_expand_graph` is not affected and is deliberately untouched.** It scopes `Relation.tenant_id` in both directions and returns only ids and hop weights, and the downstream entity fetch is tenant-scoped. It can traverse toward a foreign id and waste work; it discloses nothing. Stated explicitly because it is the obvious fourth suspect and should not be "fixed" speculatively.

## Reusing the existing machinery

`_owned_entities` is split out of `_owned_link_endpoints` so *"an entity this tenant owns"* has one definition — relations need the same test with no memory side, and a second inline copy is how the two drift apart.

The refusal message is uniform across *"no such entity"* and *"that entity is another tenant's"*. This service authenticates no request, so a distinguishable refusal is an existence oracle over the whole entity id space — the same reason `_LINK_REJECTED` is one message for both (GHSA-wgvw-28pq-jc36).

`POST /entities/relations` needed a `ValueError → 409` mapping it did not have. **The pre-fix behaviour was worse than a missing guard:** a *foreign* id returned `200`, and a *nonexistent* one returned `500` from an uncaught `ForeignKeyViolationError`. So the endpoint both leaked data and confirmed the existence of any UUID a caller cared to guess. Both are one `409` now, and a test pins the two responses as byte-identical.

## Behaviour change worth calling out

The predicate on `relation_get_outgoing` is an **inner** join, so a pre-existing straddling relation disappears from that endpoint rather than returning with a hollow target. Every row it hides is an edge into another tenant's data.

Surface 3 stays an **outer** join, so those entries keep `entity_id` and `role` and lose only the fields they should never have carried.

## Tests

Eight, against real Postgres. Each guard is probe-confirmed alone — reverting the write check fails the three write tests; reverting either read predicate fails exactly its own test and nothing else. The read probe printed the exploit verbatim: `"canonical_name":"Victim-Confidential"`, `"attributes":{"secret":"victim-only"}` in the attacker tenant's response body.

Straddling rows are inserted with raw SQL on purpose. Both write paths refuse them now, so creating them through the API would test the guard instead of the reader and every assertion would hold with the bug reintroduced — the same failure mode `test_memory_entity_links_tenant_scope._links` documents.

Three over-refusal guards cover the opposite error, since a check that refused everything would pass every attack test above.

## Verification

- core-storage-api suite: **371 passed** (363 + the 8 new).
- Full core-api suite: **6141 passed**.
- `ruff check` and `ruff format --check` clean at CI's exact scopes, run separately.
- mypy `core-storage-api`: clean, 86 files.
- Legacy-name ratchet, do-not-touch sentinel, tenant-scope gate: all exit 0.
- Broker OpenAPI baseline up to date (8 operations).

One disclosure about process: the sandbox was restarted between verification and commit, so the suites above were run before the restart and could not be re-run after it (Docker was down). The commit content is byte-identical to what was verified — it was restored from git's content-addressed index, not retyped — and lint, format, mypy and all three gates were re-run post-recovery and are green. CI re-runs everything regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
