### PR TITLE
fix(agents): add the missing write gate on PATCH /agents/{id}/tune

### DIFF
--- a/core-api/src/core_api/routes/agents.py
+++ b/core-api/src/core_api/routes/agents.py
@@ -124,7 +124,22 @@ async def patch_agent_tune(
     reset: bool = Query(default=False),
     auth: AuthContext = Depends(get_auth_context),
 ):
-    """Update an agent's search profile (per-agent retrieval tuning). Pass ?reset=true to clear."""
+    """Update an agent's search profile (per-agent retrieval tuning). Pass ?reset=true to clear.
+
+    Auth: any write-capable credential for the tenant, agent-scoped included —
+    self-tune is the point of the route. The two gates answer different
+    questions: ``enforce_read_only`` whether this credential may write at all,
+    the identity check below whose profile it may write.
+    """
+    # ``enforce_usage_limits`` is deliberately NOT applied, and pinned that way
+    # by ``test_agent_tune_still_works_when_over_usage_limits``. The principle
+    # is the one stated on ``WRITE_QUOTA_OPS`` in ``usage_service``: an update
+    # that rewrites a row rather than adding one does not grow the store, and
+    # this writes a single column on a row that must already exist. Lowering
+    # ``top_k``/``graph_max_hops`` is also how an over-quota tenant reduces
+    # retrieval cost — ``?reset=true`` is not part of that half, since it
+    # restores defaults and a default can exceed the value it replaces.
+    auth.enforce_read_only()
     auth.enforce_tenant(tenant_id)
     # An agent may tune ITS OWN profile (also exposed via MCP caura_tune), but
     # not a peer's — block cross-agent tamper while leaving self-tune + admin keys.
