### PR TITLE
fix(ingest): validate every redirect hop BEFORE requesting it

### DIFF
--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -8,6 +8,8 @@ import re
 import socket
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from urllib.parse import urlparse
 
@@ -96,6 +98,17 @@ INGEST_MAX_INPUT_BYTES = 3_000_000  # 3 MB
 
 # Back-compat alias for code/tests written before the unification.
 MAX_INGEST_CONTENT_BYTES = INGEST_MAX_INPUT_BYTES
+
+# M-43. Redirects are walked by hand so every hop can be checked BEFORE it is
+# requested, which means this module owns the cap httpx used to own. Lower than
+# httpx's default of 20: a legitimate document fetch does not need five hops,
+# and each one is an outbound request from inside the deployment network.
+#
+# This also TIGHTENS the wall-clock ceiling rather than loosening it. httpx
+# applies ``timeout`` per hop (``_send_handling_redirects`` calls
+# ``_send_single_request`` in a loop), so the old ``follow_redirects=True`` with
+# the default 20-redirect cap allowed ~21 x 30s. Six hops is 3.5x less.
+MAX_INGEST_REDIRECTS = 5
 
 # Explicit deny-list for cloud-metadata service IPs that aren't always
 # caught by ipaddress.is_link_local (AWS 169.254.169.254 IS link-local;
@@ -394,28 +407,205 @@ def _is_blocked_ip(addr: str) -> bool:
     )
 
 
-def _check_hostname_safe(url: str) -> None:
-    """Resolve the URL's hostname and reject if it points at private infra.
+# Wall-clock ceiling for one hop's DNS. Real answers land in milliseconds; this
+# is generous for a slow-but-honest resolver and short against a hostile one.
+DNS_RESOLUTION_TIMEOUT = 5.0
 
-    Light-weight SSRF defense. Does NOT handle DNS rebinding between this
-    resolution and the actual TCP connect — that's a Tier 3 hardening item.
-    Covers the accidental-misuse case (localhost, RFC1918, cloud metadata).
+# Ceiling for the WHOLE fetch, redirect chain included. Reasoned about in
+# ``_fetch_url_text``; the short version is that per-hop budgets multiply and
+# this is the only number a caller-supplied chain cannot inflate.
+MAX_INGEST_FETCH_SECONDS = 60.0
+
+# DNS runs HERE rather than on the default executor, and the two protections
+# are not interchangeable:
+#
+#   asyncio.wait_for bounds the REQUEST. It does NOT reclaim the thread — a
+#   concurrent.futures future that is already running cannot be cancelled, so
+#   the worker stays inside getaddrinfo until the resolver answers or the OS
+#   gives up. Measured: after a 0.5s wait_for timeout on a 3s blocking call,
+#   the next task on a 1-worker pool still waited 2.52s for its turn.
+#
+#   The dedicated pool bounds the BLAST RADIUS. Because the timeout cannot free
+#   threads, hostile DNS can pin every worker it is allowed to reach; the only
+#   question is which pool those are. On the default executor that is the one
+#   the whole ASGI app shares, so one tenant's slow resolver could stall
+#   unrelated blocking work — a cross-tenant DoS. Confined here, a saturated
+#   pool degrades ingest (later hops queue, then time out with a 400) and
+#   nothing else.
+#
+# The hostname is attacker-supplied by design on this endpoint, so treat both
+# as load-bearing rather than defensive decoration.
+#
+# KNOWN LIMITATION, recorded because there is no call that fixes it. A worker
+# stuck in getaddrinfo delays interpreter exit: concurrent.futures.thread's
+# atexit hook joins it, so SIGTERM during a hostile-DNS fetch can outlast the
+# shutdown grace period. Registering a shutdown on the app's lifespan does NOT
+# help — a running worker cannot be cancelled, the same limitation that makes
+# the timeout above insufficient on its own. Measured, 5s blocking call, time
+# to process exit: no shutdown 5.03s, shutdown(wait=False) 5.03s,
+# shutdown(wait=False, cancel_futures=True) 5.03s.
+#
+# And do not reach for the workaround: dropping these threads from
+# ``concurrent.futures.thread._threads_queues`` so atexit skips them leaves
+# ``threading._shutdown`` waiting on a non-daemon thread that can no longer be
+# woken, and the process hangs forever instead of for seconds. Measured too.
+#
+# What actually bounds this is the OS resolver's own timeout and max_workers.
+_DNS_EXECUTOR = ThreadPoolExecutor(max_workers=8, thread_name_prefix="ingest-dns")
+
+
+def _resolve_and_vet(url: str) -> list[str]:
+    """Resolve the URL's hostname, reject private infra, and RETURN the addresses.
+
+    Returning the vetted addresses rather than just raising is what lets the
+    caller CONNECT to one of them instead of resolving the name a second time.
+    Every address the name resolves to must pass — an attacker who can return
+    one public and one private answer must not get to pick.
     """
     parsed = urlparse(url)
     host = parsed.hostname
     if not host:
         raise HTTPException(status_code=400, detail=f"Invalid URL: no hostname in {url!r}")
+    # A redirect ``Location`` is attacker-controlled once the fetched server
+    # answers, and nothing downstream rejects a non-HTTP scheme:
+    # ``ftp://public-host/x`` resolves, vets and pins cleanly, then dies inside
+    # httpx's transport selection as ``UnsupportedProtocol`` — an exception
+    # this module does not catch, so it escapes as a 500 from the one function
+    # that turns every other malformed input into a 400.
+    #
+    # AFTER the hostname check, not before: the schemes that reach here are the
+    # ones carrying a host. ``file:///etc/passwd`` and a bare
+    # ``not-a-valid-url`` have none, and both were already refused above —
+    # putting scheme first would only change which message they get.
+    #
+    # An https -> http downgrade stays permitted. This fetches public content,
+    # and credentials cannot ride a downgrade: only an ABSOLUTE ``Location``
+    # can change the scheme, and an absolute reference replaces the whole
+    # authority, dropping userinfo with it.
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported URL scheme {parsed.scheme!r} in {url!r} (http/https only)",
+        )
+    # ``.port`` raises ValueError on a non-integer port, and it is read later by
+    # _pin_url_to_address. Touching it HERE means a malformed port is rejected
+    # at the same point as every other invalid URL, with the same 400, instead
+    # of passing vetting and then escaping this module as a 500.
+    try:
+        _ = parsed.port
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid port in URL {url!r}: {e}")
     try:
         infos = socket.getaddrinfo(host, None)
     except socket.gaierror as e:
         raise HTTPException(status_code=400, detail=f"DNS resolution failed for {host}: {e}")
-    for family, _, _, _, sockaddr in infos:
+    addrs: list[str] = []
+    for _family, _, _, _, sockaddr in infos:
         addr = str(sockaddr[0])
         if _is_blocked_ip(addr) or addr in _CLOUD_METADATA_IPS:
             raise HTTPException(
                 status_code=400,
                 detail=f"Blocked: {host} resolves to {addr} (private/loopback/link-local/metadata)",
             )
+        if addr not in addrs:
+            addrs.append(addr)
+    if not addrs:
+        raise HTTPException(status_code=400, detail=f"DNS resolution failed for {host}: no addresses")
+    return addrs
+
+
+async def _resolve_and_vet_async(url: str) -> list[str]:
+    """``_resolve_and_vet``, off the event loop.
+
+    ``socket.getaddrinfo`` blocks and takes no timeout, and M-43's per-hop loop
+    runs it up to ``MAX_INGEST_REDIRECTS + 1`` times where the old code ran it
+    twice. Six blocking resolutions inline is six chances for one tenant's slow
+    DNS to stall every other request sharing the worker — a fair objection to
+    the per-hop check, and cheaper to answer than to argue with.
+
+    A wrapper rather than making the vetting itself async: it is the policy
+    function and its logic has no business knowing about event loops.
+
+    This deliberately has NO branch for "skip pinning". An earlier cut decided
+    that by comparing the module-level checker against a snapshot taken at
+    import, so that tests substituting a yes/no stand-in kept working — which
+    made a security-critical behaviour toggle on whether a private module
+    attribute had been reassigned, silently and without a log line. Tests patch
+    this function or :func:`_resolve_and_vet` instead.
+
+    The timeout and the dedicated pool do two DIFFERENT jobs, and neither
+    substitutes for the other. See :data:`_DNS_EXECUTOR`.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        return await asyncio.wait_for(
+            loop.run_in_executor(_DNS_EXECUTOR, _resolve_and_vet, url),
+            timeout=DNS_RESOLUTION_TIMEOUT,
+        )
+    except TimeoutError:  # asyncio.TimeoutError is an alias of this since 3.11
+        host = urlparse(url).hostname or url
+        raise HTTPException(
+            status_code=400,
+            detail=f"DNS resolution timed out after {DNS_RESOLUTION_TIMEOUT}s for {host}",
+        )
+
+
+@asynccontextmanager
+async def _stream_request(client: httpx.AsyncClient, request: httpx.Request):
+    """``client.stream(...)``, but for a request built in advance.
+
+    ``client.stream`` builds its own request internally, so it cannot carry the
+    pinned URL, the ``Host`` header and the SNI extension. ``send(stream=True)``
+    can, but hands back a plain ``Response`` that has to be closed by hand —
+    ``httpx.Response`` is not an async context manager.
+    """
+    resp = await client.send(request, stream=True)
+    try:
+        yield resp
+    finally:
+        await resp.aclose()
+
+
+def _pin_url_to_address(url: str, addr: str) -> tuple[str, str]:
+    """Rewrite ``url`` to connect to ``addr``, returning (connect_url, host_header).
+
+    DNS rebinding is the gap :func:`_resolve_and_vet` cannot close on its own:
+    it resolves a name, and then httpx resolves the SAME name again when it
+    connects. An attacker serving a public answer to the first lookup and a
+    private one to the second walks straight through a check that passed
+    honestly. Connecting to the address we already vetted removes the second
+    lookup, and with it the window.
+
+    The hostname still travels — as the ``Host`` header, and as the TLS SNI name
+    the caller sets — so virtual hosting still works and the certificate is
+    still verified against the NAME, not the address. Verified against a real
+    server: with the SNI override the request succeeds; without it, or with the
+    wrong name, the handshake is refused.
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    # Both halves need brackets around an IPv6 literal: the authority so the URL
+    # parses back, and the Host header so it is valid per RFC 7230. ``hostname``
+    # strips the brackets the source URL had, so a v6 literal SOURCE host needs
+    # them put back too — otherwise "::1" with port 8443 emits the unparseable
+    # ``Host: ::1:8443``.
+    host_literal = f"[{host}]" if ":" in host else host
+    host_header = f"{host_literal}:{parsed.port}" if parsed.port else host_literal
+    literal = f"[{addr}]" if ":" in addr else addr
+    authority = f"{literal}:{parsed.port}" if parsed.port else literal
+    # Userinfo rides along, or pinning would silently strip credentials that
+    # httpx turns into a Basic auth header — a URL the old code fetched fine
+    # would start coming back 401. Taken verbatim from the netloc rather than
+    # via ``parsed.username``/``password`` so percent-encoding round-trips.
+    # It never belongs in the Host header.
+    #
+    # Cross-host redirects do not carry it: the next hop's URL comes from
+    # joining Location onto the logical URL, and an absolute Location replaces
+    # the whole authority, userinfo included.
+    userinfo = parsed.netloc.rpartition("@")[0]
+    if userinfo:
+        authority = f"{userinfo}@{authority}"
+    return parsed._replace(netloc=authority).geturl(), host_header
 
 
 # Kreuzberg config used by ``_extract_with_kreuzberg``. We request markdown
@@ -513,6 +703,40 @@ async def _extract_with_kreuzberg(body: bytes, mime: str) -> str:
 
 
 async def _fetch_url_text(url: str) -> str:
+    """One deadline for the whole fetch, however the hops divide it up.
+
+    The per-hop budgets do not compose into a bound worth having. Each hop
+    pays its own DNS timeout plus the client's request timeout, and with
+    ``MAX_INGEST_REDIRECTS`` that is 6 x (5 + 30) = 210s of wall clock a
+    caller-supplied chain can spend, every second of it holding a request
+    coroutine — a server answering each hop just under the timeout gets that
+    for free.
+
+    That ceiling is LOWER than what this code replaced, which is why it is
+    being tightened rather than introduced: httpx's ``DEFAULT_MAX_REDIRECTS``
+    is 20 and its timeout applies per hop, so ``follow_redirects=True`` allowed
+    ~21 x 30s, plus two unbounded ``getaddrinfo`` calls ON the event loop.
+    Lower is not the same as low enough: 210s still overruns the 120s request
+    timeout this platform's services are deployed with, so the caller would
+    see the proxy's 504 rather than the clean 400 this module otherwise
+    promises.
+
+    60s is chosen against the size cap, not picked round: at 100 KB/s — far
+    below any real server — ``MAX_INGEST_CONTENT_BYTES`` (3 MB) transfers in
+    30s, so this leaves 2x headroom for the body plus every redirect hop, and
+    still lands well inside 120s.
+    """
+    try:
+        async with asyncio.timeout(MAX_INGEST_FETCH_SECONDS):
+            return await _walk_redirects_and_fetch(url)
+    except TimeoutError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"URL fetch exceeded its {MAX_INGEST_FETCH_SECONDS}s budget: {url!r}",
+        )
+
+
+async def _walk_redirects_and_fetch(url: str) -> str:
     """Fetch URL, validate MIME + size, decode safely, and extract text.
 
     For ``TEXT_INGEST_MIME_TYPES`` the body is decoded with the response
