### PR TITLE
test: fail the run when a coroutine is created and dropped

### DIFF
--- a/core-api/src/core_api/services/contradiction/dispatch.py
+++ b/core-api/src/core_api/services/contradiction/dispatch.py
@@ -7,7 +7,15 @@
   * ``True``  -> route through ``ContradictionEngine.evaluate_async``.
 
 **Sync on purpose.** ``run_contradiction_detection`` is a *regular* function that
-returns an awaitable. On the legacy path it calls the detector entry
+returns a coroutine.
+
+The return type is spelled ``Coroutine`` rather than ``Awaitable`` deliberately:
+mypy's ``unused-coroutine`` check fires only for ``Coroutine``, so with
+``Awaitable`` a call site that created this and then dropped it type-checked
+clean. Since the coroutine is created eagerly here, dropping it silently
+discards the detection — which is exactly the failure this annotation now makes
+a static error. Every branch below returns a coroutine, so the narrower type is
+also the accurate one. On the legacy path it calls the detector entry
 *synchronously* and returns its coroutine, so a call site that schedules the
 result — ``track_task(run_contradiction_detection(...))`` — keeps the exact
 schedule-time semantics the direct ``detect_contradictions_async(...)`` call had
@@ -24,7 +32,8 @@ differential test pins the detection outcomes.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable
+from collections.abc import Coroutine
+from typing import Any
 from uuid import UUID
 
 from core_api.config import settings
