### PR TITLE
refactor(auth): give the self plane one gate instead of eight hand-written ifs

### DIFF
--- a/core-api/src/core_api/auth.py
+++ b/core-api/src/core_api/auth.py
@@ -253,6 +253,69 @@ class AuthContext:
                 ),
             )
 
+    def enforce_self_agent(
+        self,
+        requested_agent_id: str | None,
+        *,
+        field: str = "agent_id",
+        detail: str | None = None,
+    ) -> None:
+        """Raise 403 if an agent credential named an agent other than itself.
+
+        The self plane, which is a third question from the two gates above it:
+        ``enforce_read_only`` asks whether this credential may write at all,
+        ``enforce_not_agent_credential`` refuses agent credentials outright, and
+        this one admits an agent credential but only as ITSELF. Routes that are
+        meant to be self-service — tune your own profile, read your own notes,
+        promote your own STM — are exactly the ones that must NOT take
+        ``enforce_not_agent_credential``, since it would refuse the callers they
+        exist for, and none of the eight sites here does.
+
+        It is orthogonal to the write gate rather than paired with it: the four
+        write paths among them (tune, redistribute, clear notes, promote) also
+        call ``enforce_read_only``, and the read paths (stats, read notes, the
+        two ``/recall`` knobs) do not. Whether a caller may write and which
+        identity it may act as are independent questions.
+
+        ``None`` passes, and only ``None``. It means the caller asserted no
+        identity, which every route that can receive one treats as "use the
+        authenticated identity" or as a deliberately wider aggregate
+        (``GET /memories/stats`` documents the second); each of those
+        parameters defaults to ``None``, so an omitted one lands here.
+
+        An explicit empty string does NOT pass, and that is the one place the
+        eight call sites this replaces genuinely disagreed. Five compared
+        unconditionally, so ``?agent_id=`` was a 403; three guarded on
+        truthiness, so it was treated as omitted. Since the two groups had to
+        be reconciled, this takes the stricter reading: an empty agent id is a
+        client error, and answering it 403 is better than the alternative,
+        which on ``GET /stm/notes`` would have turned that 403 into a 200 with
+        an empty body. The three relaxed sites all take an optional parameter,
+        so nothing that omits it is affected.
+
+        Admin credentials are exempt without a special case: the only
+        ``is_admin=True`` context is built at ``auth.py``'s admin branch as
+        ``AuthContext(tenant_id=None, is_admin=True)``, leaving ``agent_id``
+        None, so the first clause already declines to fire. Checked rather than
+        assumed — an explicit ``if self.is_admin: return`` would imply an admin
+        context could carry an agent id, which none does.
+
+        The refusal is a plain-string ``detail`` rather than ``coded_detail``,
+        unlike its neighbours here, because that is what all eight call sites
+        raised before this helper existed. Giving the self plane an error code
+        changes the response body for existing clients, which is a deliberate
+        change and not a side effect of moving the condition.
+        """
+        if self.agent_id and requested_agent_id is not None and requested_agent_id != self.agent_id:
+            raise HTTPException(
+                status_code=403,
+                detail=detail
+                or (
+                    f"{field} '{requested_agent_id}' does not match the "
+                    f"authenticated agent identity '{self.agent_id}'."
+                ),
+            )
+
     def enforce_tenant(self, requested_tenant: str | None) -> None:
         """Raise if the caller may not write to ``requested_tenant``.
 

--- a/core-api/src/core_api/routes/agents.py
+++ b/core-api/src/core_api/routes/agents.py
@@ -143,8 +143,7 @@ async def patch_agent_tune(
     auth.enforce_tenant(tenant_id)
     # An agent may tune ITS OWN profile (also exposed via MCP caura_tune), but
     # not a peer's — block cross-agent tamper while leaving self-tune + admin keys.
-    if auth.agent_id and auth.agent_id != agent_id:
-        raise HTTPException(status_code=403, detail="Agents can only tune their own search profile.")
+    auth.enforce_self_agent(agent_id, detail="Agents can only tune their own search profile.")
     sc = get_storage_client()
     agent = await sc.get_agent(agent_id, tenant_id)
     if not agent:

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -513,11 +513,10 @@ async def memory_stats(
     # it to the caller would silently narrow the historical "no agent_id →
     # team/org-wide" aggregate. Rejecting the conflict closes the leak and
     # leaves every legitimate call (omitted, or naming yourself) untouched.
-    if auth.agent_id and agent_id and agent_id != auth.agent_id:
-        raise HTTPException(
-            status_code=403,
-            detail=f"agent_id must be omitted or match the authenticated agent ('{auth.agent_id}').",
-        )
+    auth.enforce_self_agent(
+        agent_id,
+        detail=f"agent_id must be omitted or match the authenticated agent ('{auth.agent_id}').",
+    )
     caller_agent_id = auth.agent_id or agent_id
     effective_agent_id = agent_id
     if scope is not None:
@@ -1809,26 +1808,12 @@ def _resolve_read_identity(auth: AuthContext, body: SearchRequest) -> tuple[str 
     ``SearchRequest`` must not disagree about what the fields mean; one
     implementation is the only way that stays true.
     """
