### PR TITLE
fix(fleet): refuse an agent-scoped credential at POST /fleet/commands

### DIFF
--- a/core-api/src/core_api/routes/fleet.py
+++ b/core-api/src/core_api/routes/fleet.py
@@ -1034,20 +1034,51 @@ async def create_command(
     body: CommandIn,
     auth: AuthContext = Depends(get_auth_context),
 ):
-    """Queue a command for a fleet node."""
-    sc = get_storage_client()
+    """Queue a command for a fleet node.
+
+    Auth: a write-capable tenant-owner key. Agent-scoped credentials are
+    blocked (BFLA) — dispatching to a node is admin-plane, the same call
+    ``DELETE /fleet/{fleet_id}`` and ``POST /fleet/{fleet_id}/purge`` make.
+    """
     # Queueing a command is a write, and the tenant it lands in comes from the
-    # REQUEST BODY. Both gates are required, and the order matters: resolve the
-    # target tenant first, then enforce against the resolved value.
+    # REQUEST BODY. All three gates are required, and the order matters: resolve
+    # the target tenant first, then enforce against the resolved value.
     #
     # Without ``enforce_tenant`` any authenticated caller could set
     # ``body.tenant_id`` to a victim tenant and queue commands into their fleet
     # — the GET sibling immediately below has always enforced this, so the write
     # was the weaker of the pair. Without ``enforce_read_only`` a
     # capabilities={'read'} credential could do the same.
+    #
+    # Neither of those constrains an agent-scoped credential naming its OWN
+    # tenant, and ``body.node_id`` is not bound to the caller's scope —
+    # ``GET /fleet/nodes`` hands out every node id in the tenant behind
+    # ``enforce_tenant`` alone. What lands on the node is not abstract: a
+    # ``deploy``/``update_plugin`` payload carrying ``source`` takes the plugin
+    # down ``deployPlugin`` (``plugin/src/deploy.ts``), which writes it over the
+    # plugin's own source tree, merges ``env_vars`` into its ``.env`` for any
+    # key with the plugin env prefix — ``CAURA_API_URL`` and ``CAURA_API_KEY``
+    # included — and builds; the caller's code goes live on the gateway restart
+    # that same branch then asks for (``plugin/src/heartbeat.ts``). So an
+    # agent-scoped key that cannot raise its own trust_level
+    # (``PATCH /agents/{id}/trust`` refuses it) could instead run code on the
+    # host answering for it.
+    #
+    # The plugin's HMAC check is not a second line of defence: nothing in
+    # core-api or core-storage-api ever puts a ``signature`` on a command — the
+    # heartbeat response above emits ``id``/``command``/``payload`` and no more
+    # — so every command arrives unsigned, which the plugin accepts by default.
+    #
+    # No internal producer loses a channel: both bypass this route. The
+    # auto-upgrade calls ``sc.create_command`` from inside the heartbeat
+    # handler, and the interview scheduler does the same behind
+    # ``enforce_admin`` on ``POST /admin/interview/schedule/run``.
     auth.enforce_read_only()
     tenant_id = body.tenant_id or auth.tenant_id
     auth.enforce_tenant(tenant_id)