@@ -136,10 +151,18 @@ async def patch_agent_tune(
         raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
 
     if reset:
-        updated = await sc.reset_search_profile(agent_id, tenant_id)
-        if not updated:
+        cleared = await sc.reset_search_profile(agent_id, tenant_id)
+        if not cleared:
             raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
-        return AgentOut.model_validate(updated)
+        # Storage answers the reset with ``{"ok": true}``, not the agent row, so
+        # the response has to come from a re-read. The merge branch below
+        # re-reads too but falls back to the stale pre-write row on a miss,
+        # where this answers 404 — a reset must not hand back the profile it
+        # just cleared.
+        refreshed = await sc.get_agent(agent_id, tenant_id)
+        if not refreshed:
+            raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
+        return AgentOut.model_validate(refreshed)
 
     # Merge: only set non-None fields, preserve existing profile values
     current = agent.get("search_profile") or {}

--- a/tests/test_api_agents.py
+++ b/tests/test_api_agents.py
@@ -171,3 +171,59 @@ async def test_agent_isolation(client):
     agent_ids = {a["agent_id"] for a in agents}
     assert agent_a in agent_ids
     assert agent_b in agent_ids
+
+
+async def test_tune_reset_returns_the_cleared_agent(client):
+    """``?reset=true`` cleared the profile and then answered 500.
+
+    Storage answers the reset with ``{"ok": true}``, not the agent row, and the
+    route validated that ack as an ``AgentOut`` — five missing fields. The side
+    effect landed and the caller was told the call had failed, so "reset
+    worked" and "reset failed" were indistinguishable from outside.
+
+    How that survived on a happy path: the flag had exactly one caller in the
+    repo, ``scripts/hyperagent_test.py``, which resets between profiles in its
+    sweep and assigns nothing from the response — so the 500 was swallowed. The
+    clear itself worked, so the sweep's results were never wrong; the error was
+    invisible rather than harmless. No test and no plugin call reached it,
+    which is why this file had no tune coverage to catch it.
+    """
+    tenant_id, headers = get_test_auth()
+    tag = _uid()
+    agent = f"agent-tune-reset-{tag}"
+    # The ``[{tag}]`` suffix is not decoration — every sibling here carries one.
+    # These tests share one accumulating tenant, and semantic dedup answers 409
+    # on a near-duplicate, so fixed content passes alone and fails in the suite.
+    await _write_memory(
+        client,
+        tenant_id,
+        headers,
+        f"A fact for the tune-reset test [{tag}]",
+        agent_id=agent,
+    )
+
+    tuned = await client.patch(
+        f"/api/v1/agents/{agent}/tune?tenant_id={tenant_id}",
+        json={"top_k": 7},
+        headers=headers,
+    )
+    assert tuned.status_code == 200, tuned.text
+    assert tuned.json()["search_profile"]["top_k"] == 7, tuned.text
+
+    resp = await client.patch(
+        f"/api/v1/agents/{agent}/tune?tenant_id={tenant_id}&reset=true",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    # The response has to describe the agent, not the storage ack.
+    assert resp.json()["agent_id"] == agent, resp.text
+    assert not (resp.json().get("search_profile") or {}), resp.text
+
+    # And it has to agree with what a subsequent read reports — a response
+    # synthesized correctly but never persisted would pass the checks above.
+    after = await client.get(
+        f"/api/v1/agents/{agent}/tune?tenant_id={tenant_id}", headers=headers
+    )
+    assert after.status_code == 200, after.text
+    assert not (after.json().get("search_profile") or {}), after.text

--- a/tests/test_route_authz_gaps.py
+++ b/tests/test_route_authz_gaps.py
@@ -115,9 +115,22 @@ async def _make_command(client, as_auth, tenant_id: str) -> str:
     return resp.json()["id"]
 
 
-async def _seed_agent(sc, tenant_id: str, agent_id: str, trust_level: int):
+async def _seed_agent(sc, tenant_id: str, agent_id: str, trust_level: int, **extra):
+    """Create an agent row. ``extra`` sets any other ``Agent`` column directly.
+
+    Storage inserts the dict as given (``agent_add`` is
+    ``pg_insert(Agent).values(**data)``) and ``search_profile`` is a real
+    column in ``AGENT_FIELDS`` — so a fixture needing a pre-existing profile
+    does not have to write one through the route under test, where a bug in
+    the route would surface as a setup failure inside a gate test.
+    """
     await sc.create_or_update_agent(
-        {"tenant_id": tenant_id, "agent_id": agent_id, "trust_level": trust_level}
+        {
+            "tenant_id": tenant_id,
+            "agent_id": agent_id,
+            "trust_level": trust_level,
+            **extra,
+        }
     )
 
 
@@ -330,6 +343,15 @@ async def test_delete_audit_attributes_gateway_agent(client, as_auth, sc):
 
 READ_ONLY = {"read"}
 
+# The two credentials that may never write, whatever route they reach:
+# ``enforce_read_only`` refuses exactly these and nothing else. Shared so the
+# parametrized users of the pair cannot drift apart — they already had, one
+# spelling the capability set as a literal.
+NON_WRITING_CREDS = [
+    pytest.param({"capabilities": READ_ONLY}, id="read-only-key"),
+    pytest.param({"is_demo": True}, id="demo-sandbox"),
+]
+
 
 async def test_fleet_command_cannot_be_queued_into_another_tenant(client, as_auth):
     """H-13: the queued command's tenant came from ``body.tenant_id``, unchecked.
@@ -500,6 +522,142 @@ async def test_agent_trust_still_works_when_over_usage_limits(client, as_auth, s
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["trust_level"] == 0
+
+
+# ---------------------------------------------------------------------------
+# PATCH /agents/{agent_id}/tune had neither write gate.
+#
+# H-12 again, on the sibling route that sweep did not reach. Of the four
+# mutating routes in ``routes/agents.py`` it was the only one without
+# ``enforce_read_only`` — trust, fleet reassignment and agent deletion all call
+# it. ``enforce_tenant`` and the self-plane check it does have say WHOSE
+# profile may be written, never whether this credential may write at all.
+#
+# The tuning knobs reached through MCP ``caura_tune`` are guarded by
+# ``_check_write_scope``, which is exactly ``enforce_read_only``'s
+# write-capability half — so the capability was required of an MCP caller and
+# not of a REST one. The two are not equivalent gates: ``enforce_read_only``
+# also refuses ``is_demo``, which the MCP path never checks.
+#
+# NOT ``enforce_not_agent_credential``: an agent tuning its OWN profile is
+# documented product behaviour, and the over-refusal guard below pins it.
+# ---------------------------------------------------------------------------
+
+
+async def _tuned_top_k(client, as_auth, tenant: str, agent: str):
+    """The agent's stored ``top_k``, read back with a credential that may read it.
+
+    RE-ARMS a plain tenant credential, so calling this mid-test replaces
+    whatever narrow credential the test had installed. Read back AFTER the
+    call under test, never before it.
+    """
+    as_auth(tenant)
+    resp = await client.get(f"/api/v1/agents/{agent}/tune?tenant_id={tenant}")
+    assert resp.status_code == 200, resp.text
+    return (resp.json().get("search_profile") or {}).get("top_k")
+
+
+@pytest.mark.parametrize("cred", NON_WRITING_CREDS)
+@pytest.mark.parametrize(
+    "attempt",
+    [
+        pytest.param({"json": {"top_k": 19}}, id="merge"),
+        pytest.param({"json": {}, "query": "&reset=true"}, id="reset"),
+    ],
+)
+async def test_agent_tune_rejects_a_non_writing_credential(
+    client, as_auth, sc, cred, attempt
+):
+    """Both halves of ``enforce_read_only``, against both write branches.
+
+    ``reset=true`` is parametrized because it is a second, separate storage
+    write (``reset_search_profile``). A gate added inside the merge branch
+    alone would leave it reachable, and that mutant fails only here.
+
+    The profile is seeded through storage rather than through the route, so a
+    bug in the route cannot masquerade as a setup failure in a gate test.
+    """
+    tenant = f"tenant-{_uid()}"
+    agent = f"agent-{_uid()}"
+    await _seed_agent(sc, tenant, agent, trust_level=1, search_profile={"top_k": 7})
+
+    as_auth(tenant, **cred)
+    resp = await client.patch(
+        f"/api/v1/agents/{agent}/tune?tenant_id={tenant}{attempt.get('query', '')}",
+        json=attempt["json"],
+    )
+    assert resp.status_code == 403, resp.text
+
+    # The refusal has to mean the write never happened, not that it was
+    # reported as refused afterwards. This is also the only check that the
+    # seed landed, so a mismatch is not necessarily a gate bypass.
+    assert await _tuned_top_k(client, as_auth, tenant, agent) == 7, (
+        "expected the seeded profile to be intact: either the gate ran after "
+        "the storage call, or the fixture never seeded"
+    )
+
+
+async def test_a_write_capable_agent_can_still_tune_itself(client, as_auth, sc):
+    """OVER-REFUSAL GUARD, and the one that matters.
+
+    Self-tune is the documented behaviour behind MCP ``caura_tune``, and this
+    route is what the plugin's own tool PATCHes. Adding a write gate must not
+    take it away from an agent credential that carries 'write' — which is the
+    shape the enterprise gateway mints. ``test_agent_tune_self_allowed_peer_blocked``
+    reaches the same path with a legacy ``capabilities=None`` key, though it
+    only asserts ``!= 403`` on a self-tune that 404s — a weaker check than the
+    200-plus-read-back here.
+    """
+    tenant = f"tenant-{_uid()}"
+    agent = f"agent-{_uid()}"
+    await _seed_agent(sc, tenant, agent, trust_level=1)
+
+    as_auth(tenant, agent_id=agent, capabilities={"read", "write"})
+    resp = await client.patch(
+        f"/api/v1/agents/{agent}/tune?tenant_id={tenant}", json={"top_k": 11}
+    )
+    assert resp.status_code == 200, resp.text
+    assert await _tuned_top_k(client, as_auth, tenant, agent) == 11
+
+
+@pytest.mark.parametrize(
+    "attempt",
+    [
+        pytest.param({"json": {"top_k": 3}, "expect": 3}, id="merge"),
+        pytest.param({"json": {}, "query": "&reset=true", "expect": None}, id="reset"),
+    ],
+)
+async def test_agent_tune_still_works_when_over_usage_limits(
+    client, as_auth, sc, attempt
+):
+    """Pins a deliberate omission, so nobody "fixes" it by adding the gate.
+
+    ``enforce_usage_limits`` is NOT applied here. The principle is the one
+    stated on ``WRITE_QUOTA_OPS`` in ``usage_service``: an update that rewrites
+    a row rather than adding one does not grow the store, and this writes a
+    single column on a row that must already exist. Lowering ``top_k`` is also
+    how an over-quota tenant reduces retrieval cost, so gating it would put
+    plan state between them and the knob that gets them back under.
+
+    The omission ships whether or not this test exists — the omission IS the
+    decision. What the test buys is legibility: it is the difference between a
+    choice and the oversight it would otherwise be indistinguishable from,
+    which is the distinction ``usage_service`` draws about the same gate on the
+    memory update route. Deleting this test is the whole cost of reversing the
+    call.
+    """
+    tenant = f"tenant-{_uid()}"
+    agent = f"agent-{_uid()}"
+    await _seed_agent(sc, tenant, agent, trust_level=1, search_profile={"top_k": 7})
+
+    as_auth(tenant, is_read_only=True)
+    resp = await client.patch(
+        f"/api/v1/agents/{agent}/tune?tenant_id={tenant}{attempt.get('query', '')}",
+        json=attempt["json"],
+    )
+    assert resp.status_code == 200, resp.text
+    # Not merely un-refused — the write has to have landed.
+    assert await _tuned_top_k(client, as_auth, tenant, agent) == attempt["expect"]
 
 
 async def test_settings_rejects_a_read_only_credential(client, as_auth):
@@ -780,13 +938,7 @@ async def _queue_command_for(client, as_auth, tenant: str) -> tuple[str, str]:
     return node_name, resp.json()["id"]
 
 
-@pytest.mark.parametrize(
-    "cred",
-    [
-        pytest.param({"capabilities": {"read"}}, id="read-only-key"),
-        pytest.param({"is_demo": True}, id="demo-sandbox"),
-    ],
-)
+@pytest.mark.parametrize("cred", NON_WRITING_CREDS)
 async def test_heartbeat_refuses_a_non_writing_credential(client, as_auth, cred):
     """A credential that cannot write must not be able to heartbeat.
 


### PR DESCRIPTION
**Not from the audit file.** Self-discovered while fixing `POST /fleet/commands` (#1335) — the same class as H-12, on the sibling route that sweep didn't reach.

## The gap

Of the four mutating routes in `routes/agents.py`, `PATCH /agents/{agent_id}/tune` was the only one without `enforce_read_only` — trust, fleet reassignment and agent deletion all call it. `enforce_tenant` and the identity check it *does* have say **whose** profile may be written, never whether the caller may write at all.

Reproduced end-to-end before anything changed: both a `capabilities={'read'}` credential and a demo-sandbox credential wrote `{"top_k": 19}` onto a seeded agent.

The clearest evidence is the twin, not the siblings. The same knobs reached through MCP `caura_tune` sit behind `_check_write_scope`, which is exactly `enforce_read_only`'s write-capability half — **the capability was required of an MCP caller and not of a REST one.** The two are not equivalent gates, and the comment says so: `enforce_read_only` also refuses `is_demo`, which the MCP path never checks.

## Two gates deliberately not added

**`enforce_not_agent_credential`.** An agent tuning its **own** profile is documented behaviour behind MCP `caura_tune`, and this route is what the plugin's own tool PATCHes. Treating tune as admin-plane, the way the fleet routes are, is the plausible wrong fix — so it's one of the mutants below, and it fails two tests including a pre-existing one.

**`enforce_usage_limits`.** On the principle stated on `WRITE_QUOTA_OPS` in `usage_service`: an update that rewrites a row rather than adding one doesn't grow the store, and this writes a single column on a row that must already exist. Lowering `top_k`/`graph_max_hops` is also how an over-quota tenant *reduces* retrieval cost.

I first left this omission unpinned, reasoning that a test would lock in a judgment that wasn't mine to make. That was wrong, and review corrected it: **the omission ships either way — the omission is the judgment.** What a test buys is legibility, which is the same distinction `usage_service` draws about this gate on the memory update route. It's pinned now, matching `patch_agent_trust`. Deleting one test is the whole cost of reversing the call.

## A second, independent defect in the same handler

Surfaced by parametrizing the gate test over the reset branch: **`?reset=true` cleared the profile and then answered 500.** Storage acks the reset with `{"ok": true}`, not the agent row, and the route validated that ack as an `AgentOut` — five missing fields. The side effect landed and the caller was told the call failed, so a successful reset was indistinguishable from a failed one. Fixed by re-reading the agent.

**How that survived on a happy path:** the flag had exactly one caller in the repo — `scripts/hyperagent_test.py`, which resets between profiles in its sweep — and that call assigns nothing from the response, so the 500 was swallowed. The clear itself worked, so the sweep's results were never wrong; the error was invisible rather than harmless. No test and no plugin call reached the branch.

I initially wrote that *nothing* called `?reset=true`. That was false — my grep couldn't match `params={"reset": "true"}`, and I drew a conclusion from a search that couldn't have found it. The real reason is better and checkable.

## Verification

Full core-api suite **6202 passed**, 0 failed, rebased onto current `main`. `ruff check` / `ruff format --check` separately at CI's scopes; mypy clean bar 2 pre-existing `dateutil` errors in an untouched file; ratchet, sentinel and tenant-scope gate after `git add` (0 allowlist churn).

Five mutants, one at a time:

```
drop the write gate         -> all 4 refusal cases FAIL
treat tune as admin-plane   -> self-tune guard FAILS (+1 pre-existing)
gate the merge branch only  -> only the 2 reset cases FAIL
revert the reset fix        -> reset tests FAIL
ADD enforce_usage_limits    -> the pinning test FAILS
```

The third is why the reset branch is parametrized at all: a gate placed inside the merge branch alone looks correct against every other case.

`test_a_write_capable_agent_can_still_tune_itself` **passes before and after, by design** — it's an over-refusal guard, and the admin-plane mutant is what it exists to fail on. Flagging that explicitly so it isn't read as a test that proves nothing.

## Test-quality changes review asked for

- The gate tests seed the profile **through storage** (`_seed_agent` now forwards any `Agent` column) rather than through the route under test, so a bug in the route can't masquerade as a setup failure inside a gate test. Removed ~5 app requests and ~19 storage round trips.
- The two non-writing credentials are one shared `NON_WRITING_CREDS`, closing pre-existing drift where the heartbeat test spelled the capability set as a literal 600 lines below the constant.
- The reset happy-path test lives in `tests/test_api_agents.py`, not the authz file — it asserts response shape on a path where authz has already passed, and that file's docstring is an explicit charter for authz gaps. `test_api_agents.py` had zero tune coverage, which is part of why this went unseen.
- One thing I kept against advice: the reset **re-read**, rather than reusing the agent row already in hand. Review showed it's provably field-identical today — no `onupdate` on `updated_at`, no triggers — but that's a column-level assumption about a write in *another service*, pinned by no test. One extra call on a cold path is the right price.

## Follow-ups, not in scope here

1. **`AuthContext.enforce_self_agent(agent_id)` + a coded error.** The inline `auth.agent_id and auth.agent_id != …` self-plane check appears at **8 sites** (`routes/agents.py`, `routes/stm.py` ×3, `routes/memories.py` ×4), none using `coded_detail` — so all collapse to a bare `FORBIDDEN`, which is exactly what `test_c32_coded_auth_errors.py` argues against. On this route the two refusals a caller most needs to tell apart are "wrong credential type" and "wrong agent", and only the first is named. Three route files and five test touchpoints; a security fix shouldn't wait on it.
2. **The merge branch's stale-row fallback** (`agents.py`): on a re-read miss it returns 200 with the *pre-write* `search_profile`. Pre-existing, and only visible now that the reset branch answers 404 to the same question.
3. **No `PLAN_LIMIT_GATED_OPS` equivalent for the agent-admin plane**, so quota decisions for `trust`/`fleet`/`tune`/`delete` live only in prose and pinning tests. Extending `MutatingOp` would make the question above a lookup instead of a comment — the direction `routes/memories.py` already moved memory ops.

Also verified and cleared: `{"ok": true}`-validated-as-a-model is a genuine **one-off**, not a class. `model_validate` appears 10 times in `core-api/src`, and every other storage-ack consumer reads the ack as an ack (`routes/fleet.py`, `routes/testing.py`, `memory_service.py`, the crystallizer). No follow-up warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
