### PR TITLE
test: drain a test's background tasks before the next one starts

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ PostgreSQL instance with pgvector — configure via TEST_DATABASE_URL env var
 or the defaults below.
 """
 
+import asyncio
 import os
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -330,6 +331,62 @@ async def _patch_storage_client(_engine, _setup_schema):
         yield
     finally:
         sc_mod._client = old_client
+
+
+# How long a leaked task gets to finish on its own before it is cancelled.
+# Small on purpose: this is a courtesy to work that is nearly done, not a
+# promise that background work completes.
+_DRAIN_GRACE_SECONDS = 0.25
+
+
+@pytest.fixture(autouse=True)
+async def _drain_background_tasks(_patch_storage_client):
+    """Stop one test's fire-and-forget work from running during a later test.
+
+    ``track_task`` registers every background task in
+    ``core_api.tasks._background_tasks`` and nothing awaits them, while
+    ``asyncio_default_test_loop_scope = session`` keeps one loop for the whole
+    run — so a task scheduled by one test keeps running through the tests that
+    follow it. Measured on this suite before this fixture existed: 207 distinct
+    tasks outlived the test that created them, and one of them was still
+    pending 746 tests later.
+
+    The damage is not theoretical:
+
+    * Log records land in a later test's ``caplog``. #1349 went red exactly
+      this way, and #1352 and #1353 had to teach four assertions to ignore
+      records they never emitted.
+    * ``tracked_task``'s failure path calls ``get_storage_client()``. Fire
+      that after ``_patch_storage_client`` has restored the original client
+      and it memoises a REAL client into the module singleton, pointed at a
+      storage server no test is running — which every later test then pays
+      for in connection errors and retries.
+
+    The dependency on ``_patch_storage_client`` is for ORDERING, not for a
+    value: it makes this fixture set up second and therefore tear down FIRST,
+    so tasks drained here still see the in-process ASGI bridge instead of
+    reaching for a real client.
+
+    Grace, then cancel — 2 of those 207 tasks never finished at all, so an
+    unconditional await would hang the run. A test that needs its background
+    work to complete must await it itself; this promises isolation, not
+    completion.
+    """
+    yield
+
+    from core_api.tasks import _background_tasks
+
+    pending = [task for task in _background_tasks if not task.done()]
+    if not pending:
+        return
+
+    _, still_running = await asyncio.wait(pending, timeout=_DRAIN_GRACE_SECONDS)
+    for task in still_running:
+        task.cancel()
+    if still_running:
+        # ``return_exceptions`` so a task that fails, or refuses to die
+        # politely, cannot turn an unrelated test's teardown into an error.
+        await asyncio.gather(*still_running, return_exceptions=True)
 
 
 @pytest.fixture

--- a/tests/test_background_task_isolation.py
+++ b/tests/test_background_task_isolation.py
@@ -1,0 +1,77 @@
+"""One test's fire-and-forget work must not be running during the next one.
+
+``track_task`` registers background tasks in ``core_api.tasks._background_tasks``
+and nothing awaits them, while ``asyncio_default_test_loop_scope = session``
+keeps a single loop for the whole run. Without the ``_drain_background_tasks``
+fixture in ``conftest.py``, a task scheduled by one test keeps running through
+the tests that follow it. Measured on this suite with the fixture disabled:
+2683 tests started with an earlier test's tasks still running.
+
+What that costs, concretely:
+
+* A leaked task's log records land in a later test's ``caplog``. #1349 went red
+  that way, and #1352 and #1353 had to teach four assertions to ignore records
+  they never emitted.
+* ``tracked_task``'s failure path calls ``get_storage_client()``. Firing after
+  ``_patch_storage_client`` restores the original client memoises a REAL client
+  into the module singleton, pointed at a storage server no test runs.
+
+THESE TWO TESTS ARE ORDER-DEPENDENT, deliberately and unavoidably: the property
+under test is "the previous test's work is not still running", which cannot be
+expressed inside a single test. The first schedules work that never finishes on
+its own; the second asserts the drain ended it. Keep them adjacent and in this
+order. (The suite installs no order-randomising plugin — only pytest-cov,
+pytest-asyncio and anyio.)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+
+async def test_schedule_a_task_that_outlives_this_test() -> None:
+    """Leaks a task on purpose, so the next test can prove it was stopped.
+
+    It waits on an ``Event`` nothing sets, so it cannot finish by itself and
+    cannot pass the next test by luck or timing — only cancellation ends it.
+    That mirrors the real leak: 2 of the 207 tasks measured outliving their
+    test never finished at all, which is why the drain cancels rather than
+    waiting.
+    """
+    from core_api.tasks import _background_tasks, track_task
+
+    never_set = asyncio.Event()
+
+    async def _waits_forever() -> None:
+        await never_set.wait()
+
+    task = track_task(_waits_forever())
+
+    # Precondition: the leak this file is about actually exists right now.
+    # Without it, the assertion in the next test could pass because nothing
+    # was ever scheduled.
+    assert not task.done(), "the task finished immediately; it cannot leak"
+    assert task in _background_tasks, (
+        "track_task did not register the task, so the drain will never see it"
+    )
+
+
+async def test_the_previous_tests_task_is_no_longer_running() -> None:
+    """The drain must have ended it before this test began.
+
+    Fails without ``_drain_background_tasks``: the task above waits on an
+    Event nobody sets, so it is still pending here and stays pending for the
+    rest of the run.
+    """
+    from core_api.tasks import _background_tasks
+
+    still_running = [task for task in _background_tasks if not task.done()]
+    assert still_running == [], (
+        "a task scheduled by an earlier test is still running during this one; "
+        "its log records, storage calls and failures will be attributed here: "
+        f"{[repr(task) for task in still_running]}"
+    )