@@ -521,82 +745,169 @@ async def _fetch_url_text(url: str) -> str:
     Kreuzberg for format-specific extraction.
 
     Raises ``HTTPException`` for:
-    - 400: invalid URL, DNS failure, hostname resolves to a blocked IP range
+    - 400: invalid URL, DNS failure, hostname resolves to a blocked IP range,
+           or the redirect chain exceeds ``MAX_INGEST_REDIRECTS``
     - 413: fetched body exceeds ``MAX_INGEST_CONTENT_BYTES``
     - 422: response Content-Type isn't in the allowlist, or Kreuzberg
            rejected the content (encrypted PDF, malformed file, empty
            text extraction, etc.)
     - 4xx/5xx: passed through from the upstream server
+
+    M-43. The redirect chain is walked HERE, one hop at a time, because
+    ``follow_redirects=True`` checks nothing on the way. httpx walks the whole
+    chain inside ``client.stream`` — issuing a real GET to every hop — and only
+    hands back the final response, so a check on ``resp.url`` afterwards runs
+    long after the request to the private host was sent and answered. The
+    previous version did exactly that, and its comment claimed the check
+    "re-validates the FINAL host post-redirect (the upstream may have redirected
+    us to a private host)". It did not prevent that request; it only prevented
+    reading its body. ``raise_for_status()`` even ran first, so the internal
+    host's status code surfaced to the caller too.
+
+    That is a live SSRF: an authenticated tenant submits a URL they control
+    which 302s to ``169.254.169.254`` or any RFC1918 address, and core-api
+    issues the GET from inside the deployment network.
+
+    Checking each hop before requesting it is the only ordering that helps,
+    which is why the cap moved here as well — ``follow_redirects=False`` means
+    httpx no longer enforces one.
+
+    DNS rebinding, the gap this deliberately left open at first, is closed too:
+    each hop CONNECTS to an address that was just vetted rather than resolving
+    the name a second time. See :func:`_pin_url_to_address`.
     """
-    _check_hostname_safe(url)
-
-    async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
-        async with client.stream("GET", url) as resp:
-            resp.raise_for_status()
-
-            # Re-validate the FINAL host post-redirect (the upstream may
-            # have redirected us to a private host). httpx exposes the
-            # ultimate URL via resp.url; ``follow_redirects=True`` already
-            # walked the chain.
-            _check_hostname_safe(str(resp.url))
-
-            # MIME allowlist on the final response, not the initial request.
-            content_type = resp.headers.get("content-type", "").split(";")[0].strip().lower()
-            if content_type and content_type not in ALLOWED_INGEST_MIME_TYPES:
-                raise HTTPException(
-                    status_code=422,
-                    detail=(
-                        f"Unsupported content type: {content_type}. "
-                        f"Allowed: {sorted(ALLOWED_INGEST_MIME_TYPES)}"
-                    ),
-                )
-
-            # Pre-check Content-Length if the server bothered to send it.
-            # Saves us from downloading anything when the server is honest.
-            cl_header = resp.headers.get("content-length")
-            if cl_header:
-                try:
-                    if int(cl_header) > MAX_INGEST_CONTENT_BYTES:
-                        raise HTTPException(
-                            status_code=413,
-                            detail=(f"Content too large: {cl_header} bytes (max {MAX_INGEST_CONTENT_BYTES})"),
-                        )
-                except ValueError:
-                    # Malformed Content-Length — fall through to streaming.
-                    pass
-
-            # Stream the body, abort if it exceeds the cap after
-            # decompression. httpx transparently decompresses gzip/br
-            # within ``aiter_bytes`` so this measures decompressed bytes
-            # (gzip-bomb guard).
-            chunks: list[bytes] = []
-            total = 0
-            async for chunk in resp.aiter_bytes():
-                total += len(chunk)
-                if total > MAX_INGEST_CONTENT_BYTES:
+    # No keep-alive. httpcore pools connections by the request URL's origin and
+    # reads ``sni_hostname`` only when it OPENS one, so once every hop is pinned
+    # to an address, two hops with different hostnames on one IP look like one
+    # origin — and the second would ride a TLS session verified for the first
+    # one's name. Today nothing is pooled anyway, because a redirect response is
+    # closed without its body being read and httpcore cannot resync a half-read
+    # HTTP/1.1 connection. That is an accident of body handling, not a promise:
+    # draining a redirect body, here or in some later change, restores reuse and
+    # the hole with it. Measured — drained bodies reuse, this setting stops it.
+    async with httpx.AsyncClient(
+        follow_redirects=False,
+        timeout=30.0,
+        limits=httpx.Limits(max_keepalive_connections=0),
+    ) as client:
+        current = url
+        for _hop in range(MAX_INGEST_REDIRECTS + 1):
+            # BEFORE the request, every time — including the first.
+            # Non-empty or it raised — there is no path here that vets a name
+            # and then connects to it by name anyway.
+            addrs = await _resolve_and_vet_async(current)
+            connect_url, host_header = _pin_url_to_address(current, addrs[0])
+            request = client.build_request(
+                "GET",
+                connect_url,
+                headers={"Host": host_header},
+                extensions={"sni_hostname": urlparse(current).hostname or ""},
+            )
+            async with _stream_request(client, request) as resp:
+                if resp.is_redirect and not resp.has_redirect_location:
+                    # A 3xx with no Location. ``is_redirect`` is the STATUS CODE
+                    # ALONE — httpx's own docstring says to use
+                    # ``has_redirect_location`` when the header matters — so
+                    # indexing ``headers["location"]`` behind an ``is_redirect``
+                    # check raises KeyError on a response a hostile server can
+                    # simply choose to send.
+                    #
+                    # 400 rather than falling through to the normal path: there
+                    # ``raise_for_status()`` raises on 3xx as well, and
+                    # ``upstream_http_error_handler`` re-raises anything under
+                    # 500 into the catch-all, so falling through is another 500
+                    # — which is what the pre-M-43 code did here too. Neither
+                    # the old 500 nor a KeyError is right for a malformed
+                    # upstream reply to a caller-supplied URL. Same 400 as the
+                    # redirect cap, for the same reason.
                     raise HTTPException(
-                        status_code=413,
+                        status_code=400,
+                        detail=f"Upstream returned {resp.status_code} with no Location header for {current!r}",
+                    )
+
+                if resp.has_redirect_location:
+                    # Location may be relative, so it is resolved against a
+                    # base.
+                    #
+                    # That base is ``current`` — the LOGICAL url — and NOT
+                    # ``resp.url``, which since pinning is the address-rewritten
+                    # one. Joining "/next" against the pinned form would produce
+                    # an address-based URL, dropping the hostname needed for the
+                    # next hop's Host header, its SNI name and its own vetting.
+                    current = str(httpx.URL(current).join(resp.headers["location"]))
+                    continue
+
+                resp.raise_for_status()
+
+                # MIME allowlist on the final response, not the initial request.
+                content_type = resp.headers.get("content-type", "").split(";")[0].strip().lower()
+                if content_type and content_type not in ALLOWED_INGEST_MIME_TYPES:
+                    raise HTTPException(
+                        status_code=422,
                         detail=(
-                            f"Content too large: exceeded {MAX_INGEST_CONTENT_BYTES} bytes "
-                            f"after decompression"
+                            f"Unsupported content type: {content_type}. "
+                            f"Allowed: {sorted(ALLOWED_INGEST_MIME_TYPES)}"
                         ),
                     )
-                chunks.append(chunk)
-            body = b"".join(chunks)
 
-            # ---- PR #8: binary formats route through Kreuzberg ----
-            if content_type in BINARY_INGEST_MIME_TYPES:
-                return await _extract_with_kreuzberg(body, content_type)
+                # Pre-check Content-Length if the server bothered to send it.
+                # Saves us from downloading anything when the server is honest.
+                cl_header = resp.headers.get("content-length")
+                if cl_header:
+                    try:
+                        if int(cl_header) > MAX_INGEST_CONTENT_BYTES:
+                            raise HTTPException(
+                                status_code=413,
+                                detail=(
+                                    f"Content too large: {cl_header} bytes (max {MAX_INGEST_CONTENT_BYTES})"
+                                ),
+                            )
+                    except ValueError:
+                        # Malformed Content-Length — fall through to streaming.
+                        pass
 
-            # Decode using the response's declared charset, falling back
-            # to UTF-8. httpx's default is ISO-8859-1 when no charset is
-            # advertised, which mojibakes any UTF-8 page that omits a
-            # charset declaration.
-            encoding = resp.charset_encoding or "utf-8"
+                # Stream the body, abort if it exceeds the cap after
+                # decompression. httpx transparently decompresses gzip/br
+                # within ``aiter_bytes`` so this measures decompressed bytes
+                # (gzip-bomb guard).
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in resp.aiter_bytes():
+                    total += len(chunk)
+                    if total > MAX_INGEST_CONTENT_BYTES:
+                        raise HTTPException(
+                            status_code=413,
+                            detail=(
+                                f"Content too large: exceeded {MAX_INGEST_CONTENT_BYTES} bytes "
+                                f"after decompression"
+                            ),
+                        )
+                    chunks.append(chunk)
+                body = b"".join(chunks)
 
-    # PR #9: shared decoder. HTML still gets the tag-strip path;
-    # markdown / plain / csv preserve newlines.
-    return decode_text_body(body, content_type, encoding)
+                # ---- PR #8: binary formats route through Kreuzberg ----
+                if content_type in BINARY_INGEST_MIME_TYPES:
+                    return await _extract_with_kreuzberg(body, content_type)
+
+                # Decode using the response's declared charset, falling back
+                # to UTF-8. httpx's default is ISO-8859-1 when no charset is
+                # advertised, which mojibakes any UTF-8 page that omits a
+                # charset declaration.
+                encoding = resp.charset_encoding or "utf-8"
+
+            # PR #9: shared decoder. HTML still gets the tag-strip path;
+            # markdown / plain / csv preserve newlines. Outside the ``stream``
+            # context so the connection is released before we decode.
+            return decode_text_body(body, content_type, encoding)
+
+        # Fell out of the loop: every iteration was a redirect. httpx used to
+        # raise ``TooManyRedirects`` here; walking the chain by hand means this
+        # module has to say so itself, and as a 400 rather than a 500 — a URL
+        # that redirects forever is the caller's input, not our fault.
+        raise HTTPException(
+            status_code=400,
+            detail=f"Too many redirects (max {MAX_INGEST_REDIRECTS}) starting from {url!r}",
+        )
 
 
 async def _find_prior_ingest_by_doc_hash(tenant_id: str, doc_hash: str) -> list[dict]:

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -1,7 +1,10 @@
 """Tests for the URL-fetch hardening introduced in PR #1.
 
 Covers:
