### PR TITLE
fix(storage): insert entity links in one global lock order

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -139,6 +139,37 @@ def _get_read_session_factory() -> async_sessionmaker[AsyncSession]:
     return _read_session_factory
 
 
+def _ordered_link_rows(rows: list[dict]) -> list[dict]:
+    """Dedup ``memory_entity_links`` rows by key and fix one global insert order.
+
+    A statement carrying several pairs takes its row locks in the order it is
+    given them. Two concurrent statements covering an overlapping set in
+    different orders each take one key and then wait on the other's
+    transaction — a cycle Postgres resolves by killing one of them, which
+    reaches the caller as a 500 on an ordinary write rather than as anything
+    about locking.
+
+    ``ON CONFLICT`` does not help with that, which an earlier comment on
+    ``memory_add_entity_links`` claimed it did. The clause decides what happens
+    once the wait resolves, not whether there is a wait: an inserter whose key
+    is held by an in-flight transaction blocks until that transaction ends,
+    measured at the shape used here. Sorting is the whole mitigation, and it is
+    the one ``evolve_service`` already applies to ``related_ids`` before its
+    multi-row UPDATE.
+
+    Sorted on the STRING form of each id so the order is the same for callers
+    that pass ``UUID`` objects and callers that pass strings; a mixed batch
+    would otherwise order by object identity and defeat the point.
+
+    First occurrence of a repeated key wins — the row a single ``DO NOTHING``
+    statement would have kept anyway, so deduping here changes no result.
+    """
+    by_key: dict[tuple[str, str], dict] = {}
+    for row in rows:
+        by_key.setdefault((str(row["memory_id"]), str(row["entity_id"])), row)
+    return [by_key[key] for key in sorted(by_key)]
+
+
 @asynccontextmanager
 async def get_session() -> AsyncIterator[AsyncSession]:
     """Transactional writer session; commits on success, rolls back on error."""
