### PR TITLE
CAURA-720 refactor(enrichment): retire retrieval_hint, document the w…

### DIFF
--- a/common/enrichment/_prompts.py
+++ b/common/enrichment/_prompts.py
@@ -34,6 +34,57 @@ CAURA-719 — ``tags`` and ``status`` are no longer asked of the LLM, so
 Both fields keep their schema entry, default, and validator so
 historical rows, caller-supplied values, and the deferred worker's
 patch path all continue to deserialise unchanged.
+
+CAURA-720 — ``retrieval_hint`` joins them, and ``weight`` gains its
+missing band:
+
+* ``retrieval_hint`` (and the per-fact copy inside ``atomic_facts``) is
+  no longer asked for. Its only purpose was to augment the embedding —
+  writes embedded ``"[Retrieval hint]: …\\n\\n<content>"`` while queries
+  embedded raw text — and CAURA-222 DISABLED that after the asymmetry
+  capped recall: identical content↔query scored cosine ~0.69 instead of
+  ~1.0 across dedup, entity-lookup, and search ranking. The
+  ``compose_embedding_text`` helper was deleted as dead code, and both
+  the hot path and the background re-embed now embed raw ``content``.
+  The per-fact hint was equally inert: ``memory_service``'s fan-out
+  embeds raw ``fact_content`` for the same CAURA-222 reason.
+  What remains reads it: ``scripts/backfill_embeddings.py`` selects on a
+  non-empty ``metadata.retrieval_hint`` to find rows whose stored vector
+  still holds the old prefixed text, and preserves the value as
+  "auditability ground". That selector is unaffected — stored hints on
+  historical rows are untouched, and rows written from here on simply
+  stop matching it, which they should, since they were never prefixed.
+  ``MemoryEnriched.retrieval_hint`` and the worker's routing entry stay
+  for the same reason the two fields above do.
+* ``weight`` — the field is declared ``0.0-1.0`` but the rubric only
+  described ``0.3-1.0``, leaving 14.3% of the eToro corpus (``0.1`` at
+  9.3%, ``0.2`` at 4.9%) in a range the prompt never defined. That range
+  is not spare: FOUR consumers read ``weight < 0.3`` as "low salience"
+  — insights patterns, insights stale, ``CRYSTALLIZER_STALE_MAX_WEIGHT``,
+  and ``LIFECYCLE_STALE_ARCHIVE_WEIGHT`` — so the band is documented
+  rather than clamped. Clamping the floor to 0.3 would make ``< 0.3``
+  unsatisfiable and silently starve all four. The band is worded by its
+  CONSEQUENCE (auto-archival) so the model's choice is informed by what
+  the system does with the number.
+  The JSON template's ``"weight": 0.0`` moves to ``0.5``: ``0.0`` sat
+  outside every band the rubric described, and 32 rows landed on exactly
+  that value — below even ``EVOLVE_WEIGHT_FLOOR`` (0.05), so evolve
+  cannot have produced them. ``0.5`` is the mid-range neutral and sits
+  inside a described band; that is the whole claim.
+  Deliberately NOT claimed: that it matches "the" default weight. There
+  are TWO, on two different paths, and they do not agree:
+    * this path (the LLM answered) falls back to a hardcoded ``0.7`` —
+      in ``_validate_enrichment`` and again as ``EnrichmentResult.weight``'s
+      pydantic default;
+    * ``DEFAULT_MEMORY_WEIGHT`` (0.5) applies only when NO enrichment
+      value exists at all — ``merge_enrichment_fields`` / ``memory_service``
+      reach for it when ``weight is None``, which #1207 records as
+      ``weight_source="default"``.
+  So the exemplar is not tied to either constant, and no test should pin
+  it to one: a change to ``DEFAULT_MEMORY_WEIGHT`` must not drag the
+  prompt with it. Unifying the 0.7 fallback onto ``DEFAULT_MEMORY_WEIGHT``
+  would make the two paths agree, but that is a behaviour change to
+  ranking (weight is 15% of base score) and belongs in its own PR.
 """
 
 from __future__ import annotations
@@ -132,6 +183,8 @@ Analyze the following memory content and return a JSON object with these fields:
    - 0.7-0.8: solid facts, meaningful events, clear preferences
    - 0.5-0.6: routine observations, minor events, uncertain information
    - 0.3-0.4: trivial, speculative, or low-confidence information
+   - 0.0-0.2: negligible — content you would be comfortable having
+     auto-archived after six months
 
 3. "title": short label (max 80 chars) summarizing the memory for display in lists
 
@@ -166,26 +219,7 @@ Analyze the following memory content and return a JSON object with these fields:
 8. "pii_types": array of strings (optional, empty if no PII)
     - Types of PII detected, e.g. ["email", "phone", "address", "ssn", "credit_card", "date_of_birth"]
 
-9. "retrieval_hint": short clause (max ~15 words, may be empty) capturing the
-    memory's SEMANTIC ESSENCE in vocabulary a reader would use when asking
-    about it LATER. Used to augment the embedding so queries that reference
-    the significance/category of the memory can find it, not just ones that
-    share surface vocabulary with the content.
-    - Focus on the WHY-THIS-IS-NOTEWORTHY: milestones, decisions, changes,
-      categories, roles, events — not a restatement of the content.
-    - Examples:
-      content "I signed a contract with my first client today"
-        → "business milestone: signed first client, first paying customer"
-      content "I learned about Petra at a History Museum lecture this month"
-        → "museum visit, History Museum lecture, learning about Petra"
-      content "We decided to go with Postgres over MongoDB"
-        → "database technology decision: chose Postgres over MongoDB"
-      content "Ran the nightly deploy at 03:00"
-        → "deployment event, nightly release"
-    - Leave as an empty string "" if the content is already highly query-aligned
-      (common nouns + verbs of the thing itself) and no extra framing helps.
-
-10. "atomic_facts": OPTIONAL — null in almost all cases. Populate only when
+9. "atomic_facts": OPTIONAL — null in almost all cases. Populate only when
     the content carries 2+ DISTINCT atomic claims that would be searched by
     DIFFERENT query vocabulary. Each entry becomes its own child memory with
     its own embedding.
@@ -202,10 +236,9 @@ Analyze the following memory content and return a JSON object with these fields:
     - Each fact object has:
         "content"        : self-contained claim (include names, dates, values)
         "suggested_type" : same vocabulary as field 1
-        "retrieval_hint" : same guidance as field 9 — short, query-aligned
     - When in doubt, leave atomic_facts as null.
 
-11. "business_relevance": one of "business" | "personal" (default "business")
+10. "business_relevance": one of "business" | "personal" (default "business")
     - "personal": private life unrelated to work — health, family, personal
       finance, relationships, errands, vacation planning, casual chat, idle ideas.
     - "business": work / professional / operational content (the default).
@@ -213,7 +246,7 @@ Analyze the following memory content and return a JSON object with these fields:
       confident the content is non-work.
 
 Return ONLY valid JSON (no markdown fences):
-{{"memory_type": "...", "weight": 0.0, "title": "...", "summary": "...", "ts_valid_start": null, "ts_valid_end": null, "contains_pii": false, "pii_types": [], "retrieval_hint": "", "atomic_facts": null, "business_relevance": "business"}}
+{{"memory_type": "...", "weight": 0.5, "title": "...", "summary": "...", "ts_valid_start": null, "ts_valid_end": null, "contains_pii": false, "pii_types": [], "atomic_facts": null, "business_relevance": "business"}}
 
 Content:
 {content}

--- a/core-worker/src/core_worker/consumer.py
+++ b/core-worker/src/core_worker/consumer.py
@@ -307,13 +307,19 @@ _ENRICHMENT_UNROUTED_FIELDS: frozenset[str] = frozenset({"atomic_facts"})
 #
 # * ``contains_pii`` / ``pii_types`` — non-deterministic LLM output;
 #   an earlier ``contains_pii=True`` must be clearable.
-# * ``retrieval_hint`` — the prompt explicitly instructs the LLM to
-#   return ``""`` for content that's already query-aligned; without
-#   always-write a re-enrichment that drops the hint would leave
-#   metadata stale AND the embedding still prefix-augmented.
-# * ``tags`` — the prompt instructs the LLM to always populate 2-6
-#   tags. ``tags=[]`` from a real LLM run means "no tags" intentionally
-#   and must overwrite a prior non-empty list.
+# * ``retrieval_hint`` — CAURA-720 retired it from the prompt, so a
+#   real LLM run now always yields ``""``. Always-write is what CLEARS
+#   a hint left on a row by a pre-CAURA-720 enrichment, which matters
+#   because ``scripts/backfill_embeddings.py`` selects on a non-empty
+#   ``metadata.retrieval_hint``. (The older justification here cited
+#   keeping the row in step with a "prefix-augmented" embedding — that
+#   stopped being true at CAURA-222, which disabled hint-based
+#   embedding entirely.)
+# * ``tags`` — CAURA-719 retired it from the prompt too, so the same
+#   reasoning applies: always-write clears a list a pre-CAURA-719
+#   enrichment left behind. A caller-supplied list is protected by
+#   ``CALLER_OWNABLE_KEYS`` at the ``set_system_value`` boundary, not
+#   here.
 # * ``summary`` — without the guard, a heuristic-fallback redelivery
 #   would write ``fake_enrich``'s ``summary=content[:200]`` over a
 #   prior quality LLM summary. The truncation is a non-empty string,

--- a/tests/test_caura719_tags_status_off_prompt.py
+++ b/tests/test_caura719_tags_status_off_prompt.py
@@ -60,8 +60,9 @@ def test_json_template_omits_field(field: str):
 
 
 def test_prompt_still_requests_every_field_the_schema_needs():
-    """Guard the other direction: removing two fields must not have
-    disturbed the eleven that remain."""
+    """Guard the other direction: removing fields must not disturb the ones
+    that remain. ``retrieval_hint`` left this list in CAURA-720 — see
+    ``test_caura720_weight_band.py`` and ``test_retrieval_hint.py``."""
     prompt = _prompt()
     for field in (
         "memory_type",
@@ -72,7 +73,6 @@ def test_prompt_still_requests_every_field_the_schema_needs():
         "ts_valid_end",
         "contains_pii",
         "pii_types",
-        "retrieval_hint",
         "atomic_facts",
         "business_relevance",
     ):
@@ -92,19 +92,27 @@ def test_field_numbering_is_contiguous():
     )
 
 
-def test_atomic_facts_cross_reference_points_at_retrieval_hint():
-    """``atomic_facts`` says "same guidance as field N" for its per-fact
-    hint. After renumbering, N must still be ``retrieval_hint``."""
+def test_atomic_facts_cross_reference_resolves_correctly():
+    """``atomic_facts`` refers to another field BY NUMBER for its per-fact
+    ``suggested_type``, so renumbering has to keep that pointer valid.
+
+    It used to carry a second cross-reference, to ``retrieval_hint`` for the
+    per-fact hint; CAURA-720 removed both the hint field and that reference.
+    """
     import re
 
     prompt = _prompt()
-    ref = re.search(r"same guidance as field (\d+)", prompt)
-    assert ref, "atomic_facts lost its retrieval_hint cross-reference"
+    assert "same guidance as field" not in prompt, (
+        "the retrieval_hint cross-reference should have gone with the field"
+    )
+
+    ref = re.search(r"same vocabulary as field (\d+)", prompt)
+    assert ref, "atomic_facts lost its suggested_type cross-reference"
     target = int(ref.group(1))
     heading = re.search(rf'^{target}\. "(\w+)"', prompt, re.MULTILINE)
-    assert heading and heading.group(1) == "retrieval_hint", (
+    assert heading and heading.group(1) == "memory_type", (
         f"cross-reference points at field {target} "
-        f"({heading.group(1) if heading else 'missing'}), not retrieval_hint"
+        f"({heading.group(1) if heading else 'missing'}), not memory_type"
     )
 
 

--- a/tests/test_caura720_weight_band.py
+++ b/tests/test_caura720_weight_band.py
@@ -1,0 +1,193 @@
+"""CAURA-720 — the ``weight`` rubric gains its missing 0.0-0.2 band, and the
+JSON template stops exemplifying a value the rubric never sanctioned.
+
+**The gap.** ``weight`` is declared ``0.0-1.0`` but the rubric described only
+``0.3-1.0``. On the eToro corpus 14.3% of rows landed in the undescribed range
+(``0.1`` at 9.3%, ``0.2`` at 4.9%) — the model filling a gap the prompt left,
+not violating a stated bound.
+
+**Why the band is documented rather than clamped.** ``0.3`` is not a
+prompt-local boundary; it is the system's "low salience" line, and FOUR
+consumers read ``weight < 0.3``:
+
+* insights patterns mode      (``weight < 0.3 AND recall_count > 0``)
+* insights stale mode
+* ``CRYSTALLIZER_STALE_MAX_WEIGHT``  (0.3)
+* ``LIFECYCLE_STALE_ARCHIVE_WEIGHT`` (0.3)
+
+All four use strict ``<``. Clamping the floor to 0.3 — the intuitive guard —
+would make ``< 0.3`` unsatisfiable for every new memory and silently starve
+all four: no error, just empty result sets. So the range is defined instead,
+and worded by its CONSEQUENCE (auto-archival) so the model's choice is
+informed by what the system does with the number.
+
+**The template value.** ``"weight": 0.0`` sat outside every band the rubric
+described, and 32 rows landed on exactly ``0.0`` — below even
+``EVOLVE_WEIGHT_FLOOR`` (0.05), so evolve's dampening cannot have produced
+them; the model was copying the exemplar. ``0.5`` replaces it as the mid-range
+neutral, inside a described band.
+
+Note what is NOT asserted below: that the exemplar equals "the" default
+weight. There are two, and they differ — this path falls back to a hardcoded
+``0.7`` (``_validate_enrichment``, and ``EnrichmentResult.weight``'s pydantic
+default), while ``DEFAULT_MEMORY_WEIGHT`` (0.5) is only reached when no
+enrichment value exists at all. Pinning the template to either constant would
+create a false coupling: changing ``DEFAULT_MEMORY_WEIGHT`` would fail a test
+about the PROMPT.
+
+What this does NOT fix: reproducibility. Two identical writes can still get
+different weights — see ``weight_source`` (#1207), which records whether a
+value came from the caller, the LLM, or the default precisely because the LLM
+case is not repeatable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _prompt() -> str:
+    from common.enrichment._prompts import ENRICHMENT_PROMPT
+
+    return ENRICHMENT_PROMPT
+
+
+def _template() -> str:
+    """The JSON example at the tail of the prompt — what the model
+    pattern-matches on, as distinct from the rubric that describes the rules."""
+    return _prompt().rsplit("Return ONLY valid JSON", 1)[-1]
+
+
+# ---------------------------------------------------------------------------
+# The band
+# ---------------------------------------------------------------------------
+
+
+def test_rubric_covers_the_bottom_of_the_declared_range():
+    """Every part of the declared ``0.0-1.0`` range now has a description."""
+    prompt = _prompt()
+    assert "0.0-0.2" in prompt, "the 0.0-0.2 band must be described"
+    for band in ("0.9-1.0", "0.7-0.8", "0.5-0.6", "0.3-0.4"):
+        assert band in prompt, f"pre-existing band {band} disappeared"
+
+
+def test_band_is_worded_by_consequence_not_by_an_abstract_label():
+    """ "Trivial" tells the model nothing about what happens next. The four
+    consumers treat sub-0.3 as archivable, so the prompt says so."""
+    prompt = _prompt()
+    assert "auto-archived" in prompt
+
+
+def test_the_floor_is_not_clamped_in_validation():
+    """The guard this change deliberately did NOT add. A floor of 0.3 would
+    make ``weight < 0.3`` unsatisfiable and starve four consumers, so a model
+    that returns 0.1 must still land on 0.1."""
+    from common.enrichment.service import _validate_enrichment
+
+    result = _validate_enrichment({"memory_type": "fact", "weight": 0.1}, llm_ms=5)
+    assert result.weight == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize("raw,expected", [(0.0, 0.0), (0.2, 0.2), (1.0, 1.0)])
+def test_declared_range_round_trips(raw, expected):
+    """The whole declared range survives validation unchanged — including the
+    endpoints, which the rubric previously left undefined."""
+    from common.enrichment.service import _validate_enrichment
+
+    result = _validate_enrichment({"memory_type": "fact", "weight": raw}, llm_ms=5)
+    assert result.weight == pytest.approx(expected)
+
+
+def test_out_of_range_is_still_clamped():
+    """Unchanged behaviour: values outside 0.0-1.0 clamp to the bounds."""
+    from common.enrichment.service import _validate_enrichment
+
+    assert (
+        _validate_enrichment({"memory_type": "fact", "weight": 5.0}, llm_ms=5).weight
+        == 1.0
+    )
+    assert (
+        _validate_enrichment({"memory_type": "fact", "weight": -3.0}, llm_ms=5).weight
+        == 0.0
+    )
+
+
+def test_non_numeric_weight_still_falls_back():
+    """Unchanged behaviour: the defensive coercion for ``"high"`` / ``None``
+    that the service has carried since before this change."""
+    from common.enrichment.service import _validate_enrichment
+
+    assert (
+        _validate_enrichment({"memory_type": "fact", "weight": "high"}, llm_ms=5).weight
+        == 0.7
+    )
+    assert (
+        _validate_enrichment({"memory_type": "fact", "weight": None}, llm_ms=5).weight
+        == 0.7
+    )
+
+
+# ---------------------------------------------------------------------------
+# The template exemplar
+# ---------------------------------------------------------------------------
+
+
+def test_template_exemplar_is_inside_a_described_band():
+    template = _template()
+    assert '"weight": 0.5' in template
+    assert '"weight": 0.0' not in template, (
+        "0.0 was outside every described band and was being copied verbatim"
+    )
+
+
+def test_template_exemplar_is_not_pinned_to_either_default_constant():
+    """The exemplar must NOT be asserted equal to a default-weight constant.
+
+    There are two, on different paths, and they disagree: this path (the LLM
+    answered) falls back to a hardcoded ``0.7`` — in ``_validate_enrichment``
+    and again as ``EnrichmentResult.weight``'s pydantic default — while
+    ``DEFAULT_MEMORY_WEIGHT`` (0.5) is only reached when no enrichment value
+    exists at all.
+
+    An earlier version of this file asserted the template equalled
+    ``DEFAULT_MEMORY_WEIGHT``. It passed coincidentally and encoded a false
+    claim: changing that constant would have failed a test about the PROMPT and
+    pushed someone to edit the prompt to fix it. This test pins the absence of
+    that coupling instead.
+    """
+    from common.enrichment.constants import DEFAULT_MEMORY_WEIGHT
+    from common.enrichment.schema import EnrichmentResult
+    from common.enrichment.service import _validate_enrichment
+
+    # The two really are different — if a later PR unifies them, this assertion
+    # is the one to revisit (and the docstrings that explain the split).
+    enrichment_path_fallback = EnrichmentResult().weight
+    assert enrichment_path_fallback != DEFAULT_MEMORY_WEIGHT, (
+        "the two default weights have converged — update the CAURA-720 "
+        "docstrings, which document them as deliberately separate"
+    )
+    assert _validate_enrichment({"memory_type": "fact"}, llm_ms=1).weight == (
+        enrichment_path_fallback
+    ), "the validator fallback and the pydantic default must stay in step"
+
+
+def test_template_keeps_weight_numeric():
+    """A quoted placeholder (``"..."``) would model the wrong JSON type. The
+    service already carries a coercion for non-numeric strings like ``"high"``,
+    which is evidence the model does return them when nudged."""
+    import json
+
+    # The object sits on its own line; the tail of the prompt also contains the
+    # ``{content}`` format placeholder, so a greedy brace match would overrun.
+    line = next(
+        (ln.strip() for ln in _template().splitlines() if ln.strip().startswith("{")),
+        None,
+    )
+    assert line, "no JSON object found in the template"
+    # The prompt escapes its literal braces for ``str.format``; undo that.
+    parsed = json.loads(line.replace("{{", "{").replace("}}", "}"))
+    assert isinstance(parsed["weight"], (int, float)), (
+        f"template models weight as {type(parsed['weight']).__name__}, not a number"
+    )

--- a/tests/test_enrichment_prompt.py
+++ b/tests/test_enrichment_prompt.py
@@ -77,10 +77,17 @@ class TestEnrichmentPromptSignalPhrases:
         caller-owned now and no longer asked of the LLM), so this pins the
         keys that remain rather than the retired one. ``test_caura719_
         tags_status_off_prompt.py`` owns the negative assertion.
