### PR TITLE
fix(memory): sanitize caller metadata on the bulk and update write paths

### DIFF
--- a/core-api/src/core_api/services/governance_gate.py
+++ b/core-api/src/core_api/services/governance_gate.py
@@ -109,8 +109,9 @@ def mark_pii_flagged(metadata: dict, findings: list[Finding]) -> None:
 
     C25: routed through ``set_system_value`` so the flags land in the
     ``_system`` namespace too (legacy top-level keys kept for one release).
-    Caller forgeries of these keys are stripped at the ``create_memory``
-    chokepoint before this gate runs.
+    Caller forgeries of these keys are stripped by ``sanitize_caller_metadata``
+    on whichever write path reached this gate — each one applies it before
+    calling here, which is what makes the flags written below trustworthy.
     """
     from core_api.services.system_metadata import set_system_value
 

--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -1046,12 +1046,15 @@ async def ingest_commit(request: IngestCommitRequest) -> dict:
             # supplied request URL wins, else the fact's own source_uri
             # from preview, else "text-input".
             effective_source = request_url_override or fact.source_uri or "text-input"
+            # CAURA-703 used to be stamped here as
+            # ``metadata["memory_type_agent_set"] = False``. It moved to the
+            # ``memory_type_is_agent_set`` argument on the bulk call below,
+            # because C25 sanitation now strips PLATFORM_ONLY_KEYS from item
+            # metadata — this dict is caller-adjacent, and a platform flag put
+            # in it is indistinguishable from a forged one.
             metadata: dict = {
                 "source": "ingest",
                 "ingest_url": request_url_override or fact.source_uri or None,
-                # CAURA-703: ingest types come from the extraction LLM's
-                # suggested_type, not the calling agent — mark as not agent-set.
-                "memory_type_agent_set": False,
             }
             if request.doc_hash:
                 metadata["doc_hash"] = request.doc_hash
@@ -1108,7 +1111,13 @@ async def ingest_commit(request: IngestCommitRequest) -> dict:
                 items=batch,
             )
             try:
-                bulk_response = await create_memories_bulk(bulk_data, bulk_attempt_id=run_id)
+                bulk_response = await create_memories_bulk(
+                    bulk_data,
+                    bulk_attempt_id=run_id,
+                    # CAURA-703: every item's type came from the extraction
+                    # LLM's ``suggested_type``, never from the calling agent.
+                    memory_type_is_agent_set=False,
+                )
                 created += bulk_response.created
                 skipped_in_loop += bulk_response.duplicates
                 errored += bulk_response.errors

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -804,13 +804,18 @@ async def create_memory(data: MemoryCreate) -> MemoryOut:
         enforce_reserved_write_id(data.agent_id)
     except ReservedAgentIdError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    # C25 — sanitize caller metadata at the single entry chokepoint, BEFORE any
-    # platform writer touches it: forgeable platform-only keys (llm_ms,
-    # write_latency_ms, pii flags, …) and the _system namespace are stripped
-    # from caller input here, so everything a downstream step (governance
+    # C25 — sanitize caller metadata for the SINGLE-write path, BEFORE any
+    # platform writer touches it, so everything a downstream step (governance
     # gate, enrichment merge, row writer) adds is authentically
     # platform-written. Doing this later — e.g. in MergeEnrichmentFields —
     # would nuke the governance gate's own PII flags along with the forgeries.
+    #
+    # One of three call sites, one per write surface; bulk and update reach
+    # storage without passing through this function. Bulk and update each have
+    # a route-level test that fails if its own call is removed. THIS site does
+    # not: every test of the sanitizer drives it directly, which is exactly how
+    # the other two gaps stayed invisible. If a fourth write path appears, it
+    # needs its own call and its own route-level test.
     if data.metadata:
         data.metadata = sanitize_caller_metadata(data.metadata)
     if _USE_PIPELINE_WRITE:
@@ -1847,6 +1852,7 @@ async def create_memories_bulk(
     data: BulkMemoryCreate,
     *,
     bulk_attempt_id: str,
+    memory_type_is_agent_set: bool | None = None,
 ) -> BulkMemoryResponse:
     """Create multiple memories with per-attempt idempotency (CAURA-602).
 