+    auth.enforce_not_agent_credential("queue fleet commands")
+
+    sc = get_storage_client()
     try:
         cmd = await sc.create_command(
             {

--- a/tests/test_route_authz_gaps.py
+++ b/tests/test_route_authz_gaps.py
@@ -31,8 +31,11 @@ fixture, so the in-process storage app can see them.
 from __future__ import annotations
 
 import uuid
+from typing import NamedTuple
 
 import pytest
+
+from core_api import errors
 
 pytestmark = pytest.mark.asyncio
 
@@ -71,19 +74,33 @@ def _uid() -> str:
     return uuid.uuid4().hex[:8]
 
 
-async def _make_command(client, as_auth, tenant_id: str) -> str:
-    """Heartbeat a node and dispatch a command for ``tenant_id``; return command id."""
+class _Node(NamedTuple):
+    fleet_id: str
+    node_name: str
+    node_id: str
+
+
+async def _seed_node(client, as_auth, tenant_id: str) -> _Node:
+    """Register one node in a fresh fleet, and hand back all three identifiers.
+
+    Arms a plain tenant credential to do it, so a caller under test that holds
+    a narrower one (read-only, or agent-scoped) starts from a node it did not
+    create itself.
+    """
+    fleet_id = f"fleet-{_uid()}"
+    node_name = f"node-{_uid()}"
     as_auth(tenant_id)
     resp = await client.post(
         "/api/v1/fleet/heartbeat",
-        json={
-            "tenant_id": tenant_id,
-            "node_name": f"node-{_uid()}",
-            "fleet_id": f"fleet-{_uid()}",
-        },
+        json={"tenant_id": tenant_id, "node_name": node_name, "fleet_id": fleet_id},
     )
     assert resp.status_code == 200, resp.text
-    node_id = resp.json()["node_id"]
+    return _Node(fleet_id, node_name, resp.json()["node_id"])
+
+
+async def _make_command(client, as_auth, tenant_id: str) -> str:
+    """Heartbeat a node and dispatch a command for ``tenant_id``; return command id."""
+    node_id = (await _seed_node(client, as_auth, tenant_id)).node_id
 
     resp = await client.post(
         "/api/v1/fleet/commands",
@@ -324,17 +341,7 @@ async def test_fleet_command_cannot_be_queued_into_another_tenant(client, as_aut
     attacker = f"attacker-{_uid()}"
 
     # A real node in the victim's fleet, created by the victim.
-    as_auth(victim)
-    resp = await client.post(
-        "/api/v1/fleet/heartbeat",
-        json={
-            "tenant_id": victim,
-            "node_name": f"node-{_uid()}",
-            "fleet_id": f"fleet-{_uid()}",
-        },
-    )
-    assert resp.status_code == 200, resp.text
-    node_id = resp.json()["node_id"]
+    node_id = (await _seed_node(client, as_auth, victim)).node_id
 
     as_auth(attacker)
     resp = await client.post(
@@ -360,10 +367,14 @@ async def test_fleet_command_cannot_target_another_tenants_node(client, as_auth)
 
     ``enforce_tenant`` only checks ``body.tenant_id``, so a caller naming its OWN
     tenant clears it — while still pointing ``body.node_id`` at somebody else's
-    node. Nothing downstream re-checks the pair: the insert satisfies the FK to
-    ``fleet_nodes.id`` on its own, and the pending-command query the heartbeat
-    runs is keyed on ``node_id`` alone. The row is therefore handed to the other
-    tenant's node on its next heartbeat.
+    node. The insert satisfies the FK to ``fleet_nodes.id`` on its own, so
+    nothing about the write itself objects.
+
+    Two independent gates stop it, and this test covers the write half — the
+    404 below. Delivery is gated separately and was closed later, by #1173:
+    ``fleet_get_pending_commands`` filters the (node, tenant, status) triple
+    rather than ``node_id`` alone, so a row written before either fix is not
+    handed over either.
 
     Queueing into a node you do not own is a 404, not a 403 — the same
     non-disclosing answer ``POST /fleet/commands/{id}/result`` gives for a
@@ -372,20 +383,9 @@ async def test_fleet_command_cannot_target_another_tenants_node(client, as_auth)
     """
     victim = f"victim-{_uid()}"
     attacker = f"attacker-{_uid()}"
-    victim_node_name = f"node-{_uid()}"
 
     # A real node in the victim's fleet, created by the victim.
-    as_auth(victim)
-    resp = await client.post(
-        "/api/v1/fleet/heartbeat",
-        json={
-            "tenant_id": victim,
-            "node_name": victim_node_name,
-            "fleet_id": f"fleet-{_uid()}",
-        },
-    )
-    assert resp.status_code == 200, resp.text
-    victim_node_id = resp.json()["node_id"]
+    _, victim_node_name, victim_node_id = await _seed_node(client, as_auth, victim)
 
     # The attacker queues into its own tenant — the tenant gate passes cleanly —
     # but aims the command at the victim's node.
@@ -402,8 +402,9 @@ async def test_fleet_command_cannot_target_another_tenants_node(client, as_auth)
     assert resp.status_code == 404, resp.text
 
     # The whole point: the victim's node must not be handed the command when it
-    # next checks in. Asserting on the queue alone would miss a row that is
-    # filed under the attacker's tenant but still delivered on node_id.
+    # next checks in. The victim's own queue listing cannot settle that — a row
+    # filed under the ATTACKER's tenant never appears in it — so this heartbeat
+    # is the assertion that spans both gates at once.
     as_auth(victim)
     resp = await client.post(
         "/api/v1/fleet/heartbeat",
@@ -443,17 +444,7 @@ async def test_fleet_command_for_an_unknown_node_is_404_not_500(client, as_auth)
 async def test_fleet_command_rejects_a_read_only_credential(client, as_auth):
     """H-13, second half: queueing a command is a write."""
     tenant = f"tenant-{_uid()}"
-
-    as_auth(tenant)
-    resp = await client.post(
-        "/api/v1/fleet/heartbeat",
-        json={
-            "tenant_id": tenant,
-            "node_name": f"node-{_uid()}",
-            "fleet_id": f"fleet-{_uid()}",
-        },
-    )
-    node_id = resp.json()["node_id"]
+    node_id = (await _seed_node(client, as_auth, tenant)).node_id
 
     as_auth(tenant, capabilities=READ_ONLY)
     resp = await client.post(
@@ -774,18 +765,7 @@ async def test_promote_refuses_a_quarantined_agent(client, as_auth, sc, _stm_ena
 
 async def _queue_command_for(client, as_auth, tenant: str) -> tuple[str, str]:
     """Register a node and queue one command for it. Returns (node_name, command_id)."""
-    node_name = f"node-{_uid()}"
-    as_auth(tenant)
-    resp = await client.post(
-        "/api/v1/fleet/heartbeat",
-        json={
-            "tenant_id": tenant,
-            "node_name": node_name,
-            "fleet_id": f"fleet-{_uid()}",
-        },
-    )
-    assert resp.status_code == 200, resp.text
-    node_id = resp.json()["node_id"]
+    _, node_name, node_id = await _seed_node(client, as_auth, tenant)
 
     resp = await client.post(
         "/api/v1/fleet/commands",
@@ -930,14 +910,7 @@ async def test_heartbeat_delivers_commands_to_a_writing_credential(client, as_au
 
 async def _seed_fleet(client, as_auth, tenant: str) -> str:
     """Heartbeat one node into a fresh fleet; return the fleet_id."""
-    fleet_id = f"fleet-{_uid()}"
-    as_auth(tenant)
-    resp = await client.post(
-        "/api/v1/fleet/heartbeat",
-        json={"tenant_id": tenant, "node_name": f"node-{_uid()}", "fleet_id": fleet_id},
-    )
-    assert resp.status_code == 200, resp.text
-    return fleet_id
+    return (await _seed_node(client, as_auth, tenant)).fleet_id
 
 
 async def _node_count(client, as_auth, tenant: str, fleet_id: str) -> int:
@@ -980,4 +953,81 @@ async def test_a_tenant_credential_can_still_delete_a_fleet(client, as_auth):
 
     assert await _node_count(client, as_auth, tenant, fleet_id) == 0, (
         "the fleet's node survived a delete by a credential that may delete it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /fleet/commands accepted an agent-scoped credential.
+#
+# Same missing gate as M-25 above, on the route that dispatches TO a node
+# rather than deleting one. Why the other two gates do not narrow this caller,
+# and what a ``deploy`` payload reaches on the node, is on ``create_command``
+# in ``core_api/routes/fleet.py`` — not restated here.
+#
+# These assert the ERROR CODE, not just the status. All three of this route's
+# gates answer 403 (bar ``enforce_tenant``'s no-tenant 400), so a status-only
+# test would pass against a version that refused for the wrong reason — or one
+# that refuses every caller.
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_credential_cannot_queue_a_fleet_command(client, as_auth):
+    """The finding. The payload is the code the node would go on to run."""
+    tenant = f"tenant-{_uid()}"
+    node_id = (await _seed_node(client, as_auth, tenant)).node_id
+
+    as_auth(tenant, agent_id=f"agent-{_uid()}")
+    resp = await client.post(
+        "/api/v1/fleet/commands",
+        json={
+            "tenant_id": tenant,
+            "node_id": node_id,
+            "command": "deploy",
+            "payload": {"source": "export const injected = 1;"},
+        },
+    )
+    assert resp.status_code == 403, resp.text
+    code = resp.json()["error"]["code"]
+    assert code == errors.AUTH_AGENT_CREDENTIAL_FORBIDDEN, resp.text
+
+    # The status is not the property that matters — assert the row was never
+    # written, so a gate placed AFTER the storage call still fails here.
+    #
+    # This listing settles delivery too, without a second heartbeat.
+    # ``fleet_list_commands`` filters on ``tenant_id`` alone (no status, limit
+    # 50), while ``fleet_get_pending_commands`` filters the (node, tenant,
+    # status='pending') triple — so an empty listing for a fresh tenant is the
+    # strict superset of what any node in it could be handed.
+    as_auth(tenant)
+    listed = await client.get(f"/api/v1/fleet/commands?tenant_id={tenant}")
+    assert listed.status_code == 200, listed.text
+    assert listed.json() == [], f"the refused command was queued anyway: {listed.text}"
+
+
+async def test_a_tenant_credential_can_still_queue_a_fleet_command(client, as_auth):
+    """OVER-REFUSAL GUARD, and it is load-bearing.
+
+    This is the dashboard's own dispatch path — an operator restarting a node
+    or pushing a deploy. Refusing every caller would satisfy the test above and
+    leave the fleet uncommandable, which is worse than the bug being fixed.
+    """
+    tenant = f"tenant-{_uid()}"
+    node_id = (await _seed_node(client, as_auth, tenant)).node_id
+
+    as_auth(tenant)
+    resp = await client.post(
+        "/api/v1/fleet/commands",
+        json={
+            "tenant_id": tenant,
+            "node_id": node_id,
+            "command": "deploy",
+            "payload": {"source": "export const legitimate = 1;"},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+    listed = await client.get(f"/api/v1/fleet/commands?tenant_id={tenant}")
+    assert listed.status_code == 200, listed.text
+    assert [c["id"] for c in listed.json()] == [resp.json()["id"]], (
+        f"a legitimate command did not reach the queue: {listed.text}"
     )


### PR DESCRIPTION
**Not from the audit file.** Found while fixing M-25 (#1325's predecessor), which closed this same missing gate on `DELETE /fleet/{fleet_id}`. I read it as higher severity than the MEDIUMs still in the queue, which is why it jumped them.

## The gap

`POST /fleet/commands` had `enforce_read_only` and `enforce_tenant` and nothing else. Neither narrows an agent-scoped credential naming its **own** tenant — it may write, and the tenant it names is its own. `body.node_id` isn't bound to the caller's scope either, and `GET /fleet/nodes` hands out every node id in the tenant behind `enforce_tenant` alone.

What that reaches is not abstract:

| step | where |
|---|---|
| `payload.source` written over the plugin's source tree | `plugin/src/deploy.ts` |
| `payload.env_vars` merged into its `.env`, any plugin-prefixed key — `CAURA_API_URL`, `CAURA_API_KEY` included | `plugin/src/deploy.ts` |
| `npm run build` | `plugin/src/deploy.ts` |
| gateway restart, so the caller's code goes live | `plugin/src/heartbeat.ts` |

So an agent-scoped key refused at `PATCH /agents/{id}/trust` could instead run code on the host answering for it.

**Scope, stated plainly: within-tenant privilege escalation, not cross-tenant.** `enforce_tenant` still holds and storage 404s another tenant's node. The escalation is agent-plane → admin-plane inside one tenant. Also worth being explicit that the gate's teeth come from the gateway: `X-Agent-ID` is trustworthy on the gateway path (`X-Gateway-Secret`, and the gateway overwrites client-supplied values), and on the OSS-direct path every caller shares one key, so there's no agent/tenant distinction there to protect in the first place. Same deployment model M-25 accepted.

## The HMAC check is not a compensating control

`signature` appears **nowhere** in core-api or core-storage-api — the heartbeat response emits `id`/`command`/`payload` and stops. `verifyCommandSignature` defaults to permissive, so every command arrives unsigned and is accepted. The one setting that would fail closed, `CAURA_REQUIRE_SIGNED_COMMANDS=true`, would reject **every** command this backend issues, auto-upgrades included.

That's a control an operator could switch on and lose their fleet to. It is not fixed here and wants its own issue — see the follow-ups below.

## Nothing legitimate loses a channel

Both internal producers bypass this route: the auto-upgrade calls `sc.create_command` from inside the heartbeat handler, and the interview scheduler does the same behind `enforce_admin` on `POST /admin/interview/schedule/run`. No plugin or client posts to this route — the plugin posts only to `/fleet/commands/{id}/result`. The full suite passing unchanged is the other half of that argument: no existing test asserted an agent credential may queue.

## Verification

Full core-api suite **6196 passed**, 0 failed. `ruff check` / `ruff format --check` separately at CI's scopes; mypy clean bar 2 pre-existing `dateutil` errors in an untouched file; ratchet, sentinel and tenant-scope gate after `git add` (the tenant-scope gate reports 0 allowlist churn).

Three mutants, one at a time:

```
drop the gate (the finding)   -> refusal test FAILS
refuse every caller           -> over-refusal test FAILS (+6 pre-existing)
gate placed after the write   -> refusal test FAILS on STATE, not status
```

The tests assert the error **code**, not just 403 — all three gates on this route answer 403, so a status-only test would pass against a version that refused for the wrong reason. That is what kills the middle mutant.

## Two false claims corrected, one of them mine

Both comment-only, both disproved while writing the above:

- `test_fleet_command_cannot_target_another_tenants_node` said "nothing downstream re-checks the pair" and that the pending-command query "is keyed on `node_id` alone". `fleet_get_pending_commands` filters the **(node, tenant, status)** triple — a second, independent gate, added later by #1173. I checked the blame rather than assuming the two gates shipped together, which is how I caught that my first version of the correction was also wrong about the history.
- **My own first draft** justified an extra heartbeat assertion with that same wrong claim. Since delivery is tenant-scoped, the queue listing is the strict superset — the heartbeat was redundant. Removed; the three mutants still die, which is the evidence it cost no coverage.

`/simplify` caught the second one. The first was pre-existing and two screens above my new code, so I fixed it rather than leaving a false security claim next to a true one.

## Stability label

`POST /fleet/commands` is in the stable REST surface in `docs/public-api-stability.md`, so narrowing which credentials may call it is arguably breaking, and the doc says to over-label and let review decide. Hence `kind/breaking`.

I have **deliberately not** added the `BREAKING CHANGE:` trailer: release-please would turn it into a major version bump for the whole repo, and that's a release decision, not mine. Say the word and I'll amend it in.

## Follow-ups this surfaced — filed separately, not here

1. **An admin-plane route inventory test.** This class has now been fixed one route at a time six times, and `POST /fleet/commands` is the second visit to *this* handler — the 2026-08-14 pass added `enforce_read_only` and `enforce_tenant` here and walked away without the plane gate. Scoped to the 6 admin-plane routers it's ~20 mutating routes, 6 gated, so ~14 allowlist entries — comparable to `tenant_scope_gate`'s 63 — and AST-detectable, since `enforce_not_agent_credential` reads no body. App-wide it would need a 49-entry allowlist, which that gate's own docstring argues trains reviewers to skim.
2. **`POST /fleet` and `PATCH /agents/{agent_id}/tune`** — the same shape already in the tree. `create_fleet` has no plane gate while its lifecycle siblings do (low impact, and gating only the explicit route would be cosmetic while the heartbeat creates fleets implicitly). `patch_agent_tune` has `enforce_tenant` and a self-plane check but **no `enforce_read_only` and no `enforce_usage_limits`** — that is the H-12 defect surviving on the sibling route the sweep didn't reach, and it's the more real of the two.
3. **Server-side command signing: implement or delete.** Per above.
4. **`CommandIn.payload` has no size cap**, while its sibling `HeartbeatIn` caps `recall_metrics` at 4 KB and `reconcile` at 8 KB with a paragraph of reasoning each. `middleware/ingest_body_size.py` gates only `/ingest/*`, so `payload` is an unbounded JSONB write; `MAX_SOURCE_SIZE` is enforced on the node, after the row is stored.

Deliberately **not** validating `CommandIn.command` against an enum: the plugin already answers unknown commands with a recorded failure, this file twice cites the no-version-handshake posture as why `HeartbeatIn`/`CommandResultIn` are permissive, and an enum would mean a backend deploy before any node could be told to run a new command. The dangerous commands are the known ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