@@ -4478,19 +4509,25 @@ class PostgresService:
         the same way and a fix to one cannot miss the others.
         """
         # Bulk-insert with ``ON CONFLICT (memory_id, entity_id) DO NOTHING``
-        # so two concurrent writes targeting the same ``(memory_id,
-        # entity_id)`` pair don't serialise on ``Lock/transactionid``
-        # (CAURA-686). Each ``link`` dict carries ``entity_id`` (UUID) and
-        # ``role`` (str).
+        # so a pair another writer already committed is skipped instead of
+        # raising a unique violation (CAURA-686). Each ``link`` dict carries
+        # ``entity_id`` (UUID) and ``role`` (str).
+        #
+        # It does NOT keep concurrent writers off ``Lock/transactionid``, which
+        # is what an earlier version of this comment claimed and why nothing
+        # here was ordered; ``_ordered_link_rows`` carries the correction and
+        # the measurement.
         if not links:
             # Nothing is written, so there is nothing to scope. Reported as
             # success rather than checked-then-succeeded: the answer is the
             # same for every tenant, so it discloses nothing either way.
             return True
         entity_ids = {link["entity_id"] for link in links}
-        rows = [
-            {"memory_id": memory_id, "entity_id": link["entity_id"], "role": link["role"]} for link in links
-        ]
+        # Ordered + deduped so two concurrent statements over an overlapping
+        # set cannot form a lock cycle.
+        rows = _ordered_link_rows(
+            [{"memory_id": memory_id, "entity_id": link["entity_id"], "role": link["role"]} for link in links]
+        )
         async with get_session() as session:
             owned_memories, owned_entities = await self._owned_link_endpoints(
                 session, tenant_id, {memory_id}, entity_ids
@@ -7433,7 +7470,11 @@ class PostgresService:
                 # and no surrogate ``id`` column, so RETURNING must reference
                 # real columns; with ON CONFLICT DO NOTHING only actually-
                 # inserted rows return, keeping the count accurate.
-                rows = [{**row, "role": "mentioned"} for row in to_insert]
+                # Ordered for the same reason as ``memory_add_entity_links``:
+                # this statement carries many pairs, and ``to_insert`` is built
+                # by iterating candidates, so without this its order is
+                # whatever the scan returned.
+                rows = _ordered_link_rows([{**row, "role": "mentioned"} for row in to_insert])
                 insert_link_returning = (
                     pg_insert(MemoryEntityLink)
                     .values(rows)

--- a/tests/test_entity_link_lock_order.py
+++ b/tests/test_entity_link_lock_order.py
@@ -1,0 +1,209 @@
+"""``memory_entity_links`` inserts take their locks in one global order.
+
+The comment this replaces said ``ON CONFLICT ... DO NOTHING`` was what kept
+concurrent writers off ``Lock/transactionid``. It is not, and the difference
+matters: the clause decides what happens once a wait resolves, not whether
+there is a wait. Measured against the real database at the shape the service
+uses, a second inserter of a held key blocked for as long as the first
+transaction stayed open (~600ms), then proceeded.
+
+That wait is unavoidable. A CYCLE of waits is not, and it is what turns an
+ordinary write into a 500: two transactions covering an overlapping set of
+pairs in different orders each take one key and then wait on the other, and
+Postgres breaks the tie by killing one of them with ``DeadlockDetectedError``.
+
+``test_opposite_insert_orders_deadlock_at_the_sql_level`` below pins that
+hazard against Postgres itself — with a barrier rather than a race, so it
+cannot itself become the flaky test — and the reason ``_ordered_link_rows``
+exists stays checkable rather than becoming folklore. The unit tests around
+it pin the ordering the helper produces, which is the part a future edit
+would break.
+
+Scope, stated because it is easy to over-read: this closes the ordering
+hazard. It is NOT known to be the cycle behind the suite's intermittent
+``DeadlockDetectedError`` on this table — the statement in that traceback was
+the per-item upsert, which opens one transaction per row and so cannot hold
+two keys at once. Its cycle more likely runs through the foreign-key locks on
+the parent ``memories`` / ``entities`` rows against a concurrent UPDATE from
+background enrichment, which nothing here addresses.
+"""
+
+import asyncio
+import uuid
+
+import asyncpg
+import pytest
+
+from core_storage_api.services.postgres_service import _ordered_link_rows
+from tests.conftest import TEST_DB_URL
+
+# ---------------------------------------------------------------------------
+# The ordering itself
+# ---------------------------------------------------------------------------
+
+
+def _row(mid, eid, role="subject") -> dict:
+    return {"memory_id": mid, "entity_id": eid, "role": role}
+
+
+def test_rows_come_back_sorted_by_the_conflict_key() -> None:
+    """Insert order is the conflict key's order, whatever the caller passed."""
+    mid = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    ids = [
+        uuid.UUID("dddddddd-0000-0000-0000-000000000000"),
+        uuid.UUID("aaaaaaaa-0000-0000-0000-000000000000"),
+        uuid.UUID("cccccccc-0000-0000-0000-000000000000"),
+        uuid.UUID("bbbbbbbb-0000-0000-0000-000000000000"),
+    ]
+    forward = _ordered_link_rows([_row(mid, e) for e in ids])
+    reverse = _ordered_link_rows([_row(mid, e) for e in reversed(ids)])
+
+    got = [str(r["entity_id"]) for r in forward]
+    assert got == sorted(got), got
+    # The property that actually prevents the cycle: two callers holding the
+    # same pairs in opposite orders emit the SAME sequence.
+    assert forward == reverse
+
+
+def test_multi_memory_batches_order_on_both_halves_of_the_key() -> None:
+    """A batch spanning memories sorts on ``(memory_id, entity_id)``.
+
+    ``entity_discover_cross_links`` builds exactly this shape, so ordering on
+    the entity alone would leave its statement unordered across memories.
+    """
+    m1 = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    m2 = uuid.UUID("22222222-2222-2222-2222-222222222222")
+    e1 = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000000")
+    e2 = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000000")
+
+    scrambled = [_row(m2, e2), _row(m1, e2), _row(m2, e1), _row(m1, e1)]
+    got = [
+        (str(r["memory_id"]), str(r["entity_id"]))
+        for r in _ordered_link_rows(scrambled)
+    ]
+    assert got == sorted(got), got
+
+
+def test_a_repeated_key_keeps_its_first_row() -> None:
+    """Dedup keeps the first occurrence — what DO NOTHING already did.
+
+    So a caller repeating a pair with two roles still gets the first role,
+    and the statement stops taking the same lock twice.
+    """
+    mid = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    eid = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000000")
+    out = _ordered_link_rows([_row(mid, eid, "subject"), _row(mid, eid, "object")])
+    assert out == [_row(mid, eid, "subject")]
+
+
+def test_string_and_uuid_ids_sort_together() -> None:
+    """Mixed id types must not order by object identity.
+
+    The service is called with ``UUID`` objects from the pipeline and with
+    strings from the REST body, so a batch can carry both. Sorting the raw
+    values would raise or fall back to identity; the helper sorts on ``str``.
+    """
+    mid = "11111111-1111-1111-1111-111111111111"
+    rows = [
+        _row(mid, "cccccccc-0000-0000-0000-000000000000"),
+        _row(uuid.UUID(mid), uuid.UUID("aaaaaaaa-0000-0000-0000-000000000000")),
+        _row(mid, "bbbbbbbb-0000-0000-0000-000000000000"),
+    ]
+    got = [str(r["entity_id"]) for r in _ordered_link_rows(rows)]
+    assert got == sorted(got), got
+
+
+# ---------------------------------------------------------------------------
+# Why the ordering is needed at all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_opposite_insert_orders_deadlock_at_the_sql_level(_setup_schema) -> None:
+    """Postgres itself, not a claim about it: opposite orders deadlock.
+
+    Deliberately NOT routed through the service — the point is the database
+    behaviour ``_ordered_link_rows`` exists to avoid, so it must not depend on
+    the helper. It therefore passes with or without the ordering; the mutants
+    on the helper are what hold the mitigation, and this holds the reason.
+
+    The cycle is built rather than raced. Each writer takes one key, both wait
+    on a barrier until the other has taken theirs, and only then does each
+    reach for the other's key — so neither can proceed and Postgres has to
+    kill one of them. Racing N pairs in opposite orders reproduces the same
+    thing, but only usually, and a test that asserts a race outcome is the
+    problem this file is about.
+    """
+    dsn = TEST_DB_URL.replace("postgresql+asyncpg://", "postgresql://")
+    tenant = f"test-tenant-{uuid.uuid4().hex[:8]}"
+
+    setup = await asyncpg.connect(dsn)
+    try:
+        mid = uuid.uuid4()
+        await setup.execute(
+            "INSERT INTO memories (id, tenant_id, agent_id, content, memory_type,"
+            " status, visibility, weight, content_hash)"
+            " VALUES ($1,$2,$3,$4,'fact','active','scope_team',0.5,$5)",
+            mid,
+            tenant,
+            "agent-lockorder",
+            f"a memory whose links two writers race to insert {uuid.uuid4().hex[:8]}",
+            uuid.uuid4().hex,
+        )
+        first, second = uuid.uuid4(), uuid.uuid4()
+        for i, eid in enumerate((first, second)):
+            await setup.execute(
+                "INSERT INTO entities (id, tenant_id, entity_type, canonical_name)"
+                " VALUES ($1,$2,'person',$3)",
+                eid,
+                tenant,
+                f"Person {i} {uuid.uuid4().hex[:6]}",
+            )
+    finally:
+        await setup.close()
+
+    took_first = asyncio.Event()
+    took_second = asyncio.Event()
+
+    async def writer(mine, theirs, took_mine, took_theirs) -> str:
+        conn = await asyncpg.connect(dsn)
+        try:
+            tx = conn.transaction()
+            await tx.start()
+            try:
+                await conn.execute(
+                    "INSERT INTO memory_entity_links (memory_id, entity_id, role)"
+                    " VALUES ($1,$2,'subject') ON CONFLICT DO NOTHING",
+                    mid,
+                    mine,
+                )
+                took_mine.set()
+                await took_theirs.wait()
+                # Both keys are now held, one by each transaction. Reaching for
+                # the other's is what closes the cycle.
+                await conn.execute(
+                    "INSERT INTO memory_entity_links (memory_id, entity_id, role)"
+                    " VALUES ($1,$2,'subject') ON CONFLICT DO NOTHING",
+                    mid,
+                    theirs,
+                )
+                await tx.commit()
+                return "ok"
+            except asyncpg.exceptions.DeadlockDetectedError:
+                await tx.rollback()
+                return "deadlock"
+        finally:
+            await conn.close()
+
+    outcomes = await asyncio.gather(
+        writer(first, second, took_first, took_second),
+        writer(second, first, took_second, took_first),
+    )
+    assert "deadlock" in outcomes, (
+        f"expected a deadlock from crossed insert orders, got {outcomes} — if "
+        "Postgres no longer cycles here, _ordered_link_rows may no longer be "
+        "load-bearing"
+    )
+    # Exactly one victim: the other writer must still have committed, which is
+    # what makes this a deadlock rather than both writers failing.
+    assert sorted(outcomes) == ["deadlock", "ok"], outcomes