-    if auth.agent_id and body.filter_agent_id and body.filter_agent_id != auth.agent_id:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                f"filter_agent_id '{body.filter_agent_id}' does not match the "
-                f"authenticated agent identity '{auth.agent_id}'."
-            ),
-        )
+    auth.enforce_self_agent(body.filter_agent_id, field="filter_agent_id")
     # Same rule for the identity knob. ``caller_agent_id`` feeds exactly the two
     # things ``filter_agent_id`` used to smuggle in — the visibility identity and
     # the subject of the trust<2 fleet forcing — so leaving it unguarded would
     # reopen the escalation the check above closes, by a new spelling.
-    if auth.agent_id and body.caller_agent_id and body.caller_agent_id != auth.agent_id:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                f"caller_agent_id '{body.caller_agent_id}' does not match the "
-                f"authenticated agent identity '{auth.agent_id}'."
-            ),
-        )
+    auth.enforce_self_agent(body.caller_agent_id, field="caller_agent_id")
     # Identity, in precedence order: an authenticated agent always wins, then an
     # explicit assertion, then the legacy derivation from the filter so existing
     # callers are untouched. The filter itself is passed separately at the
@@ -2292,13 +2277,7 @@ async def redistribute_memories(
     # caller-asserted ``agent_id`` would let a low-trust agent credential
     # clear it by naming some trust-3 agent in the query string (privilege
     # escalation). Mirrors the precedence pattern in delete/update_memory.
-    if auth.agent_id and agent_id != auth.agent_id:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                f"agent_id '{agent_id}' does not match the authenticated agent identity '{auth.agent_id}'."
-            ),
-        )
+    auth.enforce_self_agent(agent_id)
 
     # Verify requesting agent is admin
     caller = await lookup_agent(tenant_id, agent_id)

