### PR TITLE
test: cancel a test's leaked tasks outright instead of waiting first

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,12 +333,6 @@ async def _patch_storage_client(_engine, _setup_schema):
         sc_mod._client = old_client
 
 
-# How long a leaked task gets to finish on its own before it is cancelled.
-# Small on purpose: this is a courtesy to work that is nearly done, not a
-# promise that background work completes.
-_DRAIN_GRACE_SECONDS = 0.25
-
-
 @pytest.fixture(autouse=True)
 async def _drain_background_tasks(_patch_storage_client):
     """Stop one test's fire-and-forget work from running during a later test.
@@ -367,10 +361,14 @@ async def _drain_background_tasks(_patch_storage_client):
     so tasks drained here still see the in-process ASGI bridge instead of
     reaching for a real client.
 
-    Grace, then cancel — 2 of those 207 tasks never finished at all, so an
-    unconditional await would hang the run. A test that needs its background
-    work to complete must await it itself; this promises isolation, not
-    completion.
+    Cancelled outright, with no grace period. Waiting was never an option —
+    2 of those 207 tasks never finished at all, so an unconditional await
+    hangs the run — and a bounded wait was worse than either: it spends real
+    time to make completion *likely* for whichever tasks happen to be nearly
+    done, which is a race dressed up as a courtesy. A test that needs its
+    background work to complete must await it itself, as
+    ``test_governance_bulk_inline_remediation`` does. This fixture promises
+    isolation, not completion.
     """
     yield
 
@@ -380,13 +378,13 @@ async def _drain_background_tasks(_patch_storage_client):
     if not pending:
         return
 
-    _, still_running = await asyncio.wait(pending, timeout=_DRAIN_GRACE_SECONDS)
-    for task in still_running:
+    for task in pending:
         task.cancel()
-    if still_running:
-        # ``return_exceptions`` so a task that fails, or refuses to die
-        # politely, cannot turn an unrelated test's teardown into an error.
-        await asyncio.gather(*still_running, return_exceptions=True)
+    # Awaited so cancellation has actually landed before the next test starts;
+    # ``Task.cancel()`` only requests it. ``return_exceptions`` so a task that
+    # fails, or refuses to die politely, cannot turn an unrelated test's
+    # teardown into an error.
+    await asyncio.gather(*pending, return_exceptions=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
Drops the 0.25s grace period from `_drain_background_tasks`, as requested on [#1354](https://github.com/caura-ai/caura/pull/1354).

Not just the constant: at `timeout=0` the two-phase `asyncio.wait` is a no-op that still *reads* as though it does something, so the machinery goes with the number.

```diff
-    _, still_running = await asyncio.wait(pending, timeout=_DRAIN_GRACE_SECONDS)
-    for task in still_running:
+    for task in pending:
         task.cancel()
-    if still_running:
-        await asyncio.gather(*still_running, return_exceptions=True)
+    await asyncio.gather(*pending, return_exceptions=True)
```

## This corrects #1354

#1354's body explained the 4 tests still starting with a foreign task as **structural** — *"anything scheduled later in the finalisation chain escapes by construction"*. That was wrong. Cancel-only takes it to zero, which a structural limit could not.

| | inherited-task observations |
| --- | --- |
| no drain at all | 6860 |
| drain + 0.25s grace | 6 |
| **cancel outright** | **0** |

**The real mechanism, verified rather than guessed.** `process_entity_extraction` is scheduled as a background task, and at `entity_extraction_worker.py:769` it calls `track_task` *again* to enqueue contradiction detection. During the grace, an extraction task could finish and schedule a **successor** — a task created after the drain had already taken its `pending` snapshot, and so never cancelled.

The grace period was manufacturing the leak it was meant to be a courtesy for. Cancelling first closes the window, because a cancelled task never runs far enough to schedule anything.

## Cancelling is also quieter than waiting

`CancelledError` derives from `BaseException`, and `tracked_task` catches `Exception` — so cancellation does **not** run its failure path. No "Background task failed" logs, no `add_task_failure` write, nothing hitting storage during teardown. A bounded wait runs exactly those paths for whichever tasks happen to fail inside the window, which is the opposite of what a teardown should be doing.

The `gather` stays: `Task.cancel()` only *requests* cancellation, so it has to be awaited for the cancellation to have landed before the next test begins.

## Verification

- **6258 passed, 0 failed** — reconciling exactly: 6255 at #1352's base, +1 from #1353, +2 from #1354.
- **0** tests start with another test's tasks running, measured with the same probe as before.
- The isolation pair still has teeth — with the fixture off, exactly one test fails, the second. Its task waits on an `Event` nothing sets, so cancel-only still ends it and no timing can pass it by luck.
- `ruff check` and `ruff format --check` clean on `tests/`; legacy-name ratchet and do-not-touch sentinel green.
- No measurable change in suite time, which has ranged 151–160s across these runs either way. I am not claiming a speedup.

## Still true from #1354

Creators that bypass `track_task` are not drained, and the ordering dependency on `_patch_storage_client` remains load-bearing and unguarded — a reviewer "tidying up the unused argument" would silently reintroduce the storage-singleton poisoning. Both were flagged there and neither changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