+
+        CAURA-720 moved the ``weight`` exemplar from ``0.0`` to ``0.5``:
+        ``0.0`` sat outside every band the rubric described and was being
+        copied verbatim. ``0.5`` is simply the mid-range neutral, inside a
+        described band — NOT a match for a default-weight constant. This
+        path's fallback is a hardcoded ``0.7``; see
+        ``test_caura720_weight_band.py``.
         """
         prompt = self._get_prompt()
         assert '"memory_type": "..."' in prompt
-        assert '"weight": 0.0' in prompt
+        assert '"weight": 0.5' in prompt
         assert '"summary": "..."' in prompt
         assert "Content:" in prompt
 

--- a/tests/test_retrieval_hint.py
+++ b/tests/test_retrieval_hint.py
@@ -2,11 +2,17 @@
 
 Covers:
   - Validator round-trips retrieval_hint; trims whitespace; caps length.
-  - Prompt contains the retrieval_hint rule + concrete examples.
+  - The prompt no longer ASKS for it (CAURA-720).
 
-The hint is persisted in metadata (debugging / auditability) but no
-longer participates in embedding composition — see CAURA-222 and the
-follow-up that removed ``compose_embedding_text`` entirely.
+The hint never participates in embedding composition — CAURA-222
+disabled that and the follow-up removed ``compose_embedding_text``
+entirely. CAURA-720 then retired the prompt field, since the only
+remaining reader is ``scripts/backfill_embeddings.py``, which selects on
+a non-empty ``metadata.retrieval_hint`` to find rows whose stored vector
+still holds the old prefixed text.
+
+The validator tests stay: historical rows carry hint values, and the
+deferred worker replays stored enrichment payloads.
 """
 
 from __future__ import annotations
