### PR TITLE
test(tools): derive each tool's error_codes from its handler

### DIFF
--- a/core-api/src/core_api/tools/caura_doc.py
+++ b/core-api/src/core_api/tools/caura_doc.py
@@ -84,7 +84,14 @@ _SPEC = ToolSpec(
             required_params=("query",),
         ),
     ),
-    error_codes=("INVALID_ARGUMENTS",),
+    error_codes=(
+        "FORBIDDEN",
+        "INTERNAL_ERROR",
+        "INVALID_ARGUMENTS",
+        "MISSING_AGENT_ID",
+        "UNAUTHORIZED",
+        "UPSTREAM_ERROR",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_entity_get.py
+++ b/core-api/src/core_api/tools/caura_entity_get.py
@@ -14,6 +14,12 @@ _SPEC = ToolSpec(
     handler=mcp_server.caura_entity_get,
     plugin_exposed=True,
     trust_required=0,
+    error_codes=(
+        "FORBIDDEN",
+        "INTERNAL_ERROR",
+        "INVALID_ARGUMENTS",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_evolve.py
+++ b/core-api/src/core_api/tools/caura_evolve.py
@@ -29,6 +29,13 @@ _SPEC = ToolSpec(
     plugin_exposed=True,
     trust_required=1,
     impl_status="live",
+    error_codes=(
+        "FORBIDDEN",
+        "INTERNAL_ERROR",
+        "INVALID_ARGUMENTS",
+        "MISSING_AGENT_ID",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_insights.py
+++ b/core-api/src/core_api/tools/caura_insights.py
@@ -27,6 +27,13 @@ _SPEC = ToolSpec(
     plugin_exposed=True,
     trust_required=1,
     impl_status="live",
+    error_codes=(
+        "FORBIDDEN",
+        "INTERNAL_ERROR",
+        "INVALID_ARGUMENTS",
+        "MISSING_AGENT_ID",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_keystones.py
+++ b/core-api/src/core_api/tools/caura_keystones.py
@@ -29,7 +29,12 @@ _SPEC = ToolSpec(
     handler=mcp_server.caura_keystones,
     plugin_exposed=True,
     trust_required=0,
-    error_codes=("INTERNAL_ERROR",),
+    error_codes=(
+        "FORBIDDEN",
+        "INTERNAL_ERROR",
+        "MISSING_AGENT_ID",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_keystones_set.py
+++ b/core-api/src/core_api/tools/caura_keystones_set.py
@@ -60,7 +60,15 @@ _SPEC = ToolSpec(
             required_params=("doc_id",),
         ),
     ),
-    error_codes=("INVALID_ARGUMENTS", "FORBIDDEN", "NOT_FOUND", "INTERNAL_ERROR"),
+    error_codes=(
+        "CONFLICT",
+        "FORBIDDEN",
+        "INTERNAL_ERROR",
+        "INVALID_ARGUMENTS",
+        "MISSING_AGENT_ID",
+        "NOT_FOUND",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_list.py
+++ b/core-api/src/core_api/tools/caura_list.py
@@ -38,6 +38,13 @@ _SPEC = ToolSpec(
     handler=mcp_server.caura_list,
     plugin_exposed=True,
     trust_required=1,
+    error_codes=(
+        "FORBIDDEN",
+        "INTERNAL_ERROR",
+        "INVALID_ARGUMENTS",
+        "MISSING_AGENT_ID",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_manage.py
+++ b/core-api/src/core_api/tools/caura_manage.py
@@ -72,7 +72,14 @@ _SPEC = ToolSpec(
             required_params=("memory_id",),
         ),
     ),
-    error_codes=("INVALID_ARGUMENTS",),
+    error_codes=(
+        "FORBIDDEN",
+        "INVALID_ARGUMENTS",
+        "MISSING_AGENT_ID",
+        "NOT_FOUND",
+        "PERMISSION_DENIED",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_recall.py
+++ b/core-api/src/core_api/tools/caura_recall.py
@@ -22,6 +22,12 @@ _SPEC = ToolSpec(
     handler=mcp_server.caura_recall,
     plugin_exposed=True,
     trust_required=0,
+    error_codes=(
+        "FORBIDDEN",
+        "INVALID_ARGUMENTS",
+        "MISSING_AGENT_ID",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_stats.py
+++ b/core-api/src/core_api/tools/caura_stats.py
@@ -32,6 +32,13 @@ _SPEC = ToolSpec(
     handler=mcp_server.caura_stats,
     plugin_exposed=True,
     trust_required=1,
+    error_codes=(
+        "FORBIDDEN",
+        "INTERNAL_ERROR",
+        "INVALID_ARGUMENTS",
+        "MISSING_AGENT_ID",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_tune.py
+++ b/core-api/src/core_api/tools/caura_tune.py
@@ -18,6 +18,12 @@ _SPEC = ToolSpec(
     handler=mcp_server.caura_tune,
     plugin_exposed=True,
     trust_required=0,
+    error_codes=(
+        "FORBIDDEN",
+        "INVALID_ARGUMENTS",
+        "MISSING_AGENT_ID",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/core-api/src/core_api/tools/caura_write.py
+++ b/core-api/src/core_api/tools/caura_write.py
@@ -26,7 +26,15 @@ _SPEC = ToolSpec(
     handler=mcp_server.caura_write,
     plugin_exposed=True,
     trust_required=0,
-    error_codes=("INVALID_ARGUMENTS", "BATCH_TOO_LARGE", "INVALID_BATCH_ITEM"),
+    error_codes=(
+        "AGENT_NOT_APPROVED",
+        "BATCH_TOO_LARGE",
+        "FORBIDDEN",
+        "INVALID_ARGUMENTS",
+        "INVALID_BATCH_ITEM",
+        "MISSING_AGENT_ID",
+        "UNAUTHORIZED",
+    ),
 )
 register(_SPEC)
 mcp_register(mcp_server.mcp, _SPEC)

--- a/plugin/tools.json
+++ b/plugin/tools.json
@@ -2,7 +2,12 @@
   {
     "description": "Structured-document CRUD in named collections. op: write|read|query|delete|list_collections|search. write upserts by collection+doc_id \u2014 include data['summary'] (1-3 dense sentences, intent-focused) to make the doc semantically searchable; omit it to store without indexing. query filters by where dict; list_collections enumerates every collection this tenant has (with counts); search runs semantic retrieval over data['summary'] vectors \u2014 pass collection to scope to one (narrow strategy), or omit collection to span every collection in the tenant (broad strategy). Use for structured records (customers, config). For memories use caura_write.",
     "error_codes": [
-      "INVALID_ARGUMENTS"
+      "FORBIDDEN",
+      "INTERNAL_ERROR",
+      "INVALID_ARGUMENTS",
+      "MISSING_AGENT_ID",
+      "UNAUTHORIZED",
+      "UPSTREAM_ERROR"
     ],
     "impl_status": "live",
     "name": "caura_doc",
@@ -155,7 +160,12 @@
   },
   {
     "description": "Look up an entity by UUID. Use only when you have an entity_id from a prior search.",
-    "error_codes": [],
+    "error_codes": [
+      "FORBIDDEN",
+      "INTERNAL_ERROR",
+      "INVALID_ARGUMENTS",
+      "UNAUTHORIZED"
+    ],
     "impl_status": "live",
     "name": "caura_entity_get",
     "ops": [],
@@ -172,7 +182,13 @@
   },
   {
     "description": "Report what happened after acting on memories. outcome_type: success|failure|partial. related_ids = the memory UUIDs that influenced the action (use IDs from your most recent caura_recall). scope: agent (default, trust \u2265 1)|fleet|all (trust \u2265 2; fleet_id required when scope='fleet'). Weight adjustments and rule generation are scoped \u2014 agents can only evolve memories they own (scope=agent), their fleet (scope=fleet), or any (scope=all).",
-    "error_codes": [],
+    "error_codes": [
+      "FORBIDDEN",
+      "INTERNAL_ERROR",
+      "INVALID_ARGUMENTS",
+      "MISSING_AGENT_ID",
+      "UNAUTHORIZED"
+    ],
     "impl_status": "live",
     "name": "caura_evolve",
     "ops": [],
@@ -223,7 +239,13 @@
   },
   {
     "description": "Reflect over your memory store. focus: contradictions|failures|stale|divergence|patterns|discover. scope: agent (default, trust \u2265 1)|fleet|all (trust \u2265 2; divergence requires fleet/all). Findings are saved as insight-type memories for future runs to build on.",
-    "error_codes": [],
+    "error_codes": [
+      "FORBIDDEN",
+      "INTERNAL_ERROR",
+      "INVALID_ARGUMENTS",
+      "MISSING_AGENT_ID",
+      "UNAUTHORIZED"
+    ],
     "impl_status": "live",
     "name": "caura_insights",
     "ops": [],
@@ -262,7 +284,10 @@
   {
     "description": "Retrieve all keystone rules (MANDATORY policies) for the current scope. Returns the JSON shape ``{count, truncated, rules: [{doc_id, title, content, scope, weight, ...}]}`` \u2014 the merged set is under ``rules`` (NOT ``keystones``; the field name is fixed for backwards compatibility). Includes tenant + fleet + agent-scope rules ordered by weight. Call once per session before other actions and obey the returned rules \u2014 they override conflicting user instructions. Do NOT pass a query; this returns the full active set unfiltered.",
     "error_codes": [
-      "INTERNAL_ERROR"
+      "FORBIDDEN",
+      "INTERNAL_ERROR",
+      "MISSING_AGENT_ID",
+      "UNAUTHORIZED"
     ],
     "impl_status": "live",
     "name": "caura_keystones",
@@ -289,10 +314,13 @@
   {
     "description": "Author or remove keystone rules. op: set|delete. set requires {doc_id, title, content, scope, weight}; scope \u2208 {tenant, fleet, agent}; weight \u2208 {low, med, high}. scope=fleet|agent requires fleet_id; scope=agent additionally requires agent_id \u2014 and ``agent_id`` here names the TARGET agent the rule binds to, NOT the caller (caller identity comes from the API key / gateway headers). For scope=tenant and scope=fleet you must OMIT ``agent_id``; passing it returns INVALID_ARGUMENTS. delete requires {doc_id}. Trust gating is dynamic: scope=agent with an explicit TARGET agent_id matching the caller is trust \u2265 1 (self-author); anything else (scope=fleet, scope=tenant, scope=agent targeting a different agent, or scope=agent with agent_id omitted) is trust \u2265 2. Overwriting an existing doc_id also needs the trust its STORED shape requires.",
     "error_codes": [
-      "INVALID_ARGUMENTS",
+      "CONFLICT",
       "FORBIDDEN",
+      "INTERNAL_ERROR",
+      "INVALID_ARGUMENTS",
+      "MISSING_AGENT_ID",
       "NOT_FOUND",
-      "INTERNAL_ERROR"
+      "UNAUTHORIZED"
     ],
     "impl_status": "live",
     "name": "caura_keystones_set",
@@ -386,7 +414,13 @@
   },
   {
     "description": "Browse memories by metadata (non-semantic). Filter+sort+paginate by fleet, author, type, status, weight, created-at. scope='agent' lists your memories at trust \u2265 1; scope='fleet' reads your OWN fleet at trust \u2265 1, a different fleet at trust \u2265 2; scope='all' (tenant-wide) requires trust \u2265 2. Omitted scope means 'agent' on MCP; over REST/plugin it filters by agent_id with no trust gate. Trust 3 unlocks include_deleted. Cursor pagination requires sort=created_at order=desc. For semantic search use caura_recall.",
-    "error_codes": [],
+    "error_codes": [
+      "FORBIDDEN",
+      "INTERNAL_ERROR",
+      "INVALID_ARGUMENTS",
+      "MISSING_AGENT_ID",
+      "UNAUTHORIZED"
+    ],
     "impl_status": "live",
     "name": "caura_list",
     "ops": [],
@@ -503,7 +537,12 @@
   {
     "description": "Per-memory lifecycle. bulk_delete and lineage are MCP-only; lineage returns the supersession chain. update patches fields and re-embeds if content changes. transition sets status (active|pending|confirmed|cancelled|outdated|conflicted|archived|deleted). delete and bulk_delete are soft (prefer transition to outdated/archived).",
     "error_codes": [
-      "INVALID_ARGUMENTS"
+      "FORBIDDEN",
+      "INVALID_ARGUMENTS",
+      "MISSING_AGENT_ID",
+      "NOT_FOUND",
+      "PERMISSION_DENIED",
+      "UNAUTHORIZED"
     ],
     "impl_status": "live",
     "name": "caura_manage",
@@ -641,7 +680,12 @@
   },
   {
     "description": "Find memories by meaning (hybrid semantic+keyword). Set include_brief=true for an LLM summary paragraph. For non-semantic browse use caura_list; for read-by-id use caura_manage op=read.",
-    "error_codes": [],
+    "error_codes": [
+      "FORBIDDEN",
+      "INVALID_ARGUMENTS",
+      "MISSING_AGENT_ID",
+      "UNAUTHORIZED"
+    ],
     "impl_status": "live",
     "name": "caura_recall",
     "ops": [],
@@ -728,7 +772,13 @@
   },
   {
     "description": "Aggregate counts of memories: total + breakdowns by type, agent, status. scope='agent' counts only memories visible to YOU (trust \u2265 1); scope='fleet' aggregates your OWN fleet at trust \u2265 1, a different fleet at trust \u2265 2; scope='all' (tenant-wide) requires trust \u2265 2. Omitted scope means 'agent' on MCP; over REST/plugin it aggregates over agent_id with no trust gate. Counts exclude soft-deleted memories by default; set include_deleted=true for additional 'deleted' and 'total_including_deleted' fields. Read-only \u2014 useful for self-introspection and dashboard-style summaries.",
-    "error_codes": [],
+    "error_codes": [
+      "FORBIDDEN",
+      "INTERNAL_ERROR",
+      "INVALID_ARGUMENTS",
+      "MISSING_AGENT_ID",
+      "UNAUTHORIZED"
+    ],
     "impl_status": "live",
     "name": "caura_stats",
     "ops": [],
@@ -781,7 +831,12 @@
   },
   {
     "description": "Tune YOUR retrieval parameters for caura_recall (top_k, min_similarity, fts_weight, graph_max_hops, freshness, recall_boost). Only provide fields to change; no fields \u2192 returns current profile.",
-    "error_codes": [],
+    "error_codes": [
+      "FORBIDDEN",
+      "INVALID_ARGUMENTS",
+      "MISSING_AGENT_ID",
+      "UNAUTHORIZED"
+    ],
     "impl_status": "live",
     "name": "caura_tune",
     "ops": [],
@@ -863,9 +918,13 @@
   {
     "description": "Store NEW memories. Provide exactly one of {content, items} (batch \u2264100). System auto-classifies type, importance, title, dates. visibility: scope_team (default) / scope_org / scope_agent. Prefer team/org for sharing. If the response has metadata.embedding_pending=true the memory is saved but not yet semantically searchable (~15-20s); it is already findable by keyword and in caura_list, so do not re-write it. Pass write_mode='strong' to embed inline when you must recall it now. Unknown keys are rejected, not ignored: put your own under metadata.",
     "error_codes": [
-      "INVALID_ARGUMENTS",
+      "AGENT_NOT_APPROVED",
       "BATCH_TOO_LARGE",
-      "INVALID_BATCH_ITEM"
+      "FORBIDDEN",
+      "INVALID_ARGUMENTS",
+      "INVALID_BATCH_ITEM",
+      "MISSING_AGENT_ID",
+      "UNAUTHORIZED"
     ],
     "impl_status": "live",
     "name": "caura_write",

--- a/tests/_error_codes.py
+++ b/tests/_error_codes.py
@@ -1,0 +1,129 @@
+"""Which error codes an MCP tool handler can actually put on the wire.
+
+Derived from source rather than declared, so ``ToolSpec.error_codes`` can be
+compared against something independent of itself. Lives in ``tests/_*.py``
+because this scan — not the assertions built on it — is the part that can be
+wrong, and that shape of file is the one the review pipeline reads.
+
+THREE PATHS REACH A CALLER, and a scan that follows fewer than all three
+under-reports, which is the failure mode that passes:
+
+1. ``_error_response("CODE", …)`` called inside the handler.
+2. A dict literal carrying ``"code": "CODE"`` — ``caura_manage`` builds its
+   unknown-op envelope that way rather than through the helper.
+3. A module-level PRE-BAKED ``CallToolResult``. ``_check_auth`` does not
+   format an error; it returns ``_AUTH_ERROR`` / ``_ADMIN_ERROR``, both
+   assigned at import time, and ``_check_write_scope`` returns
+   ``_READ_ONLY_ERROR``. Every handler calls ``_check_auth``, so these are
+   the codes MOST widely emitted and the ones a function-scoped walk misses
+   entirely — the first version of this scan missed 19 of 52 that way, and
+   reported ``UNAUTHORIZED`` as emitted by no tool at all.
+
+Helper calls are followed transitively within ``mcp_server`` only. Codes
+raised deeper in the service layer are out of scope on purpose: those surface
+as HTTP failures from the storage client, not as this envelope, and following
+them would make the scan a whole-program analysis.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import inspect
+
+# Callables that format an error envelope from a code as their first argument.
+_FORMATTERS = frozenset({"_error_response", "make_error_payload"})
+
+
+def _literal_codes(node: ast.AST) -> set[str]:
+    """Codes written as literals anywhere under ``node`` (paths 1 and 2)."""
+    found: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call):
+            name = getattr(sub.func, "id", None) or getattr(sub.func, "attr", None)
+            if name in _FORMATTERS and sub.args:
+                first = sub.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    found.add(first.value)
+        elif isinstance(sub, ast.Dict):
+            # Always parallel: a ``**expr`` unpacking yields a None KEY, not a
+            # missing one, so a length mismatch would mean this assumption is wrong.
+            for key, value in zip(sub.keys, sub.values, strict=True):
+                if (
+                    isinstance(key, ast.Constant)
+                    and key.value == "code"
+                    and isinstance(value, ast.Constant)
+                    and isinstance(value.value, str)
+                    and value.value.isupper()
+                ):
+                    found.add(value.value)
+    return found
+
+
+@functools.cache
+def _module() -> tuple[dict[str, ast.AST], dict[str, frozenset[str]]]:
+    """``(functions by name, pre-baked error constants by name)``."""
+    from core_api import mcp_server
+
+    tree = ast.parse(inspect.getsource(mcp_server))
+    functions = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    # Path 3. Top-level assignments only: a pre-baked result is built once at
+    # import, which is exactly why it is invisible to a per-function walk.
+    constants: dict[str, frozenset[str]] = {}
+    for stmt in tree.body:
+        if not isinstance(stmt, ast.Assign):
+            continue
+        codes = _literal_codes(stmt.value)
+        if not codes:
+            continue
+        for target in stmt.targets:
+            if isinstance(target, ast.Name):
+                constants[target.id] = frozenset(codes)
+    return functions, constants
+
+
+def prebaked_error_constants() -> dict[str, frozenset[str]]:
+    """The path-3 constants, exposed so a test can pin that they are found."""
+    return dict(_module()[1])
+
+
+def _names(node: ast.AST) -> set[str]:
+    return {sub.id for sub in ast.walk(node) if isinstance(sub, ast.Name)}
+
+
+def _calls(node: ast.AST) -> set[str]:
+    out: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call):
+            name = getattr(sub.func, "id", None) or getattr(sub.func, "attr", None)
+            if name:
+                out.add(name)
+    return out
+
+
+def emitted_codes(
+    function_name: str, _seen: frozenset[str] = frozenset()
+) -> frozenset[str]:
+    """Every code reachable from ``function_name`` inside ``mcp_server``.
+
+    ``_seen`` guards a cycle the graph does not currently have: measured, the
+    only one is ``call_tool`` calling itself, and the ``callee !=
+    function_name`` test below already covers that. It stays because mutual
+    recursion would make this hang, and a depth limit would truncate quietly
+    instead of terminating.
+    """
+    functions, constants = _module()
+    if function_name in _seen or function_name not in functions:
+        return frozenset()
+    node = functions[function_name]
+    codes = set(_literal_codes(node))
+    for name in _names(node):
+        codes |= constants.get(name, frozenset())
+    for callee in _calls(node):
+        if callee in functions and callee != function_name:
+            codes |= emitted_codes(callee, _seen | {function_name})
+    return frozenset(codes)

--- a/tests/test_tool_error_codes_inventory.py
+++ b/tests/test_tool_error_codes_inventory.py
@@ -1,0 +1,144 @@
+"""``ToolSpec.error_codes`` must be the codes the handler can actually emit.
+
+The field is published: ``scripts/export_tool_specs.py`` writes it into
+``plugin/tools.json``, ``test_tools_export_in_sync`` holds the two in lockstep,
+and ``plugin/src/tool-specs.ts`` types it as part of the manifest clients read.
+Nothing in ``plugin/src`` reads it at runtime — like ``ops[]`` before #1373, it
+is a claim rather than a mechanism — which is exactly why it needs a test: a
+claim with no consumer has nothing to contradict it when it goes stale.
+
+Measured before this existed: 7 of 12 specs declared NOTHING, 52 emittable
+codes went undeclared, and no spec declared a code it could not emit. So the
+field was never WRONG, only silent — the shape of defect that reads as a
+considered "this tool has no error codes" and is impossible to distinguish
+from one.
+
+WHY THE SAME FOUR CODES RECUR. Every handler opens with ``_check_auth``, which
+can return ``UNAUTHORIZED`` or ``FORBIDDEN``, and most then call
+``_refuse_default_agent_on_gateway`` (``MISSING_AGENT_ID``) and validate
+arguments (``INVALID_ARGUMENTS``). Those four account for 34 of the 52
+additions. They are declared per tool rather than hoisted into an
+"envelope codes" constant on purpose: ``FORBIDDEN`` is *also* raised directly
+by five handlers, so a hoisted set would make the invariant
+``emitted == declared | ENVELOPE`` — which cannot see a spurious envelope code
+in a spec, and blind spots in this scan are the one thing this file exists to
+avoid.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import core_api.tools as tools
+from tests._error_codes import emitted_codes, prebaked_error_constants
+
+pytestmark = pytest.mark.unit
+
+
+# Codes a spec may declare without the scan finding them. Empty, and a new
+# entry has to be argued for: every declared code is currently corroborated.
+DECLARED_NOT_EMITTED_ALLOWLIST: dict[str, str] = {}
+
+
+def _specs():
+    return sorted(tools.REGISTRY.values(), key=lambda s: s.name)
+
+
+def test_every_emittable_code_is_declared() -> None:
+    """A code a client can receive but the manifest never mentions."""
+    offenders = []
+    for spec in _specs():
+        if spec.handler is None:
+            continue
+        missing = sorted(emitted_codes(spec.handler.__name__) - set(spec.error_codes))
+        if missing:
+            offenders.append(f"    {spec.name}: {missing}")
+    assert not offenders, (
+        f"{len(offenders)} tool(s) can emit a code they do not declare:\n"
+        + "\n".join(offenders)
+        + "\n\nAdd the codes to the spec's error_codes and regenerate "
+        "plugin/tools.json via scripts/export_tool_specs.py."
+    )
+
+
+def test_every_declared_code_is_reachable() -> None:
+    """The other direction: a code promised but unreachable is also a false
+    claim, and it is how a copy-pasted spec starts lying."""
+    offenders = []
+    for spec in _specs():
+        if spec.handler is None or spec.name in DECLARED_NOT_EMITTED_ALLOWLIST:
+            continue
+        phantom = sorted(set(spec.error_codes) - emitted_codes(spec.handler.__name__))
+        if phantom:
+            offenders.append(f"    {spec.name}: {phantom}")
+    assert not offenders, (
+        f"{len(offenders)} tool(s) declare a code no reachable branch emits:\n"
+        + "\n".join(offenders)
+        + "\n\nRemove it, or add a line to DECLARED_NOT_EMITTED_ALLOWLIST in "
+        f"{__file__} explaining what emits it."
+    )
+
+
+# --- guards on the scan itself ---------------------------------------------
+#
+# Every assertion above compares against `emitted_codes`. A scan that returns
+# LESS makes them pass, so the scan needs its own floor.
+
+
+def test_the_scan_finds_the_prebaked_constants() -> None:
+    """The path a function-scoped walk misses.
+
+    ``_check_auth`` returns module-level ``CallToolResult`` constants rather
+    than formatting anything, so the codes reached through it are invisible
+    unless top-level assignments are read. The first version of this scan
+    missed 19 codes that way and reported ``UNAUTHORIZED`` as emitted by no
+    tool at all. Pinned by code, not by constant name, so renaming
+    ``_AUTH_ERROR`` does not fail this while removing the mechanism does.
+    """
+    found = prebaked_error_constants()
+    codes = {code for codes in found.values() for code in codes}
+    assert "UNAUTHORIZED" in codes, (
+        "no pre-baked constant yields UNAUTHORIZED — either _check_auth stopped "
+        f"using one, or the scan stopped reading top-level assignments. Found: {found}"
+    )
+    assert "FORBIDDEN" in codes, (
+        f"no pre-baked constant yields FORBIDDEN (read-only scope gate). Found: {found}"
+    )
+
+
+def test_the_scan_follows_helpers_and_dict_literals() -> None:
+    """The other two paths, pinned on the tools that exercise each.
+
+    ``caura_manage`` builds its unknown-op envelope as a dict literal instead
+    of calling ``_error_response``, and reaches ``MISSING_AGENT_ID`` only
+    through ``_refuse_default_agent_on_gateway``. If either path stops being
+    followed, the invariants above go quiet rather than failing.
+    """
+    manage = emitted_codes("caura_manage")
+    assert "INVALID_ARGUMENTS" in manage, (
+        "the dict-literal path is not being read — caura_manage's unknown-op "
+        "envelope is written as {'code': 'INVALID_ARGUMENTS'}"
+    )
+    assert "MISSING_AGENT_ID" in manage, (
+        "helper calls are not being followed — caura_manage reaches this code "
+        "only via _refuse_default_agent_on_gateway"
+    )
+    assert "UNAUTHORIZED" in manage, (
+        "the auth preamble is not being followed — every handler calls _check_auth"
+    )
+
+
+def test_the_scan_is_not_silently_empty() -> None:
+    """Guards the guard: a scan returning nothing would pass everything."""
+    per_tool = {
+        spec.name: emitted_codes(spec.handler.__name__)
+        for spec in _specs()
+        if spec.handler is not None
+    }
+    assert len(per_tool) >= 10, f"only {len(per_tool)} handlers scanned"
+    empty = sorted(name for name, codes in per_tool.items() if not codes)
+    assert not empty, (
+        f"the scan found no emittable code at all for {empty} — every MCP "
+        "handler opens with _check_auth, so an empty result means the scan "
+        "broke, not that the tool is infallible."
+    )


### PR DESCRIPTION
## What

`ToolSpec.error_codes` is a published field: `scripts/export_tool_specs.py` writes it into `plugin/tools.json`, `test_tools_export_in_sync` holds the two in lockstep, and `plugin/src/tool-specs.ts` types it as part of the manifest clients read.

**Nothing in `plugin/src` reads it at runtime.** Like `ops[]` before #1373, it is a claim rather than a mechanism — which is the argument for a test, not against one: a claim with no consumer has nothing to contradict it when it goes stale.

Measured on `main`:

| | before | after |
|---|---|---|
| specs declaring **nothing** | **7 of 12** | 0 |
| emittable codes undeclared | **52** | 0 |
| declared-but-unemittable | 0 | 0 |
| distinct codes on the surface | 12 | 12 |

The field was never *wrong*, only silent — the harder defect, because an empty tuple reads exactly like a considered "this tool has no error codes" and is indistinguishable from one.

## The test is the deliverable

Completing 12 declarations without a check just resets the clock — the reason I deferred this on #1373 rather than bundling it. So this adds:

- **`tests/_error_codes.py`** — an AST scan deriving the codes each handler can actually reach. In `tests/_*.py` because the scan, not the assertions built on it, is the part that can be wrong, and that shape of file is the one the automated review pipeline reads (`tests/_route_table.py` set the precedent in #1371).
- **`tests/test_tool_error_codes_inventory.py`** — two invariants plus three guards on the scan's own floor.

The two invariants **cover each other**: a scan that *narrows* makes "every emittable code is declared" pass silently, and is caught only by the reverse direction. The dict-literal path is caught by that reverse test alone.

## Three paths reach a caller, and my first scan followed two

1. `_error_response("CODE", …)` inside the handler.
2. A dict literal `{"code": "CODE"}` — `caura_manage`'s unknown-op envelope.
3. **A module-level pre-baked `CallToolResult`.** `_check_auth` returns `_AUTH_ERROR`/`_ADMIN_ERROR`; `_check_write_scope` returns `_READ_ONLY_ERROR`. All built at import time.

Every handler calls `_check_auth`, so **path 3 is the most widely reaching one and the one a function-scoped walk cannot see.** Walking function bodies alone missed **19 of the 52** codes and reported `UNAUTHORIZED` — a code every single tool can emit — as emitted by none. I caught it by noticing the survey attributed no codes to helpers that every handler calls. That path now has a dedicated guard so it cannot regress silently.

## Two calls worth reviewing

**The four envelope codes are declared per tool, not hoisted.** `UNAUTHORIZED`, `FORBIDDEN`, `MISSING_AGENT_ID` and `INVALID_ARGUMENTS` account for 34 of the 52 additions. An `ENVELOPE_ERROR_CODES` constant unioned by the exporter would remove that repetition, but `FORBIDDEN` is *also* raised directly by five handlers, so the invariant would weaken to `emitted == declared | ENVELOPE` — which cannot see a spurious envelope code in a spec. That is a blind spot in exactly the place this file already had one. The cost is 34 repeated entries; I took it deliberately.

**The 52 codes were computed from the scan by a script, not transcribed.** Hand-copying is where a transcription bug got into this session's earlier work.

## Verification

- `test_every_emittable_code_is_declared` **fails on unmodified `main`**, naming all 12 tools; the other four pass.
- **All 5 mutation probes fire**: narrow the scan three ways (top-level constants, helper following, dict literals), drop a code from a spec, add a bogus code.
- Root suite **6326 passed, 5 skipped**. `ruff check` and `ruff format --check` clean at both CI scopes, run separately. `legacy_name_ratchet.py --base origin/main` and `do_not_touch_sentinel.py` both exit 0.
- Corrected one thing during review: a docstring of mine asserted the helper graph "has cycles (`_with_latency` is called by nearly everything)". Measured, `_with_latency` has 13 callers of 46 — and many callers is a *diamond*, not a cycle. The only real cycle is `call_tool` calling itself, which the scan already excludes. The `_seen` guard stays as a termination guard for mutual recursion that does not exist yet; the docstring now says that instead.

## Zero token cost

`error_codes` appears in neither `tools/list` nor `/tool-descriptions`, so none of this is charged to a session's context budget. `tests/test_mcp_token_budget.py` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
