### PR TITLE
feat(events): flip the org family's publishers to the caura twin

### DIFF
--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -213,14 +213,39 @@ def family(topic: str) -> str:
 # a no-op once ``renamed`` is the identity — and comes out with the final sweep,
 # after the legacy topics are deleted.
 #
+# ``org`` flipped 2026-09-08 — the fifth programme family and third SHARED one,
+# mirrored into caura-enterprise in the same cycle. Live remeasurement
+# immediately before the edit: 17/17 running Pub/Sub deployables dual-on, and
+# every prod twin topic and durable subscription present (32/32 stable prod
+# durables matched, zero unmatched).
+#
+# The check this family needed that the others did not: ``org.settings-changed``
+# is the only BROADCAST topic here, so each process creates its own ephemeral
+# subscription at runtime and there is no durable twin for a gate to compare. A
+# twin topic is a distinct resource with its own empty IAM policy, so what had to
+# be confirmed by hand is the per-topic attach binding ON THE TWIN — verified
+# present: ``prod--caura.org.settings-changed`` grants the custom
+# ``coreApiPubsubTopicAttacher`` role to the publishing core-api SA, matching the
+# legacy topic. Without it the flip is silent: publishing succeeds and every
+# subscriber fails to attach.
+#
+# The suspected staging ephemeral leak that held this family back did not
+# reproduce as a leak. ``expirationPolicy.ttl`` is 86,400s on every ephemeral
+# sampled across both brands and environments, and the pool size tracks one
+# TTL-window of instance churn rather than growing — 26 distinct instance hashes
+# behind the 47 subscriptions on the legacy prod topic, two per instance.
+# Bounded and reaping. Recorded as measured, not as an investigation
+# closed: that pool is still the reason the OLD topic cannot be deleted here.
+#
 # ``pipeline`` must NOT enter this set while it has zero live topics in either
 # environment: publishing to a topic that does not exist is silent loss, so
-# flipping it would move nothing and report success. ``org`` is shared AND its
-# staging ephemeral pool was under investigation as a suspected subscription
-# leak. ``audit`` LAST, unconditionally — those rows are hash-chained, and a
-# lost or reordered audit event is the one failure here that replay cannot
-# repair.
-FLIPPED_FAMILIES: frozenset[str] = frozenset({"lifecycle", "memory"})
+# flipping it would move nothing and report success. Re-confirmed 2026-09-08
+# against the live project — ``pubsub topics list`` matches no ``pipeline``
+# topic under either brand, in either environment.
+#
+# ``audit`` LAST, unconditionally — those rows are hash-chained, and a lost or
+# reordered audit event is the one failure here that replay cannot repair.
+FLIPPED_FAMILIES: frozenset[str] = frozenset({"lifecycle", "memory", "org"})
 
 
 def all_topics() -> tuple[str, ...]:

--- a/tests/test_events/test_topic_rename_cutover.py
+++ b/tests/test_events/test_topic_rename_cutover.py
@@ -22,14 +22,22 @@ described:
 The rest is about which way each default points, because the two backends need
 opposite ones and a missing twin fails differently in each.
 