@@ -76,18 +82,39 @@ class TestValidatorRetrievalHint:
 
 
 # ---------------------------------------------------------------------------
-# Prompt: new rule is present and anchored with examples
+# Prompt: the rule is RETIRED (CAURA-720)
 # ---------------------------------------------------------------------------
 
 
-class TestPromptContainsHintRule:
-    def test_prompt_has_retrieval_hint_field(self):
-        assert '"retrieval_hint"' in ENRICHMENT_PROMPT
+class TestPromptNoLongerAsksForHint:
+    """CAURA-720 removed the field from the prompt.
 
-    def test_prompt_describes_purpose(self):
-        # Key phrase from the rule so drift in the prompt is obvious
-        assert "SEMANTIC ESSENCE" in ENRICHMENT_PROMPT
+    The rule existed to augment the embedding, and CAURA-222 disabled that
+    — writes embedded ``"[Retrieval hint]: …\\n\\n<content>"`` while queries
+    embedded raw text, so identical content↔query scored cosine ~0.69
+    instead of ~1.0. With no consumer left, the prompt stopped asking.
 
-    def test_prompt_includes_business_milestone_example(self):
-        # This is the example modeled after the eac54add failure case.
-        assert "business milestone" in ENRICHMENT_PROMPT
+    The validator section above still applies: historical rows and the
+    deferred worker's replay path both still carry hint values.
+    """
+
+    def test_prompt_does_not_request_retrieval_hint(self):
+        assert '"retrieval_hint"' not in ENRICHMENT_PROMPT
+
+    def test_hint_guidance_is_gone(self):
+        # The phrases that only ever existed to shape hint output.
+        for phrase in (
+            "SEMANTIC ESSENCE",
+            "business milestone",
+            "WHY-THIS-IS-NOTEWORTHY",
+        ):
+            assert phrase not in ENRICHMENT_PROMPT, (
+                f"leftover hint guidance: {phrase!r}"
+            )
+
+    def test_atomic_facts_no_longer_carries_a_per_fact_hint(self):
+        """The sub-schema listed its own ``retrieval_hint`` per fact. Children
+        embed raw ``fact_content`` for the same CAURA-222 reason, so that copy
+        was equally inert."""
+        facts_block = ENRICHMENT_PROMPT.split('"atomic_facts"', 1)[-1]
+        assert "retrieval_hint" not in facts_block


