### PR TITLE
CAURA-722 feat(diagnostic): report why entity retrieval stayed out of…

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -1514,6 +1514,24 @@
             "title": "Candidates Considered",
             "type": "integer"
           },
+          "entity_match_declined": {
+            "default": false,
+            "description": "True when the entity match was refused as over-broad (> ENTITY_LOOKUP_MAX_MATCHES). This is the only decline that also suppresses the per-row entity boost; an under-filled pool falls through with the boost still applied and reports False here.",
+            "title": "Entity Match Declined",
+            "type": "boolean"
+          },
+          "entity_matches": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Entities the query's tokens matched in entity FTS, counted before the over-broad decline empties the set. None means the lookup never ran (entity retrieval off, no entity-shaped tokens, or a swallowed failure) — distinct from 0, which means it ran and matched nothing.",
+            "title": "Entity Matches"
+          },
           "excluded_below_min_similarity": {
             "default": 0,
             "title": "Excluded Below Min Similarity",

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1138,6 +1138,14 @@ async def caura_recall(
                     for k, v in (diagnostic_ctx.get("search_params", {}) or {}).items()
                 },
                 "all_candidates": diagnostic_ctx.get("all_candidates", []) or [],
+                # CAURA-722 — kept in step with the REST ``SearchDiagnostic``,
+                # which is where these are documented. MCP matters more than
+                # parity-for-its-own-sake here: ``caura_recall`` has no
+                # ``top_k`` cap, so it is the path an investigation reaches for
+                # once REST's limit binds, and the entity question is exactly
+                # the kind that gets probed there.
+                "entity_matches": diagnostic_ctx.get("entity_matches"),
+                "entity_match_declined": diagnostic_ctx.get("entity_match_declined", False),
             }
         if payload["truncated"]:
             # Kept alongside the structured fields above, not replaced by them:

--- a/core-api/src/core_api/openapi_responses.py
+++ b/core-api/src/core_api/openapi_responses.py
@@ -93,6 +93,10 @@ class RecallDiagnostic(BaseModel):
     top_k_used: int | None
     retrieval_strategy: str | None
     search_params: dict
+    # CAURA-722 — documented on ``SearchDiagnostic``. ``None`` on the count
+    # means entity FTS never ran, which is a different answer from ``0``.
+    entity_matches: int | None = None
+    entity_match_declined: bool = False
 
 
 class RecallResponse(BaseModel):

--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -97,6 +97,19 @@ class ClassifyQuery:
                 sc = get_storage_client()
                 matched_ids = await self._entity_fts(sc, tokens, tenant_id, fleet_ids)
 
+                # CAURA-722 — record the count HERE, before the over-broad
+                # branch below empties ``matched_ids``. Reading it later would
+                # report 0 for the decline, which is the one value that must
+                # not be confused with "FTS matched nothing" — those two send
+                # the follow-up work to different teams (threshold tuning vs
+                # entity extraction/linking).
+                #
+                # Set unconditionally rather than under ``if diagnostic``: it
+                # is one ``len()``, and gating it would put a second
+                # diagnostic-only branch in a hot path for no measurable gain.
+                # Exposure stays gated at the route.
+                ctx.data["entity_matches"] = len(matched_ids)
+
                 # CAURA-698: over-broad match → not a "name a specific entity"
                 # query. The precision argument for entity_lookup breaks down
                 # at high match counts: graph expansion + memory linking

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -2003,6 +2003,10 @@ async def _search_inner(
                 for k, v in (diagnostic_ctx.get("search_params", {}) or {}).items()
             },
             all_candidates=diagnostic_ctx.get("all_candidates", []) or [],
+            # CAURA-722 — no `or` fallback on the count: `0` is a real,
+            # different answer from `None` here (see SearchDiagnostic).
+            entity_matches=diagnostic_ctx.get("entity_matches"),
+            entity_match_declined=diagnostic_ctx.get("entity_match_declined", False),
         ),
     )
 

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -616,7 +616,72 @@ class SearchDiagnostic(BaseModel):
     search_params: dict = {}
     # One entry per widened candidate: id/title/type/status + score + factors +
     # ``excluded`` (None | "below_min_similarity" | "trimmed_by_top_k").
+    #
+    #
+    # KNOWN GAP (CAURA-722, not fixed here): five of these factors —
+    # ``entity_boost``, ``freshness``, ``recall_boost``, ``temporal_boost``,
+    # ``fts_score`` — are ``None`` on every row of the scored-search path.
+    # Storage computes them in the scored CTE, uses them to build ``score``,
+    # and then omits them from the outer ``select()``, so the route never
+    # serializes them (``postgres_service.memory_scored_search``). Only
+    # ``score``, ``vec_sim``, ``fts_match`` and ``status_penalty`` are real
+    # today. Do not read a null factor as "this signal did not apply" — it
+    # applied to ``score`` and was simply not reported.
+    #
+    # This matters most for ``entity_boost``, because it is the ONLY place the
+    # entity *boost* is observable. ``retrieval_strategy`` reports only the
+    # ENTITY_LOOKUP *short-circuit*, which fires solely when the entity-linked
+    # pool fills ``top_k`` unaided — so a run that reads the strategy alone and
+    # concludes "entity retrieval contributed nothing" has measured the
+    # short-circuit, not the subsystem, and the field that would settle it is
+    # currently null.
     all_candidates: list[dict] = []
