### PR TITLE
fix(memory): reserve the platform-written keys C25 left forgeable

### DIFF
--- a/core-api/src/core_api/services/system_metadata.py
+++ b/core-api/src/core_api/services/system_metadata.py
@@ -15,9 +15,12 @@ every writer goes through:
   ``metadata["_system"]`` namespace — EXCEPT when the caller owns the key
   (``summary`` / ``tags``): then the caller's value stays at top level and
   the platform's copy lives only under ``_system``.
-- Caller input is sanitised at write time: the forgeable telemetry keys and
-  the ``_system`` namespace itself are stripped — a caller cannot inject
-  fake platform telemetry.
+- Caller input is sanitised at write time: every key in
+  ``PLATFORM_ONLY_KEYS`` and the ``_system`` namespace itself are stripped —
+  a caller cannot inject fake platform values. That set covers more than
+  telemetry: governance verdicts, dedup outcomes and row lineage are all
+  forgeable in exactly the same way, and were accepted from callers until
+  the registry was widened to name them.
 - Read-side, ``MemoryOut.system_metadata`` is derived from ``_system`` plus
   the legacy top-level keys, so historical rows (written before this module
   existed) expose the same view without a migration.
@@ -33,20 +36,55 @@ SYSTEM_NAMESPACE = "_system"
 # ``summary`` and ``tags`` are deliberately NOT here — callers legitimately
 # own those; the platform's versions go to the ``_system`` namespace when the
 # caller has set their own.
+#
+# Grouped by the step that writes them, so a key can be traced to its writer
+# without grepping. The registry is the ONLY thing standing between a caller
+# and a forged platform value: a platform key absent from this set is written
+# by the platform and accepted from callers, which is the whole defect this
+# grouping is meant to make visible.
+#
+# ``source`` is deliberately absent. The platform writes it ("auto_chunk",
+# "atomic_fact_fanout") but so does ingest, in caller-adjacent item metadata —
+# reserving it would strip that stamp the way M-48 nearly stripped
+# ``memory_type_agent_set``. It is a shared key, not a platform-only one.
 PLATFORM_ONLY_KEYS: frozenset[str] = frozenset(
     {
+        # Write-path timing. Forgeable into fake latency/telemetry.
         "llm_ms",
         "write_latency_ms",
         "semantic_dedup_ms",
+        "near_dup_check_ms",  # DetectNearDuplicate
+        "dedup_judge_ms",  # CheckSemanticDuplicate
+        "triple_emission_ms",  # EmitMemoryTriple
+        # Governance verdicts. Forging these rewrites a compliance decision.
         "business_relevance",
         "contains_pii",
         "pii_types",
+        "pii_flagged_by",
+        "governance_llm_uncertain",  # GovernanceDecision
+        "nonbusiness_kept_private",  # GovernanceDecision
+        # Dedup / near-duplicate outcomes. ``near_duplicate_of`` is read back by
+        # callers to decide whether to merge or undo, so a forged one redirects
+        # a real decision.
+        "dedup_skipped_reason",
+        "dedup_candidate_similarity",
+        "dedup_judge_confidence",
+        "dedup_subject_preflight",
+        "near_dup_skipped_reason",
+        "near_duplicate_of",
+        "near_duplicate_similarity",
+        # Write mode and the pending flags consumers poll on.
         "write_mode",
         "enrichment_pending",
         "embedding_pending",
+        # Provenance and lineage. Forging these fabricates where a row came from.
         "memory_type_agent_set",
         "weight_source",
-        "pii_flagged_by",
+        "parent_memory_id",  # auto-chunk + atomic-fact children
+        "auto_chunked",
+        "child_count",
+        # Enrichment output.
+        "retrieval_hint",
     }
 )
 

--- a/tests/test_c25_system_metadata.py
+++ b/tests/test_c25_system_metadata.py
@@ -347,3 +347,139 @@ async def test_bulk_infers_agent_set_when_no_caller_says_otherwise():
     assert (mem["metadata_"] or {}).get("memory_type_agent_set") is True, mem[
         "metadata_"
     ]