@@ -1886,6 +1892,24 @@ async def create_memories_bulk(
     t0 = time.perf_counter()
     items = data.items
     n = len(items)
+
+    # C25 (M-48). This path does not go through ``create_memory``, so its
+    # sanitation did not cover POST /memories/bulk or the MCP batch tool.
+    # BEFORE the governance gate — same ordering reason as ``create_memory``,
+    # spelled out at its call site.
+    #
+    # Note what this means for the four internal callers (ingest, insights,
+    # interview, and any future one): item metadata is treated as caller input
+    # here, so a platform key placed in it is stripped like any forgery. That is
+    # the intended direction — ``PLATFORM_ONLY_KEYS`` belongs to the platform,
+    # not to a dict that arrives alongside caller content — but it means an
+    # internal caller cannot use ``metadata`` to pre-set one. Ingest was doing
+    # exactly that with ``memory_type_agent_set``; it now passes
+    # ``memory_type_is_agent_set`` instead, which is a parameter and therefore
+    # not reachable from a request body.
+    for item in items:
+        if item.metadata:
+            item.metadata = sanitize_caller_metadata(item.metadata)
 
     # -- Per-item validation. Short content used to raise a 422 for the
     # whole batch; now it's a per-item "error" result. Indices in this
@@ -2302,11 +2326,16 @@ async def create_memories_bulk(
         ts_valid_start = item.ts_valid_start
         ts_valid_end = item.ts_valid_end
 
-        # CAURA-703: provenance of memory_type. Ingest pre-stamps this False on
-        # its items (the type comes from the extraction LLM, not the caller), so
-        # honour an existing value; otherwise the type is agent-set iff the item
+        # CAURA-703: provenance of memory_type. Assigned, not ``setdefault``:
+        # the key is platform-only, so C25 sanitation above has already removed
+        # any copy that arrived in item metadata and there is nothing left to
+        # defer to. A trusted caller says so through the parameter — ingest
+        # passes False because the type comes from the extraction LLM rather
+        # than the calling agent. Otherwise the type is agent-set iff the item
         # carried one.
-        metadata.setdefault("memory_type_agent_set", item.memory_type is not None)
+        metadata["memory_type_agent_set"] = (
+            memory_type_is_agent_set if memory_type_is_agent_set is not None else item.memory_type is not None
+        )
         # Provenance of ``weight``, same three values as the single-write path
         # (MergeEnrichmentFields). Bulk items go through this merge rather than
         # the pipeline, so the flag has to be set here too or a bulk write would
@@ -4057,6 +4086,18 @@ async def update_memory(
     # regression for any caller that relied on null-as-clear. Force
     # them to opt into ``replace`` so the intent is explicit.
     if "metadata" in fields_set:
+        # C25 (M-52) — an update is caller input like any other write, and this
+        # path never sanitised it. Both modes carried it, via the two writes
+        # described above.
+        #
+        # Unlike the create-side gap, this one REWRITES governance output on an
+        # existing row: ``contains_pii``/``pii_types`` set by the gate at
+        # creation could be flipped or cleared afterwards by the same credential
+        # that wrote the memory.
+        #
+        # Falsy (``None`` or ``{}``) — nothing to strip either way.
+        if data.metadata:
+            data.metadata = sanitize_caller_metadata(data.metadata)
         effective_mode = data.metadata_mode or "merge"
         # Explicit None-check: ``{}`` is falsy, so ``or`` would
         # silently fall through to the legacy ``"metadata"`` key

--- a/tests/test_c25_system_metadata.py
+++ b/tests/test_c25_system_metadata.py
@@ -19,6 +19,7 @@ from core_api.services.system_metadata import (
     sanitize_caller_metadata,
     set_system_value,
 )
+from tests.conftest import get_test_auth, uid
 
 pytestmark = pytest.mark.unit
 
@@ -116,7 +117,7 @@ class _Input:
 
 
 async def test_merge_step_preserves_caller_summary():
-    """Input arrives PRE-SANITIZED (create_memory chokepoint strips forgeries
+    """Input arrives PRE-SANITIZED (the single-write path strips forgeries
     before the governance gate); the merge step's job is the clobber fix."""
     from core_api.pipeline.context import PipelineContext
     from core_api.pipeline.steps.write.merge_enrichment_fields import (
@@ -146,7 +147,7 @@ async def test_merge_step_preserves_caller_summary():
 
 async def test_merge_step_does_not_clobber_upstream_gate_flags():
     """The governance gate writes PII flags into the input metadata BEFORE the
-    merge step — the regression that moved sanitize to the entry chokepoint."""
+    merge step — the regression that moved sanitize to the write entry point."""
     from core_api.pipeline.context import PipelineContext
     from core_api.pipeline.steps.write.merge_enrichment_fields import (
         MergeEnrichmentFields,
@@ -172,3 +173,177 @@ async def test_merge_step_does_not_clobber_upstream_gate_flags():
 
 def test_registries_are_disjoint():
     assert not (PLATFORM_ONLY_KEYS & CALLER_OWNABLE_KEYS)
+
+
+# --- M-48 / M-52: the boundary has to hold on EVERY write surface -------------
+#
+# Everything above tests the sanitizer in isolation, and it always passed —
+# because the helper was never the broken part. ``create_memory`` called it and
+# the other two write paths did not: POST /memories/bulk runs its own
+# governance/embed/write loop, and PATCH /memories/{id} handed the caller's dict
+# to storage as ``metadata_``/``metadata_patch``.
+#
+# So these go through the REST routes rather than calling the helper, because a
+# helper-level test cannot tell whether a route reaches it.
+
+_FORGED = {
+    "llm_ms": 9999,  # fake telemetry
+    "contains_pii": False,  # governance verdict
+    "pii_types": [],
+    SYSTEM_NAMESPACE: {"llm_ms": 1},  # the namespace itself
+    "mine": "keep me",  # caller's own key
+    "summary": "CALLER SUMMARY",  # caller-OWNABLE, must survive
+}
+
+
+def _assert_boundary_held(metadata: dict) -> None:
+    for key in ("llm_ms", "contains_pii", "pii_types"):
+        assert key not in metadata, (
+            f"forged platform key {key!r} reached the row: {metadata!r}"
+        )
+    assert SYSTEM_NAMESPACE not in metadata or "llm_ms" not in metadata.get(
+        SYSTEM_NAMESPACE, {}
+    ), f"caller wrote into the {SYSTEM_NAMESPACE} namespace: {metadata!r}"
+    assert metadata.get("mine") == "keep me", (
+        f"over-refusal: the caller's own key was stripped: {metadata!r}"
+    )
+    assert metadata.get("summary") == "CALLER SUMMARY", (
+        f"over-refusal: a caller-ownable key was stripped: {metadata!r}"
+    )
+
+
+async def _get_metadata(client, headers, tenant_id: str, memory_id: str) -> dict:
+    resp = await client.get(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json().get("metadata") or {}
+
+
+async def test_bulk_write_sanitizes_caller_metadata(client):
+    """M-48. POST /memories/bulk never passed through ``create_memory``."""
+    tenant_id, headers = get_test_auth()
+    resp = await client.post(
+        "/api/v1/memories/bulk",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": f"c25-bulk-{uid()}",
+            "items": [{"content": f"bulk c25 boundary {uid()}", "metadata": _FORGED}],
+        },
+        headers={**headers, "X-Bulk-Attempt-Id": f"c25-{uid()}"},
+    )
+    assert resp.status_code in (200, 201), resp.text
+    results = resp.json()["results"]
+    assert len(results) == 1, resp.text
+    memory_id = results[0].get("id")
+    assert memory_id, f"bulk item did not come back with an id: {results!r}"
+
+    _assert_boundary_held(await _get_metadata(client, headers, tenant_id, memory_id))
+
+
+@pytest.mark.parametrize("mode", ["replace", "merge"])
+async def test_update_sanitizes_caller_metadata(client, mode: str):
+    """M-52. Both modes carried it.
+
+    ``replace`` set ``metadata_`` wholesale; ``merge`` went to storage as
+    ``metadata_patch``, whose shallow ``||`` lets a top-level key overwrite the
+    platform's. The second is the sharper one: it rewrites governance output on
+    an EXISTING row, so a PII verdict recorded at creation could be flipped
+    afterwards by the same credential that wrote the memory.
+    """
+    tenant_id, headers = get_test_auth()
+    created = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": f"c25-upd-{uid()}",
+            "content": f"update c25 boundary {uid()}",
+            "memory_type": "fact",
+        },
+        headers=headers,
+    )
+    assert created.status_code in (200, 201), created.text
+    memory_id = created.json()["id"]
+
+    patched = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}",
+        json={"metadata": _FORGED, "metadata_mode": mode},
+        headers=headers,
+    )
+    assert patched.status_code == 200, patched.text
+
+    _assert_boundary_held(await _get_metadata(client, headers, tenant_id, memory_id))
+
+
+# --- the other edge of the same boundary: platform callers keep their stamps --
+#
+# Sanitizing bulk items is what a caller must not get around. It is also what a
+# trusted internal caller must not be silently subjected to. Ingest sets
+# CAURA-703 provenance on every fact it commits, and while that stamp travelled
+# in item ``metadata`` the new sanitizer deleted it — flipping
+# ``memory_type_agent_set`` False->True on every ingested memory, with no test
+# failing, because the field has no in-repo consumer.
+#
+# The channel is now an argument, which no request body can reach.
+
+
+async def test_bulk_honours_memory_type_is_agent_set():
+    """The real ``create_memories_bulk`` — not the ingest fixture's stand-in.
+
+    ``tests/test_ingest_commit.py`` monkeypatches ``create_memories_bulk``, so
+    it can only assert what ingest passes. This asserts the function acts on it.
+    """
+    import uuid
+
+    from core_api.clients.storage_client import get_storage_client
+    from core_api.schemas import BulkMemoryCreate, BulkMemoryItem
+    from core_api.services.memory_service import create_memories_bulk
+
+    tenant_id, _ = get_test_auth()
+    req = BulkMemoryCreate(
+        tenant_id=tenant_id,
+        fleet_id="test-fleet",
+        agent_id=f"c25-703-{uid()}",
+        # A type IS supplied, so the inferred value would be True. Only the
+        # argument can make it False.
+        items=[
+            BulkMemoryItem(content=f"c25 703 provenance {uid()}", memory_type="fact")
+        ],
+    )
+    resp = await create_memories_bulk(
+        req, bulk_attempt_id=uuid.uuid4().hex, memory_type_is_agent_set=False
+    )
+    assert resp.results[0].status == "created", resp.results[0]
+
+    mem = await get_storage_client().get_memory(resp.results[0].id, tenant_id)
+    assert (mem["metadata_"] or {}).get("memory_type_agent_set") is False, (
+        "the trusted caller's provenance did not survive to the row: "
+        f"{mem['metadata_']}"
+    )
+
+
+async def test_bulk_infers_agent_set_when_no_caller_says_otherwise():
+    """Control: without the argument the flag is still inferred from the item.
+
+    Guards the opposite failure — an implementation that always writes False.
+    """
+    import uuid
+
+    from core_api.clients.storage_client import get_storage_client
+    from core_api.schemas import BulkMemoryCreate, BulkMemoryItem
+    from core_api.services.memory_service import create_memories_bulk
+
+    tenant_id, _ = get_test_auth()
+    req = BulkMemoryCreate(
+        tenant_id=tenant_id,
+        fleet_id="test-fleet",
+        agent_id=f"c25-703-{uid()}",
+        items=[BulkMemoryItem(content=f"c25 703 inferred {uid()}", memory_type="fact")],
+    )
+    resp = await create_memories_bulk(req, bulk_attempt_id=uuid.uuid4().hex)
+    assert resp.results[0].status == "created", resp.results[0]
+
+    mem = await get_storage_client().get_memory(resp.results[0].id, tenant_id)
+    assert (mem["metadata_"] or {}).get("memory_type_agent_set") is True, mem[
+        "metadata_"
+    ]

--- a/tests/test_ingest_commit.py
+++ b/tests/test_ingest_commit.py
@@ -57,6 +57,10 @@ def captured(monkeypatch):
     state = SimpleNamespace(
         writes=[],
         bulk_calls=[],
+        # CAURA-703 provenance, one entry per call. It travels as an argument
+        # rather than in item metadata, because C25 sanitation strips
+        # PLATFORM_ONLY_KEYS from anything arriving alongside caller content.
+        memory_type_is_agent_set=[],
         # One entry per ``create_memories_bulk`` call. H-07 made a commit of
         # >BULK_MAX_ITEMS facts issue several, and every one of them must
         # carry the SAME attempt id — see the batching comment in
@@ -97,7 +101,9 @@ def captured(monkeypatch):
             if h in state.bulk_find_result
         }
 
-    async def fake_create_memories_bulk(data, *, bulk_attempt_id):
+    async def fake_create_memories_bulk(
+        data, *, bulk_attempt_id, memory_type_is_agent_set=None
+    ):
         """Stand-in for ``create_memories_bulk`` — translates the audit
         scenarios the legacy per-fact tests modelled (409 from
         create_memory, generic raise from create_memory) into the bulk
@@ -112,6 +118,7 @@ def captured(monkeypatch):
         batch_no = len(state.bulk_calls)
         state.bulk_calls.append(data)
         state.bulk_attempt_ids.append(bulk_attempt_id)
+        state.memory_type_is_agent_set.append(memory_type_is_agent_set)
         if batch_no in state.raise_http_on_batch:
             raise state.raise_http_on_batch[batch_no]
         if state.write_delay_ms:
@@ -262,16 +269,34 @@ async def test_run_id_on_column_and_source_in_metadata(captured):
 @pytest.mark.asyncio
 async def test_ingest_marks_memory_type_not_agent_set(captured):
     """CAURA-703: an ingested fact's type comes from the extraction LLM's
-    ``suggested_type``, not the calling agent, so each write is stamped
-    ``metadata.memory_type_agent_set = False``. ``create_memories_bulk``
-    honours this pre-stamped value instead of inferring ``True`` from the
-    (LLM-supplied) ``memory_type`` on the item."""
+    ``suggested_type``, not the calling agent, so the write must record
+    ``memory_type_agent_set = False``.
+
+    This used to be pre-stamped into each item's ``metadata``. It is now an
+    argument to ``create_memories_bulk``: C25 sanitation treats item metadata
+    as caller input and strips ``PLATFORM_ONLY_KEYS`` from it, so a platform
+    flag left there would be deleted before the row was written — silently,
+    since nothing reads the field back.
+
+    Note the limit of this assertion: the fixture replaces
+    ``create_memories_bulk``, so it can only show what ingest PASSES.
+    ``test_bulk_honours_memory_type_is_agent_set`` covers the other half —
+    that the real function acts on it.
+    """
     req = _request("t1", "fact one", "fact two")
     await ingest_service.ingest_commit(request=req)
 
     assert len(captured.writes) == 2
+    assert captured.memory_type_is_agent_set == [False], (
+        "ingest must tell the bulk writer the type was not agent-set: "
+        f"{captured.memory_type_is_agent_set}"
+    )
     for mc in captured.writes:
-        assert mc.metadata["memory_type_agent_set"] is False
+        assert "memory_type_agent_set" not in (mc.metadata or {}), (
+            "platform provenance is riding in caller-adjacent metadata again, "
+            "where C25 sanitation will strip it: "
+            f"{mc.metadata}"
+        )
 
 
 @pytest.mark.unit

--- a/tests/test_ingest_idempotency_undo.py
+++ b/tests/test_ingest_idempotency_undo.py
@@ -158,7 +158,7 @@ async def test_commit_stamps_doc_hash_in_metadata_when_echoed(monkeypatch):
             default_write_mode="fast",
         )
 
-    async def _fake_bulk(data, *, bulk_attempt_id):
+    async def _fake_bulk(data, *, bulk_attempt_id, memory_type_is_agent_set=None):
         import uuid as _uuid
 
         from core_api.schemas import BulkItemResult, BulkMemoryResponse
@@ -218,7 +218,7 @@ async def test_commit_does_not_stamp_doc_hash_when_omitted(monkeypatch):
             default_write_mode="fast",
         )
 
-    async def _fake_bulk(data, *, bulk_attempt_id):
+    async def _fake_bulk(data, *, bulk_attempt_id, memory_type_is_agent_set=None):
         import uuid as _uuid
 
         from core_api.schemas import BulkItemResult, BulkMemoryResponse
@@ -277,7 +277,7 @@ async def test_commit_stamps_salience_when_present_on_ingestfact(monkeypatch):
             default_write_mode="fast",
         )
 
-    async def _fake_bulk(data, *, bulk_attempt_id):
+    async def _fake_bulk(data, *, bulk_attempt_id, memory_type_is_agent_set=None):
         import uuid as _uuid
 
         from core_api.schemas import BulkItemResult, BulkMemoryResponse


### PR DESCRIPTION
Fixes M-48 and M-52 from the OSS audit. Both verified against current source before touching anything.

## The gap

C25 strips forgeable platform-only keys from caller metadata in `create_memory`, under a comment calling it *"the single entry chokepoint"*. **It was not one.**

| write surface | reaches storage via | sanitized before |
|---|---|---|
| `POST /memories`, MCP single | `create_memory` | ✅ yes |
| `POST /memories/bulk`, MCP batch | `create_memories_bulk`'s own governance/embed/enrich/write loop | ❌ **no** (M-48) |
| `PATCH /memories/{id}`, MCP update | `metadata_` / `metadata_patch` | ❌ **no** (M-52) |

**M-52 is the sharper one.** Merge mode reaches storage as `metadata_patch`, and the SQL is a single top-level `||`:

```sql
SET metadata = COALESCE(metadata::jsonb, '{}'::jsonb) || (:patch)::jsonb
```

The patch is the right operand, so a caller's key wins over the platform's. `contains_pii` / `pii_types` written by the governance gate at creation could be flipped or cleared afterwards **by the same credential that wrote the memory** — rewriting governance output on an existing row, not just minting fake telemetry on a new one.

## Why it stayed invisible

`sanitize_caller_metadata` has thorough unit tests and they always passed, because the helper was never the broken part. Every test either called it directly or fed it input it had already sanitized. **Nothing tested whether a write path reaches it.**

So the new tests drive the REST routes instead — a helper-level test cannot answer that question. This is the general lesson worth keeping: *a helper unit-tested in isolation says nothing about whether its call sites reach it.*

## Ordering

Sanitation goes **before** the governance gate on both paths. The gate calls `mark_pii_flagged` on the same dict and enrichment adds telemetry after it, so sanitizing later would strip the platform's own flags along with the caller's forgeries — the reason `create_memory` already puts it there.

## A regression this fix created, and how it's handled

Worth reading even if you skip the rest.

Treating bulk item metadata as caller input means **a platform key placed in that dict is stripped like any forgery — including by trusted internal callers.** Ingest was doing exactly that:

```python
"memory_type_agent_set": False,   # CAURA-703: type came from the extraction LLM
```

The new sanitation deleted it, and the `setdefault` below then inferred `True`, because `suggested_type: str` is non-optional. **Every ingested memory would have silently recorded that the calling agent chose its type.** CAURA-703 reverted, deterministically, with nothing failing — the field has no in-repo consumer.

The existing test cannot catch it: `tests/test_ingest_commit.py` monkeypatches `create_memories_bulk` and asserts on the item *ingest built*, so the real function never runs.

Rather than exempt internal callers, **ingest stops smuggling platform state through the caller-metadata channel.** `create_memories_bulk` takes a `memory_type_is_agent_set` argument — a function parameter, so unlike a schema field it is not reachable from a request body. The flag is now assigned rather than `setdefault`-ed, since sanitation guarantees nothing is left to defer to.

I considered moving sanitation to the route/MCP boundary instead, which is where trust actually changes and would match the `SERVER_RESERVED_MEMORY_TYPES` precedent. I didn't, because it is fail-open: a new route added later is unprotected by default, whereas the service-level call sanitizes everything and requires an explicit opt-out. Happy to revisit if you prefer the boundary.

## Verification

- Full core-api suite: **6159 passed**, 0 failed
- `ruff check` / `ruff format --check` at CI's scopes; `mypy` clean (2 pre-existing `dateutil` errors in an untouched file)
- Legacy-name ratchet and do-not-touch sentinel pass after `git add`

Every new test confirmed to fail without its own fix, checked one at a time:

```
revert BULK sanitize (M-48)        -> test_bulk_write_sanitizes_caller_metadata
revert UPDATE sanitize (M-52)      -> test_update_sanitizes_caller_metadata[replace]
                                      test_update_sanitizes_caller_metadata[merge]
revert the bulk ARGUMENT handling  -> test_bulk_honours_memory_type_is_agent_set
revert the INGEST side             -> test_ingest_marks_memory_type_not_agent_set
```

The over-refusal half is asserted too: the caller's own keys and the caller-ownable `summary` must survive, and a control test proves the inferred `memory_type_agent_set` still applies when no trusted caller overrides it.

## Not fixed here — needs its own finding

`PLATFORM_ONLY_KEYS` is **incomplete**. These are written by platform code but absent from the registry, so they stay forgeable on all three paths — including the create path this PR leaves as it was:

- `governance_llm_uncertain`, `nonbusiness_kept_private` — governance output, the same class M-52 is about
- `near_duplicate_of`, `near_duplicate_similarity` — documented as read back by callers
- `parent_memory_id` — forging it fabricates lineage
- `dedup_*`, `near_dup_*`, `triple_emission_ms`, `retrieval_hint`, `auto_chunked`, `child_count`

None mirror into `_system`, so `extract_system_metadata` can't distinguish a forged one from a real one either. Widening the registry is a behaviour change for existing callers, so it belongs in its own PR rather than riding along here.

Also worth its own issue: three separate test files monkeypatch `create_memories_bulk`, which is why a live provenance regression sat in this diff until it was looked for specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
