### PR TITLE
fix(extraction): define what "subject" means, so updates can supersede (A66)

### DIFF
--- a/benchmark/a66_subject_stability.py
+++ b/benchmark/a66_subject_stability.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""A66 — is the N>2 chain defect real, or an artifact of the first repro?
+
+The original repro slept only 5s between the FIRST and SECOND write (55s
+thereafter), so write B's detection could run before write A had finished
+embedding. That alone could produce "no candidates found". This version waits
+the SAME settle after EVERY write, so any remaining failure is the product's.
+"""
+
+import json
+import time
+import urllib.error
+import urllib.request
+
+BASE, KEY = "http://localhost:8000", "dev-admin-key"
+SETTLE = 60
+
+
+def call(m, p, b=None):
+    r = urllib.request.Request(
+        BASE + p,
+        method=m,
+        headers={"X-API-Key": KEY, "Content-Type": "application/json"},
+        data=json.dumps(b).encode() if b is not None else None,
+    )
+    try:
+        with urllib.request.urlopen(r, timeout=180) as x:
+            return x.status, json.loads(x.read().decode(), strict=False)
+    except urllib.error.HTTPError as e:
+        return e.code, {"raw": e.read().decode()[:150]}
+
+
+def w(t, c):
+    return call(
+        "POST", "/api/v1/memories", {"tenant_id": t, "agent_id": "a66", "content": c}
+    )[1]
+
+
+def st(t, i):
+    s, m = call("GET", f"/api/v1/memories/{i}?tenant_id={t}")
+    return (m.get("status"), m.get("supersedes_id")) if s == 200 else (f"<{s}>", None)
+
+
+subjects = [
+    ("deploy window", ["01:00 UTC", "03:00 UTC", "05:00 UTC"]),
+    ("primary oncall", ["Marta", "Tomas", "Wei"]),
+    ("build agent pool size", ["4 workers", "8 workers", "16 workers"]),
+]
+bad = 0
+for n, (subj, vals) in enumerate(subjects):
+    salt = f"{int(time.time())}{n}"[-7:]
+    T, ids = f"a66r{salt}", []
+    for v in vals:
+        ids.append(w(T, f"The {salt} {subj} is {v}.").get("id"))
+        time.sleep(SETTLE)  # EQUAL settle after every write
+    rows = [(lbl, *st(T, i)) for lbl, i in zip("ABC", ids)]
+    print(f"\n--- run {n + 1}: {subj}  (settle={SETTLE}s after every write)")
+    for lbl, s, sup in rows:
+        print(f"    {lbl}: status={s:11s} supersedes={str(sup)[:8]}")
+    actives = [lbl for lbl, s, _ in rows if s not in ("outdated", "conflicted")]
+    ok = len(actives) == 1 and actives[0] == "C"
+    bad += not ok
+    print(
+        f"    exactly one winner (C)? {'yes' if ok else 'NO -> ' + ','.join(actives) + ' all live'}"
+    )
+
+print(
+    f"\nA66 RESULT: {bad}/{len(subjects)} runs ended with contradictory claims co-active"
+)

--- a/core-api/src/core_api/services/entity_extraction.py
+++ b/core-api/src/core_api/services/entity_extraction.py
@@ -39,6 +39,18 @@ Rules:
 - canonical_name: lowercase, no articles (the, a, an)
 - entity_type: one of person, organization, technology, project, concept, location, event, identifier, artifact, role
 - role: one of subject, object, mentioned
+- The SUBJECT is the entity the statement is ABOUT — the grammatical subject of
+  the main clause. The VALUE being asserted about it is the object, even when
+  that value is itself a named person, place or quantity. Choose the subject the
+  same way every time: it does not change because the value changed.
+    "The billing service owner is Dana."   -> subject: billing service owner
+                                              object:  dana
+    "The deploy window is 03:00 UTC."      -> subject: deploy window
+                                              object:  03:00 utc
+  Marking "dana" the subject there would make an UPDATE to that fact look like a
+  statement about a different subject, and the update would never supersede the
+  value it replaces. Exactly one entity carries role=subject unless the content
+  genuinely asserts facts about two independent subjects.
 - relation_type: short verb phrase like works_on, uses, belongs_to, created_by, depends_on, manages, located_in
 - Extract every distinct named subject. Include identifiers (PR-2025-A, build-734), product codes (Vermillion-7), model names (gpt-5.4-nano), and version strings as entity_type=identifier or entity_type=artifact when they refer to a specific named thing.
 - Job titles (ceo, engineer, manager, director, officer) classify as entity_type=role — NOT person. Use entity_type=person only when a named individual is referenced (e.g., "Anna Bergstrom"). "the CEO" alone is a role; "Anna, the CEO" is one person entity plus one role entity.

--- a/tests/test_a66_subject_role_is_defined.py
+++ b/tests/test_a66_subject_role_is_defined.py
@@ -1,0 +1,65 @@
+"""A66 — updates to person-valued facts could never supersede anything.
+
+Root cause was one undefined word. ``EXTRACTION_PROMPT`` listed
+``role: one of subject, object, mentioned`` and never said what "subject" meant,
+so for "The X primary oncall is Marta" the model could defensibly mark either
+``marta`` or ``x primary oncall`` as the subject — and it picked differently on
+different writes.
+
+Everything downstream then behaved correctly on unstable input:
+  * the worker only sets ``subject_entity_id`` when exactly ONE entity claims
+    role=subject;
+  * ``_subjects_differ_with_certainty`` drops candidates whose subjects differ.
+
+So each new value became a new subject, no candidate survived to the judge, and
+the old value was never retired.
+
+Measured on a live stack, same three-write chain, before and after:
+
+    before   run 1 resolved | run 2 fired NOTHING (3 subjects) | run 3 partial
+             -> 2/3 runs ended with contradictory claims co-active
+    after    3/3 resolved: A conflicted, B conflicted(sup=A), C active(sup=B)
+             -> 0/3, and all three rows now share ONE subject entity
+
+These tests pin the prompt contract. They cannot prove model behaviour — only
+the live chain repro does that (benchmark/a66_subject_stability.py) — but they
+fail loudly if the definition is dropped again, which is what made this
+regression invisible for so long.
+"""
+
+import pytest
+
+from core_api.services.entity_extraction import EXTRACTION_PROMPT
+
+pytestmark = pytest.mark.unit
+
+
+def test_prompt_defines_what_subject_means():
+    """The bug was the ABSENCE of this definition, so its presence is the fix."""
+    assert "the entity the statement is ABOUT" in EXTRACTION_PROMPT
+    assert "grammatical subject" in EXTRACTION_PROMPT
+
+
+def test_prompt_says_a_named_value_is_still_the_object():
+    """The specific confusion: a person-valued predicate. "Dana" is the value,
+    not the thing the sentence is about."""
+    assert "even when" in EXTRACTION_PROMPT
+    assert "named person" in EXTRACTION_PROMPT
+
+
+def test_prompt_states_subject_stability_across_updates():
+    """Stability across writes is the property contradiction detection depends
+    on — a subject that changes when the value changes breaks supersession."""
+    assert "it does not change because the value changed" in EXTRACTION_PROMPT
+
+
+def test_prompt_carries_worked_examples():
+    """A rule without an example was what the model was already working from."""
+    assert "billing service owner" in EXTRACTION_PROMPT
+    assert "deploy window" in EXTRACTION_PROMPT
+
+
+def test_prompt_explains_the_consequence():
+    """Keeps the next editor from trimming the rule as verbose: the paragraph
+    exists because removing it silently disables updates."""
+    assert "would never supersede" in EXTRACTION_PROMPT


### PR DESCRIPTION
## Updates to person-valued facts could never retire the value they replaced

**Root cause was one undefined word.** `EXTRACTION_PROMPT` listed:

```
- role: one of subject, object, mentioned
```

…and never said what a *subject* **is**. So for `"The X primary oncall is Marta"`, marking either `marta` or `x primary oncall` as the subject is defensible — and the model picked differently on different writes.

Everything downstream then behaved **correctly on unstable input**:

- the extraction worker sets `subject_entity_id` only when exactly **one** entity claims `role=subject`;
- `_subjects_differ_with_certainty` drops candidates whose subjects differ — in **8 ms**, before the judge.

So each new value became a new subject, no candidate survived to the judge, and the old value stayed `active`.

### The class this breaks is wide

Any predicate whose object is a named entity — **who is oncall, who owns a service, who leads a team**. Those facts change often, and none of them could be updated.

## Evidence

Same three-write chain, live stack, before and after:

```
BEFORE   run 1  resolved
         run 2  fired NOTHING — three oncall assignments, all `active`
         run 3  partial — two different values both `active`
         -> 2/3 runs ended with contradictory claims co-active

AFTER    3/3 resolved:  A conflicted | B conflicted(sup=A) | C active(sup=B)
         -> 0/3
```

Mechanism confirmed directly — the three oncall rows previously carried **three different subject entities**:

```
before   'marta' (person) | '...primary oncall' (identifier) | 'wei' (person)
after    one shared subject entity across all three
```

## The fix

The prompt now defines the subject as the entity the statement is **about** (the grammatical subject), states that a named value stays the **object**, says the subject must not change when the value changes, and carries two worked examples plus *why* the rule exists — so it doesn't get trimmed as verbose later.

## Scope — please read before approving

This changes extraction for **every write**, not just contradiction candidates.

The evidence is a live before/after on the failing scenario, because that is the only thing that can demonstrate a model-behaviour change. **A unit test asserting my own prompt text would prove nothing**, so the tests here pin the *contract* (they fail loudly if the definition is dropped again — its absence is exactly what made this invisible) and the behavioural claim rests on the repro.

**A bench A/B is still warranted to confirm no wider regression, and is not claimed here.** Happy to run one before merge if you'd rather.

## Testing

5 contract tests · repro at `benchmark/a66_subject_stability.py` · full suite **5988 passed** with the 8 failures that pre-exist on main (`test_capability_usage` / `test_request_observation`).

Refs: canonical A66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