+
+
+# --- the registry was incomplete, which made the boundary partial ------------
+#
+# M-48/M-52 fixed WHERE sanitation runs. This is WHAT it strips. Twelve keys
+# were reserved; the platform writes considerably more than twelve, and every
+# one it wrote without reserving was accepted verbatim from callers on all
+# three surfaces — including the create path, which C25 always "covered".
+#
+# Governance verdicts are the sharp end, the same class as ``contains_pii``:
+# ``GovernanceDecision`` writes ``nonbusiness_kept_private`` to record that it
+# kept a non-business memory private, and a caller could simply assert it.
+# ``near_duplicate_of`` is worse than telemetry in a different way — it is
+# documented as read back by callers to decide whether to merge or undo, so a
+# forged one redirects a decision rather than just misreporting one.
+
+_NEWLY_RESERVED: dict = {
+    # governance verdicts
+    "governance_llm_uncertain": "FORGED",
+    "nonbusiness_kept_private": "FORGED",
+    # dedup / near-duplicate outcomes
+    "near_duplicate_of": "FORGED",
+    "near_duplicate_similarity": -1.0,
+    "near_dup_skipped_reason": "FORGED",
+    "dedup_skipped_reason": "FORGED",
+    "dedup_candidate_similarity": -1.0,
+    "dedup_judge_confidence": -1.0,
+    "dedup_subject_preflight": "FORGED",
+    # timing
+    "near_dup_check_ms": -1,
+    "dedup_judge_ms": -1,
+    "triple_emission_ms": -1,
+    # lineage and enrichment output
+    "parent_memory_id": "FORGED",
+    "auto_chunked": "FORGED",
+    "child_count": -1,
+    "retrieval_hint": "FORGED",
+}
+
+
+async def _write_with_metadata(client, headers, tenant_id: str, surface: str, metadata):
+    """Write ``metadata`` through one of the three caller-facing surfaces."""
+    if surface == "create":
+        resp = await client.post(
+            "/api/v1/memories",
+            json={
+                "tenant_id": tenant_id,
+                "agent_id": f"c25-reg-{uid()}",
+                "content": f"registry boundary create {uid()}",
+                "memory_type": "fact",
+                "metadata": metadata,
+            },
+            headers=headers,
+        )
+        assert resp.status_code in (200, 201), resp.text
+        return resp.json()["id"]
+
+    if surface == "bulk":
+        resp = await client.post(
+            "/api/v1/memories/bulk",
+            json={
+                "tenant_id": tenant_id,
+                "agent_id": f"c25-reg-{uid()}",
+                "items": [
+                    {
+                        "content": f"registry boundary bulk {uid()}",
+                        "metadata": metadata,
+                    }
+                ],
+            },
+            headers={**headers, "X-Bulk-Attempt-Id": f"c25-reg-{uid()}"},
+        )
+        assert resp.status_code in (200, 201), resp.text
+        results = resp.json()["results"]
+        assert len(results) == 1, resp.text
+        memory_id = results[0].get("id")
+        assert memory_id, f"bulk item came back without an id: {results!r}"
+        return memory_id
+
+    created = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": f"c25-reg-{uid()}",
+            "content": f"registry boundary update {uid()}",
+            "memory_type": "fact",
+        },
+        headers=headers,
+    )
+    assert created.status_code in (200, 201), created.text
+    memory_id = created.json()["id"]
+    patched = await client.patch(
+        f"/api/v1/memories/{memory_id}?tenant_id={tenant_id}",
+        json={"metadata": metadata, "metadata_mode": "merge"},
+        headers=headers,
+    )
+    assert patched.status_code == 200, patched.text
+    return memory_id
+
+
+@pytest.mark.parametrize("surface", ["create", "bulk", "update"])
+async def test_platform_keys_outside_the_registry_are_not_forgeable(client, surface):
+    """Every reserved key, on every surface.
+
+    Asserts on the forged VALUES rather than key absence: several of these are
+    legitimately platform-written, and a test that demanded their absence would
+    fail the day the platform started writing one — reporting a security
+    regression that had not happened.
+
+    ``create`` is in the parametrize list on purpose. Before this, no test drove
+    the sanitizer through the create ROUTE at all — every one called the helper
+    directly, which is precisely how M-48 and M-52 stayed invisible.
+    """
+    tenant_id, headers = get_test_auth()
+    payload = {**_NEWLY_RESERVED, "mine": "keep me"}
+
+    memory_id = await _write_with_metadata(client, headers, tenant_id, surface, payload)
+    metadata = await _get_metadata(client, headers, tenant_id, memory_id)
+
+    survived = {k: metadata[k] for k in _NEWLY_RESERVED if k in metadata}
+    forged = {k: v for k, v in survived.items() if v == _NEWLY_RESERVED[k]}
+    assert not forged, f"caller-forged platform values reached the row: {forged!r}"
+
+    assert metadata.get("mine") == "keep me", (
+        f"over-refusal: the caller's own key was stripped: {metadata!r}"
+    )
+
+
+def test_source_is_deliberately_not_reserved():
+    """``source`` is written by the platform AND by callers.
+
+    Reserving it would strip ingest's own ``{"source": "ingest"}`` stamp — the
+    M-48 regression shape. Pinned so the next person widening this registry has
+    to read the reason before overriding it.
+    """
+    assert "source" not in PLATFORM_ONLY_KEYS

