### PR TITLE
fix(mcp): gate caura_insights on write scope

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -3123,6 +3123,11 @@ async def caura_insights(
     t0 = time.perf_counter()
     if err := _check_auth():
         return err
+    # Write tool despite the name: Phase 3's ``_persist_findings`` creates and
+    # supersedes ``insight`` memories. REST gates the same work —
+    # ``POST /insights/generate`` calls ``auth.enforce_read_only()``.
+    if err := _check_write_scope():
+        return err
     tenant_id = _get_tenant()
     agent_id = _get_agent_id() or agent_id
     if refuse := _refuse_default_agent_on_gateway(agent_id):

--- a/tests/test_mcp_default_agent_guard_a29.py
+++ b/tests/test_mcp_default_agent_guard_a29.py
@@ -45,7 +45,10 @@ pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
         # caura_stats: every param optional.
         ("caura_stats", {}),
         # caura_insights: focus is required and must be one of the allowed
-        # slugs to clear pre-validation before the guard fires.
+        # slugs to clear pre-validation before the guard fires. Not a read
+        # tool — it takes the write-scope gate too — but it still reaches the
+        # identity guard here, because setting no capabilities leaves
+        # ``_get_scopes()`` None and that gate passes on the legacy path.
         ("caura_insights", {"focus": "contradictions"}),
         # caura_keystones: every param optional.
         ("caura_keystones", {}),

--- a/tests/test_mcp_write_scope_gate.py
+++ b/tests/test_mcp_write_scope_gate.py
@@ -94,6 +94,26 @@ async def test_caura_evolve_blocked_for_read_only(mcp_env, monkeypatch):
     assert payload["error"]["code"] == "FORBIDDEN"
 
 
+async def test_caura_insights_blocked_for_read_only(mcp_env, monkeypatch):
+    """``caura_insights`` persists ``insight`` memories, so it is a write tool.
+
+    The tool reads as a query and was ungated to match; its REST twin settles
+    the classification, calling ``auth.enforce_read_only()`` for the same work.
+    Measured: with the gate removed, this answers a read-only credential with a
+    success payload rather than an error of any kind.
+
+    ``scope-limited to read`` is the discriminator, not the FORBIDDEN code —
+    ``_require_trust`` also answers FORBIDDEN here, and that text occurs only in
+    ``_READ_ONLY_ERROR``.
+    """
+    _force_read_only(monkeypatch)
+    out = await mcp_server.caura_insights(focus="patterns")
+    assert is_error_envelope(out)
+    payload = parse_envelope(out)
+    assert payload["error"]["code"] == "FORBIDDEN"
+    assert "scope-limited to read" in payload["error"]["message"]
+
+
 async def test_caura_tune_blocked_for_read_only(mcp_env, monkeypatch):
     _force_read_only(monkeypatch)
     out = await mcp_server.caura_tune(top_k=10)


### PR DESCRIPTION
## What

`caura_insights` persists `insight` memories, and had no write-scope gate. This adds the two lines that every other MCP write tool already has.

## The gap

Phase 3 of the handler calls `_persist_findings`, which supersedes prior insight memories and bulk-creates new ones. It was the only write tool on the MCP surface with no `_check_write_scope()` call, so a credential whose `X-Capabilities` set excludes `write` could write through this transport.

The same work over REST is refused — `POST /insights/generate` calls `auth.enforce_read_only()` ([routes/insights.py](../blob/main/core-api/src/core_api/routes/insights.py)). Two transports disagreeing about one service is what settles the classification rather than taste; the tool's name reading like a query is why it drifted in the first place.

**Measured, not inferred.** With the gate removed, the handler answers a read-only credential with a *success* payload, not an error of any kind:

```
{"focus": "patterns", "scope": "agent", "memories_analyzed": 2, "findings": [], ...}
```

(The row count there is whatever the local test database holds for `test-tenant` — the test does not patch `_QUERY_DISPATCH`. The load-bearing half is the success envelope, not the number.)

Gates it already had — `_check_auth`, `_refuse_default_agent_on_gateway`, `_require_trust`, `check_and_increment` — none of which look at credential capabilities.

## Placement

Immediately after `_check_auth()`, matching all six already-gated tools (`caura_write`, `caura_manage`, `caura_tune`, `caura_doc`, `caura_evolve`, `caura_keystones_set`). A refusal therefore costs no trust lookup, no quota budget, no analytic read, and no LLM round-trip — the last of which is a multi-second call.

## On the test

The discriminator is the `scope-limited to read` text, not the FORBIDDEN code: `_require_trust` also answers FORBIDDEN on this handler, and only `_READ_ONLY_ERROR` carries that string.

A `_persist_findings` spy was written and then dropped as redundant with that assertion. Worth recording, because my first two reasons for dropping it were both wrong: I claimed the assertion "could not fail in either direction" on the grounds that the gate returns before `_persist_findings` is imported. That holds only *with* the gate. Without it, Phase 3 calls `_persist_findings` unconditionally — the `if findings:` guard is inside that function and covers only the supersede — so the spy does fire on the ungated path. It is dropped because the message assertion already discriminates, not because it was vacuous.

`test_mcp_default_agent_guard_a29.py` grouped `caura_insights` under "simple read tools"; this change makes that false, so the classification is corrected there. That case still reaches the identity guard it exists to test — it sets no capabilities, so `_get_scopes()` is `None` and the write gate passes on the legacy path.

## Deliberately not in scope

- **The plan-limit axis.** REST insights also calls `enforce_usage_limits()`. MCP applies `_check_plan_limit` only in `caura_write`, and `MutatingOp` has no member for insights, so this is a surface-wide gap (`caura_manage` lacks it too), not something to fix inside one handler.
- **`is_demo`.** `AuthContext.enforce_read_only` tests demo *and* capabilities; `_check_write_scope` tests only capabilities, and `is_demo` appears nowhere in `mcp_server.py`. Latent rather than live — `is_demo=True` is constructed only in tests today.
- **The mechanical inventory.** The list this test joins is enumerated by hand, and nothing fails when a write tool ships with no gate *and* no test — which is exactly how this survived. `tests/test_authz_gate_inventory.py` covers the REST surface and says in its own docstring that the MCP surface "wants its own inventory and does not have one". That inventory is the follow-up, and it also has the receipts to prove hand-lists drift: that same docstring names three mutating MCP tools, and there are seven.

## Verification

- New test fails without the fix (success envelope, quoted above) and passes with it.
- Root suite: **6267 passed, 0 failed**.
- `ruff check` / `ruff format --check` clean on `core-api/src/` and `tests/`, run per-scope.
- Legacy-name ratchet and do-not-touch sentinel both clean.
- mypy: only pre-existing `dateutil` missing-stub errors in `common/enrichment/service.py`, a file this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
