### PR TITLE
fix(reports): stop leaking the caller's own private rows into group reports

### DIFF
--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -292,13 +292,28 @@ async def get_report(
         # (totals/by_type/by_agent/quality/trend). These are real, decision-
         # bearing memories an agent kept private — excluding them made
         # durable_memories_written measure "team-visible" rather than "written",
-        # and disproportionately undercounted privacy-heavy tenants. This is a
-        # pure count; the content sections (value_highlights/learning/spotlight/
-        # working_on) still exclude scope_agent — see list_query below — so no
-        # private content is surfaced to the group. Ignored on the self path
-        # (agent_id set), which already scopes visibility to the caller.
+        # and disproportionately undercounted privacy-heavy tenants. Ignored on
+        # the self path (agent_id set), which already scopes visibility to the
+        # caller.
+        #
+        # No memory title, content or memory id crosses into the response from
+        # here — the projection is (memory_type, agent_id, status[, tenant_id],
+        # COUNT(*)). Counts ARE bucketed by agent, so on this branch, where no
+        # ``agent_id`` is set, EVERY agent's private rows are counted, not just
+        # the caller's: an agent whose whole window is private still appears in
+        # by_agent with its true volume. That is the trade the paragraph above
+        # argues for, stated rather than glossed.
+        #
+        # Whether private CONTENT surfaces is a separate decision, made by
+        # ``is_self_scope`` below — see U42/M-31 there.
         "include_scope_agent": True,
     }
+    # The audience/data-scope decision, resolved ONCE. Both the breakdown below
+    # and the visibility identity on the detail path key off it, and M-31 was
+    # exactly those two drifting apart: this branch was right and ``list_query``
+    # re-derived the predicate by hand and got it wrong. Sharing the variable is
+    # what keeps them together; a comment claiming they match is not.
+    is_self_scope = False
     if org_mode:
         # Org-wide: aggregate across every tenant the credential may read.
         # Team/org-visible only (no agent_id ⇒ excludes scope_agent); the