--- a/core-api/src/core_api/routes/stm.py
+++ b/core-api/src/core_api/routes/stm.py
@@ -201,11 +201,10 @@ async def get_notes(
     # The DELETE twin directly below has enforced this since the 2026-06-11
     # audit, which left the pair lopsided: a peer's notes could not be cleared,
     # only read. Disclosure was the half still open.
-    if auth.agent_id and agent_id != auth.agent_id:
-        raise HTTPException(
-            status_code=403,
-            detail=f"agent_id '{agent_id}' does not match the authenticated agent identity.",
-        )
+    auth.enforce_self_agent(
+        agent_id,
+        detail=f"agent_id '{agent_id}' does not match the authenticated agent identity.",
+    )
     from core_api.services.stm_service import read_notes
 
     notes = await read_notes(tenant_id, agent_id, limit=limit)
@@ -229,11 +228,10 @@ async def clear_notes(
     tenant_id = _require_tenant(auth, tenant_id)
     # Authenticated agent identity (gateway X-Agent-ID) takes precedence —
     # an agent credential must not clear a peer agent's notes by naming it.
-    if auth.agent_id and agent_id != auth.agent_id:
-        raise HTTPException(
-            status_code=403,
-            detail=f"agent_id '{agent_id}' does not match the authenticated agent identity.",
-        )
+    auth.enforce_self_agent(
+        agent_id,
+        detail=f"agent_id '{agent_id}' does not match the authenticated agent identity.",
+    )
     from core_api.services.stm_service import clear_notes
 
     await clear_notes(tenant_id, agent_id)
@@ -323,11 +321,10 @@ async def promote_stm(
     # Bind the promoted memory to the authenticated agent identity when the
     # credential carries one — a caller must not promote into LTM on behalf
     # of an arbitrary peer agent.
-    if auth.agent_id and body.agent_id != auth.agent_id:
-        raise HTTPException(
-            status_code=403,
-            detail=f"agent_id '{body.agent_id}' does not match the authenticated agent identity.",
-        )
+    auth.enforce_self_agent(
+        body.agent_id,
+        detail=f"agent_id '{body.agent_id}' does not match the authenticated agent identity.",
+    )
 
     from core_api.services.organization_settings import resolve_config
 

--- a/tests/test_auth_context.py
+++ b/tests/test_auth_context.py
@@ -165,3 +165,84 @@ def test_enforce_read_only_passes_when_scopes_unset():
     is the most common path."""
     ctx = AuthContext(tenant_id="t1")
     ctx.enforce_read_only()  # no raise
+
+
+# ── enforce_self_agent ───────────────────────────────────────────────
+#
+# The self plane. Unlike its neighbours here the refusal carries a plain-string
+# ``detail`` rather than the C32 ``{"code", "message", "details"}`` shape, so
+# these assertions read ``detail`` directly — that is what all eight call sites
+# raised before the condition moved onto the helper, and changing the body for
+# existing clients is not something a consolidation should do quietly.
+
+
+def test_enforce_self_agent_noop_without_an_agent_credential():
+    """A tenant/user/admin credential carries no agent identity, so the self
+    plane has nothing to compare and must not narrow those callers."""
+    ctx = AuthContext(tenant_id="t1")
+    ctx.enforce_self_agent("someone-else")  # no raise
+
+
+def test_enforce_self_agent_allows_naming_yourself():
+    ctx = AuthContext(tenant_id="t1", agent_id="agent-a")
+    ctx.enforce_self_agent("agent-a")  # no raise
+
+
+def test_enforce_self_agent_blocks_a_peer():
+    ctx = AuthContext(tenant_id="t1", agent_id="agent-a")
+    with pytest.raises(HTTPException) as exc_info:
+        ctx.enforce_self_agent("agent-b")
+    assert exc_info.value.status_code == 403
+    # Pinned as a substring by test_route_authz_gaps and
+    # test_h06_m30_recall_identity, so it is part of the contract.
+    assert "does not match the authenticated agent identity" in exc_info.value.detail
+    assert "agent-b" in exc_info.value.detail
+
+
+def test_enforce_self_agent_allows_an_unasserted_identity():
+    """Omission means "use the authenticated identity", or a deliberately wider
+    aggregate — never "act as someone else". Every optional agent_id parameter
+    defaults to ``None``, so an omitted one arrives here."""
+    ctx = AuthContext(tenant_id="t1", agent_id="agent-a")
+    ctx.enforce_self_agent(None)  # no raise
+
+
+def test_enforce_self_agent_refuses_an_explicitly_empty_agent_id():
+    """``?agent_id=`` is an assertion, not an omission.
+
+    This is the one input the eight call sites disagreed about: five compared
+    unconditionally and answered 403, three guarded on truthiness and treated
+    it as omitted. Reconciled to the stricter reading — on ``GET /stm/notes``
+    the lenient one would have turned a 403 into a 200 with an empty body.
+    """
+    ctx = AuthContext(tenant_id="t1", agent_id="agent-a")
+    with pytest.raises(HTTPException) as exc_info:
+        ctx.enforce_self_agent("")
+    assert exc_info.value.status_code == 403
+
+
+def test_enforce_self_agent_names_the_field_it_was_given():
+    """``/recall`` refuses two different knobs and the message has to say which
+    — the two used to be separate hand-written raises."""
+    ctx = AuthContext(tenant_id="t1", agent_id="agent-a")
+    with pytest.raises(HTTPException) as exc_info:
+        ctx.enforce_self_agent("agent-b", field="filter_agent_id")
+    assert exc_info.value.detail.startswith("filter_agent_id 'agent-b'")
+
+
+def test_enforce_self_agent_keeps_a_route_specific_detail():
+    ctx = AuthContext(tenant_id="t1", agent_id="agent-a")
+    with pytest.raises(HTTPException) as exc_info:
+        ctx.enforce_self_agent(
+            "agent-b", detail="Agents can only tune their own search profile."
+        )
+    assert exc_info.value.detail == "Agents can only tune their own search profile."
+
+
+def test_enforce_self_agent_exempts_admin_without_a_special_case():
+    """Admin is exempt because the admin context carries no ``agent_id``, not
+    because the gate tests ``is_admin``. Pinned so that if an admin context ever
+    grows an agent id, this fails and the exemption gets stated deliberately."""
+    ctx = AuthContext(tenant_id=None, is_admin=True)
+    assert ctx.agent_id is None
+    ctx.enforce_self_agent("any-agent")  # no raise


### PR DESCRIPTION
## What

Eight routes asked the same question inline — *may this agent credential act as the agent it just named* — and answered it with eight hand-written `if`/`raise` pairs. `AuthContext` already owns the two neighbouring questions; this adds the third and routes all eight through it.

| gate | question |
|---|---|
| `enforce_read_only` | may this credential write at all? |
| `enforce_not_agent_credential` | may an agent credential be here at all? |
| **`enforce_self_agent`** (new) | **may it act as the agent it named?** |

Self-service routes are exactly the ones that must *not* take the plane gate — it would refuse the callers they exist for — and none of the eight does.

## The eight were not identical, which is the reason this is worth doing

Five compared unconditionally; three guarded on truthiness first. Checked site by site: **the guard tracked whether the parameter was optional, not a disagreement about the rule.** Every unconditional site takes a required `agent_id` — a path param, `Query(...)`, or a required pydantic field — so its value cannot be falsy and the two shapes agreed on every input a caller can send.

Except one. `?agent_id=` reaches a required `str` as `""`, where the five strict sites answered 403 and the three lenient ones treated it as omitted. Reconciled to the stricter reading — **`None` passes and only `None`** — because the lenient reading would have turned `GET /stm/notes?agent_id=` from a 403 into a **200 with an empty body**. All three sites that change take an optional parameter defaulting to `None`, so no caller that omits it is affected. Pinned by a test.

## Messages are preserved exactly

`field=` reproduces `/recall`'s two variants byte-for-byte, `detail=` carries the four route-specific wordings, and `redistribute_memories` already matched the default. The substring `does not match the authenticated agent identity` is asserted via `resp.text` by `test_route_authz_gaps` and `test_h06_m30_recall_identity`, so it is contract rather than incidental phrasing.

## Two things deliberately unchanged

- **Plain-string `detail`, not `coded_detail`** like every neighbour in `auth.py` — because that is what all eight sites raised. Giving the self plane an error code changes the response body for existing clients; that is a decision, not a side effect of moving a condition.
- **`services/caller_identity.py` keeps its own comparison.** It logs a warning and lets header precedence win rather than refusing — different behaviour, not a ninth copy.

## Verified rather than inherited from a comment

- **Admin exemption is real with no special case.** The only `is_admin=True` context is built at `auth.py`'s admin branch as `AuthContext(tenant_id=None, is_admin=True)`, leaving `agent_id` None, so the first clause declines to fire. A test pins it, so if an admin context ever grows an agent id the exemption has to be restated deliberately. An explicit `if self.is_admin: return` would imply the opposite.
- **The gate is orthogonal to the write gate**, not paired with it: the four write paths among the eight also call `enforce_read_only`; the read paths don't. I first wrote "all eight also call `enforce_read_only`" and measured it false before it shipped.

## Checked and NOT a finding

`GET /agents/{agent_id}/tune` has no self-plane check while its `PATCH` twin does, which looks like the lopsided read/write pair the 2026-06-11 audit found on STM notes (that pair's comment is still in `stm.py`). It isn't one — both it and `GET /agents/{agent_id}` call `sc.get_agent` and return the same `AgentOut` under the same `enforce_tenant`, so gating one leaves the identical payload one hop away. Whether the agent row should be tenant-readable at all is a real question and a wider one than this change.

## Follow-up this makes possible

`tests/test_authz_gate_inventory.py` mechanically inventories two invariants over every mutating route. The self plane could now be a third — "every route taking a caller-supplied `agent_id` either calls `enforce_self_agent` or is allowlisted with a reason" — because there is finally one named callable to look for. ~22 routes take an `agent_id` without it today, most with legitimate substitutes (the plane gate, `resolve_write_agent` precedence, admin-only), so the allowlist would carry real judgements. Not in this PR.

## Verification

- Root suite **6276 passed / 0 failed**.
- `ruff check` / `ruff format --check` clean on `core-api/src/` and `tests/`, one scope per invocation.
- mypy `core-api` clean apart from pre-existing `dateutil` missing-stub errors in a file this doesn't touch.
- Legacy-name ratchet and do-not-touch sentinel clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