### PR DESCRIPTION
Found while investigating an intermittent test failure. **This is not that fix** — see [#1345](https://github.com/caura-ai/caura/pull/1345) for the actual cause. This closes a separate, demonstrated hazard on `memory_entity_links`, plus a comment asserting the concurrency property that would have prevented it.

## The false claim

On `memory_add_entity_links`:

> Bulk-insert with `ON CONFLICT (memory_id, entity_id) DO NOTHING` so two concurrent writes targeting the same `(memory_id, entity_id)` pair don't serialise on `Lock/transactionid` (CAURA-686).

`DO NOTHING` does not do that. The clause decides what happens once a wait *resolves*, not whether there is a wait. Measured against Postgres at the shape this code uses — one connection inserts a key and holds its transaction open, a second inserts the same key:

```
B still blocked while A held its transaction: True
B's insert took 604ms (it waited for A)
```

Believing otherwise is presumably why neither multi-row insert site was ordered.

## The hazard

The wait itself is unavoidable and harmless. A **cycle** of waits is neither: two transactions covering an overlapping set of pairs in different orders each take one key and then wait on the other, and Postgres breaks the tie by killing one with `DeadlockDetectedError` — a 500 on an ordinary write, whose message says nothing about locking. Reproduced directly:

```
forward: DeadlockDetectedError: deadlock detected
DETAIL:  Process 9298 waits for ShareLock on transaction 422472; blocked by process 9299.
         Process 9299 waits for ShareLock on transaction 422471; blocked by process 9298.
```

This is production-reachable: two agents writing memories that link to an overlapping set of entities is ordinary traffic.

## The fix

`_ordered_link_rows` dedups by the conflict key and sorts on it, so every statement takes its locks in the same global order and no cycle can form. Both multi-row sites use it — `memory_add_entity_links` (caller-supplied order) and `entity_discover_cross_links` (whatever order the candidate scan returned). The third site upserts one row per transaction and cannot hold two keys, so it is left alone.

Same mitigation and the same one-line shape as `evolve_service` sorting `related_ids` before its multi-row UPDATE, which already carries a comment saying it is for exactly this reason. Sorting is on the **string** form of each id because the service is called with `UUID` objects from the pipeline and strings from the REST body, and a mixed batch would otherwise order by object identity. Dedup keeps the **first** occurrence — the row a single `DO NOTHING` statement kept anyway — so no caller-visible result changes.

## Verification

Four mutants, one at a time:

| mutant | result |
| --- | --- |
| no ordering at all | the three ordering tests fail |
| order on entity only | only the multi-memory test fails |
| last occurrence wins | only the first-row-wins test fails |
| sort the raw id values | only the mixed UUID/str test fails |

The SQL-level test asserts Postgres still cycles on crossed insert orders, so the reason this helper exists stays checkable instead of becoming folklore. It deliberately does not route through the service and **passes with or without the fix** — it pins the hazard, not the mitigation; the four mutants hold the mitigation.

It builds the cycle rather than racing for it: two keys, and a barrier so each writer has taken one before either reaches for the other's. My first version raced 40 pairs against 40 reversed ones and deadlocked on every run I tried — but whether two transactions interleave is the scheduler's business, and shipping a probabilistic assertion into the suite this came out of would have been the wrong trade. Barrier-driven it passed 5 runs out of 5 with no variance.

Full suite 6221 passed, 0 failed. `ruff` clean, mypy clean (`86 source files`), ratchet/sentinel/tenant-scope gates green.

## Scope

The intermittent suite failure that led here is a deadlock on this same table, and it lands on a **different test each time** — the unknown-field one twice, `test_p3_3_graph_fanout` on the run that produced the traceback above. But the statement in that traceback was the *per-item* upsert, which opens one transaction per row and so cannot hold two keys at once; its cycle more likely runs through the foreign-key locks on the parent `memories` / `entities` rows against a concurrent UPDATE from background enrichment. **Nothing here addresses that.** I chased the ordering hazard because it was adjacent to the evidence, and it is worth closing on its own merits, but I want to be explicit that it is not the cycle I captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