-- P1.1 Content-Type allowlist + post-redirect re-validation
+- P1.1 Content-Type allowlist
+- M-43 per-hop redirect validation (which replaced the post-redirect
+  re-validation this docstring used to name — that check ran after the
+  request it was supposed to prevent)
 - P1.1 Content-Length pre-check (413)
 - P1.1 Streaming abort on decompressed bytes (gzip-bomb guard)
 - P2.5 UTF-8 charset fallback (no ISO-8859-1 mojibake)
@@ -11,6 +14,7 @@ Covers:
 from __future__ import annotations
 
 import socket
+import threading
 from unittest.mock import patch
 
 import httpx
@@ -21,9 +25,9 @@ from core_api.services import ingest_service
 from core_api.services.ingest_service import (
     INGEST_MAX_INPUT_BYTES,
     MAX_INGEST_CONTENT_BYTES,
-    _check_hostname_safe,
     _fetch_url_text,
     _is_blocked_ip,
+    _resolve_and_vet,
     decode_text_body,
 )
 
@@ -82,7 +86,7 @@ class TestHostnameSafetyCheck:
         with (
             pytest.raises(httpx.HTTPError) if False else pytest.raises(Exception) as exc
         ):
-            _check_hostname_safe("http://127.0.0.1:8000/health")
+            _resolve_and_vet("http://127.0.0.1:8000/health")
         # The exception is a starlette HTTPException — check the status_code attr
         assert exc.value.status_code == 400
         assert "127.0.0.1" in exc.value.detail
