### PR TITLE
fix(entities): block a merge when two bracketed qualifiers conflict (A42)

### DIFF
--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -41,14 +41,47 @@ _LITERAL_OR_ATTR_RE = re.compile(
 )
 
 
+# A42 — parenthetical qualifiers, e.g. the "(delaware)" in "acme (delaware)".
+# Matches the discriminator vocabulary ``_reattach_subject_discriminators``
+# already established ("#NNNN" and parentheticals); deliberately NOT any
+# trailing word, because unbracketed tokens are usually harmless surface
+# variation ("acme" / "acme corp") rather than a distinguisher.
+_QUALIFIER_RE = re.compile(r"[(\[]([^)\]]{1,64})[)\]]")
+
+
+def _qualifier_signature(name: str) -> frozenset[str]:
+    """Bracketed qualifiers in ``name``, normalised for comparison."""
+    return frozenset(" ".join(m.strip().lower().split()) for m in _QUALIFIER_RE.findall(name) if m.strip())
+
+
 def _same_identifier_signature(a: str, b: str) -> bool:
-    """CAURA graph-build fix (B): two names may only merge if they carry the SAME set
-    of digit-bearing identifier tokens. Synthetic suffix-distinct names like
-    'comet #0002' vs 'comet #0012' embed near-identically and trip the 0.85 similarity
-    merge, collapsing distinct entities into one contaminated mega-node."""
+    """Two names may only merge if nothing in them says they are different things.
+
+    CAURA graph-build fix (B): same set of digit-bearing identifier tokens.
+    Synthetic suffix-distinct names like 'comet #0002' vs 'comet #0012' embed
+    near-identically and trip the 0.85 similarity merge, collapsing distinct
+    entities into one contaminated mega-node.
+
+    A42 (A33 mechanism ②): digits alone are too narrow. Two genuinely distinct
+    entities distinguished by a NON-digit qualifier — 'acme (delaware)' vs
+    'acme (ohio)' — both yield an empty digit set, compare equal, and merge.
+    Downstream that reads as same_subject=true and produces a false
+    contradiction between two different things.
+
+    Asymmetry is deliberate: a name with NO qualifier merges freely with a
+    qualified one ('acme' vs 'acme (ohio)' -> allowed). An absent qualifier
+    means "unspecified", not "different", and blocking it would strand every
+    qualified mention from its own plain surface form. The chosen failure
+    direction favours coalescence — an over-merge is visible and recoverable,
+    whereas an entity that never coalesces fragments the graph silently.
+    """
     ta = set(re.findall(r"\d[\w.\-]*", a.lower()))
     tb = set(re.findall(r"\d[\w.\-]*", b.lower()))
-    return ta == tb
+    if ta != tb:
+        return False
+    qa, qb = _qualifier_signature(a), _qualifier_signature(b)
+    # Only a CONFLICT between two present qualifiers blocks the merge.
+    return not qa or not qb or qa == qb
 
 
 def _is_valid_entity(name: str, blocklist: frozenset[str] | None = None) -> bool:

--- a/tests/test_a42_qualified_name_merge.py
+++ b/tests/test_a42_qualified_name_merge.py
@@ -1,0 +1,84 @@
+"""A42 — two distinct entities distinguished by a non-digit qualifier merged.
+
+``_same_identifier_signature`` compared only DIGIT-BEARING tokens, so
+'acme (delaware)' and 'acme (ohio)' both produced an empty set, compared equal,
+and were allowed to merge at cosine >= 0.85. Downstream that reads as
+same_subject=true and yields a false contradiction between two different things.
+
+The guard now also compares bracketed qualifiers — matching the discriminator
+vocabulary ``_reattach_subject_discriminators`` already uses — and blocks a merge
+only when two PRESENT qualifiers conflict.
+"""
+
+import pytest
+
+from core_api.services.entity_extraction_worker import (
+    _qualifier_signature,
+    _same_identifier_signature,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ── the bug ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("acme (delaware)", "acme (ohio)"),
+        ("priya (acmecorp)", "priya (betaindustries)"),
+        ("john smith (legal)", "john smith (engineering)"),
+        ("acme [emea]", "acme [apac]"),
+    ],
+)
+def test_conflicting_qualifiers_block_the_merge(a, b):
+    assert _same_identifier_signature(a, b) is False
+
+
+# ── what must NOT regress ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("acme", "acme corp"),
+        ("acme corp", "acme corporation"),
+        ("anna bergstrom", "anna bergström"),
+        ("acme (ohio)", "acme (ohio)"),
+        ("acme (Ohio)", "acme ( ohio )"),  # normalisation: case + whitespace
+    ],
+)
+def test_legitimate_merges_still_allowed(a, b):
+    """Fragmenting normal aliases is a worse failure than an over-merge: an
+    over-merge is visible and recoverable, an entity that never coalesces is not."""
+    assert _same_identifier_signature(a, b) is True
+
+
+def test_an_absent_qualifier_is_unspecified_not_different():
+    """Deliberate asymmetry — blocking this would strand every qualified mention
+    from its own plain surface form."""
+    assert _same_identifier_signature("acme", "acme (ohio)") is True
+    assert _same_identifier_signature("acme (ohio)", "acme") is True
+
+
+def test_the_original_digit_guard_still_holds():
+    """A42 must not weaken the case the guard was built for."""
+    assert _same_identifier_signature("comet #0002", "comet #0012") is False
+    assert _same_identifier_signature("comet #0002", "comet #0002") is True
+
+
+def test_qualifier_extraction():
+    assert _qualifier_signature("acme (delaware)") == frozenset({"delaware"})
+    assert _qualifier_signature("acme [EMEA] (legal)") == frozenset({"emea", "legal"})
+    assert _qualifier_signature("acme") == frozenset()
+    assert (
+        _qualifier_signature("acme ()") == frozenset()
+    )  # empty bracket is not a qualifier
+
+
+def test_digits_and_qualifiers_are_both_required_to_agree():
+    """A matching qualifier does not excuse a differing identifier."""
+    assert (
+        _same_identifier_signature("comet #0002 (emea)", "comet #0012 (emea)") is False
+    )


### PR DESCRIPTION
## Two distinct entities, one row

`_same_identifier_signature` compared **only digit-bearing tokens**:

```python
ta = set(re.findall(r"\d[\w.\-]*", a.lower()))
return ta == tb
```

So:

| pair | digit sets | outcome |
|---|---|---|
| `comet #0002` vs `comet #0012` | `{0002}` ≠ `{0012}` | blocked ✅ *(the case it was built for)* |
| `acme (delaware)` vs `acme (ohio)` | `{}` == `{}` | **merged** ❌ |
| `john smith (legal)` vs `john smith (engineering)` | `{}` == `{}` | **merged** ❌ |

Downstream that reads as `same_subject=true` and yields a **false contradiction between two different things**.

## Fix

Also compare **bracketed qualifiers** — matching the vocabulary `_reattach_subject_discriminators` already uses (`#NNNN` and parentheticals). A merge is blocked only when two **present** qualifiers conflict.

**Deliberately not any trailing word.** Comparing all tokens would block `acme` vs `acme corp` and fragment every alias in the graph.

**Deliberate asymmetry:** `acme` vs `acme (ohio)` still merges. An absent qualifier means *unspecified*, not *different* — blocking it would strand every qualified mention from its own plain surface form. The failure direction favours coalescence: an over-merge is visible and recoverable; an entity that never coalesces fragments the graph silently.

## Scope — what this does *not* fix

The priya-class case I observed on staging during V4 today is a **different defect**. There the extractor emitted the bare name `'priya'` for *both* memories — no qualifier at all — so this guard has nothing to compare and **correctly** allows the merge:

```
staging case   priya vs priya         -> True   (merge still allowed)
A42 case       acme(de) vs acme(oh)   -> False  (blocked)
```

That case needs extraction to *emit* a discriminator, which is mechanism ①'s territory. I've corrected the V4 verification doc, which previously said V4 was "blocked on A42" — that was imprecise.

## Testing

13 unit tests: the conflicting-qualifier block, the four legitimate merges that must not regress (`acme`/`acme corp`, corporate suffixes, diacritics, identical qualifiers), the one-sided asymmetry, and that the original `#0002`/`#0012` guard still holds.

Refs: canonical A42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)