### PR TITLE
refactor(core-api): name the write entry point for what it does

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/parallel_embed_enrich.py
+++ b/core-api/src/core_api/pipeline/steps/write/parallel_embed_enrich.py
@@ -80,7 +80,7 @@ class ParallelEmbedEnrich:
         ch = ctx.data.get("content_hash")
         resolved_write_mode = ctx.data.get("resolved_write_mode")
         # CAURA-682 Phase 1: per-phase latency capture. The summary emit
-        # lives in ``_create_memory_pipeline`` after pipeline.run; each
+        # lives in ``_run_write_pipeline`` after pipeline.run; each
         # phase deposits its duration here.
         timings: dict = ctx.data.setdefault("phase_timings", {})
 

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -231,15 +231,15 @@ async def _live_duplicate_hashes(
 ) -> set[str]:
     """Which of ``hashes`` already have a LIVE row, in dedup scope.
 
-    The server-internal write paths — auto-chunk children (both the pipeline
-    and legacy handlers) and the atomic-fact fanout — attach a ``content_hash``
-    to every child and then insert it without ever consulting a dedup lookup.
-    The public bulk path does consult one (``existing_hashes`` +
-    ``seen_hashes`` in ``create_memories_bulk``), and the single-write path has
-    ``CheckExactDuplicate``; these three had neither. That is why prod carries
-    duplicate content-hash groups with no concurrency involved at all: the same
-    document re-chunked, or an LLM emitting the same fact twice, minted a fresh
-    row every time.
+    The server-internal write paths — auto-chunk children and the atomic-fact
+    fanout — attach a ``content_hash`` to every child and then insert it
+    without ever consulting a dedup lookup. The public bulk path does consult
+    one (``existing_hashes`` + ``seen_hashes`` in ``create_memories_bulk``),
+    and the single-write path has ``CheckExactDuplicate``; those two
+    server-internal paths had neither. That is why prod carries duplicate
+    content-hash groups with no concurrency involved at all: the same document
+    re-chunked, or an LLM emitting the same fact twice, minted a fresh row
+    every time.
 
     ``_auto_chunk_request_id()`` cannot substitute for this. It mints a fresh
     UUID per item per call, so the attempt-idempotency index
@@ -460,12 +460,10 @@ async def _embed_children_or_degrade(
     the trade: refusing loses the children AND wedges every retry, while
     degrading keeps the facts and leaves a repair queued.
 
-    SHARED by the pipeline and legacy handlers on purpose. The legacy path is
-    dormant, not dead — the flag at the top of this module documents flipping
-    it as the emergency-rollback lever — and an emergency rollback is
-    plausibly happening BECAUSE something is degraded, which is the same
-    condition that trips this. Two copies of a degrade policy is how the two
-    paths diverge; one is how they cannot.
+    One caller since #1347 deleted the legacy handler this was shared with.
+    Still a named helper: two copies of this degrade decision, only one of them
+    fixed, is exactly what H-09 was. ``test_the_degrade_policy_lives_in_one_place``
+    pins one definition and one call site.
     """
     try:
         return await get_embeddings_batch(child_texts, tenant_config, background=False)
@@ -652,10 +650,11 @@ async def _create_memory_or_409(payload: dict) -> dict:
     gate answers the duplicate visible before the write, this answers the race it
     cannot see, and a caller should not have to tell the two apart.
 
