### PR TITLE
fix(storage): lock parent memories in one order, and correct the deadlock note

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -46,6 +46,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import load_only
 from sqlalchemy.sql.dml import ReturningInsert
+from sqlalchemy.sql.selectable import Select
 
 from common import duplicate_memory, permanent_failure
 from common.constants import (
@@ -168,6 +169,35 @@ def _ordered_link_rows(rows: list[dict]) -> list[dict]:
     for row in rows:
         by_key.setdefault((str(row["memory_id"]), str(row["entity_id"])), row)
     return [by_key[key] for key in sorted(by_key)]
+
+
+def _ordered_memory_lock_select(memory_ids: list[UUID], tenant_id: str) -> Select[tuple[Memory]]:
+    """``SELECT ... FOR UPDATE`` over ``memories``, locked in one global order.
+
+    Same hazard as ``_ordered_link_rows`` one table up. A multi-row
+    ``FOR UPDATE`` takes its row locks in the order the executor produces
+    them, and ``WHERE id IN (...)`` fixes no order at all — so this statement
+    and a concurrent link insert can take the same two parent memories in
+    opposite orders and cycle. Measured: with the orders crossed, Postgres
+    kills one side; with them agreed, the later writer only waits.
+
+    ``ORDER BY id`` is the whole mitigation, and it has to be THIS key to be
+    worth anything: the link path sorts on the string form of the id
+    (``_ordered_link_rows``), and Postgres orders the ``uuid`` type by its 16
+    bytes. Those two agree — checked over 500 random v4 ids, both against
+    ``sorted(str(...))`` and against ``sorted(key=.int)`` — which is what makes
+    the two paths agree rather than merely each being internally consistent.
+    """
+    return (
+        select(Memory)
+        .where(
+            Memory.id.in_(memory_ids),
+            Memory.tenant_id == tenant_id,
+            Memory.deleted_at.is_(None),
+        )
+        .order_by(Memory.id)
+        .with_for_update()
+    )
 
 
 @asynccontextmanager
@@ -4932,7 +4962,9 @@ class PostgresService:
     ) -> dict:
         """Bulk-reassign memories to ``target_agent_id`` in ONE transaction.
 
-        Locks the matching live rows ``FOR UPDATE``, loops computing
+        Locks the matching live rows ``FOR UPDATE`` in ``id`` order (see
+        ``_ordered_memory_lock_select`` — unordered, this cycles against a
+        concurrent entity-link insert), loops computing
         moved/promoted/skipped/from_agents, sets ``agent_id`` and auto-promotes
         ``scope_agent`` → ``scope_team`` to prevent data loss, and computes
         ``not_found`` for ids that didn't match (deleted, wrong tenant, or
@@ -4941,19 +4973,7 @@ class PostgresService:
         """
         async with get_session() as session:
             memories = (
-                (
-                    await session.execute(
-                        select(Memory)
-                        .where(
-                            Memory.id.in_(memory_ids),
-                            Memory.tenant_id == tenant_id,
-                            Memory.deleted_at.is_(None),
-                        )
-                        .with_for_update()
-                    )
-                )
-                .scalars()
-                .all()
+                (await session.execute(_ordered_memory_lock_select(memory_ids, tenant_id))).scalars().all()
             )
 
             found_ids = {mem.id for mem in memories}

--- a/tests/test_entity_link_lock_order.py
+++ b/tests/test_entity_link_lock_order.py
@@ -20,21 +20,48 @@ it pin the ordering the helper produces, which is the part a future edit
 would break.
 
 Scope, stated because it is easy to over-read: this closes the ordering