--- a/tests/test_ingest_commit.py
+++ b/tests/test_ingest_commit.py
@@ -301,6 +301,38 @@ async def test_ingest_marks_memory_type_not_agent_set(captured):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_ingest_item_metadata_holds_no_reserved_platform_key(captured):
+    """Generalises the assertion above to the whole registry.
+
+    ``create_memories_bulk`` treats item metadata as caller input, so ANY key
+    ingest puts there that is (or later becomes) reserved is silently deleted
+    before the row is written. That is how ``memory_type_agent_set`` was lost:
+    the flag had no in-repo consumer, so nothing failed.
+
+    This fails for the next such key too — whether it is added to ingest, or
+    added to ``PLATFORM_ONLY_KEYS`` while ingest is still stamping it — which
+    the key-specific test above cannot do.
+    """
+    from core_api.services.system_metadata import PLATFORM_ONLY_KEYS, SYSTEM_NAMESPACE
+
+    req = _request("t1", "fact one", "fact two")
+    await ingest_service.ingest_commit(request=req)
+
+    assert captured.writes, "ingest wrote nothing; the assertion below is vacuous"
+    for mc in captured.writes:
+        reserved = (set(mc.metadata or {}) & PLATFORM_ONLY_KEYS) | (
+            {SYSTEM_NAMESPACE} & set(mc.metadata or {})
+        )
+        assert not reserved, (
+            f"ingest is stamping reserved platform key(s) {sorted(reserved)} into "
+            f"item metadata, where C25 sanitation deletes them before the write. "
+            f"Pass them as an argument to create_memories_bulk instead. "
+            f"metadata={mc.metadata}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_parent_document_written_once_per_batch(captured):
     """One ingest_commit produces exactly one ``documents`` row with
     ``collection='ingest-sources'`` and ``doc_id == run_id``. The


### PR DESCRIPTION
Follow-up to #1322, from the gap I flagged in its description.

#1322 fixed **where** caller metadata is sanitized — all three write surfaces now call `sanitize_caller_metadata`. This fixes **what it strips**.

## The gap

`PLATFORM_ONLY_KEYS` listed twelve keys. The platform writes considerably more than twelve, and **every key it wrote without reserving was accepted verbatim from callers** — on all three surfaces, including the create path C25 always covered.

The registry is the only thing standing between a caller and a forged platform value, so a key missing from it isn't a documentation gap.

| newly reserved | written by | why it matters |
|---|---|---|
| `governance_llm_uncertain`, `nonbusiness_kept_private` | `GovernanceDecision` | same class as `contains_pii` — asserts a compliance decision the gate never made |
| `near_duplicate_of`, `near_duplicate_similarity`, `near_dup_skipped_reason` | `DetectNearDuplicate` | `near_duplicate_of` is **read back by callers** to decide whether to merge or undo |
| `dedup_skipped_reason`, `dedup_candidate_similarity`, `dedup_judge_confidence`, `dedup_subject_preflight` | `CheckSemanticDuplicate` | forged dedup outcomes |
| `near_dup_check_ms`, `dedup_judge_ms`, `triple_emission_ms` | the above + `EmitMemoryTriple` | fake telemetry |
| `parent_memory_id`, `auto_chunked`, `child_count` | auto-chunk / atomic-fact fan-out | fabricates row lineage |
| `retrieval_hint` | enrichment | fake enrichment output |

`near_duplicate_of` is the one I'd call worse than telemetry: it's documented as something callers read to make a decision, so forging it **redirects a decision** rather than just misreporting one.

## What I deliberately did not reserve

**`source`.** The platform writes it (`"auto_chunk"`, `"atomic_fact_fanout"`) but so does ingest, in caller-adjacent item metadata. Reserving it would strip that stamp — exactly the way widening this boundary nearly cost CAURA-703 in #1322. It's a shared key, not a platform-only one. There's a test pinning that with the reason, so the next person widening this registry has to read it before overriding.

I checked every platform writer of the newly-reserved keys sits **downstream of a sanitize point**: pipeline steps run on post-sanitize metadata, and child rows go to `sc.create_memory` with a dict built from scratch. So reserving them strips forgeries without touching a platform write. That check is the one #1322 taught me to run.

## Read-side consequence — deliberate, but call it out

`PLATFORM_KEYS = PLATFORM_ONLY_KEYS | CALLER_OWNABLE_KEYS` feeds `extract_system_metadata`, so these keys now also appear in **`MemoryOut.system_metadata`** where present. Additive, and consistent with that field's contract: it's the platform view and these are platform values.

One caveat worth stating rather than discovering later — for rows written *before* this change a caller could have forged one of these, and it will now be surfaced as platform metadata. That's inherent to the one-release legacy dual-write and already applies to the original twelve; it isn't new behaviour, just newly reaching more keys.

## Verification

- Full core-api suite: **6190 passed**, 0 failed (rebased onto `main` incl. #1316 and #1322)
- `ruff check` / `ruff format --check` at CI's scopes; mypy clean bar 2 pre-existing `dateutil` errors in an untouched file
- Ratchet and sentinel pass after `git add`

Teeth, checked one at a time:

```
restore the old 12-key registry ->
    test_platform_keys_outside_the_registry_are_not_forgeable[create]
    test_platform_keys_outside_the_registry_are_not_forgeable[bulk]
    test_platform_keys_outside_the_registry_are_not_forgeable[update]
make ingest stamp a newly-reserved key ->
    test_ingest_item_metadata_holds_no_reserved_platform_key
```

Two things about the tests worth noting:

**`create` is covered by a route test for the first time.** I flagged in #1322 that no test drove the sanitizer through the create *route* — every one called the helper directly, which is precisely how M-48 and M-52 stayed invisible. It's in the parametrize list now, and it failed against the old registry like the other two.

**The assertions are on forged values, not key absence.** Several of these are legitimately platform-written, and a test demanding their absence would fail the day the platform started writing one — reporting a security regression that hadn't happened.

**The ingest guard is generalised.** #1322 added a test that ingest doesn't stamp `memory_type_agent_set`. This asserts ingest's item metadata is disjoint from the *whole* registry, so it fires whether a reserved key is added to ingest or a key ingest stamps is added to the registry. The key-specific version couldn't catch the second direction — and that direction is what cost CAURA-703.

## Not addressed here

None of these mirror into `_system` via `set_system_value`, so the read side still can't distinguish a legacy top-level platform write from a historical forged one. Closing that means routing every writer through the helper — a larger change than reserving the keys, and a different one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
