### PR TITLE
test: scope caplog level filters to the logger under test

### DIFF
--- a/tests/test_consumer_enriched.py
+++ b/tests/test_consumer_enriched.py
@@ -30,6 +30,22 @@ from common.events.base import Event
 from common.events.topics import Topics
 from core_api import consumer
 
+
+def _consumer_errors(caplog) -> list[logging.LogRecord]:
+    """The ERROR records this module's tests are about.
+
+    ``caplog.records`` is the root handler's capture, so it holds records from
+    every logger that propagates — including background tasks unrelated to the
+    test. Filtering on level alone lets those through, which matters wherever a
+    test indexes or counts the result.
+    """
+    return [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.ERROR and r.name == consumer.logger.name
+    ]
+
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -366,8 +382,55 @@ async def test_embedded_handler_does_not_silently_absorb_a_missing_embedding(
     await consumer.handle_memory_embedded(_embedded_event(memory_id))
 
     mock_detect.assert_not_awaited()
-    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    # Scoped to the consumer's own logger. ``caplog.set_level(..., logger=...)``
+    # sets the level on that logger, but ``caplog.records`` is the root
+    # handler's capture — every logger that propagates — so an unrelated ERROR
+    # arriving mid-test would take slot [0] and this would assert against the
+    # wrong record. See the test below.
+    errors = _consumer_errors(caplog)
     assert errors, (
         f"expected an ERROR; got {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+    assert "embedding missing on read-back" in errors[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_the_missing_embedding_error_is_read_off_the_consumer_logger(
+    mock_storage_client, mock_detect, caplog
+) -> None:
+    """A foreign ERROR must not be mistaken for the consumer's.
+
+    The sibling above indexes ``[0]``, and its filter used to select on level
+    alone, so any unrelated ERROR captured during the test was read instead of
+    the consumer's. The real intruder was ``detect_contradictions_async``'s
+    ``logger.exception`` — fire-and-forget, so with a session-scoped event loop
+    its failure surfaces in whatever test happens to be running rather than the
+    one that scheduled it. That made the failure look like flakiness.
+
+    This stands in for the intruder deterministically instead of waiting for
+    the interleaving that produced it.
+    """
+    caplog.set_level(logging.WARNING, logger="core_api.consumer")
+    memory_id = uuid.uuid4()
+    mock_storage_client.get_memory.return_value = {
+        "id": str(memory_id),
+        "tenant_id": "tenant-A",
+        "fleet_id": None,
+        "content": "x",
+        "embedding": None,
+    }
+
+    # Lands ahead of the consumer's own record, exactly as a background task's
+    # would, and at a level the filter selects.
+    logging.getLogger("core_api.services.contradiction_detector").error(
+        "Async contradiction detection failed for memory %s", memory_id
+    )
+
+    await consumer.handle_memory_embedded(_embedded_event(memory_id))
+
+    errors = _consumer_errors(caplog)
+    assert len(errors) == 1, (
+        "expected only the consumer's own ERROR; got "
+        f"{[(r.name, r.getMessage()) for r in errors]}"
     )
     assert "embedding missing on read-back" in errors[0].getMessage()

--- a/tests/test_ranking_remote.py
+++ b/tests/test_ranking_remote.py
@@ -22,6 +22,20 @@ from common.ranking.protocols import RankProvider
 from common.ranking.providers.remote import RemoteRanker
 
 
+def _ranking_records(caplog, levelname: str) -> list:
+    """Records at ``levelname`` emitted by the ranking service itself.
+
+    ``caplog.records`` spans every propagating logger, so a level-only filter
+    also catches unrelated output. These tests count and negate the result, so
+    one foreign record is the difference between green and red.
+    """
+    return [
+        rec
+        for rec in caplog.records
+        if rec.levelname == levelname and rec.name == svc_mod.logger.name
+    ]
+
+
 def _cands(*contents):
     return [
         RankCandidate(id=str(i), content=c, similarity=0.5)
@@ -254,15 +268,43 @@ async def test_permanent_error_logs_once_then_debug_until_next_success(
     r = _client_with(handler)
     with caplog.at_level("DEBUG"):
         await _run_service(r, monkeypatch, attempts=1)
-        first = [rec for rec in caplog.records if rec.levelname == "ERROR"]
+        first = _ranking_records(caplog, "ERROR")
         assert len(first) == 1, "first occurrence reports in full"
 
         caplog.clear()
         await _run_service(r, monkeypatch, attempts=1)
-        assert not [rec for rec in caplog.records if rec.levelname == "ERROR"], (
+        assert not _ranking_records(caplog, "ERROR"), (
             "a repeat of the same condition must not ERROR again"
         )
-        assert [rec for rec in caplog.records if rec.levelname == "DEBUG"]
+        assert _ranking_records(caplog, "DEBUG")
+    await r._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_the_once_only_count_ignores_another_logger(monkeypatch, caplog):
+    """The dedup count must be the ranker's ERRORs, not the process's.
+
+    ``caplog.at_level("DEBUG")`` above lowers the level on the ROOT logger, so
+    the capture spans everything that propagates. "Reported exactly once" is a
+    count and "must not ERROR again" is an emptiness claim, and one unrelated
+    ERROR arriving mid-test is the difference between green and red for either.
+    Background tasks in this suite outlive the test that scheduled them, so
+    that record is not hypothetical — see the same failure mode fixed in
+    ``tests/test_consumer_enriched.py``.
+    """
+    import logging as _logging
+
+    handler, _ = _counting_handler(413, text="too big")
+    r = _client_with(handler)
+    with caplog.at_level("DEBUG"):
+        _logging.getLogger("core_api.services.contradiction_detector").error(
+            "Async contradiction detection failed for memory %s", "some-uuid"
+        )
+        await _run_service(r, monkeypatch, attempts=1)
+        assert len(_ranking_records(caplog, "ERROR")) == 1, (
+            "the count must exclude loggers this test is not about; got "
+            f"{[(rec.name, rec.getMessage()[:60]) for rec in caplog.records if rec.levelname == 'ERROR']}"
+        )
     await r._client.aclose()
 
 


### PR DESCRIPTION
The fix for the CI failure diagnosed on [#1349](https://github.com/caura-ai/caura/pull/1349#issuecomment-5570256412), sent separately since it has nothing to do with that rename.

`test_embedded_handler_does_not_silently_absorb_a_missing_embedding` turned CI red on a PR that touched neither the consumer nor contradiction detection. It wasn't flaky in the sense of *unlucky* — **it was reading the wrong log record.**

```
assert 'embedding missing on read-back' in 'Async contradiction detection failed for memory 93963fce…'
```

## The mechanism

`caplog.set_level(..., logger="core_api.consumer")` sets the level **on that logger**. `caplog.records` is the root handler's capture — every logger that propagates. The assertion filtered on level alone and then indexed `[0]`, so any unrelated ERROR captured during the test was read instead.

The intruder is `contradiction_detector.py`'s `logger.exception` inside `detect_contradictions_async`'s broad `except Exception`. Fire-and-forget, so with `asyncio_default_test_loop_scope=session` its failure surfaces in whatever test is running when the task completes — not the one that scheduled it. That's why re-running went green and why the test looked unstable rather than wrong.

## A second site, with a wider exposure

`test_permanent_error_logs_once_then_debug_until_next_success` in `tests/test_ranking_remote.py` has the same defect and less margin: `caplog.at_level("DEBUG")` takes no logger argument, so it lowers the level on the **root** logger, and the test then asserts `len(first) == 1` and `assert not [...]`. One foreign ERROR is the difference between green and red for either.

## The fix

Both files filter by logger name through a small per-file helper, taking the name off the module under test — `consumer.logger.name`, `svc_mod.logger.name` — rather than a string literal, so a module rename fails loudly instead of silently emptying the filter.

## Teeth

Each fix has a test that fails without it, standing in for the intruder deterministically instead of waiting for the interleaving that produced it. Removing just the `.name ==` predicate fails **exactly one test per file, the new one**, with the foreign record shown ahead of the real one:

```
tests/test_consumer_enriched.py: 1 failed, 10 passed
  expected only the consumer's own ERROR; got
  [('core_api.services.contradiction_detector', 'Async contradiction detection failed…'),
   ('core_api.consumer', 'memory-embedded: embedding missing on read-back; ack-dropping')]

tests/test_ranking_remote.py: 1 failed, 23 passed
  the count must exclude loggers this test is not about; got
  [('core_api.services.contradiction_detector', …), ('common.ranking._service', …)]
```

Worth noting: my first version of the ranking change had **no** teeth — with the predicate removed, all 23 tests still passed, because in a single-file run no foreign record happens to land. The hardening was correct but unproven, so I added the deterministic intruder there too rather than ship an assertion nothing exercises.

## Blast radius, surveyed rather than guessed

Fifteen comprehensions across seven files filter `caplog.records` by level with no logger check. They are not equally broken, and the difference is what the test does with the result:

| | sites | |
| --- | --- | --- |
| **fixed here** | 4 | `consumer_enriched:369`, `ranking_remote:257`, `:262`, `:265` |
| **unharmed** | 8 | match on message content — `any("text" in r.getMessage() …)` — which a foreign record cannot satisfy. Weaker than they could be, never red. |
| **can pass vacuously** | 2 | `d7_parallel_embed:213`, `:244` assert a level-only list is non-empty, so a foreign WARNING satisfies them. Wrong pass, never a wrong failure. |
| **can go red, not mechanical** | 1 | see below |

**`test_h09_autochunk_embed_degrade.py:390`** asserts `errors == []` over a level-only filter, so it is breakable exactly the same way. I did **not** fix it: scoping it means deciding which module's ERRORs the absence claim covers, and the test doesn't say. Narrowing to `memory_service` would drop an ERROR raised from the storage client, which is arguably inside "a duplicate refusal must not raise ERRORs". That is a judgement about intent, not a mechanical fix, so it's flagged rather than guessed at.

## Verification

- **6255 passed, 0 failed** (2 of those are the new tests).
- `ruff check` and `ruff format --check` clean on `tests/`.
- Legacy-name ratchet and do-not-touch sentinel green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