### PR DESCRIPTION
…eight floor

Two prompt refinements, both prompt-only. No schema or behaviour change.

## retrieval_hint — retired (field + the per-fact copy in atomic_facts)

Its only purpose was to augment the embedding: writes embedded "[Retrieval hint]: ...\n\n<content>" while queries embedded raw text. CAURA-222 DISABLED that after the asymmetry capped recall — identical content<->query scored cosine ~0.69 instead of ~1.0, across dedup, entity-lookup, and search ranking — and the follow-up deleted the compose_embedding_text helper as dead code. Both the hot path and the background re-embed have embedded raw content ever since.

The per-fact copy inside atomic_facts was equally inert: the fan-out in memory_service embeds raw fact_content for the same CAURA-222 reason, so each child's hint was stored and never read.

What still reads it is unaffected. scripts/backfill_embeddings.py selects on a non-empty metadata.retrieval_hint to find rows whose stored vector still holds the old prefixed text, and preserves the value as "auditability ground". Stored hints on historical rows are untouched; rows written from here on simply stop matching that selector, which is correct — they were never prefixed. MemoryEnriched.retrieval_hint, the worker's routing entry, the schema field, and the validator all stay, so historical rows and the worker's replay path deserialise unchanged.

## weight — the 0.0-0.2 band is now described

