### PR TITLE
fix(plugin): stop an unrecognised op falling through to a write

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -16,7 +16,7 @@
     "pretest": "bash ../scripts/gen-version.sh",
     "build": "tsc",
     "dev": "bash ../scripts/gen-version.sh && tsc --watch",
-    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/tool-identity.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/interview-buffer.test.js dist/interview-command.test.js dist/task-trail.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js dist/fleet-scope.test.js dist/gateway-methods.test.js",
+    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/tool-op-dispatch.test.js dist/tool-identity.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/interview-buffer.test.js dist/interview-command.test.js dist/task-trail.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js dist/fleet-scope.test.js dist/gateway-methods.test.js",
     "check:version": "bash -c 'V=$(node -p \"require(\\\"./package.json\\\").version\"); grep -qF \"PLUGIN_VERSION = \\\"$V\\\"\" src/version.ts || (echo \"version.ts out of sync with package.json ($V): run bash ../scripts/gen-version.sh\" >&2 && exit 1) && echo \"check:version ok: $V\"'"
   },
   "devDependencies": {

--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -143,6 +143,17 @@ export const STATUSES = [
   "outdated", "conflicted", "archived", "deleted",
 ] as const;
 
+// The ops each op-dispatched tool OFFERS on this surface. Hoisted for the
+// same reason as the two lists above: the schema a caller is validated
+// against and the refusal naming the alternatives now read one identifier,
+// so they cannot drift. Deliberately NOT `tools.json`'s `ops[]`, which is
+// what the MCP handler ACCEPTS and legitimately differs — see MCP_ONLY_OPS
+// in tool-definitions.test.ts.
+const MANAGE_OPS = ["read", "update", "transition", "delete"] as const;
+const DOC_OPS = [
+  "write", "read", "query", "delete", "search", "list_collections",
+] as const;
+
 const MEMORY_TYPE_SCHEMA = {
   type: "string",
   enum: [...MEMORY_TYPES],
@@ -211,7 +222,7 @@ const PARAM_SCHEMAS: Record<string, Record<string, unknown>> = {
     type: "object",
     required: ["op", "memory_id"],
     properties: {
-      op: { type: "string", enum: ["read", "update", "transition", "delete"] },
+      op: { type: "string", enum: [...MANAGE_OPS] },
       memory_id: { type: "string", description: "UUID of memory to act on" },
       status: { type: "string", enum: [...STATUSES], description: "Required for op=transition" },
       content: { type: "string", description: "For op=update" },
@@ -228,10 +239,7 @@ const PARAM_SCHEMAS: Record<string, Record<string, unknown>> = {
     type: "object",
     required: ["op"],
     properties: {
-      op: {
-        type: "string",
-        enum: ["write", "read", "query", "delete", "search", "list_collections"],
-      },
+      op: { type: "string", enum: [...DOC_OPS] },
       collection: {
         type: "string",
         description:
@@ -417,6 +425,21 @@ const SINGLE_WRITE_ONLY_FIELDS = [
   "write_mode",
 ] as const;
 
+/**
+ * Terminal guard for an op-dispatched tool: every op it serves returns from
+ * its own branch, so reaching the end means the op was not one of them.
+ *
+ * Not a no-op. Until this existed the last branch doubled as the else, and an
+ * unrecognised op became a write — see `tool-op-dispatch.test.ts`, which
+ * records what that cost and pins it.
+ */
+function unsupportedOp(tool: string, op: unknown, offered: readonly string[]): never {
+  throw new Error(
+    `[caura] ${tool}: unsupported op ${JSON.stringify(op)}. ` +
+      `Expected one of: ${offered.join(", ")}`,
+  );
+}
+
 const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
   caura_recall: async (params, signal) => {
     const body = await enrichBody(searchBody(params));
@@ -487,21 +510,23 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
     if (op === "delete") {
       return apiCall("DELETE", `/memories/${id}`, undefined, { tenant_id }, signal);
     }
-    // op === "update"
-    const agent_id = enriched.agent_id as string;
-    const updateFields: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(enriched)) {
-      if (v === undefined) continue;
-      if (k === "op" || k === "memory_id" || k === "tenant_id" || k === "agent_id" || k === "fleet_id") continue;
-      updateFields[k] = v;
+    if (op === "update") {
+      const agent_id = enriched.agent_id as string;
+      const updateFields: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(enriched)) {
+        if (v === undefined) continue;
+        if (k === "op" || k === "memory_id" || k === "tenant_id" || k === "agent_id" || k === "fleet_id") continue;
+        updateFields[k] = v;
+      }
+      return apiCall(
+        "PATCH",
+        `/memories/${id}`,
+        updateFields,
+        { tenant_id, agent_id },
+        signal,
+      );
     }
-    return apiCall(
-      "PATCH",
-      `/memories/${id}`,
-      updateFields,
-      { tenant_id, agent_id },
-      signal,
-    );
+    unsupportedOp("caura_manage", op, MANAGE_OPS);
   },
 
   caura_doc: async (params, signal) => {
@@ -559,14 +584,16 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
       if (enriched.fleet_id) query.fleet_id = String(enriched.fleet_id);
       return apiCall("GET", "/documents/collections", undefined, query, signal);
     }
-    // op === "delete"
-    return apiCall(
-      "DELETE",
-      `/documents/${encodeURIComponent(enriched.doc_id as string)}`,
-      undefined,
-      { tenant_id, collection: collection as string },
-      signal,
-    );
+    if (op === "delete") {
+      return apiCall(
+        "DELETE",
+        `/documents/${encodeURIComponent(enriched.doc_id as string)}`,
+        undefined,
+        { tenant_id, collection: collection as string },
+        signal,
+      );
+    }
+    unsupportedOp("caura_doc", op, DOC_OPS);
   },
 
   caura_list: async (params, signal) => {

--- a/plugin/src/tool-op-dispatch.test.ts
+++ b/plugin/src/tool-op-dispatch.test.ts
@@ -1,0 +1,146 @@
+/**
+ * An op-dispatched tool must not treat an unrecognised op as its last branch.
+ *
+ * `caura_manage` and `caura_doc` each ended their `if (op === …)` chain in a
+ * comment rather than a condition — `// op === "update"` and
+ * `// op === "delete"` — so the final branch doubled as the else. Every value
+ * the chain did not match became a WRITE. Measured against that code:
+ *
+ *     caura_manage op="lineage"  ->  PATCH  /api/v1/memories/{id}
+ *     caura_doc    op="remove"   ->  DELETE /api/v1/documents/doc-1
+ *
+ * `lineage` is a READ. `bulk_delete` and `lineage` are realistic inputs, not
+ * invented ones: the MCP handler accepts both, the tool description shared by
+ * both surfaces names both, and this plugin has an endpoint for neither. A
+ * near-miss typo lands in the same place.
+ *
+ * The only thing that had kept those branches unreachable was the `op` enum in
+ * `PARAM_SCHEMAS`, enforced by the host's schema validator rather than by this
+ * package.
+ *
+ * These assert on the requests the server would actually receive, and assert
+ * that BEFORE asserting the refusal. Ordering is load-bearing twice over: a
+ * test that only checked for a throw would pass on a dispatcher that mutated
+ * and then threw, and `assert.rejects` first would abort before the mutation
+ * check and report "missing expected rejection" instead of naming the DELETE.
+ */
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+
+// Read into module constants at import time, so it must precede the import.
+process.env.CAURA_API_URL = "http://op-dispatch.test";
+process.env.CAURA_API_KEY = "test-key";
+process.env.CAURA_TENANT_ID = "t-op-dispatch";
+
+const { createToolFromSpec } = await import("./tool-definitions.js");
+
+interface Captured {
+  url: URL;
+  method: string;
+}
+
+let captured: Captured[] = [];
+let realFetch: typeof globalThis.fetch;
+
+before(() => {
+  realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    captured.push({ url: new URL(String(input)), method: init?.method ?? "GET" });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+});
+
+after(() => {
+  globalThis.fetch = realFetch;
+});
+
+const MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Mutating requests against the resource routes.
+ *
+ * Filtered by path, not method alone: `apiCall` provisions an agent-scoped
+ * credential with its own POST whenever a call carries an `agent_id`, and
+ * counting that would make a passing dispatch look like a stray write.
+ */
+function mutations(): string[] {
+  return captured
+    .filter(
+      (c) =>
+        MUTATING.has(c.method) &&
+        (c.url.pathname.includes("/memories") || c.url.pathname.includes("/documents")),
+    )
+    .map((c) => `${c.method} ${c.url.pathname}`);
+}
+
+/** Resolves to the thrown error on refusal, or the result if it was accepted. */
+async function outcomeOf(
+  tool: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  captured = [];
+  return createToolFromSpec(tool)
+    .execute("test-call", params, undefined as never)
+    .catch((e: unknown) => e);
+}
+
+const MEMORY_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("an unrecognised op is refused, not dispatched as a write", () => {
+  // One value per tool: after the guard there is no branching on the op VALUE,
+  // so every unmatched string reaches the same line and further values would
+  // re-test one path. `bulk_delete` is the realistic case for caura_manage —
+  // the server accepts it and MCP_ONLY_OPS in tool-definitions.test.ts records
+  // that this surface does not. caura_doc has no MCP-only op, so a near-miss
+  // typo stands in.
+  test("caura_manage op=bulk_delete does not become a PATCH", async () => {
+    const outcome = await outcomeOf("caura_manage", {
+      op: "bulk_delete",
+      memory_id: MEMORY_ID,
+      content: "x",
+    });
+    assert.deepEqual(mutations(), [], "reached a mutating request");
+    assert.match(String(outcome), /unsupported op/, "was accepted, not refused");
+  });
+
+  test("caura_doc op=remove does not become a DELETE", async () => {
+    const outcome = await outcomeOf("caura_doc", {
+      op: "remove",
+      doc_id: "doc-1",
+      collection: "c-1",
+    });
+    assert.deepEqual(mutations(), [], "reached a mutating request");
+    assert.match(String(outcome), /unsupported op/, "was accepted, not refused");
+  });
+
+  test("the refusal names the ops this surface does offer", async () => {
+    const outcome = await outcomeOf("caura_manage", {
+      op: "bulk_delete",
+      memory_id: MEMORY_ID,
+    });
+    const message = String(outcome);
+    assert.match(message, /caura_manage/);
+    // Read from the schema rather than a literal, so this checks the property
+    // the message claims — that it names the enum a caller is validated
+    // against — instead of pinning that enum a second time.
+    const schema = createToolFromSpec("caura_manage").parameters as {
+      properties: { op: { enum: string[] } };
+    };
+    assert.ok(schema.properties.op.enum.length > 0, "no op enum to compare against");
+    for (const offered of schema.properties.op.enum) {
+      assert.match(message, new RegExp(offered), `message omits offered op ${offered}`);
+    }
+  });
+});
+
+// `caura_doc op=delete` was the fall-through, and nothing else in the suite
+// issues a caura_doc request at all — so a bad conversion of that branch would
+// otherwise go unnoticed. `caura_manage op=update` needs no twin here:
+// tool-identity.test.ts already drives it and asserts the PATCH.
+test("caura_doc op=delete still DELETEs the document", async () => {
+  await outcomeOf("caura_doc", { op: "delete", doc_id: "doc-1", collection: "c-1" });
+  assert.deepEqual(mutations(), ["DELETE /api/v1/documents/doc-1"]);
+});


### PR DESCRIPTION
## A typo deleted a document

`caura_manage` and `caura_doc` dispatch on an `op` string through a chain of `if (op === "…") return apiCall(…)`. Both chains **ended in a comment rather than a condition** — `// op === "update"` and `// op === "delete"` — so the final branch doubled as the else, and every value the chain didn't match became a **write**.

Measured against the unfixed dispatcher, these are the test failures:

```
caura_manage op="lineage"  →  PATCH  /api/v1/memories/11111111-1111-4111-8111-111111111111
caura_doc    op="remove"   →  DELETE /api/v1/documents/doc-1
```

`lineage` is a **read**. It became a write.

## Why those two values, specifically

Neither is invented. [#1373](https://github.com/caura-ai/caura/pull/1373) declared `bulk_delete` and `lineage` on `caura_manage` because the MCP handler accepts them — and the description they now appear in is served to *this* surface too, which has no endpoint for either. So the ops most likely to arrive here were exactly the ones that landed in the fall-through. This is the follow-up that PR named.

## What the guard is, and what it is not

The only thing that had kept those branches unreachable was the `op` enum in `PARAM_SCHEMAS` — enforced by the host's schema validator, **outside this package**. `unsupportedOp` makes that boundary local.

It does **not** replace upstream validation, and upstream validation would not make it redundant. The two cover different failure modes: a validator checks *caller input against the schema*, while this checks that a dispatcher's chain is *exhaustive over the ops it claims to serve*. Add an enum entry with no branch and a perfect validator waves it straight into the terminal position — back to a `PATCH`.

**It throws rather than returning a structured error, deliberately.** The plugin's `ToolResult` has no `isError` field and `execute` calls `textResult` unconditionally, so returning `{"error": …}` would hand the host a **success** result containing an error — precisely the `isError=false` bug the server fixed at its own chokepoint. Mirroring the server's shape would import that bug without the fix. Throwing is also the only convention on this surface (`assertSafePathSegment`, `apiCall` on any non-2xx, `createToolFromSpec`'s own drift checks).

## The op lists are hoisted, not derived

`MANAGE_OPS` / `DOC_OPS` are `as const` beside this file's existing `MEMORY_TYPES` / `STATUSES`, spread into the schema and passed to the guard — so the enum a caller is validated against and the refusal naming the alternatives read **one identifier, checked at compile time**.

An earlier draft derived the list at runtime by walking `PARAM_SCHEMAS[tool]?.properties?.op?.enum` through a cast. That degraded silently to an empty list on a mistyped tool name: a silent failure inside a guard whose entire purpose is not failing silently.

## The tests assert the mutation *before* the refusal

Ordering is load-bearing twice over:

1. A test that only checked for a throw would **pass** on a dispatcher that mutated and *then* threw.
2. `assert.rejects` first aborts before the mutation check. My first draft did exactly that, and on unfixed source reported only "missing expected rejection" — never naming the `DELETE`. Reordered, the failure prints the request.

| | result |
|---|---|
| 3 negatives against unfixed dispatcher | **fail**, with the write named in the message |
| `caura_doc op=delete` control | **passes before and after** — which is what makes it a control |

The `caura_doc` control is kept because **nothing else in the suite issues a `caura_doc` request at all**. The `caura_manage op=update` twin is dropped: `tool-identity.test.ts` already drives it and asserts the `PATCH`.

One op value per tool — after the guard nothing branches on the op *value*, so further values re-test a single line.

## CI registration, verified by observation

`npm test` enumerates each compiled test file, so an unregistered one never runs — which is how the plugin once had 423 tests and CI ran **none** of them. Rather than trust that I edited the right line, I confirmed the effect: the suite went **431 → 435**.

## Follow-ups deliberately not taken

- **A per-op lookup table** keyed by a union derived from the `as const` arrays. It would make *a missing handler* a compile error — the one failure mode nothing guards today. But 8 of the 10 op branches have no dispatch-level coverage, so converting now would mean an unreviewable-by-tests rewrite of a `DELETE`-issuing dispatcher. The harness added here is the net that refactor needs first. It also would **not** remove this guard.
- **A guard that every `plugin/src/*.test.ts` appears in the test script.** Same shape as the bug fixed here — an unhandled case silently means "do nothing" — one layer out. It needs a `dist` clean (there is no clean step, so a glob would run stale artifacts from deleted sources) plus a rename of `legacy-contracts.test.ts`, which declares no tests and is a fixture module wearing a test suffix. Worth spinning off.

## Verification

- Plugin suite **435 passed, 0 failed**; root suite **6321 passed, 5 skipped, 0 failed**.
- `tsc` clean; `legacy_name_ratchet.py` and `do_not_touch_sentinel.py` exit 0. No Python changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
