### PR TITLE
ci(npm): repoint the credential check at a manifest that exists

### DIFF
--- a/.github/workflows/verify-npm-credential.yml
+++ b/.github/workflows/verify-npm-credential.yml
@@ -13,12 +13,22 @@ name: Verify the npm credential
 # So a token minted for one is not automatically good for the other. A token
 # belonging to `caura-ai-admin` publishes the broker fine and gets a 403 on
 # the `@caura` scope unless that account is also a member with publish rights.
-# The failure surfaces only at the publish step, after a tag has been pushed,
-# and the two halves of a release can then disagree: the unscoped `caura` name
-# is unclaimed, so ANY valid account can take it, while the scoped client needs
-# the right one. Claiming the bare name under one account while the scoped
-# package lives under another is a mess to unpick afterwards, and npm does not
-# let you simply move it.
+# The failure surfaces only at the publish step, after a tag has been pushed.
+# A release is two independently tagged workflows — publish-npm-client.yml for
+# `@caura/client`, publish-npm-sdk.yml for `@caura/sdk` — so a token that can
+# publish one and not the other yields a PARTIAL release: one package on the
+# new version, the other stranded on the old one, with the tag already public.
+#
+# This paragraph previously described a worse hazard: that a bad token could
+# 403 on the scoped client while still claiming the unscoped `caura` name under
+# the wrong account. That cannot happen, and the correction is worth keeping so
+# nobody restores the reasoning. #943 established that npm REFUSES the unscoped
+# name outright — `403 Forbidden - PUT .../caura, Package name too similar to
+# existing package csurf` — so it is blocked by the typosquat filter rather than
+# merely unclaimed, and no account can take it. Nothing publishes a bare name ON
+# NPM any more; that qualifier matters, because publish-python-metapackage.yml
+# does publish the bare `caura` name on PyPI, which is a different registry with
+# a different filter. The partial release is the real reason to run this.
 #
 # Nothing here gates a release. It exists so the answer is known before a tag
 # is pushed rather than discovered by a half-finished one.
@@ -80,7 +90,7 @@ jobs:
           # non-zero npm exit makes the whole pipeline non-zero even though
           # node succeeded and already printed its own fallback, so the
           # trailing `||` fires too and REACHABLE ends up holding BOTH lines.
