### PR TITLE
fix(plugin): make a missing op branch a build error, and pin every op's route

### DIFF
--- a/plugin/src/tool-definitions.ts
+++ b/plugin/src/tool-definitions.ts
@@ -154,6 +154,11 @@ const DOC_OPS = [
   "write", "read", "query", "delete", "search", "list_collections",
 ] as const;
 
+// Derived, so the dispatcher below is checked against the same tuple the
+// inputSchema publishes rather than against a second hand-written list.
+type ManageOp = (typeof MANAGE_OPS)[number];
+type DocOp = (typeof DOC_OPS)[number];
+
 const MEMORY_TYPE_SCHEMA = {
   type: "string",
   enum: [...MEMORY_TYPES],
@@ -432,8 +437,18 @@ const SINGLE_WRITE_ONLY_FIELDS = [
  * Not a no-op. Until this existed the last branch doubled as the else, and an
  * unrecognised op became a write — see `tool-op-dispatch.test.ts`, which
  * records what that cost and pins it.
+ *
+ * `op` is typed `never` so that adding an op to MANAGE_OPS/DOC_OPS without a
+ * branch fails `tsc` here rather than reaching this line at runtime — the
+ * callers cast `op` to the derived union, so an exhausted chain narrows it to
+ * `never` and a leftover member does not.
+ *
+ * The throw is still load-bearing, and deleting it as unreachable would
+ * restore the original defect: that cast is a runtime lie. Nothing in this
+ * package validates `op` — the enum in `PARAM_SCHEMAS` is enforced by the
+ * host, so any string can arrive here.
  */
-function unsupportedOp(tool: string, op: unknown, offered: readonly string[]): never {
+function unsupportedOp(tool: string, op: never, offered: readonly string[]): never {
   throw new Error(
     `[caura] ${tool}: unsupported op ${JSON.stringify(op)}. ` +
       `Expected one of: ${offered.join(", ")}`,
@@ -490,7 +505,7 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
   caura_manage: async (params, signal) => {
     // op=update sends ``agent_id`` as a query param; the other ops ignore it.
     const enriched = await enrichBody(params, { resolveIdentity: true });
-    const op = enriched.op as string;
+    const op = enriched.op as ManageOp;
     const memory_id = enriched.memory_id as string;
     assertSafePathSegment(memory_id, "memory_id");
     const tenant_id = enriched.tenant_id as string;
@@ -531,7 +546,7 @@ const ENDPOINT_DISPATCH: Record<string, ExecuteFn> = {
 
   caura_doc: async (params, signal) => {
     const enriched = await enrichBody(params);
-    const op = enriched.op as string;
+    const op = enriched.op as DocOp;
     const collection = enriched.collection as string | undefined;
     const tenant_id = enriched.tenant_id as string;
     if (op === "write") {

--- a/plugin/src/tool-op-dispatch.test.ts
+++ b/plugin/src/tool-op-dispatch.test.ts
@@ -136,11 +136,93 @@ describe("an unrecognised op is refused, not dispatched as a write", () => {
   });
 });
 
-// `caura_doc op=delete` was the fall-through, and nothing else in the suite
-// issues a caura_doc request at all — so a bad conversion of that branch would
-// otherwise go unnoticed. `caura_manage op=update` needs no twin here:
-// tool-identity.test.ts already drives it and asserts the PATCH.
-test("caura_doc op=delete still DELETEs the document", async () => {
-  await outcomeOf("caura_doc", { op: "delete", doc_id: "doc-1", collection: "c-1" });
-  assert.deepEqual(mutations(), ["DELETE /api/v1/documents/doc-1"]);
+/**
+ * Every op both surfaces offer, and the one request each is supposed to make.
+ *
+ * The guard above only proves an UNRECOGNISED op is refused. It says nothing
+ * about a recognised one going to the wrong place, which is the same class of
+ * defect one branch further in: `transition` and `update` are both PATCH on
+ * neighbouring paths, and `read` and `delete` differ only by method on an
+ * identical path. Two ops of caura_doc reach `/documents/query` and
+ * `/documents/search` while `read` reaches `/documents/{doc_id}`, so a
+ * doc_id of "query" is a legal read that differs from the query op by method
+ * alone.
+ *
+ * Table-driven because the point is COVERAGE of the enum, and the meta-test
+ * below fails when an op is added to a surface without a row here — the
+ * test-level twin of the `never`-typed fall-through, which fails the build
+ * when an op is added without a branch.
+ */
+const ROUTES: {
+  tool: string;
+  op: string;
+  params: Record<string, unknown>;
+  expect: string;
+}[] = [
+  // caura_manage
+  { tool: "caura_manage", op: "read", params: { memory_id: MEMORY_ID },
+    expect: `GET /api/v1/memories/${MEMORY_ID}` },
+  { tool: "caura_manage", op: "transition", params: { memory_id: MEMORY_ID, status: "archived" },
+    expect: `PATCH /api/v1/memories/${MEMORY_ID}/status` },
+  { tool: "caura_manage", op: "delete", params: { memory_id: MEMORY_ID },
+    expect: `DELETE /api/v1/memories/${MEMORY_ID}` },
+  { tool: "caura_manage", op: "update", params: { memory_id: MEMORY_ID, content: "x" },
+    expect: `PATCH /api/v1/memories/${MEMORY_ID}` },
+  // caura_doc
+  { tool: "caura_doc", op: "write", params: { collection: "c-1", doc_id: "doc-1", data: { a: 1 } },
+    expect: "POST /api/v1/documents" },
+  { tool: "caura_doc", op: "read", params: { collection: "c-1", doc_id: "doc-1" },
+    expect: "GET /api/v1/documents/doc-1" },
+  { tool: "caura_doc", op: "query", params: { collection: "c-1", where: {} },
+    expect: "POST /api/v1/documents/query" },
+  { tool: "caura_doc", op: "search", params: { collection: "c-1", query: "q" },
+    expect: "POST /api/v1/documents/search" },
+  { tool: "caura_doc", op: "list_collections", params: {},
+    expect: "GET /api/v1/documents/collections" },
+  { tool: "caura_doc", op: "delete", params: { collection: "c-1", doc_id: "doc-1" },
+    expect: "DELETE /api/v1/documents/doc-1" },
+];
+
+/**
+ * Requests against the resource routes, reads included.
+ *
+ * `mutations()` cannot serve here — half these ops are GETs. Same path filter
+ * and the same reason: `apiCall` provisions an agent-scoped credential with
+ * its own request when a call carries an `agent_id`, and that route is
+ * neither `/memories` nor `/documents`.
+ */
+function resourceCalls(): string[] {
+  return captured
+    .filter(
+      (c) =>
+        c.url.pathname.includes("/memories") || c.url.pathname.includes("/documents"),
+    )
+    .map((c) => `${c.method} ${c.url.pathname}`);
+}
+
+describe("each offered op reaches its own route", () => {
+  for (const { tool, op, params, expect } of ROUTES) {
+    test(`${tool} op=${op} -> ${expect}`, async () => {
+      const outcome = await outcomeOf(tool, { op, ...params });
+      assert.ok(
+        !(outcome instanceof Error),
+        `a legitimate op was refused: ${String(outcome)}`,
+      );
+      assert.deepEqual(resourceCalls(), [expect]);
+    });
+  }
+
+  test("the table covers every op each surface offers", () => {
+    for (const tool of ["caura_manage", "caura_doc"]) {
+      const schema = createToolFromSpec(tool).parameters as {
+        properties: { op: { enum: string[] } };
+      };
+      const covered = ROUTES.filter((r) => r.tool === tool).map((r) => r.op);
+      assert.deepEqual(
+        [...covered].sort(),
+        [...schema.properties.op.enum].sort(),
+        `${tool}: the table and the published op enum disagree`,
+      );
+    }
+  });
 });


### PR DESCRIPTION
## What

#1376 stopped an unrecognised op falling through to a write, but left two gaps behind:

1. **Nothing failed if an op was added to `MANAGE_OPS`/`DOC_OPS` without a branch.** The new op would reach `unsupportedOp` and be refused at runtime — on a surface that publishes it as supported.
2. **Of the ten ops the two dispatchers offer, exactly one had a test asserting where it goes** (`caura_doc op=delete`, because it had been the fall-through).

## Five lines close the first gap at compile time

Both dispatchers took `enriched.op as string`, so the `if (op === …)` chain never narrowed and the fall-through accepted anything. Casting to a union derived from the same tuple the inputSchema publishes, and typing `unsupportedOp`'s parameter `never`, makes an exhausted chain narrow to `never` — so a leftover member is a build error:

```
error TS2345: Argument of type '"archive"' is not assignable to parameter of type 'never'
error TS2345: Argument of type '"list_collections"' is not assignable to parameter of type 'never'
```

Those are the two build probes, and I ran them before writing the comment that claims the behaviour rather than after.

**The runtime throw stays, and it is not unreachable.** The cast is a runtime lie: nothing in this package validates `op`. I checked rather than inheriting the claim from #1376's docstring — `validation.ts` exports UUID, safe-path-segment, URL, signature and prompt-length checks and no enum validation, and the only one in the execute path is `assertSafePathSegment` on ids. The `PARAM_SCHEMAS` enum is enforced by the **host**, so any string can still arrive. The docstring now says this explicitly, because deleting the throw as dead code would restore the original defect.

## A table closes the second

| tool | op | route |
|---|---|---|
| `caura_manage` | read | `GET /memories/{id}` |
| | transition | `PATCH /memories/{id}/status` |
| | delete | `DELETE /memories/{id}` |
| | update | `PATCH /memories/{id}` |
| `caura_doc` | write | `POST /documents` |
| | read | `GET /documents/{doc_id}` |
| | query | `POST /documents/query` |
| | search | `POST /documents/search` |
| | list_collections | `GET /documents/collections` |
| | delete | `DELETE /documents/{doc_id}` |

The #1376 guard only proves an *unrecognised* op is refused. It says nothing about a *recognised* one going to the wrong place — the same defect one branch further in. These routes are genuinely confusable: `transition` and `update` are both PATCH on neighbouring paths, `read` and `delete` differ only by method on an identical path, and `caura_doc op=read` with a `doc_id` of `"query"` is a legal request differing from `op=query` by method alone.

A meta-test compares the table against the published op enum, so adding an op without a row fails the tests — the test-level twin of the compile-time check. The standalone `caura_doc op=delete` test is subsumed by its row, so net churn stays small.

Added to the existing `tool-op-dispatch.test.ts` rather than a new file: CI enumerates plugin test files explicitly in `package.json`, so an unregistered `*.test.ts` never runs.

## This supersedes the lookup table I had planned

The backlog item was a per-op lookup table keyed by a derived union. Reading the dispatchers first, that turned out to be the wrong shape: each op builds a genuinely different body — `update` filters keys, `query` assembles eight fields — so a table of handlers would still need one builder per op. It would have bought compile-time exhaustiveness and nothing else, which these five lines buy without restructuring either dispatcher.

## Verification

- **445 pass, 0 fail.** 435 before, minus the subsumed test, plus eleven — the arithmetic is the check that the new tests actually registered rather than being silently skipped.
- **Four mutation probes fire, each hitting exactly one test** (no collateral failures): `read` issued as POST, `search` pointed at the query route, `transition` losing its `/status` suffix, and a row removed from the table.
- **Two build probes fire:** an op added with no branch, and a branch disabled while the op stays offered.
- `legacy_name_ratchet.py --base origin/main` and `do_not_touch_sentinel.py` both exit 0. No Python or spec files touched, so `plugin/tools.json` needs no regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