### PR DESCRIPTION
The root cause behind [#1349](https://github.com/caura-ai/caura/pull/1349)'s red build, and behind the four assertions [#1352](https://github.com/caura-ai/caura/pull/1352) and [#1353](https://github.com/caura-ai/caura/pull/1353) had to teach to ignore log records they never emitted.

`track_task` registers every background task in `core_api.tasks._background_tasks` and nothing awaits them, while `asyncio_default_test_loop_scope = session` keeps one event loop for the whole run. So a task scheduled by one test keeps running through the tests that follow it.

## Measured, not assumed

| | |
| --- | --- |
| tests starting with an earlier test's tasks running | **2683** of 6255 |
| inherited-task observations (worst single test: 9) | 6860 |
| distinct tasks outliving the test that created them | 207 |
| tests survived by the longest-lived one | **746** |
| tasks that never finished at all | 2 |

My first probe reported 5947 pending tasks, which was wrong — it counted the global set at every teardown, so one lingering task was re-counted by every later test. The giveaway was `test_cap_is_below_asyncpg_safe_window`, a pure constant assertion, showing 8 pending tasks: they were never its own. Tracking task identity gave the real number, 207.

Every leaked coroutine observed arrived through `track_task` — `tracked_task` (2277 tests) and `_track_recalls_background` (22) — so the production set is a complete handle on them.

## What it costs today

- **Log records land in a later test's `caplog`.** Exactly how #1349 went red on a rename that touched none of the code involved.
- **`tracked_task`'s failure path calls `get_storage_client()`.** Fire that after `_patch_storage_client` restores the original client and it memoises a *real* client into the module singleton, aimed at a storage server no test runs — every later test then pays in connection errors and retries.

## The fix

A short grace period for work that is nearly done, then cancel.

**It cancels rather than waits because 2 of the 207 never finish** — an unconditional await would hang the run. That is also why the existing hand-rolled drain in `tests/test_governance_bulk_inline_remediation.py` is left exactly as it is: it awaits without a timeout *inside the test body* because that test wants completion, and this fixture promises isolation, not completion.

**The dependency on `_patch_storage_client` is for ordering, not for a value.** It makes the drain set up second and therefore tear down *first*, so drained tasks still see the in-process ASGI bridge rather than reaching for a real client. Verified rather than asserted: at drain time `sc_mod._client` is still a `CoreStorageClient`, not `NoneType`, which is what a reversed order would show.

**The loop scope is deliberately untouched.** Function-scoped loops would isolate tasks completely, but session-scoped fixtures are bound to the session loop — a far larger change than this.

## Result

**2683 → 4** tests start with a foreign task running; 6860 → 6 observations; worst case 9 → 2.

The residue is structural, not a missed case: the drain can only catch what exists when its turn in finalisation comes, so anything scheduled later in the chain escapes by construction. All 4 are in `tests/test_bulk_write_mode.py` and deserve their own look.

## Teeth

`tests/test_background_task_isolation.py` is an **ordered pair**, because "the previous test's work is not still running" cannot be asserted inside a single test. The first schedules a task waiting on an `Event` nothing sets — so only cancellation can end it, and no timing luck can pass the second test. It also asserts its own preconditions, so it cannot silently stop leaking.

With the fixture switched off, **exactly one test fails — the second** — naming the pending task:

```
AssertionError: a task scheduled by an earlier test is still running during this one;
its log records, storage calls and failures will be attributed here:
["<Task pending name='Task-6' coro=<test_...>"]
```

The order dependence is documented in the module docstring, along with the fact that the suite installs no order-randomising plugin (only pytest-cov, pytest-asyncio and anyio).

## Cost

**None measurable.** 6257 passed in 155.65s, against 153.17s for the same suite without the fixture — inside run-to-run noise.

## Verification

- **6257 passed, 0 failed** (2 new tests).
- `ruff check` and `ruff format --check` clean on `tests/`.
- Legacy-name ratchet and do-not-touch sentinel green.

## Not covered

Task creators that bypass `track_task` — `storage_client.py:357`, `providers/inprocess_queue.py:32`, `routes/interview.py:204`, and the audit/usage/capability flusher loops — are not in `_background_tasks` and so are not drained. None showed up in the measurement, so this is a statement of scope rather than a known gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
