### PR TITLE
fix(skills-inbox): add the missing write gate on the five inbox actions

### DIFF
--- a/core-api/src/core_api/routes/skills_inbox.py
+++ b/core-api/src/core_api/routes/skills_inbox.py
@@ -138,6 +138,35 @@ def _require_inbox_admin(auth: AuthContext) -> None:
 
     Centralized so the check stays consistent across all five action
     handlers — a missed handler is a privilege-escalation bug.
+
+    THIS IS THE ADMIN AXIS ONLY: it says WHO the caller is, never
+    whether their credential may write. Each handler calls
+    ``auth.enforce_read_only()`` for that second axis, and the two are
+    not substitutes in either direction.
+
+    That is defence in depth rather than a closed hole, and the
+    distinction is worth stating precisely. Today no gateway-minted
+    credential is both an org admin and non-writing: the auth service
+    emits ``X-Org-Role`` only for user principals and DELETES it on the
+    API-key path, which is the only path that emits ``X-Capabilities``
+    ("keys carry no org membership, and admin surfaces stay human-only").
+    So an admin arrives with ``capabilities=None``, for which
+    ``enforce_read_only`` is a no-op.
+
+    What the gate buys is that core-api stops depending on that. It
+    reads the two axes as independent fields, so "admin implies may
+    write" held only by a convention enforced in another repo and
+    asserted in a docstring there — with nothing here to notice if an
+    ingress, an on-prem deployment, or a caller reaching core-api
+    directly (``gateway_shared_secret`` unset, where both headers are
+    client-supplied) ever presented the combination.
+
+    This is how the authz inventory found them: of the routes it counts
+    as mutating, these five were the only ones that write tenant state
+    and reached no write gate at all. Its other exemptions are
+    POST-bodied reads, gated by ``enforce_readable_tenant``, and the
+    unauthenticated bootstrap routes, which take no ``auth`` and write
+    nothing tenant-scoped.
     """
     # Mirror documents.py:215-216 — admin status may come from either
     # the legacy ``is_admin`` flag OR ``org_role == "admin"``. Keeping
@@ -646,6 +675,7 @@ async def approve(
     blocks the transition if the doc became unsafe between propose
     and apply.
     """
+    auth.enforce_read_only()
     tenant_id = _require_tenant(auth, tenant_id)
     settings = await _require_skills_factory_enabled(tenant_id)
     _require_inbox_admin(auth)
