### PR TITLE
test: guard the drain's ordering, and stop the pub/sub pull loop leaking

### DIFF
--- a/tests/test_background_task_isolation.py
+++ b/tests/test_background_task_isolation.py
@@ -75,3 +75,65 @@ async def test_the_previous_tests_task_is_no_longer_running() -> None:
         "its log records, storage calls and failures will be attributed here: "
         f"{[repr(task) for task in still_running]}"
     )
+
+
+# What the drained task saw, handed from the test below to the one after it.
+_client_at_drain: dict[str, object] = {}
+
+
+async def test_schedule_a_task_that_records_the_client_it_is_drained_with() -> None:
+    """Sets up the ordering check; the assertion is in the next test.
+
+    ``_drain_background_tasks`` takes ``_patch_storage_client`` as a parameter
+    it never reads, purely so it is set up second and therefore torn down
+    FIRST. That is what keeps the in-process ASGI bridge installed while
+    leaked tasks are being drained. Remove the parameter and the order
+    inverts — measured: the client at drain time becomes ``None`` instead of
+    the bridge — and a drained task reaching for storage then memoises a REAL
+    client into the module singleton, aimed at a server no test runs.
+
+    Nothing about the fixture's own text would catch that, which is why this
+    watches behaviour instead: the task records what was installed at the
+    moment it was cancelled.
+    """
+    import core_api.clients.storage_client as sc_mod
+    from core_api.tasks import track_task
+
+    _client_at_drain.clear()
+    _client_at_drain["during_test"] = sc_mod._client
+
+    never_set = asyncio.Event()
+
+    async def _records_what_it_is_drained_with() -> None:
+        try:
+            await never_set.wait()
+        finally:
+            # Runs while the drain's ``gather`` awaits this cancellation, so
+            # it observes exactly what a real leaked task would.
+            _client_at_drain["during_drain"] = sc_mod._client
+
+    track_task(_records_what_it_is_drained_with())
+
+    assert _client_at_drain["during_test"] is not None, (
+        "the storage bridge was not installed during the test itself, so this "
+        "check cannot say anything about teardown order"
+    )
+
+
+async def test_the_drain_ran_before_the_storage_bridge_was_removed() -> None:
+    """The drain must see the bridge, not the restored original.
+
+    Fails if ``_drain_background_tasks`` loses its ``_patch_storage_client``
+    parameter: the fixtures then tear down in the other order and the value
+    recorded above is ``None``.
+    """
+    assert "during_drain" in _client_at_drain, (
+        "the task's finally never ran, so it was not drained at all — this "
+        "check proves nothing until that works"
+    )
+    assert _client_at_drain["during_drain"] is _client_at_drain["during_test"], (
+        "the drain ran AFTER _patch_storage_client restored the original "
+        "client, so a leaked task reaching for storage would memoise a real "
+        "client into the singleton: saw "
+        f"{_client_at_drain['during_drain']!r}"
+    )

