### PR TITLE
CAURA-721 fix(dedup): scope the semantic gate to the writing agent

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/check_semantic_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/check_semantic_duplicate.py
@@ -133,6 +133,12 @@ class CheckSemanticDuplicate:
                 embedding,
                 visibility=data.visibility or "scope_team",
                 min_similarity=SEMANTIC_DEDUP_JUDGE_THRESHOLD,
+                # CAURA-721 — this is the step that 409s, so it is the one the
+                # missing owner actually cost: a candidate from another agent
+                # in the same fleet rejected a write whose author could not
+                # then read the surviving row. The same ``agent_id`` already
+                # goes to ``_enqueue_dedup_review`` further down this method.
+                agent_id=getattr(data, "agent_id", None),
             )
         )
         set_system_value(metadata, "semantic_dedup_ms", round((time.perf_counter() - t_dedup) * 1000, 1))

--- a/core-api/src/core_api/pipeline/steps/write/detect_near_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/detect_near_duplicate.py
@@ -90,6 +90,12 @@ class DetectNearDuplicate:
                 embedding,
                 visibility=data.visibility or "scope_team",
                 min_similarity=SEMANTIC_DEDUP_JUDGE_THRESHOLD,
+                # CAURA-721 — advisory here, never a 409, but the owner still
+                # has to be pinned: ``near_duplicate_of`` is handed to the
+                # caller as "you already recorded this", and pointing it at
+                # another agent's row makes that claim false (and, for a
+                # ``scope_agent`` candidate, names a row the caller cannot read).
+                agent_id=getattr(data, "agent_id", None),
             )
         )
         metadata["near_dup_check_ms"] = round((time.perf_counter() - t_dedup) * 1000, 1)

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -676,6 +676,7 @@ async def _find_semantic_duplicate(
     exclude_id: UUID | None = None,
     visibility: str | None = None,
     min_similarity: float | None = None,
+    agent_id: str | None = None,
 ) -> dict | None:
     """Find a near-duplicate memory via cosine similarity.
 
@@ -687,6 +688,14 @@ async def _find_semantic_duplicate(
     via the storage layer for back-compat. A1 #16's
     ``CheckSemanticDuplicate`` pipeline step passes
     ``SEMANTIC_DEDUP_JUDGE_THRESHOLD`` to surface the judge band.
+
+    ``agent_id`` (CAURA-721): the write's owner. Pass it on every write
+    path — without it this dedups on ``(tenant, fleet)`` and another
+    agent's row in the same fleet refuses a write whose author can then
+    never read the row that replaced it. The exact-hash gate is already
+    scoped ``(tenant, fleet, agent, content_hash)``; this makes the
+    semantic tier agree. Omitted only where there is no single owner to
+    pin.
     """
     sc = get_storage_client()
     payload: dict = {
@@ -698,6 +707,10 @@ async def _find_semantic_duplicate(
     }
     if min_similarity is not None:
         payload["min_similarity"] = min_similarity
+    # Sent only when set, so the wire body from a caller that does not pin an
+    # owner stays byte-identical to the pre-CAURA-721 one.
+    if agent_id:
+        payload["agent_id"] = agent_id
     return await sc.find_semantic_duplicate(payload)
 
 
@@ -3482,6 +3495,11 @@ async def update_memory(
                 mem.get("fleet_id"),
                 new_embedding,
                 exclude_id=memory_id,
+                # CAURA-721 — the row being edited owns the comparison, so an
+                # edit is refused only by its own author's other rows. Read off
+                # the stored row rather than the request: an update body has no
+                # ``agent_id``, and the owner is not something an edit changes.
+                agent_id=mem.get("agent_id"),
             )
             if sem_dup:
                 raise HTTPException(

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -347,6 +347,11 @@ async def find_semantic_duplicate(request: Request) -> dict:
         exclude_id=UUID(body["exclude_id"]) if body.get("exclude_id") else None,
         visibility=body.get("visibility"),
         min_similarity=body.get("min_similarity"),
+        # CAURA-721 — owner identity, so another agent's row in the same fleet
+        # cannot refuse this write. Optional for the same reason A54's is on
+        # ``/entity-overlap-candidates`` below: an older core-api sends no
+        # ``agent_id`` and keeps the pre-CAURA-721 behaviour.
+        agent_id=body.get("agent_id"),
     )
     if result is None:
         raise HTTPException(status_code=404, detail="No semantic duplicate found")

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1852,6 +1852,7 @@ class PostgresService:
         exclude_id: UUID | None = None,
         visibility: str | None = None,
         min_similarity: float | None = None,
+        agent_id: str | None = None,
     ) -> tuple[Memory, float] | None:
         """Find the closest memory above ``min_similarity``.
 
@@ -1860,6 +1861,33 @@ class PostgresService:
         back-compat with single-tier callers; A1 #16's tier-dispatching
         pipeline step passes ``SEMANTIC_DEDUP_JUDGE_THRESHOLD`` (0.85)
         so candidates in the judge band become visible.
+
+        ``agent_id`` (CAURA-721): pins the write's owner, so a candidate
+        belonging to a DIFFERENT agent in the same fleet cannot refuse
+        it. Without it this lookup dedups on ``(tenant, fleet)`` while
+        the exact-hash gate beside it dedups on
+        ``(tenant, fleet, agent, content_hash)`` — see
+        ``uq_memories_live_content_hash``, whose own comment gives the
+        rule both gates are meant to share: "two agents recording
+        identical content are two independent observations". Only the
+        semantic tier disagreed, so an exact cross-agent duplicate was
+        admitted while a mere paraphrase of it was refused.
+
+        The refusal was not a deduplication: reads can be narrowed with
+        ``filter_agent_id``, so the refused agent could not retrieve the
+        row that replaced its write — for ``scope_agent`` candidates the
+        409 also returned the id of a row the caller cannot read.
+
+        Same fix, same reason, as A54 on
+        ``memory_find_entity_overlap_candidates`` below; that one is
+        gated on the ``scope_agent`` tier only because visibility there
+        selects a chain to link INTO, whereas a write gate has to be no
+        wider than the narrowest scope a reader may ask for.
+
+        Defaults to ``None`` — meaning "do not pin" — so existing
+        callers keep the pre-CAURA-721 behaviour until they pass it, and
+        a core-api newer than its storage degrades to over-rejection
+        rather than failing.
 
         Returns ``(memory, similarity)`` or ``None``. The similarity
         field is what callers use to decide auto-reject vs judge-dispatch
@@ -1891,6 +1919,14 @@ class PostgresService:
                 stmt = stmt.where(Memory.visibility == visibility)
             if exclude_id is not None:
                 stmt = stmt.where(Memory.id != exclude_id)
+            # CAURA-721. Plain equality, not ``_content_hash_fleet_scope``'s
+            # COALESCE dance: ``Memory.agent_id`` is ``nullable=False``, so
+            # there is no NULL-vs-empty-string group to reconcile the way
+            # ``fleet_id`` needs. Falsy (``""``) is treated as absent, which
+            # matches every other optional predicate here — an unowned write
+            # has no owner to pin.
+            if agent_id:
+                stmt = stmt.where(Memory.agent_id == agent_id)
 
             result = await session.execute(stmt)
             row = result.first()

--- a/tests/test_caura721_dedup_agent_scope.py
+++ b/tests/test_caura721_dedup_agent_scope.py
@@ -1,0 +1,338 @@
+"""CAURA-721 — the semantic dedup gate is scoped to the writing agent.
+
+The defect: ``memory_find_semantic_duplicate`` filtered on ``(tenant, fleet)``
+while the exact-hash gate beside it is keyed on
+``(tenant, fleet, agent, content_hash)``. So Caura *admitted* an exact
+cross-agent duplicate inside a fleet and then *refused* a paraphrase of it —
+the semantic tier was the only gate disagreeing with the rule
+``uq_memories_live_content_hash`` states outright: "two agents recording
+identical content are two independent observations".
+
+Why that was loss rather than deduplication: reads narrow by
+``filter_agent_id``, so the refused agent could not retrieve the row that
+replaced its write. For a ``scope_agent`` candidate the 409 additionally
+returned the id, status and similarity of a row the caller has no right to
+read.
+
+Paths that reach the 409: ``write_mode=strong`` and the auto-chunk branch
+(both via ``CheckSemanticDuplicate``), plus the content-change gate on update.
+``write_mode=fast`` only tags ``near_duplicate_of`` advisorily, and
+``create_memories_bulk`` skips the semantic tier altogether — so this is
+deliberately tested through ``strong``.
+
+The load-bearing test here is
+``test_one_agent_restating_its_own_fact_is_still_refused``: pinning the owner
+must not switch dedup off for the single-agent case, which is nearly all real
+traffic.
+"""
+
+import hashlib
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from common.embedding import fake_embedding
+from core_api.services.memory_service import _find_semantic_duplicate
+from tests.conftest import get_test_auth, new_tenant_id
+
+FLEET = "caura721-fleet"
+CONTENT = "The Q3 planning session concluded that hiring is paused until January."
+
+
+def _content_hash(tenant_id: str, fleet_id: str | None, content: str) -> str:
+    return hashlib.sha256(
+        f"{tenant_id}:{fleet_id or ''}:{content}".encode()
+    ).hexdigest()
+
+
+async def _seed(tenant_id: str, *, agent_id: str, fleet_id: str | None, content: str):
+    """Insert a row straight through the storage client (no write pipeline)."""
+    from core_api.clients.storage_client import get_storage_client
+
+    return await get_storage_client().create_memory(
+        {
+            "tenant_id": tenant_id,
+            "fleet_id": fleet_id,
+            "agent_id": agent_id,
+            "memory_type": "fact",
+            "content": content,
+            "weight": 0.5,
+            "embedding": fake_embedding(content),
+            "content_hash": _content_hash(tenant_id, fleet_id, content),
+            "status": "active",
+        }
+    )
+
+
+async def _write(
+    client,
+    headers,
+    tenant_id,
+    *,
+    agent_id,
+    fleet_id,
+    content,
+    visibility,
+    write_mode="strong",
+):
+    return await client.post(
+        "/api/v1/memories",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": agent_id,
+            "fleet_id": fleet_id,
+            "content": content,
+            "visibility": visibility,
+            "write_mode": write_mode,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# The lookup itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_another_agents_row_no_longer_refuses_the_write(tenant_id):
+    """The defect, at the lookup: agent-b's write vs agent-a's row, one fleet."""
+    await _seed(tenant_id, agent_id="agent-a", fleet_id=FLEET, content=CONTENT)
+
+    dup = await _find_semantic_duplicate(
+        tenant_id, FLEET, fake_embedding(CONTENT), agent_id="agent-b"
+    )
+    assert dup is None, "a row owned by another agent must not refuse this write"
+
+
+@pytest.mark.integration
+async def test_one_agent_restating_its_own_fact_is_still_refused(tenant_id):
+    """The over-fix guard. Pinning the owner must not disable dedup.
+
+    If this ever fails, CAURA-721 has turned the gate off for the single-agent
+    case — which is nearly all real traffic — rather than narrowing it.
+    """
+    await _seed(tenant_id, agent_id="agent-a", fleet_id=FLEET, content=CONTENT)
+
+    dup = await _find_semantic_duplicate(
+        tenant_id, FLEET, fake_embedding(CONTENT), agent_id="agent-a"
+    )
+    assert dup is not None, "an agent restating its own fact must still be caught"
+    assert dup["content"] == CONTENT
+
+
+@pytest.mark.integration
+async def test_omitting_the_owner_keeps_the_pre_caura721_behaviour(tenant_id):
+    """``agent_id=None`` means "do not pin" — what every un-migrated caller gets."""
+    await _seed(tenant_id, agent_id="agent-a", fleet_id=FLEET, content=CONTENT)
+
+    dup = await _find_semantic_duplicate(tenant_id, FLEET, fake_embedding(CONTENT))
+    assert dup is not None, "omitting the owner must not narrow the lookup"
+
+
+@pytest.mark.integration
+async def test_the_owner_does_not_widen_past_the_fleet(tenant_id):
+    """Pinning the owner is an ADDITIONAL predicate, not a replacement.
+
+    Same agent, different fleet, must still not match — otherwise the fix would
+    have traded a too-wide agent scope for a too-wide fleet scope.
+    """
+    await _seed(tenant_id, agent_id="agent-a", fleet_id="fleet-a", content=CONTENT)
+
+    dup = await _find_semantic_duplicate(
+        tenant_id, "fleet-b", fake_embedding(CONTENT), agent_id="agent-a"
+    )
+    assert dup is None
+
+
+# ---------------------------------------------------------------------------
+# The wire body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_the_owner_reaches_the_storage_payload():
+    mock_sc = AsyncMock()
+    mock_sc.find_semantic_duplicate = AsyncMock(return_value=None)
+
+    with patch(
+        "core_api.services.memory_service.get_storage_client", return_value=mock_sc
+    ):
+        await _find_semantic_duplicate("t", "f", [0.0], agent_id="agent-a")
+
+    assert mock_sc.find_semantic_duplicate.call_args[0][0]["agent_id"] == "agent-a"
+
+
+@pytest.mark.unit
+async def test_no_owner_leaves_the_body_byte_identical():
+    """An unpinned call must not start sending ``agent_id: null``.
+
+    A storage older than CAURA-721 ignores unknown keys, so this is about the
+    contract rather than a crash: a caller that pins nothing should produce
+    exactly the body it produced before.
+    """
+    mock_sc = AsyncMock()
+    mock_sc.find_semantic_duplicate = AsyncMock(return_value=None)
+
+    with patch(
+        "core_api.services.memory_service.get_storage_client", return_value=mock_sc
+    ):
+        await _find_semantic_duplicate("t", "f", [0.0])
+
+    assert "agent_id" not in mock_sc.find_semantic_duplicate.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# End to end, through the route that actually 409s
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("visibility", ["scope_team", "scope_agent"])
+async def test_two_agents_in_one_fleet_can_both_record_the_same_fact(
+    client, visibility
+):
+    tenant_id, headers = get_test_auth(new_tenant_id())
+
+    a = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="agent-a",
+        fleet_id=FLEET,
+        content=CONTENT,
+        visibility=visibility,
+    )
+    assert a.status_code == 201, a.text
+
+    b = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="agent-b",
+        fleet_id=FLEET,
+        content=CONTENT,
+        visibility=visibility,
+    )
+    assert b.status_code == 201, b.text
+    assert b.json()["id"] != a.json()["id"], "two independent observations, two rows"
+
+
+@pytest.mark.integration
+async def test_an_agent_rewriting_its_own_fact_is_still_refused_over_rest(client):
+    """The end-to-end half of the over-fix guard.
+
+    Uses a paraphrase-free restatement with a distinct content hash, so the
+    refusal can only come from the SEMANTIC tier — an identical body would be
+    caught by the exact-hash gate and prove nothing about this change.
+    """
+    tenant_id, headers = get_test_auth(new_tenant_id())
+
+    a = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="agent-a",
+        fleet_id=FLEET,
+        content=CONTENT,
+        visibility="scope_team",
+    )
+    assert a.status_code == 201, a.text
+
+    again = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="agent-a",
+        fleet_id=FLEET,
+        content=CONTENT + " ",
+        visibility="scope_team",
+    )
+    assert again.status_code == 409, again.text
+    assert again.json()["error"]["details"]["reason"] == "semantic_similarity"
+
+
+@pytest.mark.integration
+async def test_the_second_agents_row_is_retrievable_by_that_agent(client, monkeypatch):
+    """The point of the fix: the write survives AND its author can read it.
+
+    Before CAURA-721 agent-b was refused and then, searching with
+    ``filter_agent_id=agent-b``, got zero rows — the fact was gone, not shared.
+    """
+    from core_api.services import memory_service
+
+    monkeypatch.setattr(memory_service, "_USE_PIPELINE_SEARCH", True)
+    tenant_id, headers = get_test_auth(new_tenant_id())
+
+    await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="agent-a",
+        fleet_id=FLEET,
+        content=CONTENT,
+        visibility="scope_team",
+    )
+    b = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="agent-b",
+        fleet_id=FLEET,
+        content=CONTENT,
+        visibility="scope_team",
+    )
+    assert b.status_code == 201, b.text
+
+    resp = await client.post(
+        "/api/v1/search",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "query": "Q3 planning hiring paused January",
+            "fleet_ids": [FLEET],
+            "filter_agent_id": "agent-b",
+            "top_k": 5,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert b.json()["id"] in [i["id"] for i in resp.json()["items"]]
+
+
+@pytest.mark.integration
+async def test_an_edit_is_not_refused_by_another_agents_row(client):
+    """The update path's content-change gate pins the edited row's own owner."""
+    tenant_id, headers = get_test_auth(new_tenant_id())
+
+    a = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="agent-a",
+        fleet_id=FLEET,
+        content=CONTENT,
+        visibility="scope_team",
+    )
+    assert a.status_code == 201, a.text
+
+    other = f"Bob switched the deploy window to Thursdays. {uuid.uuid4().hex[:8]}"
+    b = await _write(
+        client,
+        headers,
+        tenant_id,
+        agent_id="agent-b",
+        fleet_id=FLEET,
+        content=other,
+        visibility="scope_team",
+    )
+    assert b.status_code == 201, b.text
+
+    # Edit agent-b's row into agent-a's content. Allowed: different owners.
+    resp = await client.patch(
+        f"/api/v1/memories/{b.json()['id']}",
+        headers=headers,
+        params={"tenant_id": tenant_id},
+        json={"content": CONTENT},
+    )
+    assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## The defect

`memory_find_semantic_duplicate` filtered on `(tenant, fleet)`. The exact-hash gate beside it is keyed on
`(tenant, fleet, agent, content_hash)` via
`uq_memories_live_content_hash`, whose own comment states the rule both gates are meant to share:

> `agent_id` is in the key because two agents recording identical
> content are two independent observations.

Only the semantic tier disagreed. So Caura *admitted* an exact cross-agent duplicate inside a fleet and then *refused* a paraphrase of it — the near-duplicate branch was the odd one out, not the hash gate.

Reproduced through the REST routes, two agents in one fleet, `write_mode=strong`, identical content:

```
agent-a  POST /memories  fleet=shared  -> 201
agent-b  POST /memories  fleet=shared  -> 409
  reason semantic_similarity, similarity 1.0, existing_id <agent-a's row>
control: the same two writes in separate fleets -> 201, 201
```

## Why it was loss, not deduplication

Reads narrow by `filter_agent_id`. After the 409, agent-b searching with `filter_agent_id=agent-b` returns zero rows — for `scope_team` *and* `scope_agent`. The write was not merged into a shared row; it was refused on the strength of a row its author can never retrieve. A write gate must be no wider than the narrowest scope a reader may ask for.

Second defect, same cause: for a `scope_agent` candidate the 409 handed the caller the id, status and similarity of a row it has no right to read. Pinning the owner closes that with no separate redaction — the query can no longer match a foreign row, so there is no foreign id to report.

## The fix

One optional `agent_id` threaded storage -> route -> core-api wrapper -> call sites, and one extra SQL predicate. Plain equality rather than `_content_hash_fleet_scope`'s COALESCE handling: `Memory.agent_id` is `nullable=False`, so there is no NULL-vs-empty-string group to reconcile the way `fleet_id` needs.

Same fix, same reasoning, as A54 on
`memory_find_entity_overlap_candidates` — the neighbouring handler in the same router, whose comment already called this bug shape "wet-proven, not theoretical."

Call sites: `CheckSemanticDuplicate` (the step that 409s), `DetectNearDuplicate` (advisory, but `near_duplicate_of` must not name another agent's row), and `update_memory`'s content-change gate (pins the stored row's own owner — an update body carries no `agent_id`).

`create_memories_bulk` and `/ingest/commit` are untouched: they run content-hash dedup only and skip the semantic tier altogether.

## Scope and back-compat

`agent_id` defaults to `None`, meaning "do not pin" — today's exact behaviour. Existing positional callers are unchanged, and the key is sent only when set, so an unpinned call's wire body stays byte-identical. A core-api newer than its storage degrades to over-rejection rather than failing.

Deliberately NOT changed: the judge threshold, the retention direction (the older row still wins a genuine collision), and the identifier prefilter.

Known cost: multi-agent fleets will store more rows, since each agent keeps its own copy of a fact its teammates also learned. That is the correct outcome given reads can be agent-scoped, and it is already what the hash gate does. A tenant that genuinely wants fleet-wide dedup should get an explicit setting, not an accident of a missing parameter.

## Verification

- `tests/test_caura721_dedup_agent_scope.py` — 11 cases: the lookup, the wire body, and end-to-end through the route that 409s. Confirmed to fail without the source change (8 of 11; the other 3 are the back-compat and over-fix guards, which must hold in both directions).
- The load-bearing case is `test_one_agent_restating_its_own_fact_is_still_refused`: pinning the owner must not switch dedup off for the single-agent case, which is nearly all real traffic. Also asserted over REST with a distinct content hash, so only the semantic tier can be the cause.
- `test_the_owner_does_not_widen_past_the_fleet` guards the inverse mistake — trading a too-wide agent scope for a too-wide fleet scope.
- Dedup/ingest sweep: 156 passed (`test_p2_semantic_dedup`, `test_a1_16`/`17`/`18`, `test_a21_detect_near_duplicate`, `test_a1_identifier_prefilter`, `test_storage_client_routing`, `test_ingest_commit`).
- Full `tests/`: 6215 passed, 39 failed — the failure set is byte-identical to `main`'s on this machine (pre-existing FTS/relation-weight/ request-observation env failures). `core-storage-api/tests/`: 369 passed, 2 pre-existing CORS failures, likewise identical to `main`.
- `ruff check` clean, `ruff format` clean, mypy output identical to `main`'s on the changed files. `legacy_name_ratchet.py` "No new lines.", `do_not_touch_sentinel.py` all 35 strings survive, `tenant_scope_gate.py` exit 0.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