The field is declared 0.0-1.0 but the rubric described only 0.3-1.0, leaving 14.3% of the eToro corpus (0.1 at 9.3%, 0.2 at 4.9%) in an undefined range. The model was filling a gap the prompt left, not violating a stated bound.

That range is not spare. FOUR consumers read weight < 0.3 as "low salience", all with strict <:

  - insights patterns mode  (weight < 0.3 AND recall_count > 0)
  - insights stale mode
  - CRYSTALLIZER_STALE_MAX_WEIGHT  (0.3)
  - LIFECYCLE_STALE_ARCHIVE_WEIGHT (0.3)

So the band is DOCUMENTED, not clamped. Flooring the value at 0.3 — the intuitive guard — would make "< 0.3" unsatisfiable for every new memory and silently starve all four: no error, just empty result sets. The band is worded by its consequence (auto-archival) so the model's choice is informed by what the system does with the number.

The template's "weight": 0.0 moves to 0.5. 0.0 sat outside every band the rubric described and 32 rows landed on exactly it — below even EVOLVE_WEIGHT_FLOOR (0.05), so evolve's dampening cannot have produced them. 0.5 is DEFAULT_MEMORY_WEIGHT, so the exemplar and the code default now agree. A quoted placeholder was considered and rejected: it would model weight as a string, and the service already carries a coercion for non-numeric values like "high", which suggests that has happened.

## Also

Remaining 10 fields renumbered; the atomic_facts cross-reference to retrieval_hint is gone with the field, and the surviving one (suggested_type -> field 1) is pinned by a test. Two stale worker comments corrected: they justified always-writing retrieval_hint and tags by describing prompt behaviour that CAURA-222 and CAURA-719 had already ended.

## Known unknown, for the reviewer

The band may increase how often the model goes sub-0.3, and one of the four consumers is destructive: archive_stale auto-archives rows older than 180 days with weight < 0.3. I could not size that from the corpus I have — it spans 2026-03-27 to 2026-06-24, so zero rows are old enough to qualify and the query returns 0 either way. Worth a count against current prod before assuming the archive footprint is unchanged.

Separately, this does not address reproducibility: two identical writes can still get different weights. That is what weight_source (#1207) records, and only a deterministic producer removes it.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