@@ -44,7 +53,7 @@ def run_contradiction_detection(
     content: str | None = None,
     embedding: list[float] | None = None,
     new_memory: dict | None = None,
-) -> Awaitable[None]:
+) -> Coroutine[Any, Any, None]:
     if settings.contradiction_engine_enabled:
         return ContradictionEngine().evaluate_async(
             memory_id,

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,50 @@
 # asserted against other tests' leftovers. Both remaining markers were checked
 # against this setting; use `strict=False` on a marker that genuinely needs it.
 xfail_strict = true
+# A coroutine created and then dropped is scheduled work that silently never
+# ran. That is a live failure mode here rather than a theoretical one:
+# ``run_contradiction_detection`` is a sync function returning an awaitable,
+# eager on purpose, so a caller that returns or raises between the call and its
+# ``track_task(...)`` loses contradiction detection with nothing logged
+# anywhere. This gate is the only signal that would show it.
+#
+# BOTH lines are required and each is INERT alone — measured, not assumed. The
+# first turns the warning into an exception inside the coroutine's ``__del__``,
+# where exceptions are never propagated: CPython routes it to
+# ``sys.unraisablehook`` and pytest re-reports it as a warning. The second is
+# what turns that re-report into a failure. With only one of the two, the
+# offending test passes.
+#
+# ``AsyncMockMixin`` is excluded because that is a mock's OWN internal
+# coroutine rather than this codebase's work. Four tests in
+# ``test_crystallization_must_not_wedge.py`` shed one from a bare
+# ``AsyncMock()``; in the case traced to production the ``await`` is present
+# (``crystallizer_service.py:942``), and the exact mechanism was NOT
+# established — this is recorded as an exclusion, not as a diagnosis. What the
+# exclusion costs is a missing ``await`` on a call whose callee is mocked,
+# where that mock's own ``assert_awaited_once`` is the better check anyway; a
+# missing ``await`` on real code still reports that function's own name and
+# still fails here.
+#
+# No ':' may appear in a message pattern, because the filter string is split on
+# it — hence "ignored in.*coroutine object" and not the literal
+# "ignored in: <coroutine object".
+#
+# When this fails, the named test is often NOT the culprit: the warning fires
+# when the coroutine is collected, which can be a later test than the one that
+# created it (a reference held by a mock's ``call_args`` routinely outlives its
+# test). Find the real creator by re-running the suspect files with
+# PYTHONTRACEMALLOC=25, which adds the allocation traceback to the report.
+# Scope that to a handful of files: suite-wide it reached 1% in six minutes.
+# Two things NOT to reach for when this fails. An autouse fixture that disposes
+# of stray coroutines would make the gate permanently green -- it cannot tell a
+# test double's leftover from a production drop, which is the whole distinction
+# being gated. And a per-test ``filterwarnings`` marker does not reliably exempt
+# anything, because the failure is attributed to whichever test was running at
+# collection time rather than the one that created the coroutine.
+filterwarnings =
+    error:coroutine '(?!AsyncMockMixin)[^']*' was never awaited:RuntimeWarning
+    error:Exception ignored in.*coroutine object:pytest.PytestUnraisableExceptionWarning
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
 asyncio_default_test_loop_scope = session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,11 @@ or the defaults below.
 """
 
 import asyncio
+import inspect
 import os
 import uuid
 from datetime import UTC, datetime, timedelta
+from unittest.mock import DEFAULT
 
 # Set test-friendly defaults before any backend imports read settings.
 # These can be overridden by the caller via environment variables.
@@ -114,6 +116,58 @@ def get_admin_headers() -> dict:
 def uid() -> str:
     """Short unique suffix — for distinct content (409s) and distinct tenant ids."""
     return uuid.uuid4().hex[:8]
+
+
+def close_scheduled_coro(coro, *_args, **_kwargs):
+    """``side_effect`` for a mocked scheduler: dispose of the coroutine it is handed.
+
+    ``track_task(coro)`` receives an already-created coroutine, so a plain
+    ``MagicMock`` in its place leaves that coroutine unstarted — which the
+    ``filterwarnings`` gate in ``pytest.ini`` fails the run for, and whose
+    comment carries the reasoning.
+
+    Using an ``AsyncMock`` instead does NOT help: the object being dropped is
+    the argument, not the mock's return value.
+
+    Closing walks the nest rather than only the outermost coroutine, because
+    the real call is
+    ``track_task(tracked_task(detect_contradictions_async(...)))`` — closing
+    just the wrapper leaves the inner one unstarted, trading one dropped
+    coroutine for another.
+
+    ``iscoroutine`` guards the ``None`` case, which is live: several tests stub
+    ``tracked_task`` with something that returns ``None``, so this is reached
+    as ``track_task(None)``.
+
+    Returns ``mock.DEFAULT`` so the patched mock keeps its ordinary
+    ``return_value`` rather than returning ``None``. Call recording —
+    ``call_count``, ``assert_called_*``, ``call_args`` — is unaffected either
+    way, so that is not what ``DEFAULT`` is buying.
+    """
+    if inspect.iscoroutine(coro):
+        _close_coroutine_tree(coro)
+    return DEFAULT
+
+
+def _close_coroutine_tree(coro) -> None:
+    """Close ``coro``, and first any coroutine it holds as an argument.
+
+    An unstarted coroutine still has its ``cr_frame``, whose ``f_locals`` are
+    its arguments. A closed one has ``cr_frame is None``, which is what keeps
+    this from revisiting anything — and ``close()`` is idempotent besides.
+
+    Known limit, measured: only coroutines held *directly* as arguments are
+    found. One inside a tuple or list local is missed and still leaks. That is
+    fine for every scheduler in this codebase today — ``tracked_task``'s first
+    parameter is the coroutine itself — but a future wrapper taking ``*coros``
+    would need this widened rather than trusted.
+    """
+    frame = coro.cr_frame
+    if frame is not None:
+        for value in frame.f_locals.values():
+            if inspect.iscoroutine(value):
+                _close_coroutine_tree(value)
+    coro.close()
 
 
 def new_tenant_id() -> str:

--- a/tests/pipeline/test_write_pipeline.py
+++ b/tests/pipeline/test_write_pipeline.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 from common.models.memory import Memory
 from core_api.constants import VECTOR_DIM
 from core_api.schemas import MemoryCreate, MemoryOut
+from tests.conftest import close_scheduled_coro
 
 TENANT_ID = f"test-pipeline-{uuid.uuid4().hex[:8]}"
 FLEET_ID = "test-fleet"
@@ -685,7 +686,8 @@ async def test_schedule_background_tasks_fast_mode_fires_full_fan_out():
     )
 
     with patch(
-        "core_api.pipeline.steps.write.schedule_background_tasks.track_task"
+        "core_api.pipeline.steps.write.schedule_background_tasks.track_task",
+        side_effect=close_scheduled_coro,
     ) as mock_track:
         step = ScheduleBackgroundTasks()
         await step.execute(ctx)
@@ -725,7 +727,8 @@ async def test_schedule_background_tasks_strong_mode_fires_entity_and_contradict
     )
 
     with patch(
-        "core_api.pipeline.steps.write.schedule_background_tasks.track_task"
+        "core_api.pipeline.steps.write.schedule_background_tasks.track_task",
+        side_effect=close_scheduled_coro,
     ) as mock_track:
         step = ScheduleBackgroundTasks()
         await step.execute(ctx)

--- a/tests/test_a63_subject_writeback.py
+++ b/tests/test_a63_subject_writeback.py
@@ -24,6 +24,7 @@ from uuid import uuid4
 import pytest
 
 from core_api.services.entity_extraction_worker import process_entity_extraction
+from tests.conftest import close_scheduled_coro
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
@@ -95,7 +96,7 @@ async def _run(mock_extract_graph, sc, memory_id=None):
             new=AsyncMock(return_value=[0.1] * 8),
         ),
         patch("core_api.services.entity_extraction_worker.log_action", new=AsyncMock()),
-        patch("core_api.tasks.track_task"),
+        patch("core_api.tasks.track_task", side_effect=close_scheduled_coro),
     ):
         await process_entity_extraction(
             memory_id=memory_id or uuid4(),

--- a/tests/test_atomic_fact_unembedded_persist.py
+++ b/tests/test_atomic_fact_unembedded_persist.py
@@ -16,6 +16,7 @@ import pytest
 
 from core_api.services import memory_service
 from core_api.services.memory_enrichment import AtomicFact
+from tests.conftest import close_scheduled_coro
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
@@ -96,7 +97,9 @@ async def _run_fanout(embed_stub):
 
     with (
         patch.object(memory_service, "get_storage_client", lambda: sc),
-        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(
+            memory_service, "track_task", MagicMock(side_effect=close_scheduled_coro)
+        ),
         patch.object(memory_service, "tracked_task", new=_stub_tracked_task),
         patch.object(
             memory_service, "_schedule_embed_or_reembed", new=_capture_schedule
@@ -227,7 +230,9 @@ async def test_missing_child_id_is_reported_not_counted_as_scheduled() -> None:
 
     with (
         patch.object(memory_service, "get_storage_client", lambda: sc),
-        patch.object(memory_service, "track_task", MagicMock()),
+        patch.object(
+            memory_service, "track_task", MagicMock(side_effect=close_scheduled_coro)
+        ),
         patch.object(memory_service, "tracked_task", new=MagicMock()),
         patch.object(
             memory_service,

--- a/tests/test_embed_off_hot_path.py
+++ b/tests/test_embed_off_hot_path.py
@@ -31,6 +31,7 @@ from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.steps.write.parallel_embed_enrich import ParallelEmbedEnrich
 from core_api.schemas import MemoryCreate
 from tests._scoped_module import scoped
+from tests.conftest import close_scheduled_coro
 
 pytestmark = pytest.mark.asyncio
 
@@ -219,7 +220,7 @@ async def test_reembed_skips_initial_sleep_when_flag_off() -> None:
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_fake_sleep)),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch(
             "core_api.services.organization_settings.resolve_config",
             new=AsyncMock(return_value=None),
@@ -258,7 +259,7 @@ async def test_reembed_sleeps_on_failure_path_when_flag_on() -> None:
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_fake_sleep)),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch(
             "core_api.services.organization_settings.resolve_config",
             new=AsyncMock(return_value=None),
@@ -284,13 +285,9 @@ async def test_reembed_schedules_contradiction_after_success() -> None:
     )
     sc.update_embedding = AsyncMock()
 
-    # Stubbing ``tracked_task`` lets us read the scheduled task name
-    # from its 2nd positional arg and close the inline coroutine to
-    # avoid leaked-coroutine warnings at GC time.
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
+    # Stubbing ``tracked_task`` lets us read the scheduled task name from its
+    # 2nd positional arg. Disposal of the coroutine is ``close_scheduled_coro``'s
+    # job, shared with every other stand-in in the suite.
     async def _noop_sleep(_secs: float) -> None:
         return None
 
@@ -303,11 +300,11 @@ async def test_reembed_schedules_contradiction_after_success() -> None:
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_noop_sleep)),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ) as tracked,
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -344,10 +341,6 @@ async def test_reembed_race_guard_fires_with_flag_on_too() -> None:
     async def _noop_sleep(_secs: float) -> None:
         return None
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     with (
         # Flag ON — the configuration where the earlier guard was broken.
         patch.object(memory_service.settings, "deployment_mode", "inline"),
@@ -358,11 +351,11 @@ async def test_reembed_race_guard_fires_with_flag_on_too() -> None:
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_noop_sleep)),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ) as tracked,
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -409,10 +402,6 @@ async def test_reembed_respects_existing_embedding_from_enrich_race() -> None:
 
         return _noop()
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     async def _noop_sleep(_secs: float) -> None:
         return None
 
@@ -429,11 +418,11 @@ async def test_reembed_respects_existing_embedding_from_enrich_race() -> None:
             "core_api.services.contradiction_detector.detect_contradictions_async",
             new=_fake_detect,
         ),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ) as tracked,
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -476,20 +465,16 @@ async def test_bulk_reembed_preserves_batching() -> None:
         batch_calls.append(len(texts))
         return [[0.1] * VECTOR_DIM for _ in texts]
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     items = [(uuid.uuid4(), f"memory {i} body") for i in range(5)]
 
     with (
         patch.object(memory_service, "get_embeddings_batch", new=_fake_batch),
         patch.object(memory_service, "get_storage_client", return_value=sc),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ) as tracked,
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -574,10 +559,6 @@ async def test_enrich_no_contradiction_when_no_prior_embedding() -> None:
         atomic_facts=None,
     )
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     with (
         patch.object(memory_service.settings, "deployment_mode", "deferred"),
         patch.object(
@@ -588,10 +569,10 @@ async def test_enrich_no_contradiction_when_no_prior_embedding() -> None:
             "core_api.services.memory_enrichment.enrich_memory",
             new=AsyncMock(return_value=enrichment),
         ),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch(
             "core_api.services.task_tracker.tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ) as tracked,
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -648,7 +629,7 @@ async def test_reembed_is_failure_fallback_triggers_backoff() -> None:
         ),
         patch.object(memory_service, "get_storage_client", return_value=sc),
         patch.object(memory_service, "asyncio", scoped(asyncio, sleep=_fake_sleep)),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch(
             "core_api.services.organization_settings.resolve_config",
             new=AsyncMock(return_value=None),
@@ -676,8 +657,8 @@ async def test_bulk_reembed_fallback_passes_is_failure_fallback() -> None:
 
     def _capture(*args, **kwargs):
         # Sync wrapper so args are recorded at CALL time (not await time
-        # — the tracked_task stub below closes the coroutine without
-        # awaiting, so an async-def body would never run).
+        # — the tracked_task stand-in closes the coroutine without awaiting,
+        # so an async-def body would never run).
         called_with.append({"args": args, "kwargs": kwargs})
 
         async def _noop() -> None:
@@ -688,18 +669,14 @@ async def test_bulk_reembed_fallback_passes_is_failure_fallback() -> None:
     async def _failing_batch(_texts, _cfg, *, budget_s=None, **_kwargs):
         raise RuntimeError("simulated provider outage")
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     with (
         patch.object(memory_service, "get_embeddings_batch", new=_failing_batch),
         patch.object(memory_service, "_schedule_embed_or_reembed", new=_capture),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ),
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -841,10 +818,6 @@ async def _provenance_harness(
 
         return _noop()
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     with (
         patch.object(memory_service, "get_embeddings_batch", new=_batch),
         patch.object(memory_service, "get_storage_client", return_value=sc),
@@ -855,11 +828,11 @@ async def _provenance_harness(
             "core_api.services.contradiction_detector.detect_contradictions_async",
             new=_fake_detect,
         ),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ),
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -895,18 +868,14 @@ async def test_bulk_reembed_fallback_catches_unexpected_exception_types() -> Non
 
         return _noop()
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     with (
         patch.object(memory_service, "get_embeddings_batch", new=_failing_batch),
         patch.object(memory_service, "_schedule_embed_or_reembed", new=_capture),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ),
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -951,10 +920,6 @@ async def test_bulk_reembed_reschedules_items_whose_get_memory_failed() -> None:
 
         return _noop()
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     with (
         patch.object(memory_service, "get_embeddings_batch", new=_batch),
         patch.object(memory_service, "get_storage_client", return_value=sc),
@@ -962,14 +927,14 @@ async def test_bulk_reembed_reschedules_items_whose_get_memory_failed() -> None:
             "core_api.services.contradiction_detector.detect_contradictions_async",
             new=_fake_detect,
         ),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         # _reembed_memories_bulk uses the module-level tracked_task
         # binding (not a local re-import like _enrich_memory_background),
         # so we patch memory_service.tracked_task directly.
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ) as tracked,
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -1028,10 +993,6 @@ async def test_bulk_reembed_patch_failure_reschedules_item() -> None:
 
         return _noop()
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     with (
         patch.object(memory_service, "get_embeddings_batch", new=_batch),
         patch.object(memory_service, "get_storage_client", return_value=sc),
@@ -1039,11 +1000,11 @@ async def test_bulk_reembed_patch_failure_reschedules_item() -> None:
             "core_api.services.contradiction_detector.detect_contradictions_async",
             new=_fake_detect,
         ),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ) as tracked,
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -1105,10 +1066,6 @@ async def test_bulk_reembed_respects_existing_embedding_per_item() -> None:
 
         return _noop()
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     with (
         patch.object(memory_service, "get_embeddings_batch", new=_batch),
         patch.object(memory_service, "get_storage_client", return_value=sc),
@@ -1116,11 +1073,11 @@ async def test_bulk_reembed_respects_existing_embedding_per_item() -> None:
             "core_api.services.contradiction_detector.detect_contradictions_async",
             new=_fake_detect,
         ),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ),
         patch(
             "core_api.services.organization_settings.resolve_config",
@@ -1161,20 +1118,16 @@ async def test_bulk_reembed_falls_back_on_length_mismatch() -> None:
     )
     sc.update_embedding = AsyncMock()
 
-    def _stub_tracked_task(coro, _name, *_a, **_k):
-        coro.close()
-        return None
-
     items = [(uuid.uuid4(), f"m{i}") for i in range(5)]
 
     with (
         patch.object(memory_service, "get_embeddings_batch", new=_short_batch),
         patch.object(memory_service, "get_storage_client", return_value=sc),
-        patch.object(memory_service, "track_task"),
+        patch.object(memory_service, "track_task", side_effect=close_scheduled_coro),
         patch.object(
             memory_service,
             "tracked_task",
-            new=MagicMock(side_effect=_stub_tracked_task),
+            new=MagicMock(side_effect=close_scheduled_coro),
         ) as tracked,
         patch(
             "core_api.services.organization_settings.resolve_config",

--- a/tests/test_entity_linking_wiring.py
+++ b/tests/test_entity_linking_wiring.py
@@ -14,6 +14,7 @@ import pytest
 from core_api.services.entity_extraction_worker import (
     process_entity_extraction,
 )
+from tests.conftest import close_scheduled_coro
 
 # ── Helpers ───────────────────────────────────────────────────────────
 
@@ -100,7 +101,7 @@ async def test_extraction_triggers_cross_links_when_enabled(
 
     memory_id = uuid.uuid4()
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=memory_id,
             tenant_id="test-tenant",
@@ -179,7 +180,7 @@ async def test_extraction_skips_cross_links_when_disabled(
 
     memory_id = uuid.uuid4()
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=memory_id,
             tenant_id="test-tenant",
@@ -260,7 +261,7 @@ async def test_extraction_cross_link_failure_is_nonfatal(
 
     memory_id = uuid.uuid4()
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         # Should NOT raise — cross-link failure is non-fatal
         await process_entity_extraction(
             memory_id=memory_id,
@@ -362,7 +363,7 @@ async def test_a_memory_dropped_during_extraction_gets_no_entities(
     sc = _graph_sc(deleted_at="2026-09-05T00:00:00Z")
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -402,7 +403,7 @@ async def test_the_liveness_check_reads_the_writer(
     sc = _graph_sc(deleted_at=None)
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -451,7 +452,7 @@ async def test_a_drop_landing_during_the_writes_purges_what_was_just_written(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -493,7 +494,7 @@ async def test_a_row_still_live_after_the_writes_is_not_purged(
     sc = _graph_sc(deleted_at=None)
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -556,7 +557,7 @@ async def test_a_detected_drop_stops_the_writes_that_come_after_the_purge(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -609,7 +610,7 @@ async def test_a_live_row_still_gets_its_relations_written(
     sc = _graph_sc(deleted_at=None)
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -676,7 +677,7 @@ async def test_a_drop_landing_after_the_relation_write_is_still_purged(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -744,7 +745,7 @@ async def test_a_transient_liveness_read_failure_does_not_discard_the_audit_work
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -816,7 +817,7 @@ async def test_a_crash_after_the_writes_still_purges_a_dropped_row(
     # function leaves with graph rows written and no normal-path check run.
     mock_upsert_relation.side_effect = RuntimeError("storage went away mid-write")
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         # Extraction is fire-and-forget; swallowing is the established contract
         # and not what this test is about.
         await process_entity_extraction(
@@ -867,7 +868,7 @@ async def test_a_crash_before_any_write_costs_no_extra_liveness_read(
     sc.bulk_resolve_entities = AsyncMock(side_effect=RuntimeError("resolve failed"))
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -904,7 +905,7 @@ async def test_a_crash_before_the_storage_client_exists_does_not_raise(
     mock_resolve.return_value = _fake_config()
     mock_extract.side_effect = RuntimeError("extraction provider is down")
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -958,7 +959,7 @@ async def test_an_entity_upsert_that_raises_is_still_treated_as_maybe_written(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -1018,7 +1019,7 @@ async def test_cross_link_discovery_alone_still_owes_the_memory_a_liveness_check
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -1091,7 +1092,7 @@ async def test_an_unreadable_purge_response_does_not_escape_the_except_handler(
     mock_upsert_relation.side_effect = RuntimeError("storage went away mid-write")
 
     # The assertion IS that this returns rather than raising.
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",
@@ -1152,7 +1153,10 @@ async def test_entities_committed_without_their_links_are_named_in_the_log(
     )
     mock_sc_factory.return_value = sc
 
-    with caplog.at_level("ERROR"), patch("core_api.tasks.track_task"):
+    with (
+        caplog.at_level("ERROR"),
+        patch("core_api.tasks.track_task", side_effect=close_scheduled_coro),
+    ):
         await process_entity_extraction(
             memory_id=uuid.uuid4(),
             tenant_id="test-tenant",

--- a/tests/test_p1_entity_extraction_bulk.py
+++ b/tests/test_p1_entity_extraction_bulk.py
@@ -32,6 +32,7 @@ from uuid import uuid4
 import pytest
 
 from core_api.services.entity_extraction_worker import process_entity_extraction
+from tests.conftest import close_scheduled_coro
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
@@ -133,7 +134,7 @@ async def test_bulk_path_collapses_to_3_storage_https_for_n_entities(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",
@@ -186,7 +187,7 @@ async def test_embeddings_fire_concurrently_via_gather(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",
@@ -224,7 +225,7 @@ async def test_zero_entities_skips_bulk_https_entirely(
     sc = _build_sc_mock(resolve_returns=[], upsert_returns=[])
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",
@@ -273,7 +274,7 @@ async def test_blocklisted_entities_filtered_before_bulk_path(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",
@@ -331,7 +332,7 @@ async def test_duplicate_canonical_names_collapse_to_first(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",
@@ -400,7 +401,7 @@ async def test_first_seen_wins_canonical_when_longer_name_arrives(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",
@@ -461,7 +462,7 @@ async def test_existing_aliases_preserved_and_extended(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",
@@ -511,7 +512,7 @@ async def test_no_match_takes_create_path(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",
@@ -567,7 +568,7 @@ async def test_embedding_failure_yields_null_in_resolve_payload(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",
@@ -624,7 +625,7 @@ async def test_link_role_binding_preserved_per_entity(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",
@@ -674,7 +675,7 @@ async def test_threshold_constant_passed_to_resolve(
     )
     mock_sc_factory.return_value = sc
 
-    with patch("core_api.tasks.track_task"):
+    with patch("core_api.tasks.track_task", side_effect=close_scheduled_coro):
         await process_entity_extraction(
             memory_id=uuid4(),
             tenant_id="t1",


### PR DESCRIPTION
Closes the item left open on [#869](https://github.com/caura-ai/caura/issues/869) after #1354–#1356 fixed the leak that issue is titled after. This is the other half: coroutines that are created and then **dropped**, which the drain cannot touch because there is no task to cancel.

`run_contradiction_detection` returns its coroutine eagerly, on purpose, so a caller that returns or raises between the call and its `track_task(...)` would lose contradiction detection with nothing logged anywhere. Two gates, one static and one at runtime.

## The static half, which is the cheaper gate

`contradiction/dispatch.py` declared `-> Awaitable[None]`. **mypy's `unused-coroutine` check fires only for `Coroutine`**, so a call site that created this and dropped it type-checked clean. Narrowed to `Coroutine[Any, Any, None]` — also the accurate type, since all three branches return coroutines. No runtime change.

It has teeth: dropping the `await` at `consumer.py:165` now fails mypy with `Value of type "Coroutine[Any, Any, None]" must be used  [unused-coroutine]`.

This came out of the review and is the better altitude — the runtime gate below defends the same hazard, but only in paths a test happens to exercise, after the fact. Caveat: 7 of the 9 caller modules sit on core-api's `ignore_errors` list, so today this covers `consumer.py` plus every future non-exempt caller. That list's own comment calls each line "a to-do, not a policy", so it's a ratchet rather than full coverage.

## The runtime half, and why my first proposal was inert

On #869 I said `filterwarnings = error` would do this. **It does nothing** — the offending test still passes. The RuntimeWarning is raised from the coroutine's `__del__`, exceptions there are never propagated, so CPython routes it to `sys.unraisablehook` and pytest re-reports it as a `PytestUnraisableExceptionWarning` — a warning again.

| gate | result |
| --- | --- |
| coroutine `RuntimeWarning` → error, alone | 2 passed |
| unraisable wrapper → error, alone | 2 passed |
| both | 1 failed |
| an unrelated `__del__` that raises, under both | 1 passed — stays scoped |

Two details now recorded at the gate because they cost me time: **no `:` may appear in a message pattern** (the filter string is split on it), and **`-W` on the command line treats the message as a literal while ini `filterwarnings` treats it as a regex** — so a command-line probe of a regex filter silently matches nothing.

`AsyncMockMixin` is excluded: that is a mock's *own* internal coroutine, not this codebase's work. Four tests in `test_crystallization_must_not_wedge.py` shed one from a bare `AsyncMock()` whose `return_value` is itself an `AsyncMock`, so an ordinary sync `.get()` at `crystallizer_service.py:942` returns a coroutine that correct code discards. Recorded as an exclusion, **not** as a diagnosis — my first draft asserted a mechanism I hadn't established, and the review couldn't construct one either. An AST scan over the four service trees found zero bare-statement calls to a locally-defined async function, so the exclusion isn't currently hiding a live defect.

## What the call sites had in common

Every drop came through one boundary. `track_task(coro)` receives an already-created coroutine, so a plain `MagicMock` in its place leaves it unstarted. **An `AsyncMock` does not help** — the dropped object is the *argument*, not the mock's return value. That corrects what I wrote on #869, where I said the fix was an `AsyncMock`; it would have sent whoever picked it up down the wrong path.

The fix disposes of what the stand-in receives — an idiom this repo already had in ten files. This lifts it into one documented helper and **folds twelve byte-identical local copies** in `test_embed_off_hot_path.py` into it, so the file it touches most heavily doesn't end up carrying two spellings of one fix.

Closing has to **walk the nest**: the real call is `track_task(tracked_task(detect_contradictions_async(...)))`, and closing only the wrapper strands the inner coroutine — trading one dropped coroutine for another, which is exactly what 23 remaining drops after my first pass were. The walk's limit is measured and documented in the helper: a coroutine held in a *tuple or list* local is missed. `tracked_task`'s first parameter is the coroutine itself, so every scheduler here is covered today; a future wrapper taking `*coros` would need this widened rather than trusted.

**One edit was reverted as dead.** `patch.object(memory_service, "tracked_task", ...)` does nothing for `_enrich_memory_background`, which re-imports the name from `task_tracker` at call time — the trap that `test_embed_off_hot_path.py:967` already documents. That patch was dead before this change too, so it's left as found rather than silently removed. Worth a follow-up; not worth smuggling into this one.

## Verification

- **6260 passed, 0 failed**, across five gated runs.
- mypy clean on `core-api/src`; `ruff check` / `ruff format --check` clean, **one scope per invocation as CI runs them** — combining every scope into a single `ruff` command changes config discovery and flagged 12 files that are in fact clean.
- Legacy-name ratchet exit 0; do-not-touch sentinel intact.

Each piece is load-bearing:

| experiment | result |
| --- | --- |
| helper closes only the outer coroutine | **8 failures** |
| one call site loses its `side_effect` | **1 failure** |
| gate removed, fixes kept | 6260 passed, **zero** dropped-coroutine reports |

I predicted that last row wrongly, and the difference matters: I expected the drops to reappear as warnings once the gate was gone. They don't — the fixes remove the drops themselves, and the gate only decides what happens when one occurs. So that row says the suite is clean on its own merits and the gate is masking nothing; the first two rows are what show the gate has teeth.

**Scope:** the gate covers the root `tests/` suite only. `core-operations`, `core-storage-api` and `core-worker` each have their own `pytest.ini`, and pytest resolves config from the arguments' directory — `pytest core-storage-api/tests/` reports `configfile: pytest.ini` under `core-storage-api/`. I checked this rather than assuming it, having first assumed the opposite. All three are free of dropped coroutines today, so extending the gate is a separate cheap change.

## Before this fails on someone

**Attribution follows garbage collection, not creation.** The warning fires when the coroutine is collected, routinely a later test than the one that created it — a reference held by a mock's `call_args` outlives its test. Of the 30 tests this gate failed before the fixes, roughly half were bystanders that create no coroutines at all (`test_c33_openapi_completeness`, `test_d14_rate_limited_response_param`, `test_fixture_hygiene`). Treat a failure as *"something in this run dropped a coroutine"*, not as an accusation against the named test.

**To find the real creator**, re-run the suspect files with `PYTHONTRACEMALLOC=25`, which adds the allocation traceback. Scope it to a handful of files — suite-wide it reached 1% in six minutes before I killed it. For exact blame I used a throwaway plugin forcing `gc.collect()` in each teardown, which pins the warning to its creator; that produced the final list of 23.

`pytest.ini` also records the two things *not* to reach for: an autouse fixture that disposes of stray coroutines would make the gate permanently green, since it can't tell a test double's leftover from a production drop; and a per-test `filterwarnings` marker doesn't reliably exempt anything, for the attribution reason above.

## Deliberately not done

- **A shared context manager for the 30 identical `patch("core_api.tasks.track_task", side_effect=...)` sites.** Two reviewers suggested it and it would remove real repetition, but it also removes the patch target from the line that patches it. This repo leans on grep-based audits, and `grep "core_api.tasks.track_task"` currently finds every site; behind a helper it would find none of them. Recorded as a judgement call, not an oversight.
- **Sweeping the ~21 other ad-hoc `coro.close()` stubs** across nine untouched files onto the shared helper. Correct direction, but it adds files to a 9-file diff for no behavioural change. Natural follow-up.
- **Fixing `_storage_mock` in `test_crystallization_must_not_wedge.py`** to return real dicts, which would stop the AsyncMock drops at source and make the `AsyncMockMixin` exclusion unnecessary. The better end state; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