-          # Same trap as the dependency check in publish-npm-caura.yml.
+          # Same trap as the dependency check in publish-npm-sdk.yml.
           RAW_PKGS=$(npm access list packages --json 2>/dev/null || true)
           REACHABLE=$(printf '%s' "$RAW_PKGS" | node -e '
             let s = "";
@@ -91,18 +101,26 @@ jobs:
           echo "── this token can reach ${REACHABLE} package(s) (names withheld: public log) ──"
           echo
           echo "── publish rights on the two packages this release needs ──"
-          # Names read from the manifests rather than written out, so this
-          # cannot drift from what the publish workflows actually ship.
+          # Names read from the manifests rather than written out, so a package
+          # RENAME cannot drift this out of step with what the publish workflows
+          # ship. Note what that does NOT cover: the manifest itself going away.
+          # The second line here read clients/npm-caura/package.json, which #943
+          # moved, #1099 moved again and #1244 deleted — so it is NOT repointed
+          # at that manifest's descendant, because there is none. @caura/sdk is a
+          # different package (added by #950) that happens to be the other half
+          # of a release today. Check that against the publish workflows if this
+          # ever looks wrong; the pairing is a fact about releases, not a rename.
+          # tests/test_workflow_require_paths.py covers the vanishing-path case.
           CLIENT_PKG=$(node -p "require('./clients/typescript/package.json').name")
-          META_PKG=$(node -p "require('./clients/npm-caura/package.json').name")
+          SDK_PKG=$(node -p "require('./clients/npm-sdk/package.json').name")
           BLOCKED=0
-          for PKG in "$CLIENT_PKG" "$META_PKG"; do
-            # An unpublished name has no collaborator list and cannot have
-            # one. That is not a failure: an unclaimed name is publishable by
-            # any valid account, which is exactly what this repo is trying to
-            # do with the unscoped name.
+          for PKG in "$CLIENT_PKG" "$SDK_PKG"; do
+            # An unpublished name has no collaborator list and cannot have one,
+            # so "not published" is not a permission finding. Both packages are
+            # published today; this branch is defensive, for a future package
+            # whose first release has not happened yet.
             if ! npm view "$PKG" version >/dev/null 2>&1; then
-              printf "  %-26s not published yet — any valid account may claim it\n" "$PKG"
+              printf "  %-26s not published yet — no collaborator list to check\n" "$PKG"
               continue
             fi
             # `collaborators`, not `get status`: status reports whether a
@@ -134,17 +152,15 @@ jobs:
           echo
           if [[ "${BLOCKED}" == "1" ]]; then
             echo "::error::This token cannot publish everything the release needs."
-            echo "The dangerous part is that it would not fail cleanly. The unscoped"
-            echo "name is unclaimed, so ANY valid account can take it — so a release"
-            echo "attempted with this token can 403 on the scoped client while still"
-            echo "claiming the bare name, leaving the two packages under two different"
-            echo "owners. npm has no self-service way to move a package between"
-            echo "owners; undoing it means going through npm support."
+            echo "A release is two independently tagged workflows, so this does not"
+            echo "fail before the tag — it fails at the publish step, leaving"
+            echo "@caura/client and @caura/sdk on different versions with a tag"
+            echo "already public and the version numbers diverged."
             echo
-            echo "Use a token from an account with publish rights on the @caura scope,"
-            echo "with 'All packages' selected rather than named packages — the"
-            echo "unscoped name does not exist yet, so it cannot appear in a"
-            echo "selected-packages list."
+            echo "Use a token from an account with publish rights on the @caura SCOPE,"
+            echo "granted as the whole scope rather than as named packages. A"
+            echo "scope-wide token keeps covering the release when a package is added;"
+            echo "a named-package token silently stops covering it."
             exit 1
           fi
           echo "No blocker found. Note this proves publish RIGHTS, not that a"

--- a/tests/test_workflow_require_paths.py
+++ b/tests/test_workflow_require_paths.py
@@ -1,0 +1,117 @@
+"""Every repo path a workflow ``require()``s must actually exist.
+
+``verify-npm-credential.yml`` read ``./clients/npm-caura/package.json`` to learn
+the name of the second package a release publishes. #943 moved that directory,
+#1099 moved it again and #1244 deleted it outright. Nothing failed at any point,
+because the workflow is ``workflow_dispatch``-only: the reference was broken from
+2026-08-24 and surfaced on 2026-09-06, when someone ran it to answer a question
+and got ``Cannot find module`` instead of an answer.
+
+The shape is worth naming. Reading the name out of the manifest instead of
+hard-coding it protects against the package being RENAMED — but it silently
+introduces a dependency on the manifest's PATH, and nothing checked that. The
+comment on that line claimed the arrangement "cannot drift from what the publish
+workflows actually ship", which was true of one kind of drift and false of the
+kind that happened. A ``workflow_dispatch``-only file is the worst place for it,
+since the gap between breaking and finding out is bounded only by when someone
+next needs the thing.
+
+WHAT THIS DOES NOT DO, stated so the green is not read as more than it is.
+``require()`` is one of several ways a workflow names a repo path — the others
+are ``working-directory:``, ``cd`` in a ``run:`` block, script arguments and
+``on: paths:`` filters. None of those are checked here, and a stale ``paths:``
+filter fails just as silently as this did. Covering them is worth doing and is
+deliberately not done here.
+
+Resolution is also approximate for one shape. A ``defaults.run.working-directory``
+set at job level is the base for every run step in that job, so it REPLACES the
+repository root rather than adding to it, and that is what ``_bases`` implements.
+A workflow whose steps declare several different working directories gets all of
+them as candidates, so a path valid under one step's directory would be accepted
+from another. No workflow currently mixes ``require()`` with per-step working
+directories, so nothing relies on that today.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO / ".github/workflows"
+
+# Only repo-relative requires. A bare `require('fs')` or `require('semver')` is
+# resolved from node_modules and has nothing to do with the tree.
+_REQUIRE_RE = re.compile(r"""require\(\s*['"](\./[^'"]+)['"]\s*\)""")
+
+_WORKDIR_RE = re.compile(r"^\s*working-directory:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def _workflow_files() -> list[Path]:
+    return sorted([*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")])
+
+
+def _bases(text: str) -> list[Path]:
+    """Directories a relative path in this workflow's ``run:`` steps resolves against.
+
+    A declared ``working-directory`` REPLACES the repository root; it does not
+    add to it. Getting that wrong is what made the first draft of this test
+    almost worthless: a ``package.json`` exists at the repository root, so with
+    the root always among the candidates every ``require('./package.json')``
+    resolved there regardless of which directory its job actually ran in. Nine
+    of the eleven requires in this repo could not have failed, and the only two
+    genuinely under test were the two in the file this test was written for.
+    """
+    declared = _WORKDIR_RE.findall(text)
+    return [REPO / d for d in declared] if declared else [REPO]
+
+
+def _requires() -> list[tuple[Path, list[Path], list[str]]]:
+    """Each workflow that has repo-relative requires, with its bases and paths."""
+    found = []
+    for workflow in _workflow_files():
+        text = workflow.read_text()
+        # Deduped: a workflow reading the same manifest from five steps is one
+        # broken path, and five identical failure lines obscure the other files.
+        paths = list(
+            dict.fromkeys(raw.removeprefix("./") for raw in _REQUIRE_RE.findall(text))
+        )
+        if paths:
+            found.append((workflow, _bases(text), paths))
+    return found
+
+
+def test_every_workflow_require_path_exists() -> None:
+    unresolved = []
+    for workflow, bases, paths in _requires():
+        shown = ", ".join(
+            "<repo root>" if base == REPO else str(base.relative_to(REPO))
+            for base in bases
+        )
+        for rel in paths:
+            if not any((base / rel).is_file() for base in bases):
+                unresolved.append(
+                    f"{workflow.name}: require('./{rel}') — not found under {shown}"
+                )
+
+    assert unresolved == [], (
+        "workflow requires a path that does not exist:\n" + "\n".join(unresolved)
+    )
+
+
+def test_the_scan_is_not_vacuous() -> None:
+    """A regex that matches nothing passes the test above for the wrong reason.
+
+    If the workflows are ever reorganised so that no ``require('./…')`` remains,
+    this fails and asks for a decision — delete both tests deliberately, or fix
+    the pattern — rather than leaving a green check that verifies nothing.
+    """
+    assert _workflow_files(), f"no workflow files found under {WORKFLOWS}"
+    assert _requires(), (
+        "no repo-relative require() found in any workflow — either the pattern "
+        "stopped matching or the workflows changed shape; both need a human"
+    )


### PR DESCRIPTION
## What broke

`verify-npm-credential.yml` read `./clients/npm-caura/package.json` to learn the second package a release publishes. #943 moved that directory, #1099 moved it again, and #1244 deleted it.

The workflow is `workflow_dispatch`-only, so nothing caught it. The reference was broken from **2026-08-24** and surfaced on **2026-09-06**, when it was run to answer a live question — "can `NPM_TOKEN` publish a release?" — and died with `Cannot find module` before reaching the answer. [Run 34021589371](https://github.com/caura-ai/caura/actions/runs/34021589371).

It is **not** repointed at that manifest's descendant, because there is none. `@caura/sdk` (`clients/npm-sdk`, added by #950) is the other half of a release today — a fact about releases, not a rename. Worth knowing if this ever looks wrong later.

## Three comments asserting things that are no longer true

The file reasoned carefully about a hazard that cannot happen, so the reasoning is corrected rather than deleted:

| Claim | Reality |
|---|---|
| "the unscoped `caura` name is unclaimed, so ANY valid account can take it" — a bad token could 403 on the scoped client while claiming the bare name | #943 established npm **refuses** it: `403 Forbidden - PUT .../caura, Package name too similar to existing package csurf`. Blocked by the typosquat filter, not merely unclaimed. The verdict message repeated the same wrong reasoning to whoever hit the failure. |
| "cannot drift from what the publish workflows actually ship" | True of a **rename**, false of the **move** that happened — reading the name from a manifest trades a hard-coded name for a hard-coded path, and nothing checked the path. |
| "Same trap as the dependency check in `publish-npm-caura.yml`" | Also deleted by #943. Now points at `publish-npm-sdk.yml`, which carries the same `\|\| true`-under-`pipefail` trap. |

The replacement hazard is the real one: a release is two independently tagged workflows, so a token that can publish one and not the other produces a **partial release** — the two packages on different versions, with a tag already public.

## The test, and the false green in its own first draft

`tests/test_workflow_require_paths.py` covers the class rather than the instance.

**Its first draft was itself nearly vacuous, and this is the part worth reviewing.** It resolved each path against the repo root *plus* every declared `working-directory`. A `package.json` exists at the repo root, so every `require('./package.json')` resolved there regardless of which directory its job actually ran in — **nine of the eleven requires in this repo could not have failed**, and the only two genuinely under test were the two being fixed. A test shaped exactly around the line that broke.

A declared `working-directory` **replaces** the root rather than adding to it. With that corrected, mutating `clients/npm-sdk` is now caught in `publish-npm-sdk.yml` too — the tag-triggered release workflow, which matters more than the one this started from:

```
publish-npm-sdk.yml: require('./package.json') — not found under clients/npm-sdk
verify-npm-credential.yml: require('./clients/npm-sdk/package.json') — not found under <repo root>
```

Confirmed failing against the unfixed workflow, and passing with it.

## Scope this deliberately does not cover

`require()` is one of several ways a workflow names a repo path. `working-directory:`, `cd` in a `run:` block, script arguments and `on: paths:` filters are all unchecked, and a stale `paths:` filter fails just as silently as this did. Worth a follow-up; not folded in here.

## Checks

- `ruff check tests/` and `ruff format --check tests/` — CI's exact scopes, run separately
- `actionlint` on the changed workflow — clean
- Test verified failing without the fix, and by mutation against a second workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)