@@ -309,6 +324,7 @@ async def get_report(
         # Narrowest: only the caller's own contributions.
         breakdown_query["agent_id"] = caller_agent_id
         scope_label = "self"
+        is_self_scope = True
     else:
         # internal_group / external: the caller's own fleet (team/org-visible).
         # ``external`` shares the same query but its detail is stripped below.
@@ -345,24 +361,31 @@ async def get_report(
         # over-fetch: the surviving pool must still exceed the downstream
         # _LEARNING_LIMIT / _HIGHLIGHTS_LIMIT slices.
 
+        # U42/M-31. The VISIBILITY identity — self path only. Storage admits
+        # ``scope_agent`` rows authored by this agent when it is set and
+        # excludes all of them when it is not (``memory_list_by_filters``), so
+        # on a group/org report it puts the caller's OWN private titles into
+        # learning / value_highlights / working_on / the spotlight headline.
+        # It used to be passed unconditionally.
+        visibility_agent_id = caller_agent_id if is_self_scope else None
+
         # Recent-ordered fetch → LEARNING (recent insights) + working-on LANES.
         list_query: dict = {
             "tenant_id": tenant_id,
-            "caller_agent_id": caller_agent_id,
+            "caller_agent_id": visibility_agent_id,
             "created_after": window_start.isoformat(),
             "sort": "created_at",
             "order": "desc",
             "limit": _DURABLE_FETCH_LIMIT,
         }
-        # Self audiences scope to the caller's OWN authored rows, mirroring the
-        # ``agent_id`` filter applied to breakdown_query on this path — so the
+        # Self audiences scope to the caller's OWN authored rows, so the
         # list-derived sections (learning, value_highlights, working_on) stay
         # consistent with the breakdown-derived counts (durable_total, per_agent).
         # NOTE: /memories/list filters authorship via ``written_by`` (``agent_id``
-        # is not read on that path); ``caller_agent_id`` above is the visibility
-        # identity, not an author filter. Skipped in org_mode: an org-scope report
-        # aggregates the whole readable set, so it must not narrow to one author.
-        if dest in _SELF_AUDIENCES and caller_agent_id and not org_mode:
+        # is not read on that path). That is a DIFFERENT knob from the visibility
+        # identity above — a row can be visible without being authored by the
+        # caller, which is the whole group view.
+        if is_self_scope:
             list_query["written_by"] = caller_agent_id
         if org_mode:
             list_query["readable_tenant_ids"] = readable
@@ -417,7 +440,7 @@ async def get_report(
         if not org_mode:
             if dest == AUDIENCE_GROUP:
                 agent_rows = p1.get("agents") or []
-            elif dest in _SELF_AUDIENCES:
+            elif is_self_scope:
                 agent_rows = [caller] if caller else []
             else:
                 agent_rows = []
@@ -596,6 +619,12 @@ async def get_report(
                 "durable, decision-bearing memories (excl. episodic logs, the "
                 "'main' firehose, and heartbeat/health/status noise)"
             ),
+            # Deliberately NOT ``is_self_scope``: this one omits the
+            # ``caller_agent_id`` conjunct, so a human-dashboard caller (no agent
+            # identity) asking for a self destination still gets the default
+            # belonging block even though its ``scope`` reads "group". Response
+            # shape, not visibility — swapping in the shared predicate here would
+            # silently start returning null.
             "belonging": (
                 {"type": belonging_type, "owner_ref": owner_ref}
                 if dest in _SELF_AUDIENCES and not org_mode

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -6,6 +6,7 @@ Real FastAPI app + in-process storage (see conftest). Validates:
 - period validation.
 """
 
+import json
 import uuid
 
 import pytest
@@ -288,7 +289,14 @@ async def test_report_group_counts_private_writes_but_hides_content(client):
     """Agent-private (``scope_agent``) durable writes are COUNTED in the group
     aggregates — durable_memories_written / by_type / per_agent / trend — but
     their CONTENT is never surfaced (value_highlights). Visibility is an audience
-    attribute, not a measure of whether a memory is knowledge produced."""
+    attribute, not a measure of whether a memory is knowledge produced.
+
+    The counting half is what this test really pins. Its caller is an admin
+    credential with no agent identity, so the content half holds here for a
+    reason unrelated to the route's audience logic and would have passed against
+    the M-31 leak — see
+    ``test_report_group_hides_private_content_from_an_agent_caller``.
+    """
     tag = _uid()
     tenant_id, headers = get_test_auth(f"rep-tenant-{tag}")
     fleet, a1 = f"rep-fleet-{tag}", f"rep-a1-{tag}"
@@ -335,6 +343,155 @@ async def test_report_group_counts_private_writes_but_hides_content(client):
     ]
 
 
+async def _seed_private_insight(client, headers, tenant_id, fleet, agent, title):
+    """A ``scope_agent`` ``insight`` with an exact title.
+
+    ``_seed_titled`` (below) is the ``scope_team`` equivalent; the whole point
+    here is the private one. Both PATCH the title for the same reason — so the
+    assertion does not depend on what enrichment chose to call the row.
+
+    ``insight`` is set the same way rather than on the write: it is in
+    ``SERVER_RESERVED_MEMORY_TYPES``, which the route refuses on a write, and
+    the report's ``learning`` section selects on exactly that type — so a row
+    of that type has to be made after the fact.
+    """
+    r = await client.post(
+        "/api/v1/memories",
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": agent,
+            "fleet_id": fleet,
+            "visibility": "scope_agent",
+            "content": f"{title} {_uid()}",
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    await get_storage_client().update_memory(
+        r.json()["id"], tenant_id, {"title": title, "memory_type": "insight"}
+    )
+
+
+async def test_report_group_hides_private_content_from_an_agent_caller(client):
+    """M-31. The same invariant as the test above, asserted against a caller
+    that can actually violate it.
+
+    That test passes for a reason unrelated to the route's logic: it calls with
+    ``get_test_auth()``, an ADMIN credential with no agent identity, so
+    ``asserted_agent`` is None, ``caller_agent_id`` stays None, and the storage
+    predicate then drops every ``scope_agent`` row regardless of what the
+    route's audience handling decided. The invariant is real; that caller cannot
+    violate it, so it cannot test it either.
+
+    An AGENT caller can. ``list_query`` set ``caller_agent_id`` on every detail
+    path, and the predicate admits ``scope_agent`` rows authored by that agent —
+    so an agent asking for an ``internal_group`` report got its OWN private
+    titles back in the content sections, which is the audience-class narrowing
+    the two-check design exists to enforce. The agent then relays that verbatim
+    into a group channel.
+
+    The breakdown path already got this right (it sets ``agent_id`` only on the
+    self branch); only ``list_query`` did not.
+    """
+    tag = _uid()
+    tenant_id, headers = get_test_auth(f"rep-tenant-{tag}")
+    fleet, a1 = f"rep-fleet-{tag}", f"rep-a1-{tag}"
+    await _register(tenant_id, fleet, a1)
+
+    await _seed(client, headers, tenant_id, fleet, a1, "decision", 2)
+    private_title = f"private runway concern {tag}"
+    await _seed_private_insight(client, headers, tenant_id, fleet, a1, private_title)
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": "internal_group",
+            # The difference that matters: this makes the caller an AGENT, so
+            # ``caller_agent_id`` is set and the private row becomes visible to
+            # the storage predicate.
+            "agent_id": a1,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # The caller really did resolve to an agent. Without this the test passes
+    # VACUOUSLY if identity resolution ever breaks — ``caller_agent_id`` would
+    # be None, the storage predicate would exclude private rows for that reason
+    # instead of this fix, and the assertions below would prove nothing. That is
+    # the exact failure mode of the test this one exists to supplement, so it
+    # gets an explicit witness. ``meta.fleet_id`` is ``caller.get("fleet_id")``
+    # and stays None unless an agent row was fetched.
+    assert body["meta"]["fleet_id"] == fleet, (
+        f"caller did not resolve to an agent; this test would prove nothing: {body['meta']}"
+    )
+
+    # Counted — unchanged, and the reason the leak is not visible in the totals.
+    assert body["summary"]["durable_memories_written"] == 3, body["summary"]
+
+    # Not surfaced, anywhere. Checked against the whole serialized body rather
+    # than section by section, because the title reaches learning,
+    # value_highlights, the working-on lanes and the spotlight headline by four
+    # separate routes and a per-section list would rot as sections are added.
+    assert private_title not in json.dumps(body), (
+        "an agent's own scope_agent title reached an internal_group report: "
+        f"{json.dumps(body)}"
+    )
+    # Independent of the check above: catches a private row surfacing under a
+    # DIFFERENT string, since ``_title()`` falls back to metadata.summary and
+    # then "(untitled)".
+    assert all(h["type"] == "decision" for h in body["value_highlights"]), body[
+        "value_highlights"
+    ]
+
+    # Over-refusal guard: the team-visible rows must still be there. Dropping
+    # ``caller_agent_id`` must narrow visibility, not empty the report.
+    assert len(body["value_highlights"]) == 2, body["value_highlights"]
+
+
+@pytest.mark.parametrize("destination", ["owner_1to1", "private_session"])
+async def test_report_self_view_still_shows_the_agent_its_own_private_rows(
+    client, destination
+):
+    """The other side of M-31: the self audiences are the caller's OWN view.
+
+    Narrowing the group path must not narrow these — an agent asking for its
+    self report is entitled to its private rows, and that is exactly what
+    ``caller_agent_id`` is for. Without this, "fix the leak" could be satisfied
+    by never passing the visibility identity at all, which is a fix in the sense
+    that a disconnected cable fixes a noisy line.
+
+    Both members of ``_SELF_AUDIENCES`` are covered, not just the common one.
+    """
+    tag = _uid()
+    tenant_id, headers = get_test_auth(f"rep-tenant-{tag}")
+    fleet, a1 = f"rep-fleet-{tag}", f"rep-a1-{tag}"
+    await _register(tenant_id, fleet, a1)
+
+    private_title = f"private runway concern {tag}"
+    await _seed_private_insight(client, headers, tenant_id, fleet, a1, private_title)
+
+    resp = await client.get(
+        "/api/v1/reports",
+        params={
+            "tenant_id": tenant_id,
+            "period": "week",
+            "destination": destination,
+            "agent_id": a1,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["meta"]["scope"] == "self", body["meta"]
+    assert any(item["title"] == private_title for item in body["learning"]), (
+        f"the self view lost the caller's own private row: {body['learning']}"
+    )
+
+
 async def test_report_org_scope_aggregates_across_tenants(client):
     """scope=org with a cross-tenant read credential aggregates across the
     readable tenant set and returns a per-tenant breakdown."""
@@ -367,6 +524,53 @@ async def test_report_org_scope_aggregates_across_tenants(client):
         assert body["summary"]["by_tenant"] == {t1: 2, t2: 3}, body["summary"][
             "by_tenant"
         ]
+    finally:
+        app.dependency_overrides.pop(get_auth_context, None)
+
+
+async def test_report_org_scope_hides_private_content_from_an_agent_caller(client):
+    """M-31, org half. ``scope=org`` carried the same defect as internal_group.
+
+    Reachable because ``asserted_agent`` falls back to the ``agent_id`` QUERY
+    PARAM: a cross-tenant reader supplying it resolves a ``caller_agent_id``,
+    and that agent's private rows then flowed into a report aggregated across
+    every readable tenant — the widest audience the endpoint produces.
+    """
+    tag = _uid()
+    t1, t2 = f"rep-org1-{tag}", f"rep-org2-{tag}"
+    a1 = f"a1-{tag}"
+    _, headers = get_test_auth(t1)
+    await _register(t1, f"f1-{tag}", a1)
+    await _register(t2, f"f2-{tag}", f"a2-{tag}")
+    await _seed(client, headers, t1, f"f1-{tag}", a1, "decision", 2)
+
+    private_title = f"private runway concern {tag}"
+    await _seed_private_insight(client, headers, t1, f"f1-{tag}", a1, private_title)
+
+    ctx = AuthContext(tenant_id=t1, readable_tenant_ids=[t1, t2])
+    app.dependency_overrides[get_auth_context] = lambda: ctx
+    try:
+        resp = await client.get(
+            "/api/v1/reports",
+            params={
+                "tenant_id": t1,
+                "period": "week",
+                "destination": "internal_group",
+                "scope": "org",
+                "agent_id": a1,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["meta"]["scope"] == "org", body["meta"]
+        # Counted, as on every other path.
+        assert body["summary"]["durable_memories_written"] == 3, body["summary"]
+        assert private_title not in json.dumps(body), (
+            "an agent's own scope_agent title reached an ORG-scope report: "
+            f"{json.dumps(body)}"
+        )
+        # Over-refusal guard: the team-visible rows survive.
+        assert len(body["value_highlights"]) == 2, body["value_highlights"]
     finally:
         app.dependency_overrides.pop(get_auth_context, None)
 


### PR DESCRIPTION
Closes audit finding **M-31** (U42). Verified against current source, then reproduced end-to-end before anything was changed.

## The leak

`GET /api/v1/reports` narrows what it returns by destination audience. The breakdown path does that correctly — it sets `agent_id` only on the self branch. **`list_query` did not**: it passed `caller_agent_id` on every detail path, and the storage visibility predicate admits `scope_agent` rows when that is set:

```python
if caller_agent_id:
    or_(scope_org, scope_team, and_(scope_agent, Memory.agent_id == caller_agent_id))
else:
    Memory.visibility != "scope_agent"
```

So an **agent** caller requesting `destination=internal_group` got its own private memories back in the content sections. One seeded private title appeared in **four places at once**:

| section | what surfaced |
|---|---|
| `learning` | title + date |
| `value_highlights` | title, type, agent |
| `working_on.Governing.items` | first item |
| **`spotlight.headline`** | the headline of the report |

That is the report an agent then relays verbatim into a group channel — the audience narrowing this two-check design exists to enforce. `scope=org` carried the same defect, reachable because `asserted_agent` falls back to the `agent_id` query param; there the audience is every readable tenant.

Scope of impact, stated plainly: the surfaced rows are the caller's **own**, not another agent's. This is self-oversharing to a wider audience, not cross-agent exposure.

## Why review missed it

`test_report_group_counts_private_writes_but_hides_content` asserts this exact invariant, and **passed against the vulnerable code**. It calls with an admin credential that has no agent identity, so `caller_agent_id` stayed `None` and the storage predicate dropped private rows for a reason unrelated to the route's audience logic. The invariant was real; that caller could not violate it, so it could not test it. Adding one query param — `agent_id=a1` — is the entire difference.

Same shape as the M-25 finding, where `enforce_not_agent_credential` returns early for admins and `get_test_auth()` returns the admin key. Worth naming as a pattern: **a test whose caller cannot reach the vulnerable path proves nothing, however precisely it states the invariant.**

## The fix, and why it isn't just a one-line gate

The audience decision is now resolved **once**, as `is_self_scope`, and used for the breakdown, the visibility identity, the author filter, and the agent leaderboard.

The predicate was previously written out by hand at each site — and M-31 *was* two of those copies disagreeing. My first version of this fix gated the identity correctly but carried a comment saying *"this mirrors that condition exactly"*, which is the same kind of unenforced claim that caused the bug. Sharing the variable makes the mirror structural instead of asserted.

`meta.belonging` deliberately keeps its own predicate, with a comment saying why: it omits the `caller_agent_id` conjunct, so a human-dashboard caller asking for a self destination still gets a belonging block even though its `scope` reads `"group"`. That is response shape, not visibility — swapping in the shared predicate would silently start returning `null`.

Also corrected: the `breakdown_query` comment claimed the content sections *"still exclude scope_agent — see list_query below — so no private content is surfaced to the group."* That was a claim about other code, and it was false. It now says what the aggregate path actually does — including that no `agent_id` is set on this branch, so counts include **every** agent's private rows, not just the caller's. Aggregates were and remain count-only; the projection is `(memory_type, agent_id, status[, tenant_id], COUNT(*))`.

## Verification

Full core-api suite **6194 passed**, 0 failed (rebased onto current `main`). `ruff check` / `ruff format --check` at CI's scopes run separately; mypy clean bar 2 pre-existing `dateutil` errors in an untouched file; ratchet and sentinel after `git add`.

Three mutants, one at a time:

```
pass the identity unconditionally (the leak)  -> group + org leak tests FAIL
never pass the identity (over-refusal)        -> both self-view params FAIL
ignore the agent_id query param               -> group leak test FAILS (+8 others)
```

The third mutant is there because the first version of these tests **passed vacuously** under it — if identity resolution breaks, `caller_agent_id` is `None`, private rows are excluded for the wrong reason, and the assertions prove nothing. The group test now asserts `meta.fleet_id` as a positive witness that the caller really resolved to an agent. The org test has no equivalent witness available (`meta.fleet_id` and `meta.belonging` are both forced `None` under `org_mode`); that limit is stated rather than papered over.

The over-refusal direction covers **both** members of `_SELF_AUDIENCES`, not just `owner_1to1`, so "fix the leak" cannot be satisfied by never passing the identity at all.

## Sibling instances: checked, none found

The thing most worth knowing about a fix like this is whether it leaves a twin open. It does not:

- **`get_agent_activity_digest`** passes `agent_id` to `sc.get_agent_activity_digest(...)` as a row **filter** over precomputed digests, never as a visibility identity — the route holds no `caller_agent_id` at all.
- **The digest generator's only memory fetch** (`agent_digest.py`) omits `caller_agent_id` entirely, so `Memory.visibility != "scope_agent"` applies and private rows never enter the corpus. The storage `/list` router has no `include_scope_agent` knob, so omission there is a hard exclusion.
- `highlights_query` is derived from `list_query` *after* the conditionals, so it inherits the fix rather than needing its own.
- `reports.py` is the only file in `core-api/src` referencing `_SELF_AUDIENCES` or `include_scope_agent`, so there is no other audience-narrowing surface.

One pre-existing, deliberate behaviour surfaced while checking, **not** changed here: a credential with no gateway agent identity (admin key, human dashboard) can name any registered agent via the query param and read that agent's `scope_agent` rows on the self path. `memories.py` documents this as intended for the dashboard. Flagging it only in case the threat model has moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