-    A helper rather than a try at each site because there are three of them (the
-    auto-chunk parent on both handlers, plus the legacy single write) and each
-    passes a long inline dict; wrapping them individually would re-indent all
-    three for no gain. It fetches the client itself so the swap is call-for-call.
+    One call site since #1347 — the auto-chunk parent. Still a helper and not
+    an inline try: the translation is the part worth naming, it has its own
+    tests driving it directly, and inlining would bury it in a try wrapped
+    around a long dict literal. It fetches the client itself so the swap is
+    call-for-call.
     """
     try:
         return await get_storage_client().create_memory(payload)
@@ -837,7 +836,7 @@ async def create_memory(data: MemoryCreate) -> MemoryOut:
     # needs its own call and its own route-level test.
     if data.metadata:
         data.metadata = sanitize_caller_metadata(data.metadata)
-    return await _create_memory_pipeline(data)
+    return await _run_write_pipeline(data)
 
 
 def _memory_out_with_created_links(ctx, memory: dict) -> MemoryOut:
@@ -860,8 +859,20 @@ def _memory_out_with_created_links(ctx, memory: dict) -> MemoryOut:
     )
 
 
-async def _create_memory_pipeline(data: MemoryCreate) -> MemoryOut:
-    """Pipeline-based create_memory — same logic, decomposed into timed steps."""
+async def _run_write_pipeline(data: MemoryCreate) -> MemoryOut:
+    """Build the pipeline context and run the write pipeline this request needs.
+
+    Kept separate from ``create_memory``, which stays a short prologue of
+    pre-write checks. Not only for readability:
+    ``test_service_layer_does_not_gate_on_reserved_types`` asserts that
+    ``SERVER_RESERVED_MEMORY_TYPES`` does NOT appear in ``create_memory``'s
+    source. An absence assertion over a short prologue is a contract; over a
+    merged body it would be a tripwire for any unrelated mention anywhere in
+    the write orchestration.
+
+    Called ``_create_memory_pipeline`` while there was a legacy handler to
+    contrast with; #1347 deleted that handler.
+    """
     from core_api.pipeline.compositions.write import (
         build_enrichment_pipeline,
         build_fast_write_pipeline,
@@ -1205,7 +1216,7 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
         # parent embed, which is already background=False.
         #
         # Degrades rather than raising — the parent is already committed. See
-        # ``_embed_children_or_degrade``, shared with the legacy handler.
+        # ``_embed_children_or_degrade``.
         child_embeddings = await _embed_children_or_degrade(
             child_texts, tenant_config, parent_id=str(parent_id)
         )
@@ -1252,7 +1263,7 @@ async def _handle_auto_chunk_from_ctx(data: MemoryCreate, ctx: object) -> Memory
         )
 
         # Queue a repair for any child that landed without a vector; a no-op on
-        # the healthy path. Shared with the legacy handler.
+        # the healthy path.
         _queue_child_reembeds(
             child_payloads,
             child_results,

--- a/tests/pipeline/test_search_pipeline.py
+++ b/tests/pipeline/test_search_pipeline.py
@@ -66,7 +66,7 @@ _SEED_CONTENTS = [
 
 
 async def _seed_memories(count: int = 3) -> list[MemoryOut]:
-    """Insert test memories via the legacy write path and return them."""
+    """Insert test memories through ``create_memory`` and return them."""
     from core_api.services.memory_service import create_memory
 
     # Use a unique tenant per call to avoid cross-test dedup collisions

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -325,7 +325,7 @@ async def test_pipeline_failed_result_surfaces_http_500_not_unbound_local(caplog
     from fastapi import HTTPException
 
     from core_api.pipeline.runner import Pipeline, PipelineResult
-    from core_api.services.memory_service import _create_memory_pipeline
+    from core_api.services.memory_service import _run_write_pipeline
 
     async def _failed_result(self, ctx):
         return PipelineResult(pipeline_name="write", failed=True)
@@ -343,7 +343,7 @@ async def test_pipeline_failed_result_surfaces_http_500_not_unbound_local(caplog
         patch.object(Pipeline, "run", _failed_result),
     ):
         with pytest.raises(HTTPException) as exc_info:
-            await _create_memory_pipeline(_make_input())
+            await _run_write_pipeline(_make_input())
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "Memory write pipeline failed unexpectedly"

--- a/tests/test_a38_mcp_contradiction_path_parity.py
+++ b/tests/test_a38_mcp_contradiction_path_parity.py
@@ -11,7 +11,7 @@ pipeline, and both entry points reach it through the same ``create_memory``:
     MCP   caura_write       -> create_memory
                                      |
                                      v
-                        _create_memory_pipeline
+                          _run_write_pipeline
                                      |
                                      v
                         ScheduleBackgroundTasks   <- entity extraction +
@@ -49,7 +49,11 @@ def test_create_memory_runs_the_pipeline():
     from core_api.services import memory_service
 
     src = inspect.getsource(memory_service.create_memory)
-    assert "_create_memory_pipeline" in src
+    assert "_run_write_pipeline" in src, (
+        "create_memory no longer hands the write to the pipeline entry point, "
+        "which is where detection is scheduled — either the entry point was "
+        "renamed, or A38 is real again."
+    )
 
 
 def test_rest_and_mcp_share_the_same_write_entry():

--- a/tests/test_child_dedup_minting_paths.py
+++ b/tests/test_child_dedup_minting_paths.py
@@ -1,9 +1,9 @@
 """The server-internal write paths must consult a dedup lookup (OSS #814).
 
-Auto-chunk children (pipeline + legacy handlers) and the atomic-fact fanout each
-attach a ``content_hash`` to every child and then inserted it unconditionally.
-The public bulk path already dedups (``existing_hashes`` + ``seen_hashes``) and
-the single-write path has ``CheckExactDuplicate``; these three had neither, which
+Auto-chunk children and the atomic-fact fanout each attach a ``content_hash`` to
+every child and then inserted it unconditionally. The public bulk path already
+dedups (``existing_hashes`` + ``seen_hashes``) and the single-write path has
+``CheckExactDuplicate``; those two server-internal paths had neither, which
 is why prod carries duplicate content-hash groups with no concurrency involved:
 18 groups / 19 surplus rows over 110k live rows, measured before this change.
 

--- a/tests/test_h852_governed_auto_chunk.py
+++ b/tests/test_h852_governed_auto_chunk.py
@@ -133,7 +133,7 @@ async def _run_auto_chunk(
     ctx = SimpleNamespace(
         data={
             # ``GovernanceDecision`` reads the request off the context, exactly
-            # as ``_create_memory_pipeline`` populates it.
+            # as ``_run_write_pipeline`` populates it.
             "input": data,
             "memory_fields": {
                 "memory_type": "fact",

--- a/tests/test_h856_deferred_auto_chunk_backfill.py
+++ b/tests/test_h856_deferred_auto_chunk_backfill.py
@@ -98,7 +98,7 @@ async def _run_auto_chunk(
 ) -> _Run:
     """Drive the multi-fact exit with ``deployment_mode`` set for real.
 
-    ``ctx`` is built the way ``_create_memory_pipeline`` builds it, but
+    ``ctx`` is built the way ``_run_write_pipeline`` builds it, but
     ``embedding``/``enrichment`` are set to what ``ParallelEmbedEnrich`` actually
     produces in each mode — ``None`` for both when deferred, because this branch
     never sets ``resolved_write_mode`` and so takes the arm keyed on


### PR DESCRIPTION
The follow-up flagged on [#1347](https://github.com/caura-ai/caura/pull/1347): `_create_memory_pipeline` → `_run_write_pipeline`, plus the comment residue that deletion left behind.

**No behaviour change** — two executable lines differ, the `def` and its one call site. Everything else is prose.

## The name

The old name distinguished the function from `_create_memory_legacy`. With that handler deleted, "pipeline" named nothing — and a private name that looks like one of a pair sends the next reader hunting for the twin.

`_search_memories_pipeline` **keeps** its suffix, and gets no note saying why. Its twin `_search_memories_legacy` sits 115 lines below it behind a live `if _USE_PIPELINE_SEARCH or diagnostic:`, so the asymmetry explains itself where a reader would ask. My first draft did document it — in the write path, the one file nobody will open when the legacy search path is finally deleted. That is the staleness class this PR exists to clean up, so writing a fresh instance of it to explain the cleanup was the wrong trade.

## The residue — comments still describing the deleted twin

Every count here was measured with an AST pass over call sites, not read off the comment being replaced.

| helper | what it claimed | what is true |
| --- | --- | --- |
| `_live_duplicate_hashes` | paths with no dedup lookup are "auto-chunk children (both the pipeline and legacy handlers) and the atomic-fact fanout … these **three** had neither" | two: `_handle_auto_chunk_from_ctx` and `_enrich_memory_background` |
| `_embed_children_or_degrade` | "SHARED by the pipeline and legacy handlers on purpose. The legacy path is dormant, not dead — **the flag at the top of this module** documents flipping it as the emergency-rollback lever" | one caller; the flag no longer exists |
| `_create_memory_or_409` | "a helper rather than a try at each site because there are **three** of them" | one call site |

The `_embed_children_or_degrade` one is the worst, and it is my miss: #1347 renamed the *test* that covers this helper (`test_both_paths_share_one_degrade_policy` → `test_the_degrade_policy_lives_in_one_place`) and left the docstring it was paired with — a paragraph arguing for sharing a helper between two handlers, pointing at a rollback lever deleted in the same PR.

Both surviving helpers keep their factoring; the docstrings now give the reason that still applies rather than the one that expired.

Two more copies live outside `memory_service.py`, and I missed both on the first pass:

- **`tests/test_child_dedup_minting_paths.py`**'s module docstring is a near-verbatim twin of the `_live_duplicate_hashes` one, stale in both the same ways. Fixing the source copy and leaving the test copy would have made the fix half-applied — and the test copy is the one that documents the invariant.
- **`tests/pipeline/test_search_pipeline.py`**'s `_seed_memories` claimed to insert "via the legacy write path" while its body calls `create_memory`. Actively confusing in that file specifically, where "legacy path" is a live and correct term for *search*.

## One count I got wrong in a way worth naming

I changed "these **three** had neither" to "these **two**" without re-reading the sentence. It ends: *"The public bulk path does consult one …, and the single-write path has `CheckExactDuplicate`; these two had neither."* The intended antecedent is the two server-internal paths from the previous sentence — but the nearest two nouns are bulk and single-write, the paths that explicitly **do** have dedup. At "three" the number itself blocked the misreading; at "two" the numbers match the wrong antecedent and a reader lands on the inverse of the point. It now names the antecedent instead of counting it.

## Why the two functions stay separate

`create_memory` is a short prologue that ends by delegating; folding them would give one ~215-line function. The reason that decides it is mechanical rather than aesthetic, and it is now in the docstring: `test_service_layer_does_not_gate_on_reserved_types` asserts `SERVER_RESERVED_MEMORY_TYPES` does **not** appear in `create_memory`'s source. An absence assertion over a short prologue is a real contract; the same assertion over a merged body becomes a tripwire that any unrelated mention inside the write orchestration sets off.

## The one test that tracks the name

`test_create_memory_runs_the_pipeline` (A38) asserts the entry point's name appears in `inspect.getsource(create_memory)`, so it needed updating — and it is worth knowing it still has teeth. Replacing the call with a behaviour-preserving `globals()` lookup produced **exactly one failure, that test**. Its new message names both possibilities, because they need opposite responses: a rename to propagate, or `create_memory` growing its own write, in which case A38's original suspicion (MCP writes bypassing contradiction detection) is real again.

## Verification

- **6242 passed, 0 failed** — identical to #1347's count, as a rename should be.
- mypy clean: core-api, 203 files.
- `ruff check` and `ruff format --check` clean at CI's scopes for `core-api/src/` and `tests/`.
- Legacy-name ratchet, do-not-touch sentinel, tenant-scope gate green.
- The three source-counting gates are unperturbed: `test_the_degrade_policy_lives_in_one_place` counts substrings over the whole module, so prose naming a helper **with** a paren would be miscounted as a real call site. Every match in the post-change file is real code — the new comments name helpers only in double-backtick form without a paren.

## Follow-ups, not done here

- **A38 deserves a better test than a name check.** The invariant is decidable at the composition layer: `ScheduleBackgroundTasks()` appears in `build_persist_pipeline`, `build_fast_write_pipeline` and `build_strong_write_pipeline`, and is deliberately absent from `build_stm_write_pipeline`. Asserting "every write pipeline that persists an LTM row schedules background tasks, STM the one declared exception" would catch what the current test cannot — detection hoisted into a route, or a fourth write pipeline composed without the step — and survive any rename. Swapping the assertion changes what is covered, so it needs its own fails-without-the-fix check rather than riding a rename.
- **A gate for this staleness class** — a comment naming a `_symbol` that resolves to no definition — is real but not cheap. I measured the candidate rule at **32 distinct tokens / 76 occurrences** today, and most are not symbols at all (`_system`, `_aliases`, `_latency_ms` are metadata keys and log-field suffixes), so it starts at ~30 exemptions and needs its own marker convention. Neither `legacy_name_ratchet.py` (text-diffs one literal against a base tree) nor `do_not_touch_sentinel.py` (asserts strings still *exist*) can host it. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
