### PR TITLE
test(authz): inventory the self plane, the third axis of the gate

### DIFF
--- a/tests/_legacy_contracts.py
+++ b/tests/_legacy_contracts.py
@@ -4,6 +4,7 @@ FROZEN_PLUGIN_SLUG = "memclaw"  # legacy-name-ok: existing plugin and skill iden
 FROZEN_TOPIC_PREFIX = "memclaw"  # legacy-name-ok: deployed Pub/Sub wire namespace
 LEGACY_API_KEY_FIELD = "memclaw_api_key"  # legacy-name-ok: Settings compatibility field
 INSIGHTS_AGENT_ID = "memclaw-insighter"  # legacy-name-ok: persisted service-agent identity
+LEGACY_KEYSTONES_ROUTE = "GET /api/v1/memclaw/keystones"  # legacy-name-floor: served mirror route, named here not declared
 
 
 def frozen_topic(suffix: str) -> str:

--- a/tests/test_authz_gate_inventory.py
+++ b/tests/test_authz_gate_inventory.py
@@ -27,8 +27,16 @@ walked away without the third, so the SECOND visit to one function is what
 found it. Manual sweeps have not converged, and prose in a route docstring is
 not readable by anything.
 
-So: enumerate the surface and make the omissions explicit. Two invariants, one
-mechanism.
+So: enumerate the surface and make the omissions explicit. Three invariants,
+one mechanism.
+
+The third is not about mutation. ``enforce_self_agent`` (#1364/#1365) asks
+whether an agent credential may act as the agent a REQUEST NAMED, and a read
+can leak on that axis as readily as a write: ``GET /stm/notes?agent_id=<peer>``
+and ``filter_agent_id`` on ``POST /recall`` were both disclosure, not tamper.
+So that invariant is scoped by the route's INTERFACE — does it take a
+caller-supplied agent identity — rather than by verb, and it reads
+``route.dependant`` rather than the handler body. See ``_identity_params``.
 
 WHAT THIS IS NOT. It does not decide whether a gate is the RIGHT one, and it
 cannot: ``skills_inbox`` guards with a module-local ``_require_inbox_admin``
@@ -47,11 +55,16 @@ it cannot silently stop running.
 from __future__ import annotations
 
 import ast
+import functools
 import inspect
 import re
 import textwrap
+import typing
+from collections.abc import Callable
+from typing import NamedTuple
 
 from core_api.app import app
+from tests._legacy_contracts import LEGACY_KEYSTONES_ROUTE
 
 MUTATING_VERBS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
@@ -86,8 +99,100 @@ WRITE_GATE_EXEMPT = frozenset({"enforce_admin"})
 # it unexempted costs nothing and the first route to use it gets looked at.
 PLANE_GATE_EXEMPT = frozenset({"enforce_admin"})
 
+# The SELF plane is the third axis, and its exemptions are the widest of the
+# three because both other gates settle it by construction: a route that has
+# already refused agent credentials outright (``enforce_not_agent_credential``)
+# or admits only the admin key (``enforce_admin``) cannot be reached by a
+# caller with an agent identity, so "may it act as the agent it named" has no
+# subject. Four routes rest on this and carry no allowlist line:
+# ``DELETE /agents/{id}``, ``PATCH /agents/{id}/fleet``,
+# ``PATCH /agents/{id}/trust``, ``GET /admin/memories``.
+SELF_GATE_EXEMPT = frozenset({"enforce_admin", "enforce_not_agent_credential"})
+
+# Module-level names a settings object is bound to, for the flag scan in
+# ``_classify``. Both spellings are live and neither is the house style:
+# ``memories``, ``interview`` and ``keystones`` import it as ``app_settings``,
+# ``stm`` and ``health`` as plain ``settings``. A third alias would be read as
+# "this handler consults no flags", so the scan is only as wide as this set.
+SETTINGS_OBJECTS = frozenset({"settings", "app_settings"})
+
 WRITE_GATE = "enforce_read_only"
 PLANE_GATE = "enforce_not_agent_credential"
+SELF_GATE = "enforce_self_agent"
+
+# Parameter names that carry a caller's ASSERTION about which agent it is. The
+# set is a judgement and the membership is the whole content of the invariant,
+# so the names left out are recorded below rather than merely absent.
+SELF_ID_PARAMS = frozenset(
+    {"agent_id", "x_agent_id", "filter_agent_id", "caller_agent_id"}
+)
+
+# Agent-shaped parameter names deliberately NOT treated as identity assertions.
+# ``test_the_excluded_identity_names_are_still_live`` fails if one stops
+# appearing, so a rename cannot turn an exclusion into silence.
+SELF_ID_PARAMS_EXCLUDED: dict[str, str] = {
+    "target_agent_id": (
+        "redistribute's DESTINATION — a payload naming where rows go, not a "
+        "claim about who the caller is. That route also takes ``agent_id`` and "
+        "IS gated on it"
+    ),
+    "agents": "fleet/heartbeat's node roster: a report about agents, not a claim to be one",
+    "agent": "install-skill's runtime selector (claude-code | codex | both)",
+}
+# ``written_by`` is the nearest miss and is deliberately not here: it is an
+# AUTHOR filter, and ``GET /memories`` documents it as distinct from the
+# visibility identity precisely so a caller can ask for a peer's authored rows
+# without claiming that peer's identity. It contains no "agent" substring, so
+# it never reaches the scan; the note is for the reader who goes looking.
+
+# There is NO substitute rule, and the first draft of this file had one. It
+# credited any handler containing ``auth.agent_id or <param>`` — the precedence
+# idiom, where the authenticated identity wins — as binding the identity
+# without needing a line. Four routes were exempted by it, and one of the four
+# should not have been.
+#
+# ``delete_memory`` decides authorization with ``caller_agent_id =
+# auth.agent_id`` (``routes/memories.py``, plain attribute, no fallback). The
+# line that matched the shape is the NEXT one, ``attribution_agent_id =
+# auth.agent_id or agent_id``, whose own comment reads "Authorization must not
+# trust this value; the audit log must not discard it". So the exemption was
+# granted by the audit-log line. Measured consequence: rewrite the real
+# principal to ``agent_id or auth.agent_id`` — the escalation — and the route
+# still counted as bound, because the attribution line satisfies the shape on
+# its own. A false negative in the one check that is supposed to catch exactly
+# that. ``tests/test_memory_byid_authz.py`` records the 2026-09-03 ruling that
+# this very expression, used as a principal, WAS the bug on that route.
+#
+# An ``any()`` over a function body cannot tell the deciding expression from a
+# bystander. The four routes carry allowlist lines instead, each naming what
+# it actually decides with — which is how the reader learns that ``delete``
+# binds more strictly than the other three, not less.
+#
+# The deeper fix, if this idiom spreads: give ``AuthContext`` an
+# ``effective_agent_id(requested)`` method, convert the call sites, and detect
+# it by NAME like every other gate. Then the exemption is bound to the
+# expression that governs. Not done here — it is production-code surgery on
+# five handlers, and this file should not be the reason for it.
+#
+# ``resolve_write_agent`` is not a substitute either, though it looks like the
+# obvious candidate. It enforces the BROKER ownership boundary (degrade an
+# install's write that names another install's agent) and documents that
+# "non-broker callers pass straight through". Binding a write to the credential
+# is a different mechanism — ``bind_write_identity_to_auth`` — which
+# ``config.py`` defaults to False and describes as shipping dark.
+
+# Imported callables worth naming in the report. Not an exemption and not
+# consulted by the invariant: purely a filter so the failure output shows the
+# identity-relevant calls instead of every ``Depends`` and ``Query``.
+IDENTITY_BINDERS = frozenset(
+    {
+        "resolve_write_agent",
+        "resolve_caller_and_gate",
+        "broker_owned_agent_id",
+        "enforce_delete",
+        "enforce_fleet_write",
+    }
+)
 
 # Routers whose mutating surface is admin-plane: operations on the fleet, on
 # agent identity, on tenant settings, on the org itself. This is where
@@ -184,7 +289,10 @@ WRITE_GATE_ALLOWLIST: dict[str, str] = {
 # for the same purpose: the alternative is a list where "excused" and "not yet
 # fixed" look identical, and then neither gets read.
 KNOWN_GAP_PREFIX = "KNOWN GAP:"
-KNOWN_GAP_CEILING = 0
+# The ceiling itself lives on ``_Axis.gap_ceiling``, one per invariant, so
+# headroom cannot be fungible between them. There is deliberately no module
+# constant here: a single number would have to be the sum, and a reader
+# lowering it after a fix could not say which axis it belonged to.
 
 PLANE_GATE_ALLOWLIST: dict[str, str] = {
     # NODE-plane, not admin-plane. The plugin holds whatever credential the
@@ -223,6 +331,132 @@ PLANE_GATE_ALLOWLIST: dict[str, str] = {
     "POST /api/v1/skills-inbox/{slug:path}/edit": "admin-only via _require_inbox_admin",
 }
 
+# The SELF plane. Every route accepting a ``SELF_ID_PARAMS`` name either calls
+# ``enforce_self_agent``, is exempt by construction (``SELF_GATE_EXEMPT``),
+# binds by ``auth.agent_id`` precedence, or has a line here.
+#
+# The lines fall into four kinds, and the count per kind is the interesting
+# part: what an ``agent_id`` MEANS is not constant across this surface, and
+# every past bug on this axis was a route where two meanings shared one
+# parameter (``GET /memories/stats``'s knob was both author filter and
+# visibility identity; ``/recall``'s ``filter_agent_id`` was both).
+SELF_GATE_ALLOWLIST: dict[str, str] = {
+    # PRECEDENCE: the handler builds its identity as ``auth.agent_id or
+    # <param>``, so an authenticated agent always wins and a caller-supplied
+    # name is used only by a credential that asserts none. Read individually
+    # rather than exempted by a rule, because an ``any()`` over the body cannot
+    # tell this expression from an audit-log line with the same shape — see the
+    # note above ``SELF_ID_PARAMS``.
+    "GET /api/v1/memories": (
+        "precedence: caller_agent_id = auth.agent_id or agent_id is the "
+        "visibility identity, so an agent credential cannot borrow a peer's"
+    ),
+    "PATCH /api/v1/memories/{memory_id}": (
+        "precedence: the update's agent_id is auth.agent_id or agent_id, and "
+        "enforce_tenant bounds the row"
+    ),
+    "GET /api/v1/reports": (
+        "precedence: asserted_agent = auth.agent_id or agent_id, then handed "
+        "to resolve_caller_and_gate, which applies the same rule again"
+    ),
+    # STRICTER than precedence, and the reason it is worth its own line. The
+    # authorization principal here is ``auth.agent_id`` alone — the query param
+    # is never promoted — and ``enforce_delete`` then gates that principal at
+    # trust >= 3. The ``auth.agent_id or agent_id`` in the same handler is the
+    # AUDIT attribution and is documented as not for authorization.
+    #
+    # Nothing HERE would notice if that changed: no static check in this file
+    # can tell which of two same-shaped expressions governs, which is why the
+    # rule that tried was removed. What holds the line is behavioural —
+    # ``test_memory_byid_authz.test_rest_delete_byid_tenant_key_not_trust_gated``
+    # is documented as the test that fails if the param becomes a principal
+    # again, and it is where a reader should go, not this line.
+    "DELETE /api/v1/memories/{memory_id}": (
+        "principal is auth.agent_id alone, gated by enforce_delete at "
+        "trust >= 3; the query param reaches only the audit row"
+    ),
+    # FILTERS, not identity assertions. The parameter narrows which rows the
+    # call touches; the caller's own identity is established elsewhere.
+    "DELETE /api/v1/memories": (
+        "filter: narrows the delete; the caller's own trust is what is gated, "
+        "by enforce_delete(auth.agent_id) at trust >= 3"
+    ),
+    "GET /api/v1/keystones": "filter: narrows a fleet listing, no visibility identity attached",
+    # The literal path is hoisted to ``tests/_legacy_contracts.py`` rather
+    # than written here: an allowlist key must equal the path the app
+    # serves, so the legacy spelling is mandatory, and a marker on this
+    # line would be displaced the first time ``ruff format`` wrapped it.
+    LEGACY_KEYSTONES_ROUTE: "filter: the permanent legacy alias of the line above",
+    "GET /api/v1/reports/agent-activity": (
+        "filter: narrows a digest on a surface that is cross-agent by design — "
+        "GET /reports builds a per_agent breakdown of the tenant"
+    ),
+    # READS of the agent row itself. Tenant-readable by design, and gating one
+    # spelling would leave the identical payload one hop away: both call
+    # sc.get_agent and return the same AgentOut under the same enforce_tenant.
+    # Whether the row should be tenant-readable at all is a real question and a
+    # wider one than this invariant — raised in #1364, not settled there.
+    "GET /api/v1/agents/{agent_id}": "tenant-readable agent row; the /tune twin serves the same payload",
+    "GET /api/v1/agents/{agent_id}/tune": "tenant-readable agent row; same payload as GET /agents/{agent_id}",
+    # BOUND by an imported resolver rather than by the local precedence shape.
+    # resolve_caller_and_gate applies the same rule one layer down —
+    # ``auth.agent_id or body_agent_id`` — so a named peer is discarded, not
+    # refused. It LOGS the mismatch instead of raising, which is why it is not
+    # a caller of the gate; see the note in AuthContext.enforce_self_agent.
+    "POST /api/v1/evolve/report": "bound by resolve_caller_and_gate: the verified identity wins",
+    "POST /api/v1/insights/generate": "bound by resolve_caller_and_gate: the verified identity wins",
+    # INERT. Both reach ``ingest_preview``, which never reads
+    # ``request.agent_id`` — its first use is on the commit path, which is the
+    # entry below. "Persists nothing" is also true but argues the write axis,
+    # and this invariant opens by saying it is not about mutation; the
+    # parameter being unread is the fact that settles a read too.
+    "POST /api/v1/ingest/file": "inert: ingest_preview never reads the agent_id it is handed",
+    "POST /api/v1/ingest/preview": "inert: ingest_preview never reads the agent_id it is handed",
+    # NODE-plane in intent — the interviewer runs under the install's
+    # credential and reports on the worker node it watches, so ``agent_id``
+    # names the SUBJECT and ``enforce_self_agent`` would refuse the case the
+    # route exists for (``routes/interview.py`` declares it required and its own
+    # comment calls it "the WORKER agent the window belongs to").
+    #
+    # Recorded as a gap anyway, because by this file's taxonomy that is what it
+    # is: ``interview_service`` persists memories with
+    # ``agent_id=<caller-named>``, the same property the two ``POST /memories``
+    # lines below record. Narrower in blast radius — visibility is forced to
+    # ``scope_team``, so nothing lands in a peer's private scope — and the
+    # ``metadata.written_by`` the service comment offers as the mitigation is
+    # the constant string ``"interviewer"``, not the submitting credential, so
+    # no row identifies who sent it.
+    "POST /api/v1/interview/submit": (
+        "KNOWN GAP: node-plane by intent, but persists memories attributed to "
+        "a caller-named agent; scope_team caps the blast radius"
+    ),
+    # KNOWN GAPs. Write attribution is caller-named on the agent plane today:
+    # an agent credential may write a memory attributed to a peer. This is
+    # acknowledged and staged, not unnoticed — ``config.py`` carries
+    # ``bind_write_identity_to_auth`` ("Phase 2 (spoof hardening), ships dark",
+    # default False), which is exactly this fix, held until the reserved-`main`
+    # credentials are re-identified. resolve_write_agent does NOT close it: it
+    # enforces the broker/install ownership boundary and passes non-broker
+    # callers straight through.
+    "POST /api/v1/memories": (
+        "KNOWN GAP: attribution is caller-named; binding is behind "
+        "bind_write_identity_to_auth, which ships dark"
+    ),
+    "POST /api/v1/memories/bulk": (
+        "KNOWN GAP: attribution is caller-named; binding is behind "
+        "bind_write_identity_to_auth, which ships dark"
+    ),
+    # Named without the flag, deliberately: this handler never reads it, and
+    # ``test_allowlist_reasons_that_name_a_mechanism_are_corroborated`` is what
+    # said so. The two entries above DO read it, which is the difference — this
+    # path would still be caller-named with Phase 2 fully enabled.
+    "POST /api/v1/ingest/commit": (
+        "KNOWN GAP: attribution is caller-named; broker_owned_agent_id gates "
+        "install ownership only, and nothing here binds the write to the "
+        "calling credential"
+    ),
+}
+
 
 # ---------------------------------------------------------------------------
 # Route resolution
@@ -235,7 +469,11 @@ def _normalise(path: str) -> str:
 
 
 def _resolve_operations() -> list[tuple[str, str, object]]:
-    """Flatten the live app to ``(verb, path, endpoint)``.
+    """Flatten the live app to ``(verb, path, route)``.
+
+    The ROUTE rather than the endpoint, because the self-plane invariant needs
+    ``route.dependant`` — the request interface — while the other two need
+    ``route.endpoint``, which is one attribute away.
 
     The walk has to be the source, not ``app.openapi()``: the schema carries no
     endpoint function, and this check is about what the handler does. FastAPI
@@ -264,7 +502,7 @@ def _resolve_operations() -> list[tuple[str, str, object]]:
             if isinstance(route, APIRoute):
                 for verb in sorted(route.methods or []):
                     if verb not in ("HEAD", "OPTIONS"):
-                        found.append((verb, prefix + route.path, route.endpoint))
+                        found.append((verb, prefix + route.path, route))
                 continue
             context = getattr(route, "include_context", None)
             original = getattr(route, "original_router", None)
@@ -293,11 +531,98 @@ def _resolve_operations() -> list[tuple[str, str, object]]:
 
 
 # ---------------------------------------------------------------------------
+# Request-interface inspection (the self plane)
+# ---------------------------------------------------------------------------
+
+
+def _body_models(annotation) -> list[type]:
+    """Pydantic models reachable from a body annotation, through ``Optional``,
+    ``Annotated`` and unions."""
+    if annotation is None:
+        return []
+    found = [annotation] if hasattr(annotation, "model_fields") else []
+    for arg in typing.get_args(annotation) or ():
+        found.extend(_body_models(arg))
+    return found
+
+
+def _request_params(route) -> frozenset[str]:
+    """Every parameter name this route accepts, from any source.
+
+    Two attribute choices decide how much of the surface this sees, and both
+    of the plausible-looking alternatives fail QUIETLY — they return a smaller
+    set, never an error, and the invariant then passes over what is left.
+    Counted on this tree:
+
+        route.dependant + field_info.annotation   34 routes   (this)
+        route.dependant, field.type_ only         24 routes
+        inspect.signature(endpoint)               30 routes
+
+    ``inspect.signature`` loses the four handlers whose module carries
+    ``from __future__ import annotations`` — ``POST /stm/promote``,
+    ``POST /evolve/report``, ``POST /insights/generate``,
+    ``POST /interview/submit`` — because their body annotation is the STRING
+    ``"PromoteRequest"``, which has no ``model_fields``.
+
+    ``field.type_`` is ``None`` on the FastAPI/pydantic build here, so reading
+    only it loses every body-borne identity: ten routes, including
+    ``POST /recall`` and ``POST /search``, which are the two the gate was
+    written for. Both spellings are tried, and
+    ``test_the_identity_scan_sees_body_borne_ids`` is what stops a FastAPI
+    upgrade from shrinking this invariant in silence.
+    """
+    found: set[str] = set()
+    seen: set[int] = set()
+
+    def visit(dependant) -> None:
+        if dependant is None or id(dependant) in seen:
+            return
+        seen.add(id(dependant))
+        for group in ("path_params", "query_params", "header_params", "cookie_params"):
+            for field in getattr(dependant, group, None) or ():
+                found.add(field.name)
+        for field in getattr(dependant, "body_params", None) or ():
+            found.add(field.name)
+            annotation = getattr(field, "type_", None)
+            if not hasattr(annotation, "model_fields"):
+                annotation = getattr(
+                    getattr(field, "field_info", None), "annotation", None
+                )
+            for model in _body_models(annotation):
+                found.update(model.model_fields)
+        for sub_dependant in getattr(dependant, "dependencies", None) or ():
+            visit(sub_dependant)
+
+    visit(getattr(route, "dependant", None))
+    return frozenset(found)
+
+
+def _identity_params(route) -> frozenset[str]:
+    """The ``SELF_ID_PARAMS`` this route actually accepts."""
+    return frozenset(_request_params(route) & SELF_ID_PARAMS)
+
+
+# ---------------------------------------------------------------------------
 # Handler classification
 # ---------------------------------------------------------------------------
 
 
+@functools.cache
 def _parse(fn) -> ast.AST | None:
+    """Cached because the fifteen tests here re-derive the same rows.
+
+    Every test calls a row builder, each builder walks the whole app, and
+    ``_classify`` parses each handler plus two levels of helpers — so one file
+    run did ~7,100 ``getsource`` + ``ast.parse`` pairs over a few hundred
+    distinct functions. Measured: the cache takes the in-test work from 1.83s
+    to 0.55s.
+
+    Safe because a function's source cannot change mid-run and nothing mutates
+    the returned tree — every reader is an ``ast.walk``. Keyed on the function
+    object, which is what ``route.endpoint`` holds from registration, so it is
+    also stable across the monkeypatching the wider suite does (which targets
+    services and settings, never a registered handler).
+    """
     try:
         return ast.parse(textwrap.dedent(inspect.getsource(fn)))
     except (OSError, TypeError, SyntaxError):
@@ -319,8 +644,10 @@ def _refuses(tree: ast.AST) -> bool:
     )
 
 
-def _classify(fn, _depth: int = 0) -> tuple[frozenset[str], frozenset[str]]:
-    """``(enforce_* names, module-local guard helpers)`` reachable from ``fn``.
+def _classify(
+    fn, _depth: int = 0
+) -> tuple[frozenset[str], frozenset[str], frozenset[str], frozenset[str]]:
+    """``(enforce_* names, guard helpers, imported call names, settings flags)``.
 
     Two levels of module-local indirection are resolved. What that buys is
     narrower than it first appears, and worth stating precisely: all five
@@ -341,24 +668,47 @@ def _classify(fn, _depth: int = 0) -> tuple[frozenset[str], frozenset[str]]:
 
     Two known blind spots, both measured rather than assumed:
 
-    - IMPORTED helpers are skipped (the ``__module__`` filter below), so
-      ``enforce_delete``, ``enforce_fleet_write``, ``enforce_fleet_read_many``,
-      ``resolve_caller_and_gate`` and ``update_memory`` are not followed. All
-      14 routes reaching them also call ``enforce_read_only`` directly, so
-      nothing is missed today — and the limitation fails SAFE: a route whose
-      only guard is imported reports no gates and fails the invariant.
+    - IMPORTED helpers are still not FOLLOWED (the ``__module__`` filter
+      below), so ``enforce_delete``, ``enforce_fleet_write``,
+      ``enforce_fleet_read_many``, ``resolve_caller_and_gate`` and
+      ``update_memory`` contribute no gates. All 14 routes reaching them also
+      call ``enforce_read_only`` directly, so nothing is missed today — and the
+      limitation fails SAFE: a route whose only guard is imported reports no
+      gates and fails the invariant. Their NAMES are now recorded in
+      ``imported_calls``, which is a strictly weaker claim: "this handler calls
+      ``resolve_write_agent``" is a fact, "that covers the self plane" is a
+      judgement, and the judgement stays in the allowlist where
+      ``test_allowlist_reasons_that_name_a_mechanism_are_corroborated`` checks
+      the fact under it. Deliberately NOT gate attribution: following an
+      imported service function would credit a route with a gate that runs
+      three layers down, which is exactly the attribution this file avoids.
     - ``ast.walk`` ignores control flow and ordering, so a gate inside an
       ``if``, after an early ``return``, or in a nested ``def`` all count.
       No route relies on that for either invariant gate today (three
       ``memories`` routes do it for ``enforce_usage_limits``). Ordering is
       asserted behaviourally in ``tests/test_route_authz_gaps.py`` instead,
       which is where a "gate ran after the write" mutant is caught.
+
+    ``flags`` records ``settings.<name>`` / ``app_settings.<name>`` reads, on
+    the same terms as ``imported_calls``: a behaviour held behind a feature
+    flag is a fact about the handler, and an allowlist line naming the flag
+    should be falsifiable. It says nothing about the flag's VALUE —
+    ``bind_write_identity_to_auth`` defaults to False, and a reader who needs
+    that has to open ``config.py``.
     """
     tree = _parse(fn)
     if tree is None:
-        return frozenset(), frozenset()
+        return frozenset(), frozenset(), frozenset(), frozenset()
     gates: set[str] = set()
     helpers: set[str] = set()
+    imported: set[str] = set()
+    flags: set[str] = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id in SETTINGS_OBJECTS
+    }
     module = inspect.getmodule(fn)
     module_globals = getattr(module, "__dict__", {})
     for node in ast.walk(tree):
@@ -375,46 +725,92 @@ def _classify(fn, _depth: int = 0) -> tuple[frozenset[str], frozenset[str]]:
             if not inspect.isfunction(target):
                 continue
             if getattr(target, "__module__", None) != fn.__module__:
-                continue  # only module-local helpers; imports are someone else's surface
+                # An imported callable: record the NAME and do not follow it.
+                imported.add(node.func.id)
+                continue
             sub_tree = _parse(target)
             if sub_tree is None:
                 continue
-            sub_gates, sub_helpers = _classify(target, _depth + 1)
+            sub_gates, sub_helpers, sub_imported, sub_flags = _classify(
+                target, _depth + 1
+            )
+            # Imported names merge unconditionally while gates merge only from a
+            # helper that guards. The asymmetry is deliberate: ``helpers``
+            # answers "is this a guard", which needs evidence, and
+            # ``imported_calls`` answers "what does the reachable code call",
+            # which does not. ``POST /memories`` reaches ``resolve_write_agent``
+            # through ``_write_memory_inner``, which neither refuses nor adds a
+            # gate of its own.
+            imported |= sub_imported
+            flags |= sub_flags
             if sub_gates or _refuses(sub_tree):
                 helpers.add(node.func.id)
                 gates |= sub_gates
                 helpers |= sub_helpers
-    return frozenset(gates), frozenset(helpers)
+    return frozenset(gates), frozenset(helpers), frozenset(imported), frozenset(flags)
+
+
+def _row(verb: str, path: str, route) -> dict:
+    endpoint = route.endpoint
+    gates, helpers, imported, flags = _classify(endpoint)
+    return {
+        "key": f"{verb} {path}",
+        "router": endpoint.__module__.rsplit(".", 1)[-1],
+        "handler": endpoint.__name__,
+        "gates": gates,
+        "helpers": helpers,
+        "imported_calls": imported,
+        "settings_flags": flags,
+        "identity_params": _identity_params(route),
+    }
 
 
 def _mutating_routes(include_test_only: bool = False) -> list[dict]:
     rows = []
-    for verb, path, endpoint in _resolve_operations():
+    for verb, path, route in _resolve_operations():
         if verb not in MUTATING_VERBS:
             continue
-        router = endpoint.__module__.rsplit(".", 1)[-1]
-        if router in TEST_ONLY_ROUTERS and not include_test_only:
+        row = _row(verb, path, route)
+        if row["router"] in TEST_ONLY_ROUTERS and not include_test_only:
             continue
-        gates, helpers = _classify(endpoint)
-        rows.append(
-            {
-                "key": f"{verb} {path}",
-                "router": router,
-                "handler": endpoint.__name__,
-                "gates": gates,
-                "helpers": helpers,
-            }
-        )
+        rows.append(row)
+    return rows
+
+
+def _self_plane_routes() -> list[dict]:
+    """Every route, ANY verb, that accepts a caller-supplied agent identity.
+
+    No ``include_test_only`` knob, unlike ``_mutating_routes``: measured, no
+    ``testing`` route takes a ``SELF_ID_PARAMS`` name, so the parameter would
+    have had one value at every call site.
+
+    ``_identity_params`` is checked BEFORE ``_row``, which is the cheap order —
+    the scan costs 0.16ms over all 115 routes and classifying them costs 132ms,
+    and 81 of the 115 are discarded.
+    """
+    rows = []
+    for verb, path, route in _resolve_operations():
+        if not _identity_params(route):
+            continue
+        row = _row(verb, path, route)
+        if row["router"] in TEST_ONLY_ROUTERS:
+            continue
+        rows.append(row)
     return rows
 
 
 def _report(row: dict) -> str:
-    return (
-        f"    {row['key']}\n"
-        f"        handler: {row['router']}.{row['handler']}\n"
-        f"        enforce_* called: {sorted(row['gates']) or 'NONE'}\n"
-        f"        refusing helpers: {sorted(row['helpers']) or 'none'}"
-    )
+    lines = [
+        f"    {row['key']}",
+        f"        handler: {row['router']}.{row['handler']}",
+        f"        enforce_* called: {sorted(row['gates']) or 'NONE'}",
+        f"        refusing helpers: {sorted(row['helpers']) or 'none'}",
+    ]
+    if row["identity_params"]:
+        binders = sorted(row["imported_calls"] & IDENTITY_BINDERS)
+        lines.append(f"        identity params: {sorted(row['identity_params'])}")
+        lines.append(f"        identity-binding calls: {binders or 'none'}")
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -436,13 +832,64 @@ def _unguarded_for_plane(row: dict) -> bool:
     )
 
 
-# ``(name, allowlist, predicate)`` — the pairing the entry-hygiene checks walk.
-# Sharing the predicates with the invariant tests is the point: an entry is
-# "needed" exactly when the invariant would flag the route, by one definition
-# rather than two that can drift.
+def _unguarded_for_self(row: dict) -> bool:
+    """Would this route fail the self-plane invariant without an entry?"""
+    return (
+        bool(row["identity_params"])
+        and SELF_GATE not in row["gates"]
+        and not (row["gates"] & SELF_GATE_EXEMPT)
+    )
+
+
+class _Axis(NamedTuple):
+    """One invariant, and everything the hygiene checks need to police it.
+
+    Sharing the predicate with the invariant test is the original point: an
+    entry is "needed" exactly when the invariant would flag the route, by one
+    definition rather than two that can drift. ``rows`` and ``gap_ceiling``
+    joined it for the same reason — the self plane arrived needing a different
+    route surface (every verb, not just mutating ones) and its own ratchet, and
+    both started life as separate structures keyed by ``name``. A fourth axis
+    would then have inherited the staleness, unnecessary-entry and
+    corroboration checks automatically and silently had NO gap ceiling, which
+    is the "sat outside both sets with nothing failing" failure this file
+    records against ``keystones``.
+    """
+
+    name: str
+    allowlist: dict[str, str]
+    needs_entry: Callable[[dict], bool]
+    rows: Callable[[], list[dict]]
+    gap_ceiling: int
+
+
+# Ceilings are PER AXIS, not one number across all three, so headroom cannot be
+# fungible: closing a self-plane gap must not silently license a new write-gate
+# one. The self plane starts at 4 because the axis is newer than the gaps on it
+# — write attribution is caller-named today and ``config.py`` already carries
+# the staged fix — and the ceiling is what stops a fifth joining quietly.
 _ALLOWLISTS = (
-    ("WRITE_GATE_ALLOWLIST", WRITE_GATE_ALLOWLIST, _unguarded_for_write),
-    ("PLANE_GATE_ALLOWLIST", PLANE_GATE_ALLOWLIST, _unguarded_for_plane),
+    _Axis(
+        "WRITE_GATE_ALLOWLIST",
+        WRITE_GATE_ALLOWLIST,
+        _unguarded_for_write,
+        _mutating_routes,
+        0,
+    ),
+    _Axis(
+        "PLANE_GATE_ALLOWLIST",
+        PLANE_GATE_ALLOWLIST,
+        _unguarded_for_plane,
+        _mutating_routes,
+        0,
+    ),
+    _Axis(
+        "SELF_GATE_ALLOWLIST",
+        SELF_GATE_ALLOWLIST,
+        _unguarded_for_self,
+        _self_plane_routes,
+        4,
+    ),
 )
 
 
@@ -491,6 +938,124 @@ def test_admin_plane_mutating_routes_refuse_agent_credentials() -> None:
     )
 
 
+def test_routes_taking_an_agent_identity_gate_the_self_plane() -> None:
+    """A caller must not act as an agent it merely named.
+
+    The third axis, and the one that is not about mutation:
+    ``GET /stm/notes?agent_id=<peer>`` returned a peer's private notes and
+    ``filter_agent_id`` on ``POST /recall`` returned a peer's private rows.
+    Both reads, both found and fixed one route at a time — the 2026-06-11
+    audit closed the STM DELETE twin and left the read open (``routes/stm.py``
+    still carries the note), and H-06 was the ``/recall`` half. #1364 is what
+    gave the rule one name to look for.
+
+    A route satisfies it three ways: call ``enforce_self_agent``; refuse agent
+    credentials outright, so the question has no subject (``SELF_GATE_EXEMPT``);
+    or carry a line in ``SELF_GATE_ALLOWLIST`` saying what the parameter means
+    instead. There is deliberately no fourth, mechanism-shaped exemption — the
+    note above ``SELF_ID_PARAMS`` records the one that was tried and what it
+    let through.
+    """
+    offenders = [
+        row
+        for row in _self_plane_routes()
+        if _unguarded_for_self(row) and row["key"] not in SELF_GATE_ALLOWLIST
+    ]
+    assert not offenders, (
+        f"{len(offenders)} route(s) accept a caller-supplied agent identity, "
+        f"do not call {SELF_GATE}, are not admin-only or "
+        "agent-credential-free, and are not listed in SELF_GATE_ALLOWLIST:\n"
+        + "\n".join(_report(r) for r in offenders)
+        + f"\n\nAdd the gate, or add a line to SELF_GATE_ALLOWLIST in {__file__} "
+        "saying what this route's agent_id means if not 'act as this agent'."
+    )
+
+
+def test_the_identity_scan_sees_body_borne_ids() -> None:
+    """Guards the scan itself, which failed silently on its first draft.
+
+    ``_request_params`` documents which attributes it reads and what each
+    alternative loses. This pins three of the ten routes that the plausible
+    wrong one drops: the ones that ARE gated, so a regression on them is a real
+    hole rather than a missing allowlist line, and two of the three are what
+    ``enforce_self_agent`` was written for.
+
+    A FastAPI upgrade that moves the annotation again fails HERE, naming what
+    broke, instead of quietly narrowing the invariant to the query string.
+    """
+    rows = {row["key"]: row for row in _self_plane_routes()}
+    expected = {
+        "POST /api/v1/recall": {"filter_agent_id", "caller_agent_id"},
+        "POST /api/v1/search": {"filter_agent_id", "caller_agent_id"},
+        "POST /api/v1/stm/promote": {"agent_id"},
+    }
+    missing = {
+        key: (
+            "route not in the self-plane set at all"
+            if key not in rows
+            else f"found {sorted(rows[key]['identity_params'])}, want {sorted(want)}"
+        )
+        for key, want in expected.items()
+        if key not in rows or not want <= rows[key]["identity_params"]
+    }
+    assert not missing, (
+        "the identity scan stopped seeing body-borne agent ids:\n"
+        + "\n".join(f"    {k}: {v}" for k, v in sorted(missing.items()))
+        + "\nFix _request_params before trusting a green run — the self-plane "
+        "invariant checks whatever this finds, and finding less passes."
+    )
+
+
+def test_the_excluded_identity_names_are_still_live() -> None:
+    """``SELF_ID_PARAMS_EXCLUDED`` documents names that are NOT assertions.
+
+    A name that stops appearing on the surface makes its line a decision about
+    nothing, and the next reader takes it as evidence the question was asked
+    recently. Same failure the allowlist staleness checks exist for, one level
+    down: these exclusions are why routes are absent from the scan entirely,
+    so nothing else would notice.
+    """
+    live: set[str] = set()
+    for _verb, _path, route in _resolve_operations():
+        live |= {n for n in _request_params(route) if "agent" in n.lower()}
+    dead = sorted(set(SELF_ID_PARAMS_EXCLUDED) - live)
+    assert not dead, (
+        f"SELF_ID_PARAMS_EXCLUDED names parameters no route takes: {dead}\n"
+        f"Agent-shaped names actually on the surface: {sorted(live)}\n"
+        "Delete the entries, or correct them to the name that replaced them."
+    )
+    unclassified = sorted(live - SELF_ID_PARAMS - set(SELF_ID_PARAMS_EXCLUDED))
+    assert not unclassified, (
+        f"agent-shaped parameter name(s) in neither set: {unclassified}\n"
+        "Add each to SELF_ID_PARAMS if it is a claim about who the caller is, "
+        "or to SELF_ID_PARAMS_EXCLUDED with what it means instead. A new name "
+        "must not join the surface unexamined."
+    )
+
+
+def test_the_self_plane_scope_is_not_silently_empty() -> None:
+    """Guards the guard: the invariant must be checking a real surface.
+
+    ``_self_plane_routes`` filters on ``identity_params``, so a scan that
+    returned nothing would make ``test_routes_taking_an_agent_identity_gate_
+    the_self_plane`` pass over an empty list. Asserted loosely — the point is
+    "many routes", not a number to update whenever one is added.
+
+    Only the COUNT is asserted. A companion check that ``>= 10`` of them still
+    call the gate was removed after measuring what it caught: blind
+    ``_classify`` to ``enforce_self_agent`` and 11 of the 12 gated routes turn
+    into offenders of the invariant above, which fails with the full report,
+    because nothing consults the allowlist for a route that has no entry in it.
+    A second magic number guarding a mutant that already fails two tests up.
+    """
+    rows = _self_plane_routes()
+    assert len(rows) >= 25, (
+        f"only {len(rows)} routes take a caller-supplied agent identity; there "
+        "were 34 when this was written, so the scan has probably stopped "
+        "seeing a whole parameter source."
+    )
+
+
 def test_allowlists_have_no_unnecessary_entries() -> None:
     """An entry excusing a route that now passes on its own is dead.
 
@@ -506,23 +1071,23 @@ def test_allowlists_have_no_unnecessary_entries() -> None:
     write gaps left their ``KNOWN GAP`` entries excusing five routes that had
     just been gated, and every check in this file still passed. Hence this one.
     """
-    rows = {row["key"]: row for row in _mutating_routes()}
     unnecessary: dict[str, str] = {}
-    for name, allowlist, needs_entry in _ALLOWLISTS:
-        for key, reason in allowlist.items():
+    for axis in _ALLOWLISTS:
+        rows = {row["key"]: row for row in axis.rows()}
+        for key, reason in axis.allowlist.items():
             row = rows.get(key)
             if row is None:
                 continue  # test_allowlists_have_no_stale_entries owns this
-            if not needs_entry(row):
-                unnecessary[f"{name}[{key}]"] = (
+            if not axis.needs_entry(row):
+                unnecessary[f"{axis.name}[{key}]"] = (
                     f"route now satisfies the invariant on its own "
                     f"(gates: {sorted(row['gates'])}) — reason still says {reason!r}"
                 )
     assert not unnecessary, (
         "allowlist entries excuse routes that no longer need excusing:\n"
         + "\n".join(f"    {k}: {v}" for k, v in sorted(unnecessary.items()))
-        + "\n\nDelete the entries. If one was a KNOWN GAP, lower "
-        "KNOWN_GAP_CEILING to match."
+        + "\n\nDelete the entries. If one was a KNOWN GAP, lower that axis's "
+        "gap_ceiling in _ALLOWLISTS to match."
     )
 
 
@@ -533,18 +1098,14 @@ def test_allowlists_have_no_stale_entries() -> None:
     line that once meant something — the failure mode
     ``test_api_read_scope_params`` guards its own opt-out table against.
     """
-    live = {row["key"] for row in _mutating_routes()}
-    stale = {
-        name: sorted(set(allowlist) - live)
-        for name, allowlist in (
-            ("WRITE_GATE_ALLOWLIST", WRITE_GATE_ALLOWLIST),
-            ("PLANE_GATE_ALLOWLIST", PLANE_GATE_ALLOWLIST),
-        )
-        if set(allowlist) - live
-    }
+    stale = {}
+    for axis in _ALLOWLISTS:
+        live = {row["key"] for row in axis.rows()}
+        if set(axis.allowlist) - live:
+            stale[axis.name] = sorted(set(axis.allowlist) - live)
     assert not stale, (
-        "allowlist entries name routes that are no longer mutating routes on "
-        f"this app — renamed, removed, or their verb changed:\n{stale}\n"
+        "allowlist entries name routes this app no longer serves on that "
+        f"axis — renamed, removed, or their verb changed:\n{stale}\n"
         "Delete the entries; do not update them to match a route you have not "
         "re-examined."
     )
@@ -599,6 +1160,17 @@ def test_the_test_only_exclusion_is_not_silently_empty() -> None:
     )
 
 
+# Which words in a reason are read as claims about code. Extended past the
+# original ``_private``/``enforce_*`` pair for the self plane, whose mechanisms
+# are ordinary imported names (``resolve_caller_and_gate``,
+# ``broker_owned_agent_id``). A name outside this pattern is not checked, so
+# keeping it in step with the vocabulary the reasons use is what stops a line
+# from being unfalsifiable prose — and ``bind_write_identity_to_auth`` is
+# deliberately in it, so the KNOWN GAP lines naming the dark flag are checked
+# against the handler that reads it.
+_MECHANISM_NAMES = r"\b(_\w+|enforce_\w+|resolve_\w+|broker_\w+|bind_\w+)\b"
+
+
 def test_allowlist_reasons_that_name_a_mechanism_are_corroborated() -> None:
     """A reason that names code must be checkable, and is checked here.
 
@@ -616,20 +1188,22 @@ def test_allowlist_reasons_that_name_a_mechanism_are_corroborated() -> None:
     the allowlist masks a blinded classifier. Requiring corroboration means a
     classifier that stops seeing ``_require_inbox_admin`` fails here.
     """
-    rows = {row["key"]: row for row in _mutating_routes()}
     broken: dict[str, str] = {}
-    for name, allowlist in (
-        ("WRITE_GATE_ALLOWLIST", WRITE_GATE_ALLOWLIST),
-        ("PLANE_GATE_ALLOWLIST", PLANE_GATE_ALLOWLIST),
-    ):
-        for key, reason in allowlist.items():
+    for axis in _ALLOWLISTS:
+        rows = {row["key"]: row for row in axis.rows()}
+        for key, reason in axis.allowlist.items():
             row = rows.get(key)
             if row is None:
                 continue  # staleness is test_allowlists_have_no_stale_entries' job
-            observed = row["gates"] | row["helpers"]
-            for claimed in re.findall(r"\b(_\w+|enforce_\w+)\b", reason):
+            observed = (
+                row["gates"]
+                | row["helpers"]
+                | row["imported_calls"]
+                | row["settings_flags"]
+            )
+            for claimed in re.findall(_MECHANISM_NAMES, reason):
                 if claimed not in observed:
-                    broken[f"{name}[{key}]"] = (
+                    broken[f"{axis.name}[{key}]"] = (
                         f"reason names {claimed!r}, which the handler does not "
                         f"call; observed {sorted(observed) or 'nothing'}"
                     )
@@ -647,24 +1221,28 @@ def test_known_gaps_do_not_grow() -> None:
     ``test_c33_openapi_completeness``: the point is a number that only goes
     down. Fixing a gap means deleting its line and lowering the ceiling; a new
     route must not borrow the headroom a fix created.
+
+    One ceiling PER AXIS, carried on ``_Axis``. A single shared number would
+    make headroom fungible across invariants — closing a self-plane gap would
+    license a new write-gate one without anything failing.
     """
-    gaps = sorted(
-        f"{key}  ({reason})"
-        for allowlist in (WRITE_GATE_ALLOWLIST, PLANE_GATE_ALLOWLIST)
-        for key, reason in allowlist.items()
-        if reason.startswith(KNOWN_GAP_PREFIX)
-    )
-    assert len(gaps) <= KNOWN_GAP_CEILING, (
-        f"{len(gaps)} known gaps, ceiling is {KNOWN_GAP_CEILING}:\n    "
-        + "\n    ".join(gaps)
-        + "\n\nAdd the gate rather than raising the ceiling. The ceiling exists "
-        "to be lowered."
-    )
-    assert len(gaps) == KNOWN_GAP_CEILING, (
-        f"{len(gaps)} known gaps but the ceiling is still {KNOWN_GAP_CEILING} — "
-        "a gap was fixed without lowering it, so the ratchet has slack a new "
-        f"gap could take up silently. Set KNOWN_GAP_CEILING = {len(gaps)}."
-    )
+    for axis in _ALLOWLISTS:
+        gaps = sorted(
+            f"{key}  ({reason})"
+            for key, reason in axis.allowlist.items()
+            if reason.startswith(KNOWN_GAP_PREFIX)
+        )
+        assert len(gaps) <= axis.gap_ceiling, (
+            f"{axis.name}: {len(gaps)} known gaps, ceiling is "
+            f"{axis.gap_ceiling}:\n    " + "\n    ".join(gaps) + "\n\nAdd the gate "
+            "rather than raising the ceiling. The ceiling exists to be lowered."
+        )
+        assert len(gaps) == axis.gap_ceiling, (
+            f"{axis.name}: {len(gaps)} known gaps but the ceiling is still "
+            f"{axis.gap_ceiling} — a gap was fixed without lowering it, so the "
+            "ratchet has slack a new gap could take up silently. Set this "
+            f"axis's gap_ceiling to {len(gaps)}."
+        )
 
 
 def test_every_router_is_classified() -> None:


### PR DESCRIPTION
## The axis the inventory did not ask about

`test_authz_gate_inventory.py` enumerated two: may this credential write at all (`enforce_read_only`), and may an agent credential be here at all (`enforce_not_agent_credential`). #1364/#1365 named a third — may an agent credential act as the agent a request **named** — and nothing enumerated it.

It could not be bolted onto the existing surface, because **it is not about mutation**. `GET /stm/notes?agent_id=<peer>` returned a peer's private notes; `filter_agent_id` on `POST /recall` returned a peer's private rows. Both reads. Both found one route at a time — the 2026-06-11 audit closed the STM `DELETE` twin and left the read open, and `routes/stm.py` still carries the note.

So this invariant is scoped by the route's **interface** — does it accept a caller-supplied agent identity — not by verb, and it reads `route.dependant` instead of the handler body.

## What the surface turns out to be

34 routes take such a parameter:

| | count |
|---|---|
| call `enforce_self_agent` | 12 |
| exempt by construction (`enforce_admin` / `enforce_not_agent_credential`) | 4 |
| allowlist line | 14 |
| **KNOWN GAP**, under a per-axis ceiling | 4 |

The 14 lines split into six kinds, and that spread is the finding: **what `agent_id` means is not constant across this surface**. 3 precedence, 1 stricter than precedence, 4 filters, 2 agent-row reads, 2 bound by an imported resolver, 2 inert. Every past bug on this axis was a route where two of those meanings shared one parameter.

## Reading the request interface is the part that fails silently

Both plausible spellings do, and both fail by returning **less**, never by erroring — so the invariant then passes over what is left.

| how | routes seen |
|---|---|
| `route.dependant` + `field_info.annotation` | **34** |
| `inspect.signature(endpoint)` | 30 |
| `route.dependant`, `field.type_` only | 24 |

`inspect.signature` loses the four handlers whose module has `from __future__ import annotations` — their body annotation is the *string* `"PromoteRequest"`. `field.type_` is `None` on this FastAPI/pydantic build, losing every body-borne identity: ten routes, including `POST /recall` and `POST /search`, which are the two the gate was written for.

`test_the_identity_scan_sees_body_borne_ids` pins three of those routes, and `test_the_self_plane_scope_is_not_silently_empty` fails if the surface collapses. A FastAPI upgrade that moves the annotation again fails there, naming what broke.

## There is no mechanism-shaped exemption, and the first draft had one

It credited any handler containing `auth.agent_id or <param>` — the precedence idiom — as binding the identity. Four routes matched. One should not have.

`delete_memory` decides authorization with `caller_agent_id = auth.agent_id`: plain attribute, no fallback. The line that matched the shape is the **next** one, whose own comment reads *"Authorization must not trust this value; the audit log must not discard it"*. So the exemption was granted by an audit-log line.

Measured, not argued: rewrite the real principal to the escalation form `agent_id or auth.agent_id` and the route **still counted as bound**, because the attribution line satisfies the shape on its own. A false negative in the one check meant to catch exactly that.

An `any()` over a function body cannot tell the deciding expression from a bystander. The rule is gone; those four carry lines naming what they actually decide with — which is how a reader learns `delete` binds *more* strictly than the other three, not less.

## Structure

The three hygiene checks and the ratchet now run per axis off an `_Axis` registry rather than a hard-coded pair. The self plane needed a different route surface (every verb) and its own ceiling; a fourth axis added to the old shape would have inherited the staleness and corroboration checks silently while having **no** gap ceiling — the "sat outside both sets with nothing failing" failure this file already records against `keystones`. Ceilings are per axis so headroom is not fungible: closing a self-plane gap must not license a write-gate one.

`_classify` also records imported callee names and `settings.<name>` reads, on strictly weaker terms than gates. "This handler calls `resolve_write_agent`" is a fact; "that covers the self plane" is a judgement. The fact goes in the classifier, the judgement stays in the allowlist, and `test_allowlist_reasons_that_name_a_mechanism_are_corroborated` checks the fact under it. Imported helpers are still not *followed* — crediting a gate three layers down is the attribution this file exists to avoid.

## Cost

`_parse` is cached. Fifteen tests each rebuild the same rows: ~7,100 `getsource`+`parse` pairs over a few hundred distinct functions. The file goes 3.07s → 1.75s, **below the 1.67s it cost before this change**.

## Verification

- 14 tests in the file; full root suite **6298 passed, 5 skipped, 0 failed**.
- Mutation-checked rather than assumed: adding a spurious `KNOWN GAP` entry for an already-gated route fails both `test_allowlists_have_no_unnecessary_entries` and the per-axis ratchet, and the ratchet message names the axis.
- `ruff check tests/` and `ruff format --check tests/` clean, run separately at CI's scopes.
- `legacy_name_ratchet.py --base origin/main` and `do_not_touch_sentinel.py` both exit 0.

The legacy alias path is hoisted into `tests/_legacy_contracts.py` rather than marked in place. An allowlist key must equal the path the app serves, so the legacy spelling is mandatory there — and `tests/ruff.toml` documents that a marker on such a line gets displaced the first time `ruff format` wraps it. That module exists for this, and this is the fifth entry.

## Not in this PR

The four KNOWN GAPs are recorded, not closed. Write attribution is caller-named on the agent plane today; `config.py` already carries `bind_write_identity_to_auth` ("Phase 2 (spoof hardening), ships dark", default `False`), which is the staged fix. Turning it on is a separate decision — it needs the reserved-`main` credentials re-identified first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