@@ -90,17 +94,17 @@ class TestHostnameSafetyCheck:
     def test_rejects_rfc1918_hostname(self) -> None:
         # Use the explicit IP as the hostname — getaddrinfo will return it back
         with pytest.raises(Exception) as exc:
-            _check_hostname_safe("http://10.0.0.5/")
+            _resolve_and_vet("http://10.0.0.5/")
         assert exc.value.status_code == 400
 
     def test_rejects_metadata_ip(self) -> None:
         with pytest.raises(Exception) as exc:
-            _check_hostname_safe("http://169.254.169.254/latest/meta-data/")
+            _resolve_and_vet("http://169.254.169.254/latest/meta-data/")
         assert exc.value.status_code == 400
 
     def test_rejects_invalid_url(self) -> None:
         with pytest.raises(Exception) as exc:
-            _check_hostname_safe("not-a-valid-url")
+            _resolve_and_vet("not-a-valid-url")
         assert exc.value.status_code == 400
         assert "no hostname" in exc.value.detail.lower()
 
@@ -111,7 +115,7 @@ class TestHostnameSafetyCheck:
             return_value=[(socket.AF_INET, 0, 0, "", ("1.1.1.1", 0))],
         ):
             # Should not raise
-            _check_hostname_safe("https://example.com/page")
+            _resolve_and_vet("https://example.com/page")
 
 
 # ---------------------------------------------------------------------------
@@ -138,9 +142,11 @@ def _make_client(handler) -> httpx.AsyncClient:
 class TestFetchUrlText:
     async def test_text_html_succeeds(self, monkeypatch) -> None:
         """text/html with UTF-8 body returns extracted text."""
-        # Skip the SSRF check by patching it (the URL we pass is public-ish)
+        # Answer the SSRF vetting with a fixed public address rather than
+        # hitting live DNS. The check still runs, and pinning still happens.
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -165,7 +171,8 @@ class TestFetchUrlText:
         flow through the new path).
         """
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
 
         async def fake_extract(data, mime, *_a, **_kw):
@@ -199,7 +206,8 @@ class TestFetchUrlText:
     async def test_docx_routed_through_kreuzberg(self, monkeypatch) -> None:
         """Office DOCX MIME also goes through Kreuzberg."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
 
         async def fake_extract(data, mime, *_a, **_kw):
@@ -238,7 +246,8 @@ class TestFetchUrlText:
     async def test_encrypted_pdf_returns_422(self, monkeypatch) -> None:
         """Encrypted PDF surfaces as 422 with a clean error message."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
         import kreuzberg as _kz
 
@@ -268,7 +277,8 @@ class TestFetchUrlText:
     async def test_malformed_pdf_parsing_error_422(self, monkeypatch) -> None:
         """Garbage PDF bytes → Kreuzberg raises ParsingError → 422."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
         import kreuzberg as _kz
 
@@ -297,7 +307,8 @@ class TestFetchUrlText:
     async def test_empty_extracted_content_422(self, monkeypatch) -> None:
         """Image-only PDF (no OCR backend) → empty extraction → 422."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
 
         async def fake_extract(data, mime, *_a, **_kw):
@@ -330,7 +341,8 @@ class TestFetchUrlText:
     async def test_octet_stream_rejected_422(self, monkeypatch) -> None:
         """Unknown binary MIME → 422."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -351,7 +363,8 @@ class TestFetchUrlText:
     async def test_content_length_precheck_413(self, monkeypatch) -> None:
         """Honest Content-Length header > cap → 413 before downloading."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
         oversized = str(MAX_INGEST_CONTENT_BYTES + 1)
 
@@ -375,7 +388,8 @@ class TestFetchUrlText:
     async def test_streaming_abort_on_oversize_body(self, monkeypatch) -> None:
         """Body exceeds cap mid-stream → 413 (gzip-bomb guard)."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
         oversize_body = b"x" * (MAX_INGEST_CONTENT_BYTES + 5_000)
 
@@ -396,7 +410,8 @@ class TestFetchUrlText:
     async def test_under_cap_succeeds(self, monkeypatch) -> None:
         """Body comfortably under cap → success."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -416,7 +431,8 @@ class TestFetchUrlText:
     async def test_utf8_body_with_no_charset_header(self, monkeypatch) -> None:
         """P2.5: UTF-8 body without a charset declaration should NOT mojibake."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
         # Japanese characters in UTF-8, no charset in Content-Type
         body = "<html><body>こんにちは世界</body></html>".encode()
@@ -436,7 +452,8 @@ class TestFetchUrlText:
     async def test_markdown_mime_allowed(self, monkeypatch) -> None:
         """text/markdown is explicitly in the allowlist."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -457,7 +474,8 @@ class TestFetchUrlText:
     async def test_csv_mime_allowed(self, monkeypatch) -> None:
         """PR #9: text/csv is in the allowlist and rows are preserved."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
         csv_body = b"name,age,role\nAlice,30,founder\nBob,28,engineer\n"
 
@@ -480,7 +498,8 @@ class TestFetchUrlText:
         """PR #9: markdown via URL no longer collapses whitespace, so the
         chunker can detect heading boundaries on URL-fetched docs."""
         monkeypatch.setattr(
-            "core_api.services.ingest_service._check_hostname_safe", lambda url: None
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
         )
         md = b"# H1\n\nPara 1.\n\n## H2\n\nPara 2.\n"
 
@@ -564,3 +583,846 @@ async def test_extract_with_kreuzberg_501_when_extra_absent(monkeypatch) -> None
         )
     assert exc.value.status_code == 501
     assert "ingest" in exc.value.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# M-43 — the redirect chain is validated hop by hop, before each request