+    # CAURA-722 — the two facts that separate the reasons entity retrieval
+    # stayed out of a query. Before these, ``retrieval_strategy`` said only
+    # that it was not ENTITY_LOOKUP, and the three causes below were
+    # indistinguishable from outside the server; they belong to different
+    # owners, so the ambiguity blocked the follow-up.
+    #
+    #   entity_matches | declined | meaning
+    #   ---------------|----------|----------------------------------------
+    #   None           |  false   | entity FTS never ran — retrieval disabled
+    #                  |          | by org setting, no entity-shaped tokens in
+    #                  |          | the query, or the lookup raised and was
+    #                  |          | swallowed
+    #   0              |  false   | FTS ran and matched nothing → extraction /
+    #                  |          | linking question
+    #   > MAX_MATCHES  |  TRUE    | over-broad, declined by CAURA-698 → the
+    #                  |          | entity boost is SUPPRESSED for this query,
+    #                  |          | so entity really did contribute nothing
+    #   1..MAX_MATCHES |  false   | matched; if the strategy is not
+    #                  |          | ENTITY_LOOKUP the pool under-filled top_k
+    #                  |          | and the boost WAS still applied
+    #
+    # The last two rows are the pair worth the field: they have opposite
+    # answers to "did the entity signal affect this result?" and looked
+    # identical before.
+    #
+    # ``None`` vs ``0`` is load-bearing — "never asked" against "asked, got
+    # nothing" — so this is deliberately nullable rather than defaulting to 0.
+    entity_matches: int | None = Field(
+        default=None,
+        description=(
+            "Entities the query's tokens matched in entity FTS, counted "
+            "before the over-broad decline empties the set. None means the "
+            "lookup never ran (entity retrieval off, no entity-shaped tokens, "
+            "or a swallowed failure) — distinct from 0, which means it ran and "
+            "matched nothing."
+        ),
+    )
+    entity_match_declined: bool = Field(
+        default=False,
+        description=(
+            "True when the entity match was refused as over-broad "
+            "(> ENTITY_LOOKUP_MAX_MATCHES). This is the only decline that also "
+            "suppresses the per-row entity boost; an under-filled pool falls "
+            "through with the boost still applied and reports False here."
+        ),
+    )
 
 
 class ConflictOut(BaseModel):

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -4572,6 +4572,11 @@ async def _search_memories_pipeline(
         diagnostic_ctx["counts"] = ctx.data.get("diagnostic_counts", {})
         sp_applied = ctx.data.get("search_params") or {}
         diagnostic_ctx["min_similarity_applied"] = sp_applied.get("min_similarity")
+        # CAURA-722 — why entity retrieval stayed out of this query.
+        # ``.get`` with no default for the count: absent means the FTS never
+        # ran, and that must survive as None rather than collapsing to 0.
+        diagnostic_ctx["entity_matches"] = ctx.data.get("entity_matches")
+        diagnostic_ctx["entity_match_declined"] = bool(ctx.data.get("entity_match_declined"))
 
     if recall_ctx is not None:
         # Written by TrackRecalls on every path it takes. Defaulting to False

--- a/core-api/src/core_api/services/recall_service.py
+++ b/core-api/src/core_api/services/recall_service.py
@@ -185,6 +185,14 @@ async def summarize_memories(
                 "all_candidates": diagnostic_ctx.get("all_candidates", []),
                 "top_k_used": top_k,
                 "retrieval_strategy": diagnostic_ctx.get("retrieval_strategy"),
+                # CAURA-722 — this block already reports
+                # ``retrieval_strategy``, which is the field that reads as
+                # "entity retrieval did nothing" whenever the ENTITY_LOOKUP
+                # short-circuit did not fire. Surfacing these two beside it is
+                # what makes that reading falsifiable. Documented on
+                # ``SearchDiagnostic``; same ``diagnostic_ctx`` keys.
+                "entity_matches": diagnostic_ctx.get("entity_matches"),
+                "entity_match_declined": diagnostic_ctx.get("entity_match_declined", False),
                 "search_params": {
                     k: (float(v) if isinstance(v, (int, float)) else v)
                     for k, v in diagnostic_ctx.get("search_params", {}).items()
@@ -227,6 +235,14 @@ async def summarize_memories(
                 "all_candidates": diagnostic_ctx.get("all_candidates", []),
                 "top_k_used": top_k,
                 "retrieval_strategy": diagnostic_ctx.get("retrieval_strategy"),
+                # CAURA-722 — this block already reports
+                # ``retrieval_strategy``, which is the field that reads as
+                # "entity retrieval did nothing" whenever the ENTITY_LOOKUP
+                # short-circuit did not fire. Surfacing these two beside it is
+                # what makes that reading falsifiable. Documented on
+                # ``SearchDiagnostic``; same ``diagnostic_ctx`` keys.
+                "entity_matches": diagnostic_ctx.get("entity_matches"),
+                "entity_match_declined": diagnostic_ctx.get("entity_match_declined", False),
                 "search_params": {
                     k: (float(v) if isinstance(v, (int, float)) else v)
                     for k, v in diagnostic_ctx.get("search_params", {}).items()
@@ -322,6 +338,9 @@ async def summarize_memories(
             "all_candidates": diagnostic_ctx.get("all_candidates", []),
             "top_k_used": top_k,
             "retrieval_strategy": diagnostic_ctx.get("retrieval_strategy"),
+            # CAURA-722 — see SearchDiagnostic for what the pair means.
+            "entity_matches": diagnostic_ctx.get("entity_matches"),
+            "entity_match_declined": diagnostic_ctx.get("entity_match_declined", False),
             "search_params": {
                 k: (float(v) if isinstance(v, (int, float)) else v)
                 for k, v in diagnostic_ctx.get("search_params", {}).items()

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -236,6 +236,19 @@ async def scored_search(request: Request) -> list[dict]:
             row["status_penalty"] = (
                 float(r.status_penalty) if getattr(r, "status_penalty", None) is not None else 1.0
             )
+            # CAURA-722 — the score's ingredients, for
+            # ``SearchDiagnostic.all_candidates``, which declared all five per
+            # row and reported None for every one of them.
+            #
+            # Left as ``None`` when absent rather than defaulted to the
+            # identity (1.0): the query above always produces a value, so a
+            # missing attribute means something upstream changed shape, and
+            # saying "no boost applied" on that basis is the precise failure
+            # this change exists to end. A null now means "not reported",
+            # which is the truth, and the diagnostic documents it as such.
+            for _factor in ("fts_score", "freshness", "entity_boost", "recall_boost", "temporal_boost"):
+                _v = getattr(r, _factor, None)
+                row[_factor] = float(_v) if _v is not None else None
             row["entity_links"] = r.entity_links or []
             out.append(row)
     except Exception:

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2632,6 +2632,71 @@ class PostgresService:
                 fts_match,
                 has_embedding,
                 status_penalty,
+                # CAURA-722 — the score's own ingredients, carried out of the
+                # CTE rather than discarded at its boundary.
+                #
+                # These are the five factors ``SearchDiagnostic.all_candidates``
+                # has always declared per row and always reported as ``None``:
+                # each was computed here, multiplied (or added, under the A50
+                # formula) into ``score``, and then left behind because the CTE
+                # select list did not name it. core-api reads all five by name
+                # in ``execute_scored_search`` and the diagnostic rounds each
+                # through ``_f()``, so three layers were built to receive values
+                # the query never sent. Nothing was wrong with ranking — only
+                # with explaining it, which is what made a null read as "this
+                # signal did not apply" and cost a benchmark the conclusion that
+                # entity retrieval contributed nothing.
+                #
+                # No new computation: every expression below already exists
+                # above because ``score`` needs it. ``reserved_stmt`` even
+                # ORDER BYs ``fts_score`` already.
+                #
+                # Always selected, not gated on a diagnostic flag: storage takes
+                # no such flag, and plumbing one through the route to save five
+                # floats per row — on a response already carrying each row's
+                # full content — costs more than it saves.
+                #
+                # Both union branches derive from this statement, so they stay
+                # column-compatible. Dedup behaviour is unchanged too: the
+                # factors are deterministic per ``mem_id``, so rows that
+                # collapsed before still collapse.
+                #
+                # ``fts_score`` is the one with a price, and it is paid
+                # deliberately. The four below are CASE or literal expressions
+                # over the row, so naming them costs nothing. ``fts_score`` is
+                # ``ts_rank_cd``, and SQLAlchemy inlines an expression at every
+                # site that names it, so one more reference takes the compiled
+                # statement from 9 renders to 10 and ``plainto_tsquery`` from 20
+                # to 21 — the ratchet ``test_fts_score_single_render`` guards,
+                # and whose constants move with this change.
+                #
+                # Only +1 rather than +2 because ``reserved_stmt`` already
+                # ORDER BYs ``fts_score``; once it is a real column that clause
+                # references the label instead of re-pasting the expression.
+                #
+                # The cost, from the measurement recorded on ``_saturate_rank``
+                # (halving 18 -> 9 renders bought 92.0ms -> 56.4ms at 11,505
+                # matching rows on a 31,446-memory corpus): about 4ms per
+                # render at that worst case, less on smaller matches, and
+                # diluted again end-to-end because the same query pays six
+                # pgvector distance computations per row. Against a ~1,300ms
+                # search p50 that is well under a percent, in exchange for the
+                # fifth factor ``SearchDiagnostic`` declares actually arriving.
+                #
+                # It also lands inside this CTE rather than after the
+                # entity-link fanout in the outer query, so it is evaluated per
+                # candidate row and not per joined row.
+                #
+                # The real fix is the inner-projection work ``_saturate_rank``
+                # describes, which takes renders to 1 and makes every factor
+                # free to project; that needs an optimisation barrier and its
+                # own plan-shape review. When it lands, the constant drops and
+                # this reference costs nothing.
+                fts_score,
+                freshness,
+                entity_boost,
+                recall_boost_expr,
+                temporal_boost,
             )
             # Multi-tenant read predicate: when ``readable_tenant_ids``
             # is provided (cross-tenant agent key), reads widen across
@@ -2804,6 +2869,12 @@ class PostgresService:
                 scored_cte.c.fts_match,
                 scored_cte.c.has_embedding,
                 scored_cte.c.status_penalty,
+                # CAURA-722 — see the CTE select list above.
+                scored_cte.c.fts_score,
+                scored_cte.c.freshness,
+                scored_cte.c.entity_boost,
+                scored_cte.c.recall_boost,
+                scored_cte.c.temporal_boost,
                 MemoryEntityLink.entity_id,
                 MemoryEntityLink.role,
                 Agent.display_name.label("agent_display_name"),
@@ -2836,6 +2907,12 @@ class PostgresService:
                     fts_match=row.fts_match,
                     has_embedding=row.has_embedding,
                     status_penalty=row.status_penalty,
+                    # CAURA-722 — see the CTE select list above.
+                    fts_score=row.fts_score,
+                    freshness=row.freshness,
+                    entity_boost=row.entity_boost,
+                    recall_boost=row.recall_boost,
+                    temporal_boost=row.temporal_boost,
                     entity_links=[],
                 )
             if row.entity_id is not None:

--- a/core-storage-api/tests/test_fts_score_single_render.py
+++ b/core-storage-api/tests/test_fts_score_single_render.py
@@ -31,11 +31,37 @@ from core_storage_api.services.postgres_service import _saturate_rank
 # directions matter: a rise means someone added a reference and put the per-row
 # cost back, a fall means the inner-projection work landed. Either way,
 # re-measure and move the number deliberately rather than loosening the check.
-_EXPECTED_TS_RANK_CD_RENDERS = 9
+#
+# CAURA-722 moved these 9 -> 10 and 20 -> 21, deliberately and with the trade
+# measured. ``fts_score`` is now projected out of the scored CTE so
+# ``SearchDiagnostic.all_candidates`` can report it: it declares the factor per
+# row and had returned ``None`` for it on every row of every query, because the
+# CTE computed it, folded it into ``score`` and then did not name it in its
+# select list.
+#
+# Why the rise is only +1 and not +2, with the statement appearing in two union
+# branches: ``reserved_stmt`` already ordered by ``fts_score``, and once the
+# factor is a real column that ORDER BY references the label instead of
+# re-pasting the expression.
+#
+# The price, scaled from the measurement on ``_saturate_rank`` (18 -> 9 renders
+# bought 92.0ms -> 56.4ms at 11,505 matching rows on a 31,446-memory corpus):
+# roughly 4ms per render at that worst case, less on smaller matches, and
+# smaller again end-to-end since the same query also pays six pgvector distance
+# computations per row. Against a search p50 near 1,300ms that is well under a
+# percent. The render lands inside the candidate CTE, not in the outer query
+# past the entity-link fanout, so it is per candidate row rather than per
+# joined row.
+#
+# This does not concede the ratchet. The inner-projection work
+# ``_saturate_rank`` describes still takes renders to 1 and would make every
+# factor free to project — at which point this constant drops and CAURA-722's
+# reference costs nothing. Guard both directions as before.
+_EXPECTED_TS_RANK_CD_RENDERS = 10
 # The main and reserved candidate branches each carry ``fts_match`` into the
 # candidate CTE. Projecting it there keeps the expression ahead of entity-link
 # fanout, where an outer render would evaluate it once per joined row.
-_EXPECTED_TSQUERY_RENDERS = 20
+_EXPECTED_TSQUERY_RENDERS = 21
 
 
 def _scaled_rank():

--- a/scripts/entity_retrieval_probe.py
+++ b/scripts/entity_retrieval_probe.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Ask a live Caura deployment why entity retrieval did or did not fire.
+
+Why this exists
+---------------
+A benchmark run reported the ENTITY_LOOKUP strategy firing on **0 of 589
+queries** and the finding was written up as "the entity/graph subsystem
+contributed to 0 of 589 queries". Those are different claims, and the second
+one was never measured. Two reasons:
+
+1. ``retrieval_strategy`` reports only the ENTITY_LOOKUP **short-circuit**,
+   which by design fires solely when the entity-linked pool fills ``top_k`` on
+   its own (``classify_query.py``: ``len(filtered_rows) >= top_k``). The
+   *boost* — entity signal nudging scores inside ordinary semantic search — is
+   a separate mechanism that reports no strategy of its own.
+2. The boost's effect is meant to be visible per row, in the same response,
+   as ``diagnostic.all_candidates[].entity_boost``. The probe that produced
+   the zero read eight summary scalars and discarded ``all_candidates``
+   entirely — but that turns out not to have cost it anything yet, because
+   storage does not currently serialize that factor at all (see the note in
+   ``probe()``). So the boost question is still open, and this script says so
+   explicitly instead of scoring it as a zero.
+
+So this script reads BOTH mechanisms, plus the CAURA-722 fields that say why
+the short-circuit declined when it did.
+
+What each column means
+----------------------
+``strategy``          the short-circuit: ``entity_lookup`` = fired.
+``matches``           entities the query's tokens matched in entity FTS.
+                      ``-`` means the FTS never ran (entity retrieval off, no
+                      entity-shaped tokens, or a swallowed failure) — which is
+                      a different answer from ``0``.
+``declined``          the over-broad refusal (> ENTITY_LOOKUP_MAX_MATCHES).
+                      This is the ONLY decline that also suppresses the boost.
+``boosted``           rows in the candidate set carrying a non-null, non-1.0
+                      ``entity_boost`` — i.e. the boost actually moved them.
+                      This is the column that WOULD answer "did entity
+                      retrieval contribute?", and it reads 0 with a loud
+                      warning until storage serializes the factor.
+
+Reading the verdict
+-------------------
+    declined=True                      -> entity contributed NOTHING here
+                                          (boost suppressed by design)
+    strategy=entity_lookup             -> entity answered the query outright
+    boosted>0                          -> entity contributed via the boost,
+                                          even though strategy says
+                                          "semantic_search"
+    matches=0, boosted=0               -> nothing matched; an extraction /
+                                          linking question
+    matches=-                          -> the query never asked; not evidence
+                                          about the entity index at all
+
+Read-only and side-effect free: the only call is ``POST /search`` with
+``diagnostic: true``, which the API documents as inspection rather than use
+(it does not bump ``recall_count`` — see ``SearchDiagnostic``). Nothing writes,
+deletes, ingests or purges.
+
+Usage
+-----
+    # against a local dev stack (no auth in standalone mode)
+    python scripts/entity_retrieval_probe.py \
+        --base-url http://localhost:18000/api/v1 --tenant-id my-tenant \
+        --query "What did Sarah say about the Q3 roadmap?"
+
+    # a file of queries, one per line, against a real deployment
+    CAURA_API_KEY=mc_... python scripts/entity_retrieval_probe.py \
+        --base-url https://caura.ai/api/v1 --tenant-id t \
+        --agent-id amb-persona-0 --queries-file queries.txt --top-k 20
+
+    # queries straight out of an AMB run
+    python scripts/entity_retrieval_probe.py --base-url ... --tenant-id t \
+        --amb-run outputs/personamem/caura/rag/32k.json.gz --limit 100
+
+``--json`` prints one JSON object per query instead of the table, for piping.
+
+Note on ``--top-k``: the short-circuit needs the entity pool to fill it
+entirely, so a large ``top_k`` against a small store makes ``entity_lookup``
+effectively unreachable. If every row says ``semantic_search``, re-run with a
+small ``--top-k`` before concluding anything about the entity index.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+import httpx
+
+MAX_QUERY_LENGTH = 5_000
+
+
+def _load_amb_queries(path: Path) -> list[str]:
+    """Pull the retrieval queries out of an AMB results file (.json or .json.gz)."""
+    opener = gzip.open if path.suffix == ".gz" else open
+    with opener(path, "rt", encoding="utf-8") as fh:
+        data = json.load(fh)
+    out = []
+    for r in data.get("results", []):
+        meta = r.get("meta") or {}
+        # AMB sends ``meta.retrieval_query`` to the provider when present; the
+        # bare ``query`` is the question put to the answer model.
+        out.append(meta.get("retrieval_query") or r.get("query") or "")
+    return [q for q in out if q]
+
+
+def probe(
+    client: httpx.Client,
+    base: str,
+    tenant_id: str,
+    query: str,
+    top_k: int,
+    agent_id: str | None,
+    fleet_ids: list[str] | None,
+) -> dict:
+    """One diagnostic search. Returns the entity trace, never the memories."""
+    payload: dict = {
+        "tenant_id": tenant_id,
+        "query": query[:MAX_QUERY_LENGTH],
+        "top_k": top_k,
+        "diagnostic": True,
+    }
+    if agent_id:
+        payload["filter_agent_id"] = agent_id
+    if fleet_ids:
+        payload["fleet_ids"] = fleet_ids
+
+    last_err = None
+    for attempt in range(4):
+        try:
+            r = client.post(f"{base}/search", json=payload, timeout=60.0)
+        except httpx.HTTPError as exc:
+            last_err = str(exc)
+            time.sleep(1.5 * (attempt + 1))
+            continue
+        if r.status_code == 429:
+            time.sleep(5.0 * (attempt + 1))
+            continue
+        if r.status_code != 200:
+            return {"error": f"HTTP {r.status_code}: {r.text[:200]}"}
+
+        body = r.json()
+        diag = body.get("diagnostic") or {}
+        candidates = diag.get("all_candidates") or []
+
+        # A boost of exactly 1.0 is the multiplicative identity — present but
+        # inert. Counting it as "contributed" would overstate the subsystem,
+        # which is the error this script exists to correct, so require a real
+        # deviation.
+        #
+        # ``None`` is a THIRD state and must not be read as 1.0 or as 0.
+        #
+        # As of this writing it is also the ONLY state you will see in
+        # production, and that is a defect, not a configuration: storage
+        # computes ``entity_boost`` (with ``freshness``, ``recall_boost``,
+        # ``temporal_boost``, ``fts_score``) inside the scored CTE, uses them
+        # to build ``score``, and then the outer ``select()`` does not include
+        # them — so the scored-search route never serializes them and
+        # ``all_candidates`` reports five of its nine factors as null on every
+        # query. See ``postgres_service.memory_scored_search``'s outer query.
+        #
+        # Until that is fixed, ``boosted`` cannot answer "did the boost
+        # contribute?" anywhere. The script therefore reports the boost as
+        # UNANSWERED rather than as "no" — reporting 0% from a response that
+        # never carried the number is the exact mistake this script exists to
+        # correct.
+        boosts = [
+            c.get("entity_boost")
+            for c in candidates
+            if c.get("entity_boost") is not None and c.get("entity_boost") != 1.0
+        ]
+        boost_reported = sum(1 for c in candidates if c.get("entity_boost") is not None)
+
+        return {
+            "query": query[:80],
+            "strategy": diag.get("retrieval_strategy"),
+            # CAURA-722. Absent on a deployment older than that change, which
+            # is why this reports ``None`` rather than defaulting to 0 — an
+            # old server must not look like "matched nothing".
+            "entity_matches": diag.get("entity_matches"),
+            "entity_match_declined": diag.get("entity_match_declined"),
+            "candidates": len(candidates),
+            "boosted": len(boosts),
+            "max_boost": max(boosts) if boosts else None,
+            # Did the response carry the factor at all? Distinguishes "no
+            # boost" from "cannot tell".
+            "boost_reported": boost_reported,
+            "items": len(body.get("items") or []),
+            "has_caura722_fields": "entity_matches" in diag,
+        }
+    return {"error": last_err or "exhausted retries"}
+
+
+def _verdict(row: dict) -> str:
+    if row.get("error"):
+        return "error"
+    if row.get("entity_match_declined"):
+        return "declined-over-broad (boost suppressed)"
+    if row.get("strategy") == "entity_lookup":
+        return "short-circuit fired"
+    if row.get("boosted"):
+        return "boost contributed"
+    if row.get("entity_matches") == 0:
+        return "no entity match"
+    if row.get("entity_matches") is None:
+        return "FTS never ran"
+    # Reached only when the FTS matched something, the short-circuit did not
+    # fire and it was not declined — so the boost is the open question.
+    # Whether the answer is "the boost did nothing" or "the boost was not
+    # reported" depends on the column coming back at all, and the two must not
+    # share a line: one is a finding, the other is a broken measurement.
+    if row.get("candidates") and not row.get("boost_reported"):
+        return "matched; boost NOT MEASURABLE (no score factors returned)"
+    return "matched, but no effect"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--base-url", required=True, help="e.g. http://localhost:18000/api/v1"
+    )
+    ap.add_argument("--tenant-id", required=True)
+    ap.add_argument("--agent-id", default=None, help="sets filter_agent_id")
+    ap.add_argument("--fleet-id", action="append", default=None, dest="fleet_ids")
+    ap.add_argument("--top-k", type=int, default=20)
+    ap.add_argument("--query", action="append", default=[])
+    ap.add_argument("--queries-file", type=Path, default=None)
+    ap.add_argument(
+        "--amb-run", type=Path, default=None, help="AMB results .json/.json.gz"
+    )
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--json", action="store_true", dest="as_json")
+    args = ap.parse_args()
+
+    queries: list[str] = list(args.query)
+    if args.queries_file:
+        queries += [
+            ln.strip()
+            for ln in args.queries_file.read_text().splitlines()
+            if ln.strip()
+        ]
+    if args.amb_run:
+        queries += _load_amb_queries(args.amb_run)
+    if not queries:
+        ap.error("give at least one of --query / --queries-file / --amb-run")
+    if args.limit:
+        queries = queries[: args.limit]
+
+    headers = {}
+    key = os.environ.get("CAURA_API_KEY")
+    if key:
+        headers["X-API-Key"] = key
+
+    base = args.base_url.rstrip("/")
+    rows = []
+    with httpx.Client(headers=headers) as client:
+        for i, q in enumerate(queries, 1):
+            row = probe(
+                client,
+                base,
+                args.tenant_id,
+                q,
+                args.top_k,
+                args.agent_id,
+                args.fleet_ids,
+            )
+            row["verdict"] = _verdict(row)
+            rows.append(row)
+            if args.as_json:
+                print(json.dumps(row))
+            elif i == 1 or i % 25 == 0:
+                print(f"  ... {i}/{len(queries)}", file=sys.stderr)
+
+    if args.as_json:
+        return 0
+
+    errors = [r for r in rows if r.get("error")]
+    ok = [r for r in rows if not r.get("error")]
+
+    if ok and not ok[0]["has_caura722_fields"]:
+        print(
+            "\nNOTE: this deployment does not return entity_matches — it predates\n"
+            "CAURA-722. The boost columns below are still valid; the match count\n"
+            "and decline reason are not available.\n"
+        )
+
+    print(
+        f"\n{'strategy':<18} {'matches':>8} {'decl':>5} {'cand':>5} {'boosted':>8} {'maxb':>6}  query"
+    )
+    print("-" * 100)
+    for r in ok[:40]:
+        m = r["entity_matches"]
+        mb = r["max_boost"]
+        print(
+            f"{r['strategy']!s:<18} {('-' if m is None else m):>8} "
+            f"{('Y' if r['entity_match_declined'] else '.'):>5} {r['candidates']:>5} "
+            f"{r['boosted']:>8} {(f'{mb:.3f}' if mb else '-'):>6}  {r['query']}"
+        )
+    if len(ok) > 40:
+        print(f"... {len(ok) - 40} more (use --json for all)")
+
+    print(
+        f"\n{'=' * 60}\nVERDICT over {len(ok)} queries"
+        + (f" ({len(errors)} errored)" if errors else "")
+    )
+    for verdict, n in Counter(r["verdict"] for r in ok).most_common():
+        print(f"  {n:>5}  {verdict}")
+
+    contributed = sum(1 for r in ok if r["boosted"] or r["strategy"] == "entity_lookup")
+    # Queries where scored search ran but returned no score factors: the boost
+    # is unmeasured, so they belong in neither the numerator nor a "0%" claim.
+    # Deliberately narrow. A declined query, a zero-match query and one whose
+    # FTS never ran are all DETERMINATE "entity contributed nothing" — folding
+    # them in here would understate the denominator and flatter the result.
+    # Only a query that matched, did not short-circuit and was not declined
+    # leaves the boost genuinely unobserved.
+    unmeasurable = sum(
+        1
+        for r in ok
+        if r["strategy"] != "entity_lookup"
+        and not r["entity_match_declined"]
+        and (r["entity_matches"] or 0) > 0
+        and r["candidates"]
+        and not r["boost_reported"]
+    )
+    if ok:
+        denom = len(ok) - unmeasurable
+        if denom > 0:
+            print(
+                f"\nEntity retrieval affected the result set on {contributed}/{denom} "
+                f"measurable queries ({100 * contributed / denom:.1f}%)."
+            )
+            print(
+                "Compare against the strategy column alone, which would have reported "
+                f"{sum(1 for r in ok if r['strategy'] == 'entity_lookup')}/{len(ok)}."
+            )
+        if unmeasurable:
+            print(
+                f"\n!! {unmeasurable}/{len(ok)} queries returned candidates with NO score\n"
+                "   factors (entity_boost null on every row). On current storage that column\n"
+                "   is never null — it is 1.0 when unboosted — so this deployment is not\n"
+                "   reporting them and the boost question is UNANSWERED for those queries.\n"
+                "   Do not read this as 'entity contributed nothing'; that is the error this\n"
+                "   script exists to catch. Check the storage version behind this endpoint."
+            )
+    if errors:
+        print(f"\nfirst error: {errors[0]['error']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_caura722_entity_diagnostic.py
+++ b/tests/test_caura722_entity_diagnostic.py
@@ -1,0 +1,334 @@
+"""CAURA-722 — the diagnostic says why entity retrieval stayed out of a query.
+
+Before this, ``SearchDiagnostic`` reported ``retrieval_strategy`` and nothing
+else about the entity path. Three unrelated causes were therefore
+indistinguishable from outside the server, and they belong to different owners:
+
+  * entity FTS matched nothing            -> extraction / linking
+  * it matched too much and was declined  -> threshold tuning (CAURA-698)
+  * it matched, but the pool under-filled -> the short-circuit's own fill rule
+
+Only server logs could tell them apart, which is what blocked the follow-up
+after a benchmark run reported the ENTITY_LOOKUP strategy firing on 0 of 589
+queries.
+
+Two facts close that: ``entity_matches`` and ``entity_match_declined``.
+
+The distinctions these tests pin, and which are easy to regress:
+
+  * ``None`` (FTS never ran) must not collapse to ``0`` (ran, matched nothing).
+    A plain ``or 0`` anywhere on the path destroys the field's whole purpose.
+  * The count is taken BEFORE the over-broad branch empties ``matched_ids``, so
+    a decline reports its real match count rather than 0 — 0 is precisely the
+    value it must never be confused with.
+  * ``entity_match_declined`` is True only for the over-broad decline, which is
+    the one that also suppresses the per-row entity boost. An under-filled pool
+    reports False, because there the boost still applies.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import text
+
+from core_api.constants import ENTITY_LOOKUP_MAX_MATCHES
+from core_api.pipeline.steps.search.classify_query import ClassifyQuery
+from core_api.services import memory_service
+from tests.conftest import get_test_auth, new_tenant_id
+
+
+@pytest.fixture
+def pipeline_search(monkeypatch):
+    monkeypatch.setattr(memory_service, "_USE_PIPELINE_SEARCH", True)
+
+
+async def _diag(client, headers, tenant_id, query, **extra):
+    resp = await client.post(
+        "/api/v1/search",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "query": query,
+            "top_k": 5,
+            "diagnostic": True,
+            **extra,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["diagnostic"]
+
+
+# ---------------------------------------------------------------------------
+# The fields exist and are reachable over REST
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_the_diagnostic_carries_both_entity_fields(client, pipeline_search):
+    tenant_id, headers = get_test_auth(new_tenant_id())
+
+    seeded = await client.post(
+        "/api/v1/memories",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "agent-a",
+            "content": "Sarah owns the Q3 roadmap and presented it in Berlin.",
+        },
+    )
+    assert seeded.status_code == 201, seeded.text
+
+    diag = await _diag(
+        client, headers, tenant_id, "What did Sarah say about the Q3 roadmap?"
+    )
+
+    assert "entity_matches" in diag
+    assert "entity_match_declined" in diag
+    assert diag["entity_match_declined"] is False
+    # A query with entity-shaped tokens reaches the FTS, so the count is a
+    # number rather than None — whatever the index happens to hold.
+    assert diag["entity_matches"] is None or isinstance(diag["entity_matches"], int)
+
+
+@pytest.mark.integration
+async def test_a_query_with_no_entity_tokens_reports_none_not_zero(
+    client, pipeline_search
+):
+    """``None`` means "never asked"; ``0`` means "asked, got nothing".
+
+    Collapsing them is the failure this field exists to prevent, so the
+    all-stopword query has to come back as None.
+    """
+    tenant_id, headers = get_test_auth(new_tenant_id())
+
+    diag = await _diag(client, headers, tenant_id, "of the a to be is it")
+
+    assert diag["entity_matches"] is None, (
+        "a query the tokenizer strips to nothing never reaches entity FTS, "
+        "so its match count is unknown — not zero"
+    )
+    assert diag["entity_match_declined"] is False
+
+
+@pytest.mark.integration
+async def test_the_fields_are_absent_of_effect_on_results(client, pipeline_search):
+    """D12's contract: asking for diagnostics must not change ``items``."""
+    tenant_id, headers = get_test_auth(new_tenant_id())
+
+    await client.post(
+        "/api/v1/memories",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": "agent-a",
+            "content": "Sarah owns the Q3 roadmap.",
+        },
+    )
+    body = {"tenant_id": tenant_id, "query": "Sarah Q3 roadmap", "top_k": 5}
+
+    plain = await client.post("/api/v1/search", headers=headers, json=body)
+    with_diag = await client.post(
+        "/api/v1/search", headers=headers, json={**body, "diagnostic": True}
+    )
+
+    assert plain.status_code == with_diag.status_code == 200
+    assert [i["id"] for i in plain.json()["items"]] == [
+        i["id"] for i in with_diag.json()["items"]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The count is captured before the over-broad branch empties it
+# ---------------------------------------------------------------------------
+
+
+def _ctx(query: str, top_k: int = 5):
+    """ClassifyQuery context in the shape ``test_entity_lookup_short_circuit``
+    uses — ``top_k`` and the graph knobs live under ``search_params``."""
+    from core_api.pipeline.context import PipelineContext
+
+    ctx = PipelineContext()
+    ctx.data = {
+        "query": query,
+        "tenant_id": "tenant-test",
+        "search_params": {"fts_weight": 0.3, "graph_max_hops": 0, "top_k": top_k},
+        "temporal_window": None,
+        "entity_retrieval": True,
+    }
+    return ctx
+
+
+@pytest.mark.unit
+async def test_an_over_broad_decline_reports_its_real_count_not_zero():
+    """The ordering trap.
+
+    ``classify_query`` sets ``matched_ids = []`` right after flagging the
+    over-broad decline. Reading the count after that point reports 0 — the one
+    value that must not be confused with "FTS matched nothing", since the two
+    send the work to different teams.
+    """
+    over_broad = [str(uuid.uuid4()) for _ in range(ENTITY_LOOKUP_MAX_MATCHES + 7)]
+    ctx = _ctx("Sarah Berlin roadmap")
+
+    with patch.object(ClassifyQuery, "_entity_fts", AsyncMock(return_value=over_broad)):
+        await ClassifyQuery().execute(ctx)
+
+    assert ctx.data["entity_match_declined"] is True
+    assert ctx.data["entity_matches"] == ENTITY_LOOKUP_MAX_MATCHES + 7, (
+        "the decline must report how many it matched, not the emptied list"
+    )
+
+
+@pytest.mark.unit
+async def test_a_genuine_zero_match_reports_zero_and_no_decline():
+    ctx = _ctx("Sarah Berlin roadmap")
+
+    with patch.object(ClassifyQuery, "_entity_fts", AsyncMock(return_value=[])):
+        await ClassifyQuery().execute(ctx)
+
+    assert ctx.data["entity_matches"] == 0
+    assert not ctx.data.get("entity_match_declined")
+
+
+@pytest.mark.unit
+async def test_a_swallowed_fts_failure_leaves_the_count_unknown():
+    """The step swallows entity-lookup failures. It must not then claim 0.
+
+    A count of 0 would assert "the index holds nothing matching", which a
+    failed call has not established.
+    """
+    ctx = _ctx("Sarah Berlin roadmap")
+
+    with patch.object(
+        ClassifyQuery, "_entity_fts", AsyncMock(side_effect=RuntimeError("boom"))
+    ):
+        await ClassifyQuery().execute(ctx)
+
+    assert ctx.data.get("entity_matches") is None
+    assert not ctx.data.get("entity_match_declined")
+
+
+@pytest.mark.unit
+async def test_entity_retrieval_disabled_never_reaches_the_fts():
+    ctx = _ctx("Sarah Berlin roadmap")
+    ctx.data["entity_retrieval"] = False
+    fts = AsyncMock(return_value=[])
+
+    with patch.object(ClassifyQuery, "_entity_fts", fts):
+        await ClassifyQuery().execute(ctx)
+
+    fts.assert_not_awaited()
+    assert ctx.data.get("entity_matches") is None
+
+
+# ---------------------------------------------------------------------------
+# The per-row score factors reach the caller at all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_the_diagnostic_reports_the_score_factors_it_declares(
+    client, db, pipeline_search
+):
+    """``all_candidates`` promises per-row score factors; five never arrived.
+
+    ``entity_boost``, ``freshness``, ``recall_boost``, ``temporal_boost`` and
+    ``fts_score`` were each computed in storage's scored CTE, folded into
+    ``score``, and then dropped because the CTE select list did not name them.
+    core-api reads all five by name and the diagnostic rounds each through
+    ``_f()``, so three layers were wired to receive values the query never
+    sent — and every one came back ``None`` on every row.
+
+    That is how a null came to read as "this signal did not apply". It is also
+    what made ``entity_boost`` useless as evidence, since it is the only place
+    the entity *boost* (as opposed to the ENTITY_LOOKUP short-circuit) is
+    observable at all.
+
+    ``fts_score`` is checked against the database rather than asserted
+    outright, because whether it CAN have a value depends on how the schema was
+    built. It is ``ts_rank_cd(search_vector, ...)``, and ``search_vector`` is
+    filled by a trigger created in migration 001. CI runs
+    ``alembic upgrade head``, so the trigger is there and the rank is a number;
+    ``conftest`` builds the schema with ``Base.metadata.create_all``, which
+    makes columns but not triggers, so locally the column is NULL and the rank
+    is legitimately NULL with it. Asserting non-null unconditionally would pass
+    in CI and fail on every developer machine; asserting nothing would let the
+    projection regress in CI unnoticed. So the test asks the database which
+    world it is in — the same reason the FTS-dependent tests in ``tests/`` fail
+    on a create_all database.
+    """
+    tenant_id, headers = get_test_auth(new_tenant_id())
+
+    for content in (
+        "Sarah owns the Q3 roadmap and presented it in Berlin.",
+        "Sarah prefers async standups over daily calls.",
+        "The Q3 roadmap moved the billing rewrite to October.",
+    ):
+        r = await client.post(
+            "/api/v1/memories",
+            headers=headers,
+            json={"tenant_id": tenant_id, "agent_id": "agent-a", "content": content},
+        )
+        assert r.status_code == 201, r.text
+
+    diag = await _diag(client, headers, tenant_id, "Sarah Q3 roadmap Berlin")
+    candidates = diag["all_candidates"]
+    assert candidates, "precondition: the search must return candidates"
+
+    declared = (
+        "score",
+        "vec_sim",
+        "fts_match",
+        "status_penalty",
+        "fts_score",
+        "freshness",
+        "entity_boost",
+        "recall_boost",
+        "temporal_boost",
+    )
+    for row in candidates:
+        missing = [k for k in declared if k not in row]
+        assert not missing, f"all_candidates row is missing declared factors: {missing}"
+
+    # Everything except fts_score is a literal or a CASE over the row itself,
+    # so it has a value on every row regardless of the tsvector trigger.
+    for factor in ("freshness", "entity_boost", "recall_boost", "temporal_boost"):
+        nulls = [r for r in candidates if r.get(factor) is None]
+        assert not nulls, (
+            f"{factor} is null on {len(nulls)}/{len(candidates)} rows — the factor is "
+            "computed in the scored CTE and must be carried out of it, not dropped"
+        )
+
+    # The identity value is the correct report for "computed, nothing to add",
+    # and is what makes a genuine boost distinguishable from an absent one.
+    assert all(r["entity_boost"] == 1.0 for r in candidates), (
+        "with no entity boost requested every row should report the 1.0 identity, "
+        "not None and not 0"
+    )
+
+    # ``fts_score`` is only computable where the tsvector trigger exists.
+    trigger_present = bool(
+        (
+            await db.execute(
+                text(
+                    "SELECT 1 FROM pg_trigger "
+                    "WHERE tgname = 'memories_search_vector_trigger' "
+                    "AND NOT tgisinternal"
+                )
+            )
+        ).scalar()
+    )
+    fts_nulls = [r for r in candidates if r.get("fts_score") is None]
+    if trigger_present:
+        assert not fts_nulls, (
+            f"fts_score is null on {len(fts_nulls)}/{len(candidates)} rows on a "
+            "migrated schema — the factor must be projected out of the scored CTE. "
+            "This is the assertion that catches the projection regressing in CI."
+        )
+    else:
+        assert len(fts_nulls) == len(candidates), (
+            "without the migration-001 tsvector trigger, search_vector is NULL and "
+            "ts_rank_cd over it is NULL too, so every row should report None here — "
+            "a partial result would mean something other than the trigger is at play"
+        )


### PR DESCRIPTION
… a query

A benchmark run reported the ENTITY_LOOKUP strategy firing on 0 of 589 queries, and nothing in the API could say which of three unrelated causes it was. They belong to different owners:

  * entity FTS matched nothing            -> extraction / linking
  * it matched too much and was declined  -> threshold tuning (CAURA-698)
  * it matched, pool under-filled top_k   -> the fill rule itself

`SearchDiagnostic` exposed `retrieval_strategy` and nothing else about the entity path, so all three looked identical from outside and only server logs told them apart. That ambiguity is what blocked the follow-up.

## 1. Two fields that separate the causes

  entity_matches: int | None    entities matched in entity FTS
  entity_match_declined: bool   the over-broad refusal

Both were already computed inside the request and reached only the logs. Purely additive; `items` untouched.

Surfaced on all three diagnostic-bearing paths, not just REST `/search`: `/recall` (three sites) and MCP already report `retrieval_strategy`, so omitting these there would preserve the same ambiguity in the two places the follow-up is most likely to use — MCP `caura_recall` especially, since it has no `top_k` cap and is where an investigation goes once REST's limit binds.

Two properties the field set is load-bearing on:

**`None` is not `0`.** `None` means the FTS never ran — retrieval off by org setting, no entity-shaped tokens surviving the 288-stopword tokenizer, or a swallowed failure. `0` means it ran and matched nothing. Only the second is evidence about the entity index, so an `or 0` anywhere on the path destroys the field's purpose. Three tests pin it.

**The count is captured before the decline empties the list.** `classify_query` sets `matched_ids = []` immediately after flagging the over-broad decline, so reading it later reports 0 — precisely the value it must never be confused with. Verified live: a query matching 802 entities reports 802 with `declined=True`, not 0.

## 2. The per-row score factors were never being returned

Found while checking the above. `SearchDiagnostic.all_candidates` is documented as "the full widened candidate set with per-row score factors" and names nine. Five were `None` on every row of every query.

Not an old deployment — reproduced with both services from source:

```
score            null on 0/3 rows   sample=0.0
vec_sim          null on 0/3 rows   sample=0.536
status_penalty   null on 0/3 rows   sample=1.0
entity_boost     null on 3/3 rows   sample=None
freshness        null on 3/3 rows   sample=None
recall_boost     null on 3/3 rows   sample=None
temporal_boost   null on 3/3 rows   sample=None
```

Cause: `memory_scored_search` computes each factor, folds it into `score`, and then the scored CTE's own select list does not name it, so it dies at the CTE boundary. core-api reads all five by name in `execute_scored_search` and the diagnostic rounds each through `_f()` — three layers wired to receive values the query never sent.

**Ranking was never affected.** The factors did their job; they are in `score` and results are correct. What was broken is explaining a result, which is the diagnostic's only job.

The cost was not hypothetical, and it is why this is fixed here rather than filed: `entity_boost` is the only place the entity *boost* is observable, as distinct from the short-circuit `retrieval_strategy` reports. A null there reads as "this signal did not apply" — which is how the benchmark concluded the entity subsystem contributed to 0 of 589 queries, when the number that would have contradicted it was blank for reasons having nothing to do with entities. Without this half, the fields in part 1 still could not answer the question they were added for.

Fix: name the four cheap factors in the CTE select list, reference them by column in the outer query, carry them through the grouping namespace and the router. No new computation — every expression already existed because `score` needs it. Both union branches derive from the same statement so they stay column-compatible, and dedup is unchanged (the factors are deterministic per `mem_id`, so rows that collapsed before still collapse).

Always returned rather than gated on a diagnostic flag: storage takes no such flag, and plumbing one through to save four floats per row — on a response already carrying each row's full content — costs more than it saves.

Nulls are preserved rather than defaulted to the 1.0 identity. The query always produces a value, so a missing attribute means something upstream changed shape, and answering "no boost applied" on that basis is the exact failure being removed.

## 3. `fts_score`, and the render ratchet it moves

All five factors are projected, `fts_score` included — which moves `test_fts_score_single_render`'s constants from **9 -> 10** `ts_rank_cd` renders and **20 -> 21** `plainto_tsquery` renders. Flagging it because that guard exists precisely so this is a decision and not a side effect: "a rise means someone added a reference and put the per-row cost back ... re-measure and move the number deliberately rather than loosening the check."

Re-measured. The rise is +1, not +2 despite the statement appearing in two union branches, because `reserved_stmt` already ordered by `fts_score`; once the factor is a real column that ORDER BY references the label instead of re-pasting the expression.

The price, scaled from the measurement recorded on `_saturate_rank` (halving 18 -> 9 renders bought 92.0ms -> 56.4ms at 11,505 matching rows on a 31,446-memory corpus): roughly **4ms per render** at that worst case, less on smaller matches, and smaller again end-to-end since the same query also pays six pgvector distance computations per row. Against a search p50 near 1,300ms that is well under a percent, in exchange for the fifth declared factor actually arriving.

The render also lands inside the candidate CTE rather than in the outer query past the entity-link fanout, so it is evaluated per candidate row and not per joined row.

This does not concede the ratchet. The inner-projection work `_saturate_rank` describes still takes renders to 1 and would make every factor free to project; when it lands the constant drops and this reference costs nothing. The guard keeps checking both directions.

## 4. scripts/entity_retrieval_probe.py

A read-only probe that reads both entity mechanisms — the short-circuit and the boost — plus the new fields. Only call is `POST /search` with `diagnostic: true`, documented as inspection with no `recall_count` bump. Takes `--query`, `--queries-file`, or `--amb-run` (reads an AMB results .json/.json.gz directly, so re-probing a recorded run is one command).

It refuses to overclaim in either direction:

  * `entity_boost == 1.0` is the multiplicative identity — present but inert — and is not counted as a contribution.
  * an all-null `entity_boost` column is a THIRD state, not a zero: it means the factors were not reported, so the boost question is unanswered. Those queries leave the denominator and are flagged loudly. Reporting 0% from a response that never carried the number is the exact error the script exists to catch.
  * declined / zero-match / never-ran queries stay IN the denominator — those are determinate "contributed nothing", and excusing them would flatter the result.

`--top-k` carries a warning: the short-circuit needs the entity pool to fill it, so a large `top_k` against a small store makes `entity_lookup` effectively unreachable — the likeliest reason the benchmark saw zero (top_k=20 against a ~24-row per-persona store).

## Verification

Run against core-api from this branch, all four diagnostic states distinguished on real data:

```
strategy          matches  decl   query
entity_lookup           1     .   tokyo review
semantic_search       802     Y   comet incident timeline
semantic_search         -     .   of the a to be is it
semantic_search         0     .   zzzqqq flibbertigibbet nonexistent
```

Row 2 is the ordering fix earning itself: 802, not 0. Rows 3 and 4 are the None/0 distinction on a live wire.

- `tests/test_caura722_entity_diagnostic.py` — 8 cases. 5 fail without the source change; the other 3 are contract guards (diagnostics must not change `items`; a swallowed FTS failure and disabled retrieval must not claim 0) which must hold in both directions.
- The factor test asks the database whether the migration-001 tsvector trigger exists rather than assuming. `fts_score` is `ts_rank_cd(search_vector, ...)`, CI runs `alembic upgrade head` so it is a number there, and `conftest` builds the schema with `Base.metadata.create_all`, which makes columns but not triggers, so it is legitimately NULL on a developer machine. Asserting non-null unconditionally would pass CI and fail every local run; asserting nothing would let the projection regress in CI unseen. Both branches were exercised — against a create_all database and against one with the trigger applied — and pass.
- `core-storage-api/tests/test_fts_score_single_render.py`: 9 passed at the new constants.
- Targeted sweep, post-rebase: 91 passed (`test_d12_search_diagnostics`, `test_entity_lookup_short_circuit`, `test_skip_entity_boost_on_decline`, `test_mcp_recall`, `test_c4_recall_items_alias`, `test_search_recall_tracked_flag`, `test_search_caller_identity`, `test_p2_semantic_dedup`).
- `core-storage-api/tests/`: 369 passed, 2 pre-existing CORS failures — same set as `main`. The render guard passes untouched.
- Full `tests/`: 39 failures, byte-identical to `main`'s set on this machine (pre-existing FTS / relation-weight / request-observation env failures).
- ruff check and format clean; mypy output identical to `main` on every changed file. `legacy_name_ratchet.py` "No new lines.", `do_not_touch_sentinel.py` all 35 protected strings survive, `tenant_scope_gate.py` exit 0.

Side finding for whoever debugs the local FTS failures next: because `search_vector` is trigger-filled and `create_all` makes no triggers, that column and every rank over it are NULL on a developer database no matter what this change does. With the trigger applied, `fts_score` returns 0.0 and `score` moves 0.0 -> 0.3939 as FTS starts contributing.

Not touched, per the finding's own guardrail: `ENTITY_LOOKUP_MAX_MATCHES`, the entity bypass, and the under-fill rule. Ship the fields, read the counts, then decide.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