-hazard. It is NOT known to be the cycle behind the suite's intermittent
-``DeadlockDetectedError`` on this table — the statement in that traceback was
-the per-item upsert, which opens one transaction per row and so cannot hold
-two keys at once. Its cycle more likely runs through the foreign-key locks on
-the parent ``memories`` / ``entities`` rows against a concurrent UPDATE from
-background enrichment, which nothing here addresses.
+hazard *within this table*. It is NOT the cycle behind the suite's intermittent
+``DeadlockDetectedError`` here — the statement in that traceback was the
+per-item upsert, which opens one transaction per row and so cannot hold two
+link keys at once.
+
+That much was right. The guess that followed it was wrong, and is corrected
+below with measurements rather than replaced with another guess. It read: "its
+cycle more likely runs through the foreign-key locks on the parent memories /
+entities rows against a concurrent UPDATE from background enrichment". Measured
+against the real database (``test_a_plain_parent_update_does_not_block_a_link_insert``):
+a plain non-key ``UPDATE`` of a parent memory does not block a link insert at
+all. It cannot be half of any cycle. The FK check takes ``FOR KEY SHARE``, an
+ordinary ``UPDATE`` takes ``FOR NO KEY UPDATE``, and those two do not conflict
+— that is the whole point of the row-lock refinement Postgres shipped in 9.3.
+
+What a cycle against a single-row upsert does require, also measured
+(``test_locking_an_entity_before_a_memory_deadlocks_a_single_row_upsert``): a
+partner that locks a parent ENTITY before a parent MEMORY, at ``FOR UPDATE``
+strength. One insert holds ``memories(M)`` while it reaches for
+``entities(E)``, because the two FK triggers fire in constraint-OID order and
+the memories constraint is older. A partner taking the same two rows in the
+opposite order closes the cycle; a partner taking them in the SAME order only
+blocks, which the second half of that test pins.
+
+So the parent-row lock order is a real invariant, and today it holds by
+accident in the one place that takes both: ``_PURGE_TENANT_TABLES`` and
+``_PURGE_FLEET_TABLES`` list ``memories`` before ``entities``, which is why
+purge cannot cycle against a link insert. ``test_purge_locks_memories_before_entities``
+pins that, since nothing else does and the tuples read as arbitrary.
 """
 
 import asyncio
+import contextlib
 import uuid
 
 import asyncpg
 import pytest
 
-from core_storage_api.services.postgres_service import _ordered_link_rows
+from core_storage_api.services.postgres_service import (
+    _ordered_link_rows,
+    _ordered_memory_lock_select,
+)
 from tests.conftest import TEST_DB_URL
 
 # ---------------------------------------------------------------------------
@@ -207,3 +234,256 @@ async def test_opposite_insert_orders_deadlock_at_the_sql_level(_setup_schema) -
     # Exactly one victim: the other writer must still have committed, which is
     # what makes this a deadlock rather than both writers failing.
     assert sorted(outcomes) == ["deadlock", "ok"], outcomes
+
+
+# ---------------------------------------------------------------------------
+# The parent-row lock order — what actually cycles, measured
+# ---------------------------------------------------------------------------
+
+
+def _seed_sql_memory() -> str:
+    return (
+        "INSERT INTO memories (id, tenant_id, agent_id, content, memory_type,"
+        " status, visibility, weight, content_hash)"
+        " VALUES ($1,$2,$3,$4,'fact','active','scope_team',0.5,$5)"
+    )
+
+
+_INSERT_LINK = (
+    "INSERT INTO memory_entity_links (memory_id, entity_id, role)"
+    " VALUES ($1,$2,'subject')"
+    " ON CONFLICT (memory_id, entity_id) DO UPDATE"
+    " SET role = memory_entity_links.role"
+)
+
+
+async def _seed_one_pair(dsn, tenant):
+    """One memory + one entity, returned as (memory_id, entity_id)."""
+    conn = await asyncpg.connect(dsn)
+    try:
+        mid, eid = uuid.uuid4(), uuid.uuid4()
+        await conn.execute(
+            _seed_sql_memory(),
+            mid,
+            tenant,
+            "agent-lockorder",
+            f"parent-lock-order probe {uuid.uuid4().hex[:8]}",
+            uuid.uuid4().hex,
+        )
+        await conn.execute(
+            "INSERT INTO entities (id, tenant_id, entity_type, canonical_name)"
+            " VALUES ($1,$2,'person',$3)",
+            eid,
+            tenant,
+            f"Person {uuid.uuid4().hex[:6]}",
+        )
+        return mid, eid
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_a_plain_parent_update_does_not_block_a_link_insert(
+    _setup_schema,
+) -> None:
+    """The corrected half of this file's docstring, held by Postgres.
+
+    An earlier version of that docstring guessed the intermittent deadlock ran
+    through the FK locks on the parents "against a concurrent UPDATE from
+    background enrichment". It cannot: the FK check takes ``FOR KEY SHARE`` and
+    a non-key ``UPDATE`` takes ``FOR NO KEY UPDATE``, which do not conflict.
+
+    Like ``test_opposite_insert_orders_deadlock_at_the_sql_level``, this is a
+    statement about the database rather than about our code, so it holds a
+    reason rather than a mitigation. If it ever fails, the docstring above is
+    wrong again and the enrichment path becomes a real suspect.
+    """
+    dsn = TEST_DB_URL.replace("postgresql+asyncpg://", "postgresql://")
+    tenant = f"test-tenant-{uuid.uuid4().hex[:8]}"
+    mid, eid = await _seed_one_pair(dsn, tenant)
+
+    holder = await asyncpg.connect(dsn)
+    inserter = await asyncpg.connect(dsn)
+    try:
+        tx = holder.transaction()
+        await tx.start()
+        # Exactly what enrichment does: rewrite a non-key column, stay open.
+        await holder.execute(
+            "UPDATE memories SET content = content || $2 WHERE id = $1", mid, "!"
+        )
+
+        tx2 = inserter.transaction()
+        await tx2.start()
+        try:
+            await asyncio.wait_for(
+                inserter.execute(_INSERT_LINK, mid, eid), timeout=5.0
+            )
+        except TimeoutError:  # pragma: no cover - the failure this test exists for
+            raise AssertionError(
+                "a non-key UPDATE of the parent memory blocked the link insert; "
+                "FOR KEY SHARE and FOR NO KEY UPDATE are supposed to be "
+                "compatible, so this file's docstring needs revisiting"
+            ) from None
+        await tx2.rollback()
+        await tx.rollback()
+    finally:
+        await holder.close()
+        await inserter.close()
+
+
+@pytest.mark.asyncio
+async def test_locking_an_entity_before_a_memory_deadlocks_a_single_row_upsert(
+    _setup_schema,
+) -> None:
+    """The actual cycle available to a ONE-ROW link upsert, and its absence.
+
+    A single-row insert cannot hold two link keys, but it does hold two parent
+    rows: the FK triggers fire in constraint-OID order, memories first, so the
+    statement holds ``memories(M)`` while it reaches for ``entities(E)``.
+
+    Both halves are asserted, because the second is what makes the first
+    actionable: a partner that takes the two parents in the opposite order
+    (entity, then memory) deadlocks the upsert, and a partner that takes them
+    in the same order the FK checks use only blocks. The difference is the
+    entire invariant — see ``test_purge_locks_memories_before_entities``.
+    """
+    dsn = TEST_DB_URL.replace("postgresql+asyncpg://", "postgresql://")
+
+    async def run(entity_first: bool) -> str:
+        tenant = f"test-tenant-{uuid.uuid4().hex[:8]}"
+        mid, eid = await _seed_one_pair(dsn, tenant)
+        partner = await asyncpg.connect(dsn)
+        upserter = await asyncpg.connect(dsn)
+        try:
+            ptx = partner.transaction()
+            await ptx.start()
+            first, second = (
+                ("DELETE FROM entities WHERE id = $1", eid),
+                ("DELETE FROM memories WHERE id = $1", mid),
+            )
+            if not entity_first:
+                first, second = second, first
+            await partner.execute(*first)
+
+            outcome = "ok"
+
+            async def upsert() -> None:
+                nonlocal outcome
+                utx = upserter.transaction()
+                await utx.start()
+                try:
+                    await asyncio.wait_for(
+                        upserter.execute(_INSERT_LINK, mid, eid), timeout=6.0
+                    )
+                    await utx.rollback()
+                except asyncpg.exceptions.DeadlockDetectedError:
+                    outcome = "deadlock"
+                    await utx.rollback()
+                except TimeoutError:
+                    outcome = "blocked"
+
+            async def close_the_cycle() -> None:
+                # Let the upsert reach its second FK check and park there.
+                await asyncio.sleep(0.5)
+                # Either side can be the victim; which one is Postgres's choice,
+                # and the assertion below is about the upsert's outcome only.
+                with contextlib.suppress(
+                    asyncpg.exceptions.DeadlockDetectedError, TimeoutError
+                ):
+                    await asyncio.wait_for(partner.execute(*second), timeout=6.0)
+
+            await asyncio.gather(upsert(), close_the_cycle())
+            # Already unwound if this side was the victim.
+            with contextlib.suppress(Exception):
+                await ptx.rollback()
+            return outcome
+        finally:
+            await partner.close()
+            await upserter.close()
+
+    assert await run(entity_first=True) == "deadlock", (
+        "a partner locking entities before memories no longer cycles against a "
+        "single-row link upsert — the parent lock order may have changed"
+    )
+    assert await run(entity_first=False) == "blocked", (
+        "a partner locking the parents in the FK check order should only wait, "
+        "not cycle; if this deadlocks, ordering the parents no longer helps"
+    )
+
+
+def test_purge_locks_memories_before_entities() -> None:
+    """Purge takes both parent rows in one transaction, so its order matters.
+
+    ``purge_tenant_data`` / ``purge_fleet_data`` run one DELETE per table in a
+    single session, walking these tuples in order, so the tuple order IS the
+    lock order. Listing ``entities`` before ``memories`` would put purge in the
+    cycling order measured above, against every concurrent link insert.
+
+    Nothing else records that, and the tuples otherwise read as a free choice —
+    their own comments say "ordering is free among these" of the trailing
+    group, which is true there and not true of these two.
+    """
+    from core_storage_api.services.postgres_service import (
+        _PURGE_FLEET_TABLES,
+        _PURGE_TENANT_TABLES,
+    )
+
+    for name, tables in (
+        ("_PURGE_TENANT_TABLES", _PURGE_TENANT_TABLES),
+        ("_PURGE_FLEET_TABLES", _PURGE_FLEET_TABLES),
+    ):
+        assert "memories" in tables and "entities" in tables, name
+        assert tables.index("memories") < tables.index("entities"), (
+            f"{name} lists entities before memories, which is the lock order "
+            "measured to deadlock a concurrent link insert"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The same hazard one table up: memories locked FOR UPDATE
+# ---------------------------------------------------------------------------
+
+
+def test_memory_lock_select_orders_by_id() -> None:
+    """``memory_redistribute`` must fix an order for its multi-row FOR UPDATE.
+
+    ``WHERE id IN (...)`` fixes none, which lets it take two parent memories in
+    the opposite order from a concurrent link insert and cycle — reproduced
+    before this helper existed. The compiled statement is asserted rather than
+    the Python, because dropping ``.order_by`` is the regression and it is
+    invisible in behaviour until two writers overlap.
+    """
+    stmt = str(
+        _ordered_memory_lock_select(
+            [uuid.UUID("11111111-1111-1111-1111-111111111111")], "t"
+        ).compile(compile_kwargs={"literal_binds": False})
+    )
+    normalised = " ".join(stmt.split()).lower()
+    assert "order by memories.id" in normalised, stmt
+    assert "for update" in normalised, stmt
+    # Order before lock: the LockRows node has to sit above the Sort, or the
+    # rows are locked in scan order and the ORDER BY only sorts the output.
+    assert normalised.index("order by") < normalised.index("for update"), stmt
+
+
+@pytest.mark.asyncio
+async def test_uuid_order_is_the_same_in_postgres_and_in_the_link_helper(
+    _setup_schema,
+) -> None:
+    """The two paths sort by the same key, which is what makes them agree.
+
+    ``_ordered_link_rows`` sorts on ``str(id)`` in Python; the memories lock
+    orders by the ``uuid`` column in Postgres. Ordering each consistently is
+    not enough — they have to produce the SAME sequence, or the two writers
+    still disagree and the cycle survives both mitigations.
+    """
+    dsn = TEST_DB_URL.replace("postgresql+asyncpg://", "postgresql://")
+    ids = [uuid.uuid4() for _ in range(200)]
+    conn = await asyncpg.connect(dsn)
+    try:
+        rows = await conn.fetch("SELECT u FROM unnest($1::uuid[]) AS u ORDER BY u", ids)
+    finally:
+        await conn.close()
+    in_postgres = [str(r["u"]) for r in rows]
+    in_helper = sorted(str(i) for i in ids)
+    assert in_postgres == in_helper


### PR DESCRIPTION
## What

Two things about the same invariant: the order in which a transaction takes locks on the **parent** rows of `memory_entity_links`.

#1346 fixed the order *within* the link table. It also left a guess on record about the cycle behind the suite's intermittent `DeadlockDetectedError`. That guess is wrong. This corrects it with measurements, pins what the correction rests on, and fixes the one live cycle those measurements turned up.

## The guess, and what actually happens

The docstring said the cycle "more likely runs through the foreign-key locks on the parent `memories` / `entities` rows against a concurrent UPDATE from background enrichment".

Measured against the real database:

| pairing | outcome |
|---|---|
| link insert vs **plain non-key `UPDATE`** of the parent memory | **no conflict at all** |
| link insert vs `FOR UPDATE` on the parent memory | blocks |
| single-row upsert vs partner locking **entity → memory** | **DEADLOCK** |
| single-row upsert vs partner locking **memory → entity** | blocks only |
| sorted batch insert vs unordered multi-row `FOR UPDATE` | **DEADLOCK** |

So enrichment cannot be the partner: the FK check takes `FOR KEY SHARE`, an ordinary `UPDATE` takes `FOR NO KEY UPDATE`, and those don't conflict — that is what the 9.3 row-lock refinement is for.

What the earlier note *did* get right is that the per-item upsert cannot hold two link keys. The step it missed is that a single-row insert still holds **two parent rows**: the FK triggers fire in constraint-OID order (`memory_id_fkey` 16794 before `entity_id_fkey` 16799), so the statement holds `memories(M)` while it reaches for `entities(E)`. A partner taking those two in the opposite order closes a cycle with it — which is how the per-item upsert could be the victim statement in the traceback.

## What that makes load-bearing

`purge_tenant_data` / `purge_fleet_data` are the only paths that lock both parents in one transaction — one `DELETE` per table, walking a declared tuple, so **the tuple order is the lock order**. They are safe today only because `_PURGE_TENANT_TABLES` and `_PURGE_FLEET_TABLES` list `memories` before `entities`. Nothing recorded that, and the tuples otherwise read as a free choice — their own comment says "ordering is free among these" of a later group, which is true there and not true of these two. Now pinned by a test that fails if they're reordered.

## The live cycle, fixed

`memory_redistribute` locks many rows `FOR UPDATE` through `id.in_(...)`, which fixes no order, so it can take two parent memories in the opposite order from a batch link insert (which sorts). Reproduced with a barrier.

Fixed by ordering the select, extracted as `_ordered_memory_lock_select` so the order is testable — the same shape `_ordered_link_rows` already has.

That fix only works because **both paths sort by the same key**: the link helper sorts on `str(id)` in Python, the select orders by the `uuid` column in Postgres. Each being internally consistent wouldn't be enough, so I checked the two agree over 500 random v4 ids rather than reasoning about byte order, and a test pins it.

## What is still open

The captured traceback's exact partner is **not** identified. The cycle shape that can victimise a per-item upsert requires a transaction locking an entity before a memory at `FOR UPDATE` strength, and no current path does that — purge is the only candidate and it goes the safe way. So either the capture predates current code, or the partner was test-local (one test file hard-deletes both parents). I'd rather say that than name a mechanism I haven't demonstrated, which is how the note this PR corrects came to exist.

## Verification

- Root suite **6272 passed / 0 failed**; `core-storage-api` suite **371 passed** (clean env — pointing both suites at `memclaw` trips that suite's own guard).
- mypy clean on `core-storage-api`; `ruff check` and `ruff format --check` clean, one scope per invocation.
- Both new gates confirmed to fail without their fix: the purge-order test by swapping the tuple, the `order_by` test by removing `.order_by`.
- The two characterization tests hold reasons rather than mitigations, which is the pattern this file already documents for `test_opposite_insert_orders_deadlock_at_the_sql_level`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