+# ---------------------------------------------------------------------------
+
+
+def _passthrough_client(handler, **kw) -> httpx.AsyncClient:
+    """Mock client built with the REAL kwargs the code under test passed.
+
+    ``_make_client`` hardcodes ``follow_redirects=True`` and every call site
+    drops ``**kw``. That is harmless for handlers answering 200 immediately, and
+    fatal here: it would put redirect-following back inside httpx — the exact
+    behaviour M-43 removed — so the per-hop check would never run and these
+    tests would report on a code path that does not exist any more.
+    """
+    return _real_AsyncClient(transport=_real_MockTransport(handler), **kw)
+
+
+_BLOCKED_TEST_HOSTS = {"169.254.169.254", "10.0.0.5", "127.0.0.1"}
+_TEST_PUBLIC_ADDR = "93.184.216.34"
+
+
+def _recording_resolver(checked: list[str]):
+    """Stand-in for ``_resolve_and_vet`` that records, enforces, and answers.
+
+    Deliberately not the real function: that one calls ``socket.getaddrinfo``,
+    so asserting on ORDER would make the public hops depend on live DNS. What
+    the real vetting blocks is already covered by ``TestHostnameSafetyCheck``
+    above — these tests are about WHEN it runs, which is the whole of M-43.
+
+    It patches ``_resolve_and_vet`` rather than a yes/no checker so that pinning
+    stays ON. An earlier version substituted a checker that returned nothing,
+    and the production code carried a branch to cope with that — a test seam
+    that could silently disable pinning. Returning a real address instead means
+    the tests exercise the same path production does.
+    """
+
+    def resolve(url: str) -> list[str]:
+        checked.append(url)
+        if httpx.URL(url).host in _BLOCKED_TEST_HOSTS:
+            raise HTTPException(status_code=400, detail=f"Blocked: {url}")
+        return [_TEST_PUBLIC_ADDR]
+
+    return resolve
+
+
+def _logical_url(request: httpx.Request) -> str:
+    """The URL a pinned request is *for*, as opposed to the one it connects to.
+
+    Pinning rewrites the URL to the vetted address, so ``request.url`` is the
+    address form. The logical host travels in the ``Host`` header, which is what
+    these tests mean when they talk about which URL was requested.
+    """
+    host = request.headers.get("Host") or request.url.netloc.decode()
+    return f"{request.url.scheme}://{host}{request.url.raw_path.decode()}"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestRedirectSsrf:
+    async def test_a_redirect_to_a_private_host_is_never_requested(
+        self, monkeypatch
+    ) -> None:
+        """The finding. ``follow_redirects=True`` sent the GET before any check.
+
+        httpx walked the chain inside ``client.stream`` and only handed back the
+        final response, so the old ``_resolve_and_vet(str(resp.url))`` ran
+        after the request to the metadata service had been sent and answered. It
+        stopped the body being read; it did not stop the request.
+
+        Asserting on the transport rather than on the exception is the point: a
+        version that raises 400 while still having issued the GET passes any
+        test that only checks the status code.
+        """
+        requested: list[str] = []
+        checked: list[str] = []
+        metadata = "http://169.254.169.254/latest/meta-data/"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested.append(_logical_url(request))
+            # Dispatch on the Host header: pinning means ``request.url.host`` is
+            # the vetted address, identical for every hop.
+            if request.headers["Host"] == "attacker.example":
+                return httpx.Response(302, headers={"location": metadata})
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"secrets"
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._resolve_and_vet",
+            _recording_resolver(checked),
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await _fetch_url_text("https://attacker.example/r")
+
+        assert exc.value.status_code == 400
+        assert metadata in checked, "the redirect target was never validated"
+        assert metadata not in requested, (
+            f"the GET to the metadata service was issued anyway: {requested}"
+        )
+
+    async def test_a_public_redirect_chain_still_works(self, monkeypatch) -> None:
+        """OVER-REFUSAL GUARD. Redirects are normal; only unsafe hops are refused.
+
+        Walking the chain by hand is easy to get wrong in the direction of
+        refusing everything, which would pass the test above and break ingest.
+        """
+        requested: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested.append(_logical_url(request))
+            if request.url.path == "/start":
+                return httpx.Response(
+                    302, headers={"location": "https://elsewhere.example/final"}
+                )
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                content=b"<html><body><p>Arrived.</p></body></html>",
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._resolve_and_vet",
+            _recording_resolver([]),
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        result = await _fetch_url_text("https://example.com/start")
+        assert "Arrived" in result
+        assert requested == [
+            "https://example.com/start",
+            "https://elsewhere.example/final",
+        ]
+
+    async def test_a_relative_location_is_resolved_against_its_hop(
+        self, monkeypatch
+    ) -> None:
+        """``Location`` may be relative, and the resolved URL is what gets checked.
+
+        Handing the raw header to the next iteration would check ``/next`` — no
+        hostname at all — and the real ``_resolve_and_vet`` 400s on that
+        rather than following it anywhere. Resolving keeps the redirect working
+        AND keeps the thing we validate identical to the thing we request.
+        """
+        requested: list[str] = []
+        checked: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested.append(_logical_url(request))
+            if request.url.path == "/start":
+                return httpx.Response(302, headers={"location": "/next"})
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"done"
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._resolve_and_vet",
+            _recording_resolver(checked),
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        result = await _fetch_url_text("https://example.com/start")
+        assert result == "done"
+        assert checked == ["https://example.com/start", "https://example.com/next"]
+        assert requested == checked, (
+            "a URL was requested that was not the one validated"
+        )
+
+    async def test_an_endless_redirect_chain_is_capped(self, monkeypatch) -> None:
+        """``follow_redirects=False`` means httpx no longer enforces a limit.
+
+        Without a cap of our own this loops forever, holding a worker and firing
+        an outbound request per iteration — a denial of service handed to us by
+        the caller's own URL.
+        """
+        requested: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested.append(_logical_url(request))
+            nxt = int(request.url.params.get("n", "0")) + 1
+            return httpx.Response(
+                302, headers={"location": f"https://example.com/r?n={nxt}"}
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._resolve_and_vet",
+            _recording_resolver([]),
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await _fetch_url_text("https://example.com/r?n=0")
+
+        assert exc.value.status_code == 400
+        assert "too many redirects" in exc.value.detail.lower()
+        assert len(requested) == ingest_service.MAX_INGEST_REDIRECTS + 1, requested
+
+    async def test_the_hostname_check_runs_off_the_event_loop(
+        self, monkeypatch
+    ) -> None:
+        """``socket.getaddrinfo`` blocks and takes no timeout.
+
+        Checking each hop means running it up to six times per fetch where the
+        old code ran it twice, so it moved to an executor. Asserting on the
+        THREAD rather than on timing: the property is categorical, and a timing
+        assertion here would be flaky for no extra confidence.
+        """
+        loop_thread = threading.current_thread().name
+        ran_on: list[str] = []
+
+        def check(url: str) -> list[str]:
+            ran_on.append(threading.current_thread().name)
+            return [_TEST_PUBLIC_ADDR]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"ok"
+            )
+
+        monkeypatch.setattr("core_api.services.ingest_service._resolve_and_vet", check)
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        await _fetch_url_text("https://example.com/")
+        assert ran_on, "the hostname check never ran"
+        assert all(t != loop_thread for t in ran_on), (
+            f"the blocking resolver ran on the event loop thread: {ran_on}"
+        )
+
+
+def _fake_getaddrinfo(*addrs: str):
+    """Stand in for DNS so the REAL ``_resolve_and_vet`` runs against known answers."""
+
+    def resolver(host, port, *a, **kw):
+        return [(socket.AF_INET, 0, 0, "", (addr, 0)) for addr in addrs]
+
+    return resolver
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestAddressPinning:
+    """The connection goes to the address that was vetted, not to the name again.
+
+    ``_resolve_and_vet`` resolves a name and httpx used to resolve the SAME name
+    when connecting. An attacker answering the first lookup with a public address
+    and the second with a private one walks through a check that passed honestly
+    — DNS rebinding, which the first cut of M-43 left open on purpose.
+
+    These are mock-transport tests, so they cover URL construction and the
+    headers/extensions plumbing. They CANNOT cover the TLS handshake: MockTransport
+    replaces the transport entirely. That half was verified against a real server —
+    pinned fetch succeeds with the SNI override, and is refused without it.
+    """
+
+    async def test_the_request_goes_to_the_vetted_address(self, monkeypatch) -> None:
+        seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"ok"
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.socket.getaddrinfo",
+            _fake_getaddrinfo("93.184.216.34"),
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        assert await _fetch_url_text("https://example.com/doc") == "ok"
+        req = seen[0]
+        assert req.url.host == "93.184.216.34", (
+            f"connected by name, not address: {req.url}"
+        )
+        assert req.url.path == "/doc", "pinning lost the path"
+        assert req.headers["Host"] == "example.com", "vhost routing would break"
+        assert req.extensions.get("sni_hostname") == "example.com", (
+            "without the SNI override the certificate is verified against the IP "
+            "and every https fetch fails"
+        )
+
+    async def test_a_relative_redirect_keeps_the_hostname(self, monkeypatch) -> None:
+        """The bug pinning nearly introduced.
+
+        ``resp.url`` is the PINNED url once we rewrite it, so resolving a
+        relative ``Location`` against it yields an address-based URL — the
+        hostname is gone, and with it the next hop's Host header, SNI name and
+        its own vetting. The join has to use the logical URL.
+        """
+        seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            if request.url.path == "/start":
+                return httpx.Response(302, headers={"location": "/next"})
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"done"
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.socket.getaddrinfo",
+            _fake_getaddrinfo("93.184.216.34"),
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        assert await _fetch_url_text("https://example.com/start") == "done"
+        assert len(seen) == 2, seen
+        assert seen[1].url.path == "/next"
+        assert seen[1].headers["Host"] == "example.com", (
+            f"the second hop lost the hostname: Host={seen[1].headers.get('Host')!r}"
+        )
+        assert seen[1].extensions.get("sni_hostname") == "example.com"
+
+    async def test_one_private_answer_poisons_the_whole_name(self, monkeypatch) -> None:
+        """Every address must pass, not just the one we would have picked.
+
+        A name answering with both a public and a private address must be
+        refused outright — otherwise an attacker chooses which answer we use by
+        controlling ordering.
+        """
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.socket.getaddrinfo",
+            _fake_getaddrinfo("93.184.216.34", "169.254.169.254"),
+        )
+        with pytest.raises(HTTPException) as exc:
+            await _fetch_url_text("https://example.com/")
+        assert exc.value.status_code == 400
+        assert "169.254.169.254" in exc.value.detail
+
+
+@pytest.mark.unit
+class TestPinnedUrlFormatting:
+    """Pure formatting — no network, no loop, and easy to get wrong."""
+
+    def test_pinning_preserves_port_and_brackets_ipv6(self) -> None:
+        assert ingest_service._pin_url_to_address(
+            "https://example.com/x", "1.2.3.4"
+        ) == (
+            "https://1.2.3.4/x",
+            "example.com",
+        )
+        assert ingest_service._pin_url_to_address(
+            "https://example.com:8443/x", "1.2.3.4"
+        ) == (
+            "https://1.2.3.4:8443/x",
+            "example.com:8443",
+        )
+        pinned, host = ingest_service._pin_url_to_address(
+            "https://example.com/x", "2606:2800::1"
+        )
+        assert pinned == "https://[2606:2800::1]/x", (
+            "an unbracketed IPv6 authority does not parse"
+        )
+        assert host == "example.com"
+
+    def test_host_header_brackets_an_ipv6_literal_source_host(self) -> None:
+        """``urlparse`` hands back v6 hostnames unbracketed; the header needs them.
+
+        A public IPv6 literal passes vetting and reaches here, so the malformed
+        header is reachable, not theoretical.
+        """
+        _, host = ingest_service._pin_url_to_address(
+            "https://[2606:2800::1]/x", "93.184.216.34"
+        )
+        assert host == "[2606:2800::1]", f"invalid Host header: {host!r}"
+
+        _, host = ingest_service._pin_url_to_address(
+            "https://[2606:2800::1]:8443/x", "93.184.216.34"
+        )
+        assert host == "[2606:2800::1]:8443", (
+            f"unbracketed v6 host + port is unparseable: {host!r}"
+        )
+
+    def test_pinning_keeps_url_credentials(self) -> None:
+        """httpx turns URL userinfo into Basic auth; dropping it breaks the fetch.
+
+        The Host header never carries userinfo.
+        """
+        pinned, host = ingest_service._pin_url_to_address(
+            "https://user:pa%40ss@example.com:8443/x", "1.2.3.4"
+        )
+        assert pinned == "https://user:pa%40ss@1.2.3.4:8443/x", (
+            f"credentials silently stripped by pinning: {pinned!r}"
+        )
+        assert host == "example.com:8443", "userinfo must not reach the Host header"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestCredentialsAcrossRedirects:
+    """Guards the risk that keeping userinfo introduces.
+
+    Carrying credentials through pinning is only safe while they stop at the
+    host they were given for. This is the companion to
+    ``test_pinning_keeps_url_credentials``: that one keeps them, this one
+    bounds them.
+    """
+
+    async def test_credentials_do_not_survive_a_cross_host_redirect(
+        self, monkeypatch
+    ) -> None:
+        seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            # Exact match, not a prefix: a prefix test on a host is the shape
+            # that makes "example.com.attacker.test" pass, and CodeQL is right
+            # to flag it even in a mock router. There is no port here — the URL
+            # carries none, so the pinned Host header is the bare name.
+            if request.headers["Host"] == "example.com":
+                return httpx.Response(
+                    302, headers={"location": "https://elsewhere.test/b"}
+                )
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"ok"
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.socket.getaddrinfo",
+            _fake_getaddrinfo("93.184.216.34"),
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        assert await _fetch_url_text("https://user:pass@example.com/a") == "ok"
+        assert len(seen) == 2, f"expected two hops, got {len(seen)}"
+        assert "authorization" in seen[0].headers, (
+            "credentials were dropped before they reached the host they belong to"
+        )
+        assert "authorization" not in seen[1].headers, (
+            "credentials leaked to a host the user never gave them to: "
+            f"{seen[1].headers.get('authorization')!r}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestPerHopConnections:
+    """Each hop gets its own connection — a real-socket test, because it must be.
+
+    httpcore pools by the request URL's origin and reads ``sni_hostname`` only
+    when it opens a connection. Pinning collapses every hop onto one origin when
+    the addresses match, so a reused connection would carry a later hop over TLS
+    verified for an earlier hop's name.
+
+    Nothing is pooled today, but only because a redirect response is closed
+    without its body being read. This does not fail without the accompanying
+    ``max_keepalive_connections=0`` — it fails if some later change starts
+    draining redirect bodies, which is exactly the regression that setting makes
+    unreachable. MockTransport models no pooling at all, so it cannot be written
+    against a mock.
+    """
+
+    async def test_each_hop_opens_its_own_connection(self, monkeypatch) -> None:
+        import asyncio
+
+        seen: list[tuple[int, str]] = []
+
+        async def serve(reader, writer) -> None:
+            peer_port = writer.get_extra_info("peername")[1]
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                path = line.decode().split(" ")[1]
+                headers = {}
+                while True:
+                    hl = await reader.readline()
+                    if hl in (b"\r\n", b"\n", b""):
+                        break
+                    k, _, v = hl.decode().partition(":")
+                    headers[k.strip().lower()] = v.strip()
+                seen.append((peer_port, headers.get("host", "")))
+                if path == "/":
+                    # Empty body keeps the connection cleanly reusable, which is
+                    # the shape where reuse could actually bite.
+                    writer.write(
+                        b"HTTP/1.1 302 Found\r\n"
+                        b"Location: http://second.test:%d/final\r\n"
+                        b"Content-Length: 0\r\n"
+                        b"Connection: keep-alive\r\n\r\n" % port
+                    )
+                else:
+                    writer.write(
+                        b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n"
+                        b"Content-Length: 2\r\nConnection: keep-alive\r\n\r\nok"
+                    )
+                await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_server(serve, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+
+        # Point the fake hostnames at the loopback server. Pinning stays on:
+        # patching the vetting step is how these tests supply an answer, not a
+        # way to switch pinning off.
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: ["127.0.0.1"],
+        )
+
+        async with server:
+            body = await asyncio.wait_for(
+                _fetch_url_text(f"http://first.test:{port}/"), timeout=10
+            )
+
+        assert body == "ok"
+        assert len(seen) == 2, f"expected two hops, got {seen}"
+        assert seen[0][1] != seen[1][1], f"hops did not differ in Host: {seen}"
+        assert seen[0][0] != seen[1][0], (
+            "both hops rode one TCP connection; over TLS the second host would "
+            f"have used the first host's verified session: {seen}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestOverallFetchBudget:
+    """Per-hop budgets multiply; only a whole-fetch deadline bounds the total.
+
+    Six hops x (5s DNS + 30s request) is 210s a caller-supplied chain can spend
+    holding a coroutine, which overruns the 120s request timeout this platform
+    deploys with — so the caller would get the proxy's 504 instead of this
+    module's 400.
+    """
+
+    async def test_a_slow_chain_is_cut_off_with_a_400(self, monkeypatch) -> None:
+        import asyncio as _asyncio
+
+        async def slow_handler(request: httpx.Request) -> httpx.Response:
+            await _asyncio.sleep(10)
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"too late"
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(slow_handler, **kw),
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.MAX_INGEST_FETCH_SECONDS", 0.2
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await _fetch_url_text("https://slow.example/x")
+        assert exc.value.status_code == 400
+        assert "budget" in exc.value.detail.lower()
+
+    async def test_a_prompt_fetch_is_untouched(self, monkeypatch) -> None:
+        """OVER-REFUSAL GUARD. A deadline that fires on normal traffic is worse
+        than no deadline — it turns a working ingest into a 400."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"quick"
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+        assert await _fetch_url_text("https://example.com/x") == "quick"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestRedirectWithoutLocation:
+    """A 3xx carrying no ``Location`` is not a redirect, and must not crash.
+
+    ``resp.is_redirect`` is the STATUS CODE alone — httpx's own docstring says
+    to use ``has_redirect_location`` when the header matters. Indexing
+    ``headers["location"]`` behind an ``is_redirect`` check therefore raises
+    KeyError on a malformed 3xx, which leaves this module as a 500 from a
+    function that returns clean 4xx for everything else. The fetched URL is
+    tenant-controlled by design, so a server can simply choose to answer this
+    way.
+
+    The comment on that line used to assert ``is_redirect`` meant "status AND
+    Location". It never did. Same defect class this PR fixed elsewhere: a
+    comment claiming a property the code does not have.
+
+    Note what this is NOT: it is not a regression the redirect work introduced.
+    Falling through to the normal path hits ``raise_for_status()``, which raises
+    on 3xx too, and ``upstream_http_error_handler`` re-raises sub-500s into the
+    catch-all — so the pre-M-43 code answered this with a 500 as well. The
+    KeyError was a worse 500, not a new failure. 400 is better than either.
+    """
+
+    async def test_a_3xx_without_a_location_header_is_a_400(self, monkeypatch) -> None:
+        requested: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested.append(_logical_url(request))
+            return httpx.Response(
+                302, headers={"content-type": "text/plain"}, content=b"no location here"
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await _fetch_url_text("https://example.com/x")
+        assert exc.value.status_code == 400
+        assert "no location" in exc.value.detail.lower()
+        assert requested == ["https://example.com/x"], (
+            f"a Location-less 3xx was treated as a hop: {requested}"
+        )
+
+    async def test_a_3xx_with_a_location_is_still_followed(self, monkeypatch) -> None:
+        """Over-refusal guard: the new branch must not swallow real redirects."""
+        requested: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested.append(_logical_url(request))
+            if request.headers["Host"] == "example.com":
+                return httpx.Response(
+                    302, headers={"location": "https://onward.test/y"}
+                )
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"arrived"
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service._resolve_and_vet",
+            lambda url: [_TEST_PUBLIC_ADDR],
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        assert await _fetch_url_text("https://example.com/x") == "arrived"
+        assert requested == ["https://example.com/x", "https://onward.test/y"]
+
+
+@pytest.mark.unit
+class TestSchemeAllowlistVetting:
+    """Only http/https. A redirect target is attacker-controlled.
+
+    Nothing downstream rejects another scheme: ``ftp://public-host/x`` resolves,
+    vets and pins cleanly, and only dies inside httpx's transport selection as
+    ``UnsupportedProtocol`` — uncaught here, so a 500 out of the one function
+    that turns every other malformed input into a 400.
+    """
+
+    @pytest.mark.parametrize("url", ["ftp://example.com/x", "gopher://example.com/x"])
+    def test_a_non_http_scheme_with_a_host_is_refused(self, url: str) -> None:
+        with pytest.raises(HTTPException) as exc:
+            ingest_service._resolve_and_vet(url)
+        assert exc.value.status_code == 400
+        assert "scheme" in exc.value.detail.lower()
+
+    def test_a_hostless_url_is_still_refused_on_its_hostname(self) -> None:
+        """``file:///etc/passwd`` never needed the scheme check — it has no host.
+
+        Pins the ORDER: the hostname branch runs first, so inputs that were
+        already refused keep the message they had. Putting the scheme check
+        ahead of it silently rewrote this case, and ``not-a-valid-url`` with it.
+        """
+        with pytest.raises(HTTPException) as exc:
+            ingest_service._resolve_and_vet("file:///etc/passwd")
+        assert exc.value.status_code == 400
+        assert "no hostname" in exc.value.detail.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSchemeAllowlistOverRedirects:
+    async def test_a_redirect_to_a_non_http_scheme_is_a_400(self, monkeypatch) -> None:
+        """The reachable path: the caller's URL is fine, the Location is not."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302, headers={"location": "ftp://elsewhere.test/x"})
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.socket.getaddrinfo",
+            _fake_getaddrinfo("93.184.216.34"),
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await _fetch_url_text("https://example.com/x")
+        assert exc.value.status_code == 400
+        assert "scheme" in exc.value.detail.lower()
+
+    async def test_an_ordinary_https_chain_is_unaffected(self, monkeypatch) -> None:
+        """OVER-REFUSAL GUARD, including the http hop.
+
+        An https -> http downgrade stays PERMITTED: this fetches public content,
+        and credentials cannot ride a downgrade — only an absolute ``Location``
+        can change scheme, and an absolute reference replaces the authority,
+        which drops userinfo with it.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.headers["Host"] == "example.com":
+                return httpx.Response(302, headers={"location": "http://plain.test/y"})
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"fetched"
+            )
+
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.socket.getaddrinfo",
+            _fake_getaddrinfo("93.184.216.34"),
+        )
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+        assert await _fetch_url_text("https://example.com/x") == "fetched"
+
+
+@pytest.mark.unit
+class TestMalformedPort:
+    """A bad port must 400 like every other bad URL, not escape as a 500."""
+
+    def test_a_non_integer_port_is_rejected_by_vetting(self) -> None:
+        """``.port`` raises ValueError, and it is read later by the pinning step.
+
+        ``_resolve_and_vet`` only ever looked at ``.hostname``, so such a URL
+        passed vetting and then blew up inside ``_pin_url_to_address`` — an
+        unhandled ValueError, i.e. a 500, from a module that returns a clean 400
+        for every other malformed input.
+        """
+        with pytest.raises(HTTPException) as exc:
+            ingest_service._resolve_and_vet("https://example.com:abc/x")
+        assert exc.value.status_code == 400
+        assert "port" in exc.value.detail.lower()
+
+    def test_a_valid_port_still_resolves(self, monkeypatch) -> None:
+        """Over-refusal guard: the check must not reject ordinary ports."""
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.socket.getaddrinfo",
+            _fake_getaddrinfo("93.184.216.34"),
+        )
+        assert ingest_service._resolve_and_vet("https://example.com:8443/x") == [
+            "93.184.216.34"
+        ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDnsTimeout:
+    """Hostile DNS must not hold a request open, nor reach the shared pool.
+
+    The two guards do different jobs and neither replaces the other:
+    ``wait_for`` bounds the REQUEST but cannot reclaim the thread (a running
+    executor future is not cancellable), so the dedicated pool is what bounds
+    the BLAST RADIUS.
+    """
+
+    async def test_a_hanging_resolver_becomes_a_400(self, monkeypatch) -> None:
+        import time
+
+        def hang(url: str) -> list[str]:
+            time.sleep(30)
+            return ["93.184.216.34"]
+
+        monkeypatch.setattr("core_api.services.ingest_service._resolve_and_vet", hang)
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.DNS_RESOLUTION_TIMEOUT", 0.2
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await _fetch_url_text("https://slow-dns.example/")
+        assert exc.value.status_code == 400
+        assert "timed out" in exc.value.detail.lower()
+
+    async def test_dns_does_not_run_on_the_shared_default_executor(
+        self, monkeypatch
+    ) -> None:
+        """Confinement is the half that stops a cross-tenant DoS.
+
+        Asserting the thread name rather than timing: the property is
+        categorical, and the default executor's threads are the ones the whole
+        ASGI app shares for blocking work.
+        """
+        ran_on: list[str] = []
+
+        def check(url: str) -> list[str]:
+            ran_on.append(threading.current_thread().name)
+            return [_TEST_PUBLIC_ADDR]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, headers={"content-type": "text/plain"}, content=b"ok"
+            )
+
+        monkeypatch.setattr("core_api.services.ingest_service._resolve_and_vet", check)
+        monkeypatch.setattr(
+            "core_api.services.ingest_service.httpx.AsyncClient",
+            lambda **kw: _passthrough_client(handler, **kw),
+        )
+
+        await _fetch_url_text("https://example.com/")
+        assert ran_on, "the resolver never ran"
+        assert all(name.startswith("ingest-dns") for name in ran_on), (
+            "DNS ran outside the dedicated pool — on the default executor a "
+            f"hostile resolver stalls unrelated blocking work: {ran_on}"
+        )


### PR DESCRIPTION
Closes audit finding **M-43**. Server-side request forgery.

`_fetch_url_text` checked the submitted hostname, then opened an `httpx.AsyncClient` with `follow_redirects=True`. httpx walks the entire chain inside `client.stream` — **issuing a real GET to every hop** — and only hands back the final response. The check on `resp.url` therefore ran long after the request to the private host had been sent and answered.

The comment above it claimed otherwise:

```python
# Re-validate the FINAL host post-redirect (the upstream may
# have redirected us to a private host).
_check_hostname_safe(str(resp.url))
```

It did not prevent that request. It prevented reading its body. `raise_for_status()` even ran first, so the internal host's status code reached the caller too.

An authenticated tenant submits a URL they control which 302s to `169.254.169.254` or any RFC1918 address, and core-api issues the GET from inside the deployment network — against cloud metadata, against side-effectful internal `GET` endpoints, or as a port scan whose differentiated 400s echo `{host} resolves to {addr}`.

## The fix

The chain is walked here now, one hop at a time, with the host check run **before each request, including the first**. `follow_redirects=False`, so httpx no longer enforces a limit either and `MAX_INGEST_REDIRECTS` (5) moves into this module. A relative `Location` is joined against the URL that produced it, so the URL validated and the URL requested are the same string.

**DNS rebinding is closed too** (round 2). Resolving a name and then letting httpx resolve it again at connect time leaves a window an attacker can answer twice — public first, private second. Each hop now connects to an address that was *just* vetted, with the hostname carried as the `Host` header and the TLS SNI name, so virtual hosting still works and the certificate is still verified against the **name**. Every address a name resolves to must pass, not just the one we would have picked.

## Why the obvious test would have been worthless

Run against the **original** code shape, the probe says:

```
PASS  private redirect refused (400)
PASS  metadata host WAS validated
FAIL  metadata host NEVER requested
```

The old code really does return 400, and really does run the check. **A test asserting only the status code passes on the vulnerable version.** So the test here asserts on the transport — which URLs were actually requested — and that assertion is the one that fails without the fix.

The same trap applies to pinning: asserting a fetch *succeeds* passes whether or not the connection was pinned. Those tests assert the request's URL host, `Host` header and `sni_hostname` extension instead.

## Tests

`tests/test_ingest_service.py`, 68 passing. The ones this PR adds:

**Redirect SSRF** — a 302 to the metadata IP is refused *and* never requested; an over-refusal guard, since hand-rolling this is easy to get wrong in the direction of refusing everything; relative `Location` (validated URL and requested URL asserted equal); the cap, stopping at exactly `MAX_INGEST_REDIRECTS + 1` requests; and the host check running off the event loop.

**Address pinning** — the request goes to the vetted address with the right `Host` and SNI; a relative redirect keeps the hostname; one private answer among several poisons the whole name.

**Formatting** — port and IPv6 bracketing, both for the pinned address and for an IPv6-literal source host; credentials preserved through pinning and kept out of the `Host` header.

**Credentials across redirects** — they reach the host they were given for, and do not survive a cross-host redirect.

**Per-hop connections** — a real-socket test that each hop opens its own TCP connection.

Every one of these was confirmed to **fail without its fix**, by reverting each piece individually. The single exception is called out below.

They deliberately do **not** reuse `_make_client`. That helper hardcodes `follow_redirects=True` and every call site drops `**kw` — harmless for handlers answering 200 immediately, fatal here: it would put redirect-following back inside httpx, so the per-hop check would never run and the tests would report on a code path that no longer exists. A pass-through client is used instead, and its docstring says why so nobody simplifies it back.

Also corrected: this test module's docstring advertised *"post-redirect re-validation"* as covered behaviour. That behaviour is what this PR removes.

## The one change that fixes nothing reachable

The client sets `max_keepalive_connections=0`. httpcore pools connections by the request URL's origin and reads `sni_hostname` only when it **opens** one, so once every hop is pinned to an address, two hops with different hostnames on one IP look like a single origin — and the second would ride a TLS session verified for the first one's name.

That is **not reachable today**, and the setting is not a bug fix. Measured against real sockets, all four cases:

| | no limit | limit |
|---|---|---|
| **body not drained** (what the code does) | 2 connections | 2 connections |
| **body drained** | 1 connection, **reused** | 2 connections |

Nothing is pooled today only because a redirect response is closed without its body being read, and httpcore cannot resync a half-read HTTP/1.1 connection. That is an accident of body handling, not a promise. The setting turns it into a structural guarantee.

`test_each_hop_opens_its_own_connection` **does not fail without that setting**, and is not claimed to. It fails when a redirect body is drained — the exact regression the setting makes unreachable — which is what it is there to catch. It uses real sockets because `MockTransport` models no pooling at all.

## Added during review (rounds 4-9)

Each of these has its own test, confirmed to fail without its fix.

**Overall fetch budget.** Per-hop timeouts multiply: six hops at 30s is three
minutes on one request. `MAX_INGEST_FETCH_SECONDS` (60) now caps the whole walk.

**DNS timeout, on a dedicated executor.** `getaddrinfo` is blocking and a hostile
resolver can stall it indefinitely. It runs on a private `ThreadPoolExecutor`
with a 5s `wait_for` rather than the default executor, so a stalled lookup cannot
starve unrelated blocking work. A known limitation is recorded in the source: a
timed-out lookup does not reclaim its thread, because a running
`concurrent.futures` future is not cancellable. Measured, along with the three
workarounds that do not help — the comment says not to reach for them.

**Malformed port.** `urlparse(...).port` raises `ValueError` on `:notaport`,
which escaped as an unhandled exception. Now a 400.

**A 3xx with no `Location`.** `resp.is_redirect` is the status code *alone* —
indexing `headers["location"]` behind it raises `KeyError` on a response a
hostile server can simply choose to send. Now an explicit 400. Not a regression
this PR introduced: the pre-M-43 code answered that case with a 500 too.

**Scheme allowlist.** `http`/`https` only, checked *after* the hostname branch so
inputs that were already refused keep their accurate message — putting it first
silently rewrote the error for every hostless URL and broke a pre-existing test.

One correction to the record, since I got this wrong in an earlier round and it
was quoted as justification: an unsupported scheme was **not** producing a 500.
`_fetch_url_text` has exactly one caller and it wraps the call in
`except Exception -> HTTPException(400)`, so `ftp://` and `gopher://` already
returned 400. The allowlist still earns its place, for a smaller and accurate
reason — vetting runs *before* the request, so without it an `ftp://internal-name/`
URL performs a real `getaddrinfo` on an attacker-chosen name before failing at
transport selection. With it, nothing is resolved.

**Two review findings that did not survive checking**, both recorded in the
thread rather than turned into changes: a suggested `wait_for` for thread-pool
exhaustion (cannot reclaim an executor thread), and a malformed-`Location`
finding whose premise was a 500 that measurement showed to be a 400 — and whose
proposed remedy sat on a line httpx never reaches, since `_build_redirect_request`
runs *before* the `follow_redirects` check and raises inside `send()`.

## Verification

- Full core-api suite: **6180 passed**, 5 skipped, 1 xfailed.
- `ruff check` and `ruff format --check` at CI's exact scopes, run separately.
- mypy `core-api`: clean bar two pre-existing `types-python-dateutil` errors in untouched `common/enrichment/service.py`.
- Legacy-name ratchet, do-not-touch sentinel: both pass, run after `git add`.
- Broker OpenAPI baseline up to date (8 operations).

`MockTransport` replaces the transport entirely, so no mock test can show this negotiates TLS at all. That half was verified against a real server: correct SNI → 200, wrong SNI → refused, no SNI override → refused, plus a live pinned fetch and a live redirect chain through `_fetch_url_text`. To be precise about the middle line — a wrong-SNI rejection is consistent with either server-side SNI enforcement or client-side verification; what *guarantees* verification is httpcore passing `sni_hostname` as `server_hostname` into `wrap_socket`, where Python's `ssl` checks the certificate against exactly that name.

## Not claimed

Nothing here helps against a host that is legitimately public at request time and malicious in what it serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

