### PR TITLE
docs(tools): correct four stale claims, and share the route walk they hid behind

### DIFF
--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -3934,9 +3934,12 @@ async def mcp_lifespan():
 # ── SoT registration ──────────────────────────────────────────────────────
 # Triggers loading of every `core_api.tools.caura_*.py` spec module. Each
 # spec module registers itself in the REGISTRY and calls `mcp_register(mcp, spec)`
-# to wire the handler to FastMCP. This import must run AFTER the 16 handler
-# functions above are defined — spec modules reference them via
-# `core_api.mcp_server.caura_X` attribute lookup.
+# to wire the handler to FastMCP. This import must run AFTER the `caura_*`
+# handler functions above are defined — spec modules reference them via
+# `core_api.mcp_server.caura_X` attribute lookup. Deliberately no count here:
+# this said "the 16 handler functions" from the initial release until 2026-09,
+# which was the PRE-consolidation figure and never matched the 12 that exist.
+# `test_tools_registry` pins the real number; prose beside it only drifts.
 # The `noqa: E402,F401` silences "module-level import not at top" and
 # "imported but unused" — both are intentional.
 from core_api import tools  # noqa: F401

--- a/core-api/src/core_api/tools/_builders.py
+++ b/core-api/src/core_api/tools/_builders.py
@@ -22,8 +22,10 @@ from ._types import ToolSpec
 def mcp_register(mcp, spec: ToolSpec) -> None:
     """Register `spec.handler` with the FastMCP instance, using `spec.description`.
 
-    No-op when `spec.handler is None` (Phase 1 of the refactor — handlers
-    still live in `mcp_server.py`'s `@mcp.tool` decorators).
+    No-op when `spec.handler is None`, which no registered spec is — see
+    `ToolSpec.handler`. The guard is kept for the dataclass default, not for a
+    migration; `mcp_server.py` has held zero `@mcp.tool` decorators since the
+    consolidation, and this function is how every tool reaches FastMCP.
 
     Handlers are annotated `-> str` but their error paths return
     `CallToolResult` via `_as_error_result` to preserve the unified

--- a/core-api/src/core_api/tools/_types.py
+++ b/core-api/src/core_api/tools/_types.py
@@ -57,9 +57,18 @@ class ToolSpec:
     name: str
     description: str
     handler: HandlerFn | None = None
-    """Handler is None during Phase 1 of the v1.0 refactor (handlers still
-    live in `mcp_server.py`'s `@mcp.tool` decorators). Phase 2 wires real
-    handlers in and `mcp_register` becomes the registration path."""
+    """The tool's implementation, in `mcp_server.py`.
+
+    Every registered spec sets one, and `test_tools_registry` asserts so, which
+    is why `mcp_register`'s `handler is None` guard is unreachable in practice.
+    The `None` remains only because it is the dataclass default; removing it and
+    the guard is a separate change.
+
+    An earlier version of this note described a "Phase 1" in which handlers were
+    still `None` and lived on `@mcp.tool` decorators, with `mcp_register` yet to
+    become the registration path. All three were true once and none is now:
+    `mcp_server.py` carries no `@mcp.` decorator at all, and each `caura_*` spec
+    module calls `mcp_register` itself at import."""
     trust_required: int = 0
     """Baseline trust to invoke. 0 = no MCP-level gate (existing behavior for
     tools that enforce trust deeper in the service layer)."""

--- a/tests/_route_table.py
+++ b/tests/_route_table.py
@@ -1,0 +1,59 @@
+"""Walking the real app's route table, for tests that need every declaration.
+
+WHY THIS IS NOT ``app.routes``. FastAPI 0.137 mounts
+``include_router(prefix=...)`` as an opaque ``_IncludedRouter`` whose routes are
+reachable only through the private ``original_router``. ``core_api/app.py``
+documents the same obstacle at its ``_TIMEOUT_OPT_OUT_PATHS`` guard, and
+declines to depend on it at import time for the same reason a dependency bump
+should not become a production boot failure.
+
+Because the attribute is private, a version bump can make this return NOTHING,
+and returning less is the failure mode that passes. Every caller must therefore
+assert something an empty walk breaks. Both of today's do, by construction
+rather than by promise: ``test_capability_usage`` requires every
+``_REST_CAPABILITY`` key to match a route, so an empty walk makes all of them
+unmatched, and ``test_request_observation`` requires each probe path to appear
+exactly once, which an empty walk makes zero.
+
+SCOPE, because two other walks in this repo look like this one and must NOT be
+folded into it. They answer the opposite question about prefixes:
+
+    this helper                     UNPREFIXED  ``/memories``, ``/health``
+    ``test_authz_gate_inventory``   PREFIXED    ``/api/v1/memories``
+    ``scripts/tenant_scope_gate``   PREFIXED, and in another tree
+
+The difference is load-bearing, not an accident of who wrote which. The two
+callers here match against values that are unprefixed on purpose:
+``_REST_CAPABILITY`` is keyed ``("GET", "/memories")`` and ``PROBE_ROUTES``
+holds ``/health`` rather than ``/api/v1/health``, both because the middleware
+reads the route template before the prefix is applied. Descending via
+``original_router`` alone yields exactly that. The inventory additionally reads
+``include_context`` to rebuild the prefix, because its allowlist keys are the
+paths a client calls. Unifying the two would break one side or the other.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+
+def iter_route_declarations(routes) -> Iterator[tuple[str, frozenset[str]]]:
+    """``(unprefixed path, methods)`` for every route declaration under ``routes``.
+
+    One tuple per DECLARATION rather than per path: a path declared twice yields
+    twice, which is what lets a caller assert that it is declared exactly once.
+
+    A route with no ``methods`` attribute — a ``Mount``, a WebSocket — is
+    skipped. One with an empty ``methods`` is yielded with an empty set rather
+    than dropped, so a caller that distinguishes "declared with no verbs" from
+    "not declared" still can.
+    """
+    for route in routes:
+        inner = getattr(route, "original_router", None)
+        if inner is not None:
+            yield from iter_route_declarations(inner.routes)
+            continue
+        path = getattr(route, "path", None)
+        if path is None or not hasattr(route, "methods"):
+            continue
+        yield path, frozenset(route.methods or ())

--- a/tests/test_capability_usage.py
+++ b/tests/test_capability_usage.py
@@ -248,9 +248,8 @@ async def test_every_capability_key_matches_a_real_route():
     entry is left behind, silently switching that capability off.
 
     Deliberately a test rather than an import-time check in ``app.py``.
-    Recovering the label space means descending through FastAPI's
-    ``_IncludedRouter`` via the private ``original_router``, because
-    ``include_router(prefix=...)`` mounts opaquely; the existing
+    Recovering the label space means descending through a private FastAPI
+    attribute — see ``tests/_route_table`` — and the existing
     ``_TIMEOUT_OPT_OUT_PATHS`` guard can live at import time only because
     ``app.openapi()`` is public and prefixed. Wiring a private attribute
     into startup would turn a dependency bump into a production boot
@@ -263,20 +262,12 @@ async def test_every_capability_key_matches_a_real_route():
 
     from core_api.app import app
     from core_api.middleware.request_observation import _REST_CAPABILITY
+    from tests._route_table import iter_route_declarations
 
     real: dict[str, set[str]] = collections.defaultdict(set)
-
-    def walk(routes):
-        for r in routes:
-            inner = getattr(r, "original_router", None)
-            if inner is not None:
-                walk(inner.routes)
-                continue
-            path, methods = getattr(r, "path", None), getattr(r, "methods", None)
-            if path is not None and methods:
-                real[path] |= set(methods)
-
-    walk(app.routes)
+    for path, methods in iter_route_declarations(app.routes):
+        if methods:
+            real[path] |= set(methods)
 
     missing = sorted((m, p) for (m, p) in _REST_CAPABILITY if m not in real.get(p, ()))
     assert not missing, (

--- a/tests/test_request_observation.py
+++ b/tests/test_request_observation.py
@@ -356,30 +356,21 @@ async def test_no_other_router_declares_a_probe_path():
     the assumption here: exactly one declaration per probe path, across the
     whole real app.
 
-    The walk descends through FastAPI's ``_IncludedRouter`` via
-    ``original_router``, since ``include_router(prefix=...)`` mounts the
-    router opaquely (``app.py`` documents the same obstacle). That is a
-    private attribute, so the count assertions below double as a check that
-    the walk still works: if it stops descending, the probes are found zero
-    times and this test fails rather than quietly passing.
+    The walk descends through a private FastAPI attribute — see
+    ``tests/_route_table``, which explains why and why it is not the same walk
+    as the authz inventory's. Because the attribute is private, the count
+    assertions below double as a check that it still works: if it stops
+    descending, the probes are found zero times and this fails rather than
+    quietly passing.
     """
     import collections
 
     from core_api.app import app
+    from tests._route_table import iter_route_declarations
 
     counts: collections.Counter = collections.Counter()
-
-    def walk(routes):
-        for r in routes:
-            inner = getattr(r, "original_router", None)
-            if inner is not None:
-                walk(inner.routes)
-                continue
-            path = getattr(r, "path", None)
-            if path is not None and hasattr(r, "methods"):
-                counts[path] += 1
-
-    walk(app.routes)
+    for path, _methods in iter_route_declarations(app.routes):
+        counts[path] += 1
 
     for probe in sorted(PROBE_ROUTES):
         assert counts[probe] == 1, (

--- a/tests/test_tool_descriptions_regression.py
+++ b/tests/test_tool_descriptions_regression.py
@@ -1,10 +1,17 @@
 """Phase 4 regression — `/tool-descriptions` and MCP `tools/list` derived
 from the SoT registry must produce the captured v1.0 baselines.
 
-Locks the post-consolidation 13-tool surface (10 user-facing LTM tools —
-of which 7 are live and 3 are knowledge-layer placeholders — plus 3
-STM tools). The pre-consolidation `*_16tools.json` baselines are kept
-in `tests/fixtures/` for token-budget delta measurement.
+Locks the post-consolidation surface at `EXPECTED_TOOL_COUNT` below, which is
+the one place the number lives: every tool is live, none is a placeholder
+(`test_tools_registry.EXPECTED_PLACEHOLDERS` is empty), and there are no
+separate STM tools.
+
+The header said otherwise until 2026-09 — "13-tool surface (10 user-facing LTM
+tools — of which 7 are live and 3 are knowledge-layer placeholders — plus 3 STM
+tools)" — while `EXPECTED_TOOL_COUNT` twelve lines below said 12. It also
+pointed at `*_16tools.json` baselines in `tests/fixtures/`, which do not exist;
+the directory holds `tools_list_baseline_v1.json` and the two
+`tool_descriptions_*_baseline_v1.json` files this module actually reads.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Four docstrings describing a codebase that no longer exists

Each verified against source, not taken from the note that recorded it.

**`tools/_types.py` and `tools/_builders.py`** both describe a "Phase 1" in which handlers are `None` and still live on `mcp_server.py`'s `@mcp.tool` decorators, with `mcp_register` yet to become the registration path. Measured:

| claim | reality |
|---|---|
| handlers still on `@mcp.tool` decorators | **0** `@mcp.` decorators in `mcp_server.py` |
| `handler` is `None` during Phase 1 | all **12** specs pass `handler=` |
| `mcp_register` *becomes* the path in Phase 2 | every `caura_*` spec module calls it at import |

So the `handler is None` guard is unreachable for any registered spec — `test_tools_registry` asserts exactly that. The note now says the `None` is the dataclass default and that removing it and the guard is a separate change.

**`mcp_server.py`** said its SoT import "must run AFTER the 16 handler functions above are defined". There are **12**. I deleted the number rather than correcting it: `test_tools_registry` already pins the count, and a figure in prose beside a registry that pins it is a second source of truth that only ever drifts. `16` was the pre-consolidation count — which is also where the `*_16tools.json` in the next item came from.

**`test_tool_descriptions_regression.py`** was wrong five ways in one paragraph, and contradicted its own file — it claimed a *"13-tool surface (10 user-facing LTM tools — of which 7 are live and 3 are knowledge-layer placeholders — plus 3 STM tools)"* twelve lines above `EXPECTED_TOOL_COUNT = 12`. There are 12 tools, all live, no placeholders (`EXPECTED_PLACEHOLDERS` is the empty set), no separate STM tools. It also pointed at `*_16tools.json` baselines "kept in `tests/fixtures/`" which are not there — the directory holds `tools_list_baseline_v1.json` and the two `tool_descriptions_*` files the module actually reads. It now points at the constant instead of restating it.

## The walk: the recorded task was wrong in two directions

The follow-up said "duplicated `_IncludedRouter` walk (4 copies)". Measured, it isn't:

- **`test_api_read_scope_params.py` does not walk at all.** It reads `app.openapi()` and only *mentions* `_IncludedRouter` in a comment explaining why it doesn't.
- **`test_authz_gate_inventory.py` and `scripts/tenant_scope_gate.py` walk for PREFIXED paths**, tracking `include_context`. The two real duplicates want **unprefixed** ones and descend by `original_router` alone.

That difference is load-bearing, not accidental. `_REST_CAPABILITY` is keyed `("GET", "/memories")` and `PROBE_ROUTES` holds `/health`, not `/api/v1/health` — both because the middleware sees the route template before the prefix is applied. **Folding all four together would have broken one side or the other.**

So the genuine duplication is **two** files: `test_capability_usage.py` and `test_request_observation.py` run the same eight-line descent and differ only in what they accumulate. Both now call `tests/_route_table.iter_route_declarations`, which yields `(path, methods)` per *declaration* so the caller that needs "declared exactly once" can still count. The FastAPI quirk — and the reason this is **not** the inventory's walk — is explained once there instead of twice.

`scripts/tenant_scope_gate.py` keeps its own copy: different tree, different lint config, and it wants the prefixed form anyway.

## Verified equivalent, not assumed

Both original walks run side by side with the shared one against the live app:

```
declarations walked: 119   distinct paths: 97
capability map identical: True
declaration counts identical: True
paths carrying the /api/v1 prefix: 0
```

That last line is the property the new docstring claims, measured rather than asserted.

## One deliberate placement choice

`tests/_route_table.py` is a `tests/_*.py` helper on purpose. That is the one shape of test file the review pipeline does **not** exclude — as [#1368](https://github.com/caura-ai/caura/pull/1368) and [#1369](https://github.com/caura-ai/caura/pull/1369) both demonstrated, a `test_*.py` file gets no automated read. Putting the shared walk there means it actually gets reviewed.

## Verification

- Full root suite **6321 passed, 5 skipped, 0 failed**.
- `ruff check` and `ruff format --check` clean at CI's `core-api/src/` and `tests/` scopes, run separately; `legacy_name_ratchet.py` and `do_not_touch_sentinel.py` exit 0.

No behaviour changes: three prose corrections in production files, one in a test, and a two-caller refactor proven byte-identical to what it replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
