### PR TITLE
fix(embedding): make the local provider's model configurable and refuse a width mismatch (C38)

### DIFF
--- a/common/embedding/_registry.py
+++ b/common/embedding/_registry.py
@@ -26,6 +26,13 @@ from common.provider_names import ProviderName
 
 logger = logging.getLogger(__name__)
 
+# C38 — default model for ``EMBEDDING_PROVIDER=local``. MUST emit VECTOR_DIM
+# dimensions: ``memories.embedding`` is ``vector(VECTOR_DIM)``, so a narrower
+# model is rejected by Postgres at INSERT — far from the misconfiguration that
+# caused it. bge-large is 1024; the previously hard-coded bge-BASE is 768 and
+# could never have worked against this schema.
+DEFAULT_LOCAL_EMBEDDING_MODEL = "BAAI/bge-large-en-v1.5"
+
 # Cache OpenAI provider instances by (api_key, model). Each instance
 # holds a long-lived ``AsyncOpenAI`` (and therefore a long-lived
 # ``httpx.AsyncClient`` connection pool); without the cache, every
@@ -339,6 +346,13 @@ def get_embedding_provider(
         )
 
     if name == ProviderName.LOCAL:
-        return LocalEmbedding()
+        # C38 — read from the environment, not a service's settings: this
+        # registry is shared with core-worker and must not import one service's
+        # config. pydantic-settings maps core-api's ``local_embedding_model`` to
+        # this same var, so the two stay in step. ``or`` (not a default=) so an
+        # empty value falls back rather than loading a model named "".
+        return LocalEmbedding(
+            os.environ.get("LOCAL_EMBEDDING_MODEL") or DEFAULT_LOCAL_EMBEDDING_MODEL
+        )
 
     raise ValueError(f"Unknown embedding provider: {name}")

--- a/common/embedding/providers/local.py
+++ b/common/embedding/providers/local.py
@@ -76,11 +76,20 @@ class LocalEmbedding:
             )
             test_dim = model.get_sentence_embedding_dimension()
             if test_dim != VECTOR_DIM:
-                logger.warning(
-                    "Model %s produces %d-dim vectors, expected %d (VECTOR_DIM)",
-                    self._model_name,
-                    test_dim,
-                    VECTOR_DIM,
+                # C38 — refuse, don't warn. ``memories.embedding`` is
+                # vector(VECTOR_DIM), so a mismatched model cannot produce a
+                # storable vector: every write fails at INSERT and every search
+                # fails at query-encode, with a Postgres dimension error that
+                # names neither the model nor the setting that chose it.
+                # Failing at model load points straight at the cause. The old
+                # warn-and-continue is how the default sat on a 768-dim model
+                # against a 1024-dim column without anyone noticing.
+                raise ValueError(
+                    f"Local embedding model {self._model_name!r} produces "
+                    f"{test_dim}-dim vectors, but the schema requires "
+                    f"{VECTOR_DIM} (memories.embedding is vector({VECTOR_DIM})). "
+                    f"Set LOCAL_EMBEDDING_MODEL to a {VECTOR_DIM}-dim model — "
+                    f"e.g. BAAI/bge-large-en-v1.5."
                 )
             self._model = model
 

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -48,6 +48,11 @@ class Settings(BaseSettings):
     # tenant by setting identity headers itself. Unset (OSS/standalone/dev) = no-op.
     gateway_shared_secret: str | None = None
     embedding_provider: str = "openai"  # fake | openai | local
+    # C38 — model for ``embedding_provider="local"`` (sentence-transformers).
+    # MUST emit VECTOR_DIM dimensions; the provider now refuses a mismatch at
+    # load rather than failing later at INSERT. Maps to LOCAL_EMBEDDING_MODEL,
+    # which is what common/embedding/_registry.py reads.
+    local_embedding_model: str = "BAAI/bge-large-en-v1.5"
     # Per-deploy control for where embedding + LLM enrichment run.
     #
     # - ``"inline"`` (default): both embed + enrich run on the request

--- a/tests/test_c38_local_embedder_dim_guard.py
+++ b/tests/test_c38_local_embedder_dim_guard.py
@@ -1,0 +1,80 @@
+"""C38 — EMBEDDING_PROVIDER=local was dead on arrival.
+
+``_registry`` constructed ``LocalEmbedding()`` with no arguments, hard-coding
+``BAAI/bge-base-en-v1.5`` (768-dim) while ``memories.embedding`` is
+``vector(VECTOR_DIM)`` = 1024. No configuration could change it, so that
+provider could never have worked against this schema.
+
+Worse, the width mismatch only logged a warning and carried on — the failure
+surfaced much later as a Postgres dimension error at INSERT, naming neither the
+model nor the setting responsible.
+
+Found while looking for an embedder fallback after the OpenAI account ran out of
+credits. NOT the path staging/prod use (those run TEI/bge-m3 through the
+OpenAI-compatible client), so this was a dormant provider, not a live outage.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from common.constants import VECTOR_DIM
+from common.embedding import _registry
+from common.embedding.providers.local import LocalEmbedding
+
+pytestmark = pytest.mark.unit
+
+
+async def _load(provider, dim):
+    model = MagicMock()
+    model.get_sentence_embedding_dimension.return_value = dim
+    st = MagicMock(return_value=model)
+    with patch.dict(
+        "sys.modules", {"sentence_transformers": MagicMock(SentenceTransformer=st)}
+    ):
+        await provider._ensure_model()
+
+
+def test_default_model_matches_the_schema_width():
+    """The regression guard that matters: the default must be storable. A
+    768-dim default against a 1024-dim column is exactly what shipped."""
+    assert _registry.DEFAULT_LOCAL_EMBEDDING_MODEL == "BAAI/bge-large-en-v1.5"
+
+
+async def test_mismatched_model_refuses_at_load_and_names_the_fix():
+    p = LocalEmbedding("some/768-dim-model")
+    with pytest.raises(ValueError) as e:
+        await _load(p, 768)
+    msg = str(e.value)
+    assert "768" in msg and str(VECTOR_DIM) in msg
+    assert "LOCAL_EMBEDDING_MODEL" in msg  # names the knob, not just the symptom
+    assert "bge-large" in msg  # and a model that actually works
+
+
+async def test_matching_model_loads():
+    p = LocalEmbedding("BAAI/bge-large-en-v1.5")
+    await _load(p, VECTOR_DIM)
+    assert p._model is not None
+
+
+def test_registry_honours_the_env_override():
+    with patch.dict(os.environ, {"LOCAL_EMBEDDING_MODEL": "custom/model-x"}):
+        assert _registry.get_embedding_provider("local").model == "custom/model-x"
+
+
+def test_empty_env_value_falls_back_rather_than_loading_a_nameless_model():
+    """``os.environ.get`` returning "" would otherwise load a model named ''."""
+    with patch.dict(os.environ, {"LOCAL_EMBEDDING_MODEL": ""}):
+        assert (
+            _registry.get_embedding_provider("local").model
+            == _registry.DEFAULT_LOCAL_EMBEDDING_MODEL
+        )
+
+
+def test_core_api_setting_and_registry_default_agree():
+    """pydantic-settings maps the field to LOCAL_EMBEDDING_MODEL; if the two
+    defaults drift, core-api documents one model and loads another."""
+    from core_api.config import Settings
+
+    assert Settings().local_embedding_model == _registry.DEFAULT_LOCAL_EMBEDDING_MODEL


### PR DESCRIPTION
## `EMBEDDING_PROVIDER=local` was dead on arrival

`_registry` constructed `LocalEmbedding()` with **no arguments**, hard-coding `BAAI/bge-base-en-v1.5` (**768-dim**) while `memories.embedding` is `vector(VECTOR_DIM)` = **1024**. No configuration could change it, so that provider could never have produced a storable vector against this schema.

Worse, the width mismatch only **logged a warning and continued** — so the failure surfaced much later as a Postgres dimension error at INSERT, naming neither the model nor the setting responsible. That warn-and-continue is exactly how the default sat on a 768-dim model against a 1024-dim column without anyone noticing.

## Fix

- **Model is configurable** via `LOCAL_EMBEDDING_MODEL`, defaulting to `BAAI/bge-large-en-v1.5` (natively 1024). Read from the environment rather than a service's settings, because this registry is shared with **core-worker** and must not import one service's config. core-api's `local_embedding_model` maps to the same variable, and a test pins the two defaults together so they can't drift.
- **A width mismatch raises at model load**, naming the knob and a model that works, instead of deferring the failure to the database.

## Scope — deliberately narrow

This is a **dormant provider**. Staging and prod run TEI/`bge-m3` through the OpenAI-compatible client (`OPENAI_EMBEDDING_BASE_URL`), so **nothing in a deployed environment changes**.

Found while hunting for an embedder fallback after the hosted-OpenAI account ran out of credits — the fallback didn't work, and this is why.

## Testing

6 unit tests, including that an empty env value falls back rather than loading a model named `""`.

Note on the local suite: the test database on this machine was broken (tests default to `caura:changeme@/caura`; the running Postgres serves `memclaw/memclaw`). I recreated the role/DB to unblock, but it's unseeded, so ~19 DB-backed tests fail locally **on clean main with these changes stashed** — pre-existing environment breakage, not from this PR. CI is the trustworthy signal here.

Refs: canonical C38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