-EVERY FLIPPED FAMILY IS NOW CONTRACTED, WHICH CHANGES WHAT THESE TESTS CAN USE.
-``lifecycle`` and ``memory`` both stay in ``FLIPPED_FAMILIES`` while carrying the
-current names, so ``renamed`` is the identity for them and a default-constructed
-bus is legal again. That also means the silent-failure state this file exists to
-pin can no longer be reached through any real declaration: a test that reaches
-for a real family to demonstrate it goes VACUOUS. Those tests use ``PRE_CONTRACT``
-instead. Tests about *the flag's parse rule* still take the ``nothing_flipped``
-fixture so their precondition cannot depend on cutover state.
+CONTRACTION, NOT FLIPPING, IS WHAT CHANGES WHAT THESE TESTS CAN USE.
+``lifecycle`` and ``memory`` are flipped AND contracted: they stay in
+``FLIPPED_FAMILIES`` while carrying the current names, so ``renamed`` is the
+identity for them and neither can demonstrate a mismatch. A test that reaches
+for a real family to show the silent-failure state this file exists to pin would
+therefore go VACUOUS on those two, which is why such tests use ``PRE_CONTRACT``.
+
+``org`` flipped 2026-09-08 and is NOT yet contracted, so it is currently the one
+real family for which ``publish_name`` and ``subscribe_names(dual=False)``
+disagree. That makes a default-constructed (``dual=False``) Pub/Sub bus illegal
+again until ``org`` contracts — the same window memory passed through between
+2026-09-01 and 2026-09-05. ``PRE_CONTRACT`` stays regardless: it must not depend
+on a real family happening to be mid-cutover.
+
+Tests about *the flag's parse rule* still take the ``nothing_flipped`` fixture so
+their precondition cannot depend on cutover state.
 """
 
 from __future__ import annotations
@@ -145,7 +153,7 @@ def test_subscribe_names_dual_returns_both_without_duplicates() -> None:
 # has to be stated in exactly two places — the module, and this literal — and the
 # equality in ``test_exactly_the_flipped_families_are_flipped`` is what turns the
 # second one into a deliberate stop rather than a chore.
-FLIPPED = frozenset({"lifecycle", "memory"})
+FLIPPED = frozenset({"lifecycle", "memory", "org"})
 
 # A synthetic flipped-but-NOT-contracted topic, for the tests that need the
 # silent-failure state to exist. Every real family here is now either unflipped
@@ -210,6 +218,11 @@ def test_exactly_the_flipped_families_are_flipped() -> None:
     the worst outcome available in this cutover, because it also looks like
     progress.
 
+    ``org`` joined on 2026-09-08 — the third SHARED family, mirrored into
+    caura-enterprise in the same cycle. It is flipped but NOT yet contracted, so
+    it is the family that currently makes ``unbound_publish_topics(dual=False)``
+    non-empty; see the module docstring.
+
     ``memory`` joined on 2026-09-01 — the second SHARED family, mirrored into
     caura-enterprise in the same cycle. Its absent ``.created`` declaration had
     already been removed. The live re-measurement found 12/12 running Pub/Sub
@@ -221,7 +234,6 @@ def test_exactly_the_flipped_families_are_flipped() -> None:
     assert topics_mod.FLIPPED_FAMILIES == FLIPPED
     assert "audit" not in topics_mod.FLIPPED_FAMILIES
     assert "pipeline" not in topics_mod.FLIPPED_FAMILIES
-    assert "org" not in topics_mod.FLIPPED_FAMILIES
 
 
 def test_known_families_are_derived_from_the_enums() -> None:


### PR DESCRIPTION
Fifth programme family, third shared one. `FLIPPED_FAMILIES` goes from
`{"lifecycle", "memory"}` to `{"lifecycle", "memory", "org"}`.

## Readiness, measured live immediately before the edit

| gate | result |
|---|---|
| `check_flip_readiness.py --project=alpine-theory-469016-c8` | 17/17 running Pub/Sub deployables dual-subscribing |
| `preflight_dual_subscribe.py --env=prod` | every prod twin topic and durable subscription live |
| stable prod durable twins | 32/32 matched, zero unmatched |

Both gates read configuration. Neither observes a delivered message — green here
is necessary, not proof the flip works.

## The check org needed that the earlier families did not

`org.settings-changed` is the only BROADCAST topic in this set. Each process
creates its own ephemeral subscription at runtime, so there is no durable twin
for either gate to compare and `preflight_dual_subscribe` has nothing to assert
about it.

A twin topic is a distinct resource with its own empty IAM policy, so a
project-level binding does not reach it. The binding that matters was confirmed
by hand **on the twin**:

```
prod--caura.org.settings-changed
  projects/…/roles/coreApiPubsubTopicAttacher -> prod-memclaw-core-api@…
  roles/pubsub.publisher                      -> prod-memclaw-core-api@…
```

Identical to the legacy topic's policy. Both `prod-caura-core-api` and
`prod-memclaw-core-api` run under that same SA, so both reach it. Without this
binding the flip fails silently: publishing succeeds and every subscriber fails
to attach.

## The suspected leak did not reproduce as a leak

`org` was held back partly by a suspected ephemeral-subscription leak in
staging. Measured across both brands and environments:

- `expirationPolicy.ttl` is `86400s` on **every** ephemeral sampled
- the pool tracks one TTL-window of instance churn rather than growing — 26
  distinct instance hashes behind the 47 subscriptions on the legacy prod topic,
  two per instance

Bounded and reaping. Recorded as **measured, not as an investigation closed** —
that pool is still the reason the old topic cannot be deleted yet.

## What stays out

- **`pipeline`** — re-confirmed against the live project: `pubsub topics list`
  matches no `pipeline` topic under either brand in either environment. Flipping
  it would publish into nothing and report success, which is the worst outcome
  available in this cutover because it also looks like progress.
- **`audit`** — last by rule. Those rows are hash-chained.

## Known consequence, deliberate and precedented

`org` is flipped but **not yet contracted**, so
`unbound_publish_topics(dual=False)` now names its two topics and
`PubSubEventBus` refuses to construct with `dual_subscribe` off.

This is the same window `memory` passed through between 2026-09-01 and
2026-09-05, and it closes the same way — by contracting the enum members in a
follow-up. It affects:

- **no deployable in the project** — all 17 run dual-subscribe on
- **not on-prem** — that runs the `inprocess` backend and never constructs the
  guarded bus

## Verification

- `tests/test_events/test_topic_rename_cutover.py` — 40 passed
- Confirmed load-bearing: reverting only the test's `FLIPPED` literal fails
  `test_exactly_the_flipped_families_are_flipped` and
  `test_publish_name_is_the_identity_for_every_unflipped_family`
- `tests/test_events/` — 18 pre-existing failures, byte-identical to the set on
  `origin/main` (verified by diffing the failure lists from two worktrees); none
  in the file this PR touches
- `ruff check common/`, `ruff check tests/`, `ruff format --check tests/` clean
- Legacy-name ratchet: **no new lines**. One draft line named the legacy topic
  literally; reworded rather than marked, per the gate's own guidance
- Do-not-touch sentinel: 35/35 protected strings survive

## Follow-ups, not in this PR

1. Mirror this flip into `caura-enterprise` (its copy is policy `manual` in
   `vendored_files_manifest.json`, so it is a hand edit, and its set also holds
   the enterprise-only `fleet` and `security`)
2. Contract the `Org` enum members, closing the `dual=False` window
3. `audit`, last

🤖 Generated with [Claude Code](https://claude.com/claude-code)