@@ -788,6 +818,7 @@ async def reject(
     depends on ``get_db`` (the settings gate + audit log already ignore
     their ``db`` arg and route through storage).
     """
+    auth.enforce_read_only()
     tenant_id = _require_tenant(auth, tenant_id)
     settings = await _require_skills_factory_enabled(tenant_id)
     _require_inbox_admin(auth)
@@ -940,6 +971,7 @@ async def quarantine(
     poison table — quarantine is reversible by a security admin; only
     Reject crystallizes a poison row.
     """
+    auth.enforce_read_only()
     tenant_id = _require_tenant(auth, tenant_id)
     await _require_skills_factory_enabled(tenant_id)
     _require_inbox_admin(auth)
@@ -1000,6 +1032,7 @@ async def defer(
     the next run. Stamps ``deferred_at`` so the inbox can sort
     deferred items to the bottom + show "deferred N days ago".
     """
+    auth.enforce_read_only()
     tenant_id = _require_tenant(auth, tenant_id)
     await _require_skills_factory_enabled(tenant_id)
     _require_inbox_admin(auth)
@@ -1072,6 +1105,7 @@ async def edit(
 
     Raw markdown only (per OQ-D — no WYSIWYG in MVP).
     """
+    auth.enforce_read_only()
     tenant_id = _require_tenant(auth, tenant_id)
     settings = await _require_skills_factory_enabled(tenant_id)
     _require_inbox_admin(auth)

--- a/tests/test_authz_gate_inventory.py
+++ b/tests/test_authz_gate_inventory.py
@@ -169,24 +169,13 @@ WRITE_GATE_ALLOWLIST: dict[str, str] = {
     # yet, which is the whole point. Nothing tenant-scoped is written.
     "POST /api/v1/install-plugin": "bootstrap: no auth context by design, renders a script",
     "POST /api/install-plugin": "bootstrap: no auth context by design, renders a script",
-    # KNOWN GAP, not a justification — see test_known_gaps_do_not_grow.
-    #
-    # These five call ``_require_inbox_admin``, which raises 403 unless
-    # ``is_admin`` or ``org_role == "admin"``. The first draft of this file
-    # called that "strictly narrower than the write gate". It is not, for the
-    # same reason ``enforce_org_admin`` is excluded from WRITE_GATE_EXEMPT
-    # above: ``org_role`` and ``capabilities`` are independent gateway headers,
-    # so an ORG ADMIN holding a capabilities={'read'} key clears
-    # ``_require_inbox_admin`` and then meets no write gate — and can approve,
-    # reject, quarantine, defer or edit a skill. Writing the reason down is what
-    # exposed it; it is recorded here rather than fixed because five behaviour
-    # changes each want their own over-refusal test, which is a security PR of
-    # its own and not this one.
-    "POST /api/v1/skills-inbox/{slug:path}/approve": "KNOWN GAP: _require_inbox_admin admits a read-only org admin",
-    "POST /api/v1/skills-inbox/{slug:path}/reject": "KNOWN GAP: _require_inbox_admin admits a read-only org admin",
-    "POST /api/v1/skills-inbox/{slug:path}/quarantine": "KNOWN GAP: _require_inbox_admin admits a read-only org admin",
-    "POST /api/v1/skills-inbox/{slug:path}/defer": "KNOWN GAP: _require_inbox_admin admits a read-only org admin",
-    "POST /api/v1/skills-inbox/{slug:path}/edit": "KNOWN GAP: _require_inbox_admin admits a read-only org admin",
+    # The five ``skills-inbox`` actions were here as KNOWN GAPs — guarded on
+    # the admin axis by ``_require_inbox_admin``, which admits an org admin
+    # whose key may be read-only. Closed: each handler now calls
+    # ``enforce_read_only`` itself, so they need no entry at all, and
+    # ``test_allowlists_have_no_unnecessary_entries`` is what said so rather
+    # than someone remembering. Their PLANE entries below stay — only the
+    # write axis moved.
 }
 
 # A reason starting with this is NOT a justification — it is an unfixed gap
@@ -195,7 +184,7 @@ WRITE_GATE_ALLOWLIST: dict[str, str] = {
 # for the same purpose: the alternative is a list where "excused" and "not yet
 # fixed" look identical, and then neither gets read.
 KNOWN_GAP_PREFIX = "KNOWN GAP:"
-KNOWN_GAP_CEILING = 5
+KNOWN_GAP_CEILING = 0
 
 PLANE_GATE_ALLOWLIST: dict[str, str] = {
     # NODE-plane, not admin-plane. The plugin holds whatever credential the
@@ -433,6 +422,30 @@ def _report(row: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _unguarded_for_write(row: dict) -> bool:
+    """Would this route fail the write invariant without an allowlist entry?"""
+    return WRITE_GATE not in row["gates"] and not (row["gates"] & WRITE_GATE_EXEMPT)
+
+
+def _unguarded_for_plane(row: dict) -> bool:
+    """Would this route fail the plane invariant without an allowlist entry?"""
+    return (
+        row["router"] in ADMIN_PLANE_ROUTERS
+        and PLANE_GATE not in row["gates"]
+        and not (row["gates"] & PLANE_GATE_EXEMPT)
+    )
+
+
+# ``(name, allowlist, predicate)`` — the pairing the entry-hygiene checks walk.
+# Sharing the predicates with the invariant tests is the point: an entry is
+# "needed" exactly when the invariant would flag the route, by one definition
+# rather than two that can drift.
+_ALLOWLISTS = (
+    ("WRITE_GATE_ALLOWLIST", WRITE_GATE_ALLOWLIST, _unguarded_for_write),
+    ("PLANE_GATE_ALLOWLIST", PLANE_GATE_ALLOWLIST, _unguarded_for_plane),
+)
+
+
 def test_every_mutating_route_has_a_write_gate() -> None:
     """A route that mutates must refuse a credential that may not write.
 
@@ -444,9 +457,7 @@ def test_every_mutating_route_has_a_write_gate() -> None:
     offenders = [
         row
         for row in _mutating_routes()
-        if WRITE_GATE not in row["gates"]
-        and not (row["gates"] & WRITE_GATE_EXEMPT)
-        and row["key"] not in WRITE_GATE_ALLOWLIST
+        if _unguarded_for_write(row) and row["key"] not in WRITE_GATE_ALLOWLIST
     ]
     assert not offenders, (
         f"{len(offenders)} mutating route(s) neither call {WRITE_GATE}, nor are "
@@ -468,10 +479,7 @@ def test_admin_plane_mutating_routes_refuse_agent_credentials() -> None:
     offenders = [
         row
         for row in _mutating_routes()
-        if row["router"] in ADMIN_PLANE_ROUTERS
-        and PLANE_GATE not in row["gates"]
-        and not (row["gates"] & PLANE_GATE_EXEMPT)
-        and row["key"] not in PLANE_GATE_ALLOWLIST
+        if _unguarded_for_plane(row) and row["key"] not in PLANE_GATE_ALLOWLIST
     ]
     assert not offenders, (
         f"{len(offenders)} admin-plane mutating route(s) neither call "
@@ -480,6 +488,41 @@ def test_admin_plane_mutating_routes_refuse_agent_credentials() -> None:
         + "\n".join(_report(r) for r in offenders)
         + f"\n\nAdd the gate, or add a line to PLANE_GATE_ALLOWLIST in {__file__} "
         "saying which plane this route belongs to."
+    )
+
+
+def test_allowlists_have_no_unnecessary_entries() -> None:
+    """An entry excusing a route that now passes on its own is dead.
+
+    ``test_allowlists_have_no_stale_entries`` only catches an entry naming a
+    route that no longer exists. It does not catch the commoner case: the gap
+    gets FIXED and the line stays, still reading as though someone decided the
+    route did not need the gate. That is worse than untidy — a future reader
+    takes the line at face value, and a genuinely unguarded route can later be
+    added under the same key and be excused by a reason written about
+    something else.
+
+    This was not hypothetical for one commit: closing the five ``skills_inbox``
+    write gaps left their ``KNOWN GAP`` entries excusing five routes that had
+    just been gated, and every check in this file still passed. Hence this one.
+    """
+    rows = {row["key"]: row for row in _mutating_routes()}
+    unnecessary: dict[str, str] = {}
+    for name, allowlist, needs_entry in _ALLOWLISTS:
+        for key, reason in allowlist.items():
+            row = rows.get(key)
+            if row is None:
+                continue  # test_allowlists_have_no_stale_entries owns this
+            if not needs_entry(row):
+                unnecessary[f"{name}[{key}]"] = (
+                    f"route now satisfies the invariant on its own "
+                    f"(gates: {sorted(row['gates'])}) — reason still says {reason!r}"
+                )
+    assert not unnecessary, (
+        "allowlist entries excuse routes that no longer need excusing:\n"
+        + "\n".join(f"    {k}: {v}" for k, v in sorted(unnecessary.items()))
+        + "\n\nDelete the entries. If one was a KNOWN GAP, lower "
+        "KNOWN_GAP_CEILING to match."
     )
 
 

--- a/tests/test_skills_inbox_routes.py
+++ b/tests/test_skills_inbox_routes.py
@@ -25,6 +25,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from core_api import errors
 from core_api.auth import AuthContext, get_auth_context
 from core_api.routes import skills_inbox as si
 from core_api.services.forge.sentinel_scan import ScanResult
@@ -252,10 +253,21 @@ def make_client(
     # ``tenant_id=None`` + ``is_admin=True`` reproduces the OSS admin
     # credential (auth Path 1) — the WT-4 shape.
     tenant_id: str | None = TENANT,
+    # The two axes ``enforce_read_only`` tests, independent of org role.
+    # Default ``None`` is a legacy full-scope key, which passes that gate — so
+    # every pre-existing test in this file keeps exercising the same caller.
+    capabilities: set[str] | None = None,
+    is_demo: bool = False,
 ) -> AsyncClient:
     app = FastAPI()
     app.include_router(si.router, prefix="/api/v1")
-    auth = AuthContext(tenant_id=tenant_id, org_role=org_role, is_admin=is_admin)
+    auth = AuthContext(
+        tenant_id=tenant_id,
+        org_role=org_role,
+        is_admin=is_admin,
+        capabilities=capabilities,
+        is_demo=is_demo,
+    )
 
     async def _auth_dep():
         return auth
@@ -266,6 +278,17 @@ def make_client(
 
 BASE = "/api/v1/skills-inbox"
 SLUG = "forge/summarize-oncall-handoff"
+
+# The five mutating actions and a minimal valid body for each. Shared by
+# every parametrized action test — admin-plane, write-gate, and
+# over-refusal — so a sixth action is added in one place.
+_ACTIONS = [
+    ("approve", None),
+    ("defer", None),
+    ("edit", {"summary": "x"}),
+    ("quarantine", {"reason": "r"}),
+    ("reject", {"reason": "r"}),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -439,16 +462,7 @@ async def test_list_open_to_non_admin_members(storage, settings):
     assert r.status_code == 200, r.text
 
 
-@pytest.mark.parametrize(
-    ("action", "body"),
-    [
-        ("approve", None),
-        ("defer", None),
-        ("edit", {"summary": "x"}),
-        ("quarantine", {"reason": "r"}),
-        ("reject", {"reason": "r"}),
-    ],
-)
+@pytest.mark.parametrize(("action", "body"), _ACTIONS)
 async def test_actions_are_admin_only(storage, settings, side_effects, action, body):
     storage.seed(forge_doc())
     async with make_client(org_role="member") as client:
@@ -465,6 +479,109 @@ async def test_legacy_is_admin_flag_also_grants_actions(
     async with make_client(org_role=None, is_admin=True) as client:
         r = await client.post(f"{BASE}/{SLUG}/defer", json=None)
     assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# The five actions had no WRITE gate — only an admin-plane one.
+#
+# ``_require_inbox_admin`` passes on ``is_admin or org_role == "admin"`` and
+# nothing else, and the actions called no ``auth.enforce_*`` at all, so these
+# were the only mutating routes in the app with no write gate. Found by
+# ``tests/test_authz_gate_inventory.py``, which recorded it as a KNOWN GAP
+# because closing it is five behaviour changes.
+#
+# DEFENCE IN DEPTH, not a closed hole — worth being exact, because the first
+# draft of this comment claimed a live escalation. No gateway-minted credential
+# is currently both an org admin and non-writing: the auth service emits
+# ``X-Org-Role`` only for user principals and deletes it on the API-key path,
+# which is the only path emitting ``X-Capabilities``. What these tests pin is
+# that core-api enforces the two axes itself rather than inheriting the
+# guarantee from another repo's convention — see ``_require_inbox_admin``.
+#
+# So the credential shapes below are constructed, not observed. That is the
+# point: they are what a direct caller or a future ingress could present, and
+# the gate has to hold for them.
+#
+# These assert the ERROR CODE, not just 403. Three other refusals on this path
+# also answer 403 — ``SKILLS_FACTORY_DISABLED`` from the settings gate is the
+# reachable collision for these callers, since a caller with
+# ``org_role="admin"`` never trips the admin gate — so a status-only test would
+# pass against a version that refused for the wrong reason.
+# ---------------------------------------------------------------------------
+
+_NON_WRITING = [
+    pytest.param(
+        {"capabilities": {"read"}}, errors.AUTH_READ_ONLY_KEY, id="read-only-key"
+    ),
+    pytest.param({"is_demo": True}, errors.AUTH_DEMO_SANDBOX, id="demo-sandbox"),
+]
+
+
+@pytest.mark.parametrize(("action", "body"), _ACTIONS)
+@pytest.mark.parametrize(("cred", "code"), _NON_WRITING)
+async def test_actions_refuse_a_non_writing_credential(
+    storage, settings, side_effects, action, body, cred, code
+):
+    """The finding. The caller IS an org admin, and must still be refused."""
+    storage.seed(forge_doc())
+    async with make_client(org_role="admin", **cred) as client:
+        r = await client.post(f"{BASE}/{SLUG}/{action}", json=body)
+
+    assert r.status_code == 403, f"{action}: {r.text}"
+    # ``make_client`` mounts the router on a bare app, so core-api's
+    # ``http_exception_handler`` — which lifts a ``coded_detail`` into a
+    # top-level ``error`` key — is not installed and the dict stays under
+    # ``detail``. Clients read ``error.code``; this is the harness's shape, and
+    # the reason every other coded-error assertion in the suite differs.
+    assert r.json()["detail"]["code"] == code, f"{action}: {r.text}"
+    # Status alone would pass against a gate placed after the write.
+    assert storage.upserts == [], f"{action} mutated the doc despite the refusal"
+
+
+@pytest.mark.parametrize(("action", "body"), _ACTIONS)
+async def test_a_write_capable_org_admin_can_still_act(
+    storage, settings, side_effects, action, body
+):
+    """OVER-REFUSAL GUARD.
+
+    ``org_role="admin"`` with ``write`` among its capabilities. Note this is a
+    CONSTRUCTED shape, not the one the gateway mints: a human operator arrives
+    on the session/JWT path with ``capabilities=None``, which is
+    ``make_client``'s default and therefore what every other test in this file
+    already exercises against these actions. This case covers the branch that
+    default skips — ``enforce_read_only`` only inspects the set when it is not
+    ``None``.
+
+    Spread per action for symmetry with the refusal test above, not because a
+    mutant demands it: the gate is one identical expression in all five
+    handlers and no handler carries a second capability-sensitive check, so
+    over-refusing exactly one would take separately-wrong code.
+    """
+    storage.seed(forge_doc())
+    async with make_client(org_role="admin", capabilities={"read", "write"}) as client:
+        r = await client.post(f"{BASE}/{SLUG}/{action}", json=body)
+    assert r.status_code == 200, f"{action}: {r.text}"
+
+
+async def test_the_list_stays_readable_for_a_read_only_credential(storage, settings):
+    """The write gate must go on the ACTIONS only, not the router.
+
+    ``GET /skills-inbox`` is deliberately open to any tenant member so a
+    non-admin operator can see what is in flight (``test_list_open_to_non_admin_members``,
+    which passes ``org_role=None``; this is the first case here to use a real
+    ``member``). A read-only credential is exactly who that is for, so gating
+    the list would be a straightforward regression — and it is the mistake a
+    router-level dependency would have made.
+
+    Seeds ``query_rows``, not ``docs``: ``list_inbox`` reads through
+    ``query_documents``, so a ``storage.seed()`` here would leave the listing
+    empty and the test would assert 200 on nothing.
+    """
+    storage.query_rows = [forge_doc()]
+    async with make_client(org_role="member", capabilities={"read"}) as client:
+        r = await client.get(BASE)
+    assert r.status_code == 200, r.text
+    assert r.json()["count"] == 1, r.text
 
 
 async def test_action_on_missing_doc_404(storage, settings, side_effects):


### PR DESCRIPTION
Closes the write-gate gap `tests/test_authz_gate_inventory.py` (#1340) recorded as a `KNOWN GAP`, and closes an allowlist-rot hole that same file shipped with.

## What was wrong

`approve` / `reject` / `quarantine` / `defer` / `edit` were guarded on the **admin axis only**, by `_require_inbox_admin`, and called no `auth.enforce_*` at all — neither that helper nor `_require_tenant` does; both raise `HTTPException` directly. Of the routes the inventory counts as mutating, these five were the only ones that write tenant state and reached no write gate. Its other exemptions are POST-bodied reads gated by `enforce_readable_tenant`, and the unauthenticated bootstrap routes.

## This is defence in depth, not a live escalation — and my first draft said otherwise

The first version of this change claimed `org_role` and `capabilities` are independent gateway headers, so an org admin could hold a read-only key, clear the admin check, and meet no write gate.

They **are** independent fields on `AuthContext`. But nothing mints that pair: `platform-auth-api` emits `X-Org-Role` only for user principals and **deletes** it on the API-key path, which is the only path that emits `X-Capabilities`, with its own docstring saying *"keys carry no org membership, and admin surfaces stay human-only"*. So an admin arrives with `capabilities=None`, for which `enforce_read_only` is a no-op.

I read the consumer side in core-api and inferred the producer side in another repo without opening it. The docstring, tests and commit message all say defence-in-depth now.

**What the gate still buys:** core-api stops depending on that. It parses the two axes independently, so "admin implies may write" held only by a convention enforced in another repo and asserted in a docstring there — with nothing here to notice if an ingress, an on-prem deployment, or a caller reaching core-api directly (`gateway_shared_secret` unset, where both headers are client-supplied) ever presented the combination.

## Choices worth reviewing

**Gate goes first in each handler.** The gate reads nothing but `auth`, and putting it ahead of `_require_skills_factory_enabled` refuses a non-writing credential without a cross-service settings read. This is the majority pattern, not a universal one — my first draft overstated it as "all 42 call sites put it first", a grep count that included a docstring mention and checked no positions. Measured with AST: of the 36 existing `enforce_read_only` call sites across 12 other route files, **23 put it first and 13 do not**. The 13 are consistent with the reason above — what precedes the gate is always cheap and synchronous (`enforce_tenant`, a tenant resolver, `_check_stm_enabled`, a perf timer), never an `await`. One real divergence: `documents.py` and `keystones.py` run `auth.enforce_tenant(...)` first, so a read-only key aimed at another tenant gets the tenant refusal there and `READ_ONLY_CREDENTIAL` here. Both refuse; no existing test pins that precedence.

**Written out five times** rather than folded into `_require_inbox_admin`, which all five already call. Centralising would be structurally *stronger* — the inventory's classifier resolves module-local helpers, so a sixth handler calling only `_require_inbox_admin` would satisfy the invariant — but it would make that helper two-axis and its name wrong, and renaming it reaches #1340's allowlist reasons, which are corroborated **by name**.

**The list endpoint stays open.** `GET /skills-inbox` is deliberately readable by any tenant member so a non-admin operator can see what is in flight. Asserted, because it is the regression a router-level `dependencies=[...]` would have caused — and that would have been invisible to the inventory, which reads handler bodies.

## The allowlist-rot hole

`test_allowlists_have_no_stale_entries` only caught entries naming routes that no longer exist. So fixing a gap left its five `KNOWN GAP` lines excusing five now-gated routes with **every check still green** — verified, that is exactly what happened here before the entries were removed.

`test_allowlists_have_no_unnecessary_entries` now fails on an entry whose route satisfies the invariant on its own, and the two invariant predicates are factored out so "does this route need excusing" has one definition rather than two that can drift. The five write-gate entries are deleted and `KNOWN_GAP_CEILING` drops 5 → 0; the plane entries stay, since only the write axis moved.

## Verification

Every test confirmed by mutation, one mutant at a time:

| mutant | result |
| --- | --- |
| drop the gate from all five | all 10 refusal cases fail |
| drop it from ONE handler | only that handler's 2 cases fail |
| gate the list endpoint too | the list-stays-readable test fails |
| swap it for a second admin check | all 10 fail — the false "admin check is narrower" belief does not satisfy them |

They assert the error **code**, not just 403: `SKILLS_FACTORY_DISABLED` is the reachable 403 collision for these callers, so a status-only test would pass against a version that refused for the wrong reason. Codes come from `errors.*` rather than literals — the values are `READ_ONLY_CREDENTIAL` and `DEMO_SANDBOX_READ_ONLY`, not what their constant names suggest.

The 5 → 0 ceiling move is held in **both** directions, which took two attempts to establish honestly:

| mutant | result |
| --- | --- |
| entries removed, ceiling left at 5 | fails on the `==` assertion |
| a live entry relabelled a `KNOWN GAP` | fails on the `<=` assertion |

I first "verified" the second with a mutant that inserted a duplicate key into a dict literal, where the original later entry silently won — so it exercised nothing and passed. **This corrects what I posted on #1340**, where I claimed both directions were verified when only one was. Relabelling an existing entry keeps the key real and the entry necessary, leaving the ratchet as the only thing that can fire; it is now the sole failure, which is what makes the direction tested.

93 passed on the two test files; full suite 6233 passed; `ruff check` and `ruff format --check` clean at CI's scopes; legacy-name ratchet, do-not-touch sentinel and tenant-scope gate all green.

### One unrelated flake seen along the way

`tests/test_unknown_field_rejection.py::test_memory_update_rejects_unknown_field` failed in 2 of 3 full-suite runs and passed in the third with no code change between them. It also failed earlier the same day on a different branch, passes in isolation and in subsets, and does not involve any route or module this PR touches (my two test files make no DB writes at all — one uses a bare `FastAPI()` with fakes, the other is pure `ast`/`inspect`). It looks like accumulated state in the shared test database. Filed separately rather than folded in here.

## Follow-ups not in this PR

- The FastAPI `_IncludedRouter` walk is now duplicated character-for-character between `tests/test_authz_gate_inventory.py` and `scripts/tenant_scope_gate.py` — extract to `common/`.
- No equivalent inventory for the MCP surface.
- `AuthContext.enforce_self_agent()` + a coded error across the 8 inline self-plane sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
