### PR TITLE
fix(llm): unwrap singleton JSON arrays instead of discarding valid answers

### DIFF
--- a/common/llm/providers/_json_shape.py
+++ b/common/llm/providers/_json_shape.py
@@ -1,0 +1,44 @@
+"""Shared JSON-shape coercion for ``complete_json`` responses.
+
+gemini-3.1-flash-lite (prod, 2026-09-03→06) sometimes wraps a valid
+response object in a one-element array — ~3.8% of enrichments arrived
+as ``[ {..valid enrichment..} ]`` and the CAURA-651 shape guard was
+discarding good answers into the fake fallback (~170/day). A singleton
+list holding one dict is unambiguous: unwrap it. Every other non-dict
+shape (empty or multi-element lists, scalar elements, bare scalars) is
+still garbage and stays with the caller's ShapeError.
+
+Shared between the Gemini-backed providers (``vertex.py`` ADC mode,
+``gemini.py`` API-key mode) — same rationale as ``_truncation.py``: one
+implementation, so the heuristic cannot silently drift between them.
+
+Deliberately schema-agnostic: this layer serves every ``complete_json``
+consumer (enrichment, extraction, dedup, contradiction, …) and knows
+nothing about their expected keys. A wrong-but-dict payload that slips
+through lands in the caller's own field validation (e.g.
+``_validate_enrichment``) exactly as an un-wrapped wrong dict would —
+the guard here only exists to stop bare non-dict shapes from surfacing
+as ``AttributeError`` (CAURA-651).
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def unwrap_singleton_array(
+    parsed: object,
+    *,
+    provider: str,
+    model: str,
+    log: logging.Logger,
+) -> object:
+    """Return the inner dict of a one-element list, else *parsed* unchanged.
+
+    Never raises — shape rejection stays the caller's job so the typed
+    per-provider ShapeError (and its monitoring attributes) is preserved.
+    """
+    if isinstance(parsed, list) and len(parsed) == 1 and isinstance(parsed[0], dict):
+        log.info("%s (%s) returned a singleton JSON array; unwrapped", provider, model)
+        return parsed[0]
+    return parsed

--- a/common/llm/providers/gemini.py
+++ b/common/llm/providers/gemini.py
@@ -17,6 +17,7 @@ import logging
 import time
 
 from common.llm.constants import LLM_JSON_MAX_OUTPUT_TOKENS
+from common.llm.providers._json_shape import unwrap_singleton_array
 from common.llm.providers._shape_error import ProviderResponseShapeError
 from common.llm.providers._truncation import raise_if_truncated
 from common.provider_names import ProviderName
@@ -100,7 +101,9 @@ class GeminiLLMProvider:
             model=self._model,
             max_tokens=LLM_JSON_MAX_OUTPUT_TOKENS,
         )
-        parsed = json.loads(text)
+        parsed = unwrap_singleton_array(
+            json.loads(text), provider="Gemini", model=self._model, log=logger
+        )
         if not isinstance(parsed, dict):
             raise GeminiResponseShapeError(text, type(parsed).__name__)
         return parsed

--- a/common/llm/providers/vertex.py
+++ b/common/llm/providers/vertex.py
@@ -33,6 +33,7 @@ import time
 from typing import Any
 
 from common.llm.constants import LLM_JSON_MAX_OUTPUT_TOKENS
+from common.llm.providers._json_shape import unwrap_singleton_array
 from common.llm.providers._shape_error import ProviderResponseShapeError
 from common.llm.providers._truncation import raise_if_truncated
 
@@ -182,7 +183,9 @@ class VertexLLMProvider:
             model=self._model,
             max_tokens=LLM_JSON_MAX_OUTPUT_TOKENS,
         )
-        parsed = json.loads(text)
+        parsed = unwrap_singleton_array(
+            json.loads(text), provider="Vertex", model=self._model, log=logger
+        )
         if not isinstance(parsed, dict):
             # CAURA-651: see ``VertexResponseShapeError`` above.
             raise VertexResponseShapeError(text, type(parsed).__name__)

--- a/tests/test_llm_json_truncation.py
+++ b/tests/test_llm_json_truncation.py
@@ -154,6 +154,30 @@ class TestVertexCompleteJson:
         with pytest.raises(json.JSONDecodeError):
             await p.complete_json("prompt")
 
+    @pytest.mark.asyncio
+    async def test_singleton_array_response_is_unwrapped(self):
+        # gemini-3.1-flash-lite sometimes wraps the valid response object
+        # in a one-element array (prod 2026-09-03→06, ~3.8% of
+        # enrichments) — that's a valid answer in disguise, not garbage.
+        p = self._provider()
+        p._client.models.canned_response = _response(
+            json.dumps([{"memory_type": "fact", "title": "t"}])
+        )
+        assert await p.complete_json("prompt") == {
+            "memory_type": "fact",
+            "title": "t",
+        }
+
+    @pytest.mark.asyncio
+    async def test_multi_element_and_scalar_arrays_still_raise(self):
+        from common.llm.providers.vertex import VertexResponseShapeError
+
+        p = self._provider()
+        for bad in ('[{"a": 1}, {"b": 2}]', "[1]", "[]"):
+            p._client.models.canned_response = _response(bad)
+            with pytest.raises(VertexResponseShapeError):
+                await p.complete_json("prompt")
+
     def test_multi_region_location_pins_bare_host(self, monkeypatch):
         # ``us``/``eu`` are served from the bare aiplatform host; the SDK's
         # own endpoint logic builds ``us-aiplatform.googleapis.com``, which
@@ -263,6 +287,23 @@ class TestGeminiCompleteJson:
             '{"partial": "tru', _FinishReason.MAX_TOKENS
         )
         with pytest.raises(ValueError, match="truncated at max_output_tokens"):
+            await p.complete_json("prompt")
+
+    @pytest.mark.asyncio
+    async def test_singleton_array_response_is_unwrapped(self):
+        # Same quirk as the Vertex provider — see its test for the prod
+        # evidence.
+        p = self._provider()
+        p._client.models.canned_response = _response(json.dumps([{"ok": 1}]))
+        assert await p.complete_json("prompt") == {"ok": 1}
+
+    @pytest.mark.asyncio
+    async def test_multi_element_array_still_raises(self):
+        from common.llm.providers.gemini import GeminiResponseShapeError
+
+        p = self._provider()
+        p._client.models.canned_response = _response('[{"a": 1}, {"b": 2}]')
+        with pytest.raises(GeminiResponseShapeError):
             await p.complete_json("prompt")
 
 


### PR DESCRIPTION
## Problem

Post-cutover prod monitoring (2026-09-03→06 on `gemini-3.1-flash-lite`) surfaced a new response quirk: the model sometimes wraps a **perfectly valid response object in a one-element JSON array**:

```
enrichment-primary attempt 1/2 failed (VertexResponseShapeError: Vertex returned a JSON list where a dict was expected. Response content (truncated): '[\n  {\n    "memory_type": "fact",\n    "weight": 1.0,\n    "title": "Rule: Never auto-merge PRs", ...
```

The CAURA-651 shape guard — written when list responses were garbage — rejects these, degrading the call to the fake keyword fallback. Over three days that discarded **503 valid answers** (419 enrichment, 75 crystallizer, 7 extraction, 2 contradiction; ~3.8% of the window's 11,115 worker enrichments, ~170/day).

## Fix

`complete_json` in both Gemini-backed providers (Vertex + Developer API) unwraps a list of length 1 whose only element is a dict, with an INFO log marking the unwrap. **Everything else still raises**: empty lists, multi-element lists, scalar-element lists, bare scalars — the CAURA-651 guard's purpose (no bare `AttributeError` downstream, no silent fallback) is unchanged for genuine garbage.

The OpenAI-compatible provider is deliberately left strict: its `response_format=json_object` contract guarantees an object, no cases were observed there, and a list would be a real contract violation worth surfacing.

## Testing

- New: singleton-`[dict]` unwraps (both providers); `[dict, dict]`, `[1]`, and `[]` still raise the typed ShapeError.
- The CAURA-651 suite (`test_vertex_response_shape.py`) is unaffected by design — its list cases are multi-element/scalar and keep raising.
- Full affected set green: 207 passed (truncation, shape, gemini, platform-providers, protocols, extraction-partial-parse). Ruff clean.

## Expected impact

The ~170/day enrichment fake-fallbacks on prod drop to ~0; the new `returned a singleton JSON array; unwrapped` INFO line becomes the counter for how often the quirk fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)