--- a/tests/test_events/test_pubsub_bus.py
+++ b/tests/test_events/test_pubsub_bus.py
@@ -1925,6 +1925,15 @@ async def test_start_survives_an_unreadable_instance_token(
     assert len(bus._broadcast_slot_id) == 12  # the random fallback, not a slot
     bus._stopping = True  # keep teardown of the fake client quiet
 
+    # ``start()`` above launched the pull loop, and this test used to end
+    # without stopping it: the task then ran for the remaining 652 tests in
+    # the session, on the shared session-scoped loop. Every other test here
+    # that starts the bus already calls ``stop()``; this one was the outlier.
+    # The assertion is what keeps it that way — dropping the ``stop()`` leaves
+    # ``_pull_tasks`` populated.
+    await bus.stop()
+    assert bus._pull_tasks == []
+
 
 def test_identity_survives_an_unexpected_error_in_the_claim(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes the two items left open on [#1354](https://github.com/caura-ai/caura/pull/1354). One is a real defect, the other mostly a non-finding — and the difference only appeared under measurement.

## 1. A guard for the ordering dependency

`_drain_background_tasks` takes `_patch_storage_client` as a parameter it never reads, purely so it is set up second and torn down **first**, keeping the in-process ASGI bridge installed while leaked tasks are drained. Nothing caught its removal, and "unused argument" is exactly what a tidy-up deletes.

**It is load-bearing — measured, not claimed:**

| variant | `sc_mod._client` at drain time |
| --- | --- |
| parameter present | `CoreStorageClient` — drain runs before the restore |
| parameter removed | `NoneType` — drain runs after it |

I had assumed definition order alone would hold it, since `_patch_storage_client` sits above it in the file. That was wrong; removing the parameter really does invert the order, and a drained task reaching for storage then memoises a *real* client into the module singleton, aimed at a server no test runs.

The new pair watches **behaviour, not the fixture's text**: a task records what was installed at the moment it was cancelled, and the next test asserts it saw the bridge. Drop the parameter and exactly one test fails.

## 2. The untracked `create_task` sites are mostly not a gap

#1354 listed six `asyncio.create_task` sites outside `core_api.tasks._background_tasks` as uncovered. That was factually true and misleading as a gap. Measuring **every** task on the loop rather than only the tracked set:

| | before | after |
| --- | --- | --- |
| tests ending with an untracked task alive | 796 | 185 |
| observations | 921 | 289 |
| worst single survivor | **652 tests** | 18 tests |

**The worst one was none of the six.** It was `PubSubEventBus._pull_loop`: `test_start_survives_an_unreadable_instance_token` calls `start()` and never stops the bus, so the loop ran for the rest of the session on the shared session-scoped loop. Every other test in that file that starts the bus already calls `stop()` — this one was the outlier. Fixed, with the assertion that keeps it fixed. That one task accounted for 652 of the 921 observations, which is what the drop is.

**Of the rest, 175+ are httpx request tasks from `storage_client.py:357`, and draining them would be wrong.** They are deliberately shielded so a cancelled caller cannot strand a pooled connection — the documented cause of incident 2026-06-16, where leaked slots accumulated until `max_connections=200` was hit and every acquire `PoolTimeout`ed. Their entire purpose is to outlive the caller. Cancelling them at teardown would make the test environment diverge from production in precisely the dimension that code exists to protect.

`storage_client.py:403`, `common/events/inprocess.py`, and the ranking and embedding registries each keep their own tracking set with a done-callback, so they are managed locally rather than unmanaged. About 20 `AsyncSession.close` tasks I did **not** trace to a site in this repo — they are short-lived and none appear among the longest survivors, but I am not claiming they are benign on that basis alone.

A note on reading the figures: distinct-task counts move run to run with in-flight request timing (188 before, 202 after, on a suite that also gained 2 tests), so the meaningful numbers are the observation count and the maximum survival, both of which are dominated by the one deterministic leak.

## Verification

- **6260 passed, 0 failed** (2 new guard tests).
- **Both fixes fail without themselves**, one test each: removing the parameter fails the ordering guard; removing the `stop()` call fails the cleanup assertion.
- `ruff check` and `ruff format --check` clean on `tests/`; legacy-name ratchet and do-not-touch sentinel green.

## What this does not do

It does not make the drain a general "no background work escapes" guarantee, and after this measurement I would argue it shouldn't be one: the largest population of untracked tasks is supposed to outlive its test. The invariant worth holding is the one the drain already holds — no *tracked* fire-and-forget work runs into the next test — plus tests cleaning up the long-lived things they start, which is what the pub/sub fix is.

## A hazard I walked into, recorded because the next person will

**Do not run `ruff format` on `tests/test_events/test_pubsub_bus.py`.**

`tests/ruff.toml` lists it under `[format] exclude`, annotated *"markers: 2 — the pinned wire event_type in a dict literal"*. Formatting wraps that literal across lines and detaches the trailing `legacy-name-ok:` marker from it, so the ratchet reports both a new unexempted legacy name and a removed exemption — and fails.

**Naming a file explicitly on the ruff command line bypasses `exclude`.** So `ruff format <that file>` does exactly the damage the exclusion exists to prevent, while `ruff format tests/` reports the tree clean:

| invocation | verdict on the same unmodified file |
| --- | --- |
| `ruff format --check tests/` | 399 files already formatted |
| `ruff format --check tests/test_events/test_pubsub_bus.py` | would reformat |

I initially misread that as a ruff version difference (local 0.15.9 vs the repo's pinned v0.15.4). It is not — same binary, same file, two answers, because one invocation discovers the exclusion and the other overrides it. The first push of this branch carried five unrelated reformatting hunks and a failing ratchet; it has been amended to 71 insertions and 0 deletions, and the note above is now in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
