### PR TITLE
fix(tests): stop test_pipeline_equivalence leaking the legacy write path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -493,6 +493,47 @@ def _reset_hooks():
     reset_hooks()
 
 
+@pytest.fixture(autouse=True)
+def _write_path_flag_is_not_leaked():
+    """Fail the test that leaves ``_USE_PIPELINE_WRITE`` flipped, not its victims.
+
+    Several tests flip this module flag to exercise the deprecated legacy write
+    path, and it is a plain module global, so a missed restore silently
+    redirects EVERY later write in the session. That is not a small blast
+    radius: ``_USE_PIPELINE_WRITE`` is ``True`` in production, so a leak means
+    thousands of tests stop covering the path that ships and start covering the
+    one scheduled for removal — with nothing failing to say so.
+
+    It surfaces instead as an unrelated flake, because the two paths do not
+    answer alike. The legacy path 409s on a semantic near-duplicate where the
+    pipeline path records the same candidate as advisory metadata and returns
+    201, so any later test that needs a write to SUCCEED starts failing once
+    the shared ``default`` tenant has accumulated enough near-identical
+    content — and which test that is depends on which content happens to cross
+    the similarity threshold, so it moves between runs. That is how it read as
+    flakiness in three separate tests before it read as a leak.
+
+    Checked after each test, so the report lands on the test that caused it,
+    and the flag is put back BEFORE asserting so it lands there only. Leaving
+    it flipped would fail every test that followed too, which is a worse
+    version of the same problem: a wall of identical failures whose first
+    entry is the only informative one.
+    """
+    yield
+    from core_api.services import memory_service
+
+    leaked = memory_service._USE_PIPELINE_WRITE is not True
+    memory_service._USE_PIPELINE_WRITE = True
+    assert not leaked, (
+        "this test left core_api.services.memory_service._USE_PIPELINE_WRITE "
+        "set to False. Every write after it would have taken the deprecated "
+        "legacy path; this fixture has put it back, so the failure you are "
+        "reading is the cause and not a consequence. Restore it in a "
+        "``finally`` (see test_pipeline_equivalence) rather than assigning a "
+        "literal at the end of the test body."
+    )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _disable_rate_limiter():
     """Disable the slowapi rate limiter for the whole test suite.

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -616,18 +616,24 @@ async def test_pipeline_equivalence():
     content_a = "Pipeline equivalence test memory content A — testing that both paths produce the same output fields."
     content_b = "Pipeline equivalence test memory content B — testing that both paths produce the same output fields."
 
-    # Legacy path
-    memory_service._USE_PIPELINE_WRITE = False
-    data_legacy = _make_input(content=content_a)
-    result_legacy = await _create_memory_legacy(data_legacy)
+    # Restored in ``finally`` rather than assigned a literal at the end, which
+    # is what this test used to do — and it assigned ``False``, under a comment
+    # reading "Reset", against a module default of ``True``. Nothing failed
+    # here, so it went unnoticed while every later write in the session took
+    # the deprecated legacy path.
+    original = memory_service._USE_PIPELINE_WRITE
+    try:
+        # Legacy path
+        memory_service._USE_PIPELINE_WRITE = False
+        data_legacy = _make_input(content=content_a)
+        result_legacy = await _create_memory_legacy(data_legacy)
 
-    # Pipeline path
-    memory_service._USE_PIPELINE_WRITE = True
-    data_pipeline = _make_input(content=content_b)
-    result_pipeline = await _create_memory_pipeline(data_pipeline)
-
-    # Reset
-    memory_service._USE_PIPELINE_WRITE = False
+        # Pipeline path
+        memory_service._USE_PIPELINE_WRITE = True
+        data_pipeline = _make_input(content=content_b)
+        result_pipeline = await _create_memory_pipeline(data_pipeline)
+    finally:
+        memory_service._USE_PIPELINE_WRITE = original
 
     # Compare key fields (IDs and timestamps will differ)
     assert result_legacy.tenant_id == result_pipeline.tenant_id


### PR DESCRIPTION
The reported flake was `tests/test_unknown_field_rejection.py::test_memory_update_rejects_unknown_field`. **Nothing is wrong with that test.** The defect is one line in `tests/pipeline/test_write_pipeline.py`:

```python
    # Reset
    memory_service._USE_PIPELINE_WRITE = False
```

The module default is `True`, so that "reset" set the flag to the opposite of what it found, with no `try`/`finally`. `tests/pipeline/` collects before `tests/test_*`, so from that test onward **every write in the session took the deprecated legacy path**.

## Demonstrated, not argued

A probe test appended after that file, with the new guard neutralised so only the fix is on trial:

| | a later test sees |
| --- | --- |
| with the `try`/`finally` fix | `_USE_PIPELINE_WRITE = True` |
| without it | `_USE_PIPELINE_WRITE = False` |

42 tests in that file pass either way, which is why it went unnoticed.

## Why it surfaced in an unrelated test

The two write paths don't answer alike on a semantic near-duplicate. The legacy path raises `409 DUPLICATE_MEMORY`; the pipeline path records the same candidate as advisory `near_duplicate_of` metadata and returns 201 — `DetectNearDuplicate`'s own docstring says *"The write is NOT rejected"*.

So once the flag leaks, any later test that needs a write to **succeed** can start failing. The write in question targets the shared `default` tenant, which no sweep reclaims (`purge_test_rows` matches `tenant_id LIKE 'test-tenant-%'`). That tenant holds 23,087 memories locally, **96 of them near-identical to this test's own content** — one per past run. Whether any crosses the auto-reject threshold depends on the random `uid` in the content, so it fails on some runs and not others, and gets likelier as the tenant grows.

The captured failure, which is what tied it together:

```
assert created.status_code == 201
E  assert 409 == 201
E  {"error":{"code":"DUPLICATE_MEMORY","details":{"reason":"semantic_similarity", ...}}}
Captured log: memory_service.py:823 legacy write path invoked
```

That last line is the victim's own write announcing which path it took.

## The guard is the second half

A missed restore of this flag deserves to fail the test that caused it, because the consequence is otherwise invisible: production runs `_USE_PIPELINE_WRITE = True`, so a leak quietly moves thousands of tests off the path that ships and onto the one scheduled for removal, and **nothing goes red**.

`_write_path_flag_is_not_leaked` checks after each test and puts the flag back *before* asserting, so the report lands on the culprit alone rather than on every test that follows. Verified: with the leaking line restored the guard produces exactly one error, naming that test, and the 40 tests after it still pass. (My first version omitted the repair and produced 22 identical errors — a wall whose first entry was the only informative one.)

## Verification

Full suite **6244 passed**, 0 failed. `ruff check` and `ruff format --check` clean at CI's scopes. Legacy-name ratchet, do-not-touch sentinel and tenant-scope gate all green.

## Deliberately not in this PR

- Three tests in `test_unknown_field_rejection.py` need a write to succeed against the never-swept `default` tenant, so they stay exposed to accumulated state on any path that hard-rejects. The sibling convention is `get_test_auth(new_tenant_id())` — see `test_api_interview.py`, changed for #858, the same class of bug. Worth doing, but it is a different change from this one.
- **The legacy path is now genuinely uncovered** by everything that was accidentally exercising it. Whether it should be deleted or kept with real coverage is a call I'm not making here, and it's the one I'd most like your view on.
- A separate `DeadlockDetectedError` on `memory_entity_links`, caught in the same investigation, is on its own branch.

## What I got wrong on the way

I ruled out semantic dedup early and said so, on the grounds that this write resolves to the fast path where near-dup is advisory. That reasoning was correct about the pipeline and wrong about the request: I never checked which path the call actually took. The user's original hypothesis was right; I read one end and inferred the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
