### PR TITLE
test(plugin): fail when a test file is not registered with the runner

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -16,7 +16,7 @@
     "pretest": "bash ../scripts/gen-version.sh",
     "build": "tsc",
     "dev": "bash ../scripts/gen-version.sh && tsc --watch",
-    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/tool-op-dispatch.test.js dist/tool-identity.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/interview-buffer.test.js dist/interview-command.test.js dist/task-trail.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js dist/fleet-scope.test.js dist/gateway-methods.test.js",
+    "test": "tsc && NODE_ENV=test node --test dist/educate.test.js dist/tool-definitions.test.js dist/tool-op-dispatch.test.js dist/tool-identity.test.js dist/env.test.js dist/transport.test.js dist/health.test.js dist/config.test.js dist/runtime-contract.test.js dist/identity.test.js dist/install-id.test.js dist/validation.test.js dist/reconcile-skills.test.js dist/context-engine.test.js dist/heartbeat.test.js dist/interview-buffer.test.js dist/interview-command.test.js dist/task-trail.test.js dist/keystones.test.js dist/resolve-agent.test.js dist/bootstrap-memoization.test.js dist/fleet-scope.test.js dist/gateway-methods.test.js dist/test-registration.test.js",
     "check:version": "bash -c 'V=$(node -p \"require(\\\"./package.json\\\").version\"); grep -qF \"PLUGIN_VERSION = \\\"$V\\\"\" src/version.ts || (echo \"version.ts out of sync with package.json ($V): run bash ../scripts/gen-version.sh\" >&2 && exit 1) && echo \"check:version ok: $V\"'"
   },
   "devDependencies": {

--- a/plugin/src/config.test.ts
+++ b/plugin/src/config.test.ts
@@ -15,7 +15,7 @@ import {
   PLUGIN_ID,
 } from "./config.js";
 import { getPluginDir } from "./paths.js";
-import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.fixture.js";
 
 describe("PLUGIN_ID", () => {
   // The id lives in two files that are read by different consumers:

--- a/plugin/src/context-engine.test.ts
+++ b/plugin/src/context-engine.test.ts
@@ -19,7 +19,7 @@ import {
   MemClawContextEngine as ContextEngine,  // legacy-name-ok: references the class as currently named
   type ShouldRecallInput,
 } from "./context-engine.js";
-import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.fixture.js";
 
 describe("prepareSubagentSpawn — OpenClaw's rollback contract", () => {
   // OpenClaw's contract is `Promise<SubagentSpawnPreparation | undefined>` with

--- a/plugin/src/educate.test.ts
+++ b/plugin/src/educate.test.ts
@@ -16,7 +16,7 @@ import { MEMORY_TYPES, STATUSES } from "./tool-definitions.js";
 import {
   FROZEN_PLUGIN_ID,
   LEGACY_DISPLAY_NAME,
-} from "./legacy-contracts.test.js";
+} from "./legacy-contracts.fixture.js";
 
 const BACKUP_SUFFIX = `.${FROZEN_PLUGIN_ID}-bak`;
 

--- a/plugin/src/heartbeat.test.ts
+++ b/plugin/src/heartbeat.test.ts
@@ -13,7 +13,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 
 import { __DEPLOY_INTERNALS__ } from "./heartbeat.js";
-import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.fixture.js";
 import { PLUGIN_VERSION } from "./version.js";
 
 describe("deploy cooldown lifecycle", () => {

--- a/plugin/src/install-id.test.ts
+++ b/plugin/src/install-id.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 import { getInstallId, _resetInstallIdCacheForTesting } from "./install-id.js";
-import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.fixture.js";
 
 let _origHome: string | undefined;
 let _tmpHome: string | undefined;

--- a/plugin/src/legacy-contracts.fixture.ts
+++ b/plugin/src/legacy-contracts.fixture.ts
@@ -1,0 +1,9 @@
+/**
+ * Frozen identifiers used to exercise compatibility with existing installs.
+ *
+ * Declares no tests. It was named `*.test.ts` and so looked like a suite
+ * that CI had simply forgotten to register — `*.fixture.ts` says what it is
+ * and keeps `test-registration.test.ts` from demanding it be run.
+ */
+export const FROZEN_PLUGIN_ID = "memclaw"; // legacy-name-ok: permanent on-disk plugin identifier
+export const LEGACY_DISPLAY_NAME = "MemClaw"; // legacy-name-ok: historical on-disk prose fixture

--- a/plugin/src/legacy-contracts.test.ts
+++ b/plugin/src/legacy-contracts.test.ts
@@ -1,3 +1,0 @@
-/** Frozen identifiers used to exercise compatibility with existing installs. */
-export const FROZEN_PLUGIN_ID = "memclaw"; // legacy-name-ok: permanent on-disk plugin identifier
-export const LEGACY_DISPLAY_NAME = "MemClaw"; // legacy-name-ok: historical on-disk prose fixture

--- a/plugin/src/reconcile-skills.test.ts
+++ b/plugin/src/reconcile-skills.test.ts
@@ -25,7 +25,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, readdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.fixture.js";
 
 // Set env BEFORE importing reconcile-skills.js — module reads from
 // process.env at import time via env.ts.

--- a/plugin/src/runtime-contract.test.ts
+++ b/plugin/src/runtime-contract.test.ts
@@ -29,7 +29,7 @@
 import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import cauraPlugin from "./index.js";
-import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.fixture.js";
 import {
   _resetReachabilityForTests,
   getReachability,

--- a/plugin/src/test-registration.test.ts
+++ b/plugin/src/test-registration.test.ts
@@ -1,0 +1,73 @@
+/**
+ * A test file this package does not list is a test file CI never runs.
+ *
+ * `npm test` enumerates its inputs explicitly — `node --test dist/a.test.js
+ * dist/b.test.js …` — and the CI job is just `cd plugin && npm test`. So an
+ * unlisted `src/*.test.ts` compiles, ships, and is silently never executed.
+ * Nothing failed when that happened, because the suite that would have
+ * complained is the one that did not run.
+ *
+ * The list is kept explicit rather than replaced with a `dist/*.test.js`
+ * glob on purpose: there is no clean step before `tsc`, so a glob would also
+ * run stale artifacts left behind by deleted or renamed sources. This guard
+ * gets the completeness a glob would give without inheriting that problem.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Compiled to dist/, so the package root is one level up either way.
+const PLUGIN_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+const testScript: string = (
+  JSON.parse(readFileSync(join(PLUGIN_ROOT, "package.json"), "utf8")) as {
+    scripts: { test: string };
+  }
+).scripts.test;
+
+/**
+ * The dist entries the script names, as exact tokens.
+ *
+ * Tokenised rather than substring-matched because this package contains both
+ * `identity.test.ts` and `tool-identity.test.ts`: asking whether the script
+ * "includes" `dist/identity.test.js` answers yes when only the tool- one is
+ * listed, and the guard would pass while the file went unrun.
+ */
+const listed = new Set(
+  testScript.split(/\s+/).filter((tok) => tok.startsWith("dist/") && tok.endsWith(".test.js")),
+);
+
+const sources = readdirSync(join(PLUGIN_ROOT, "src")).filter((f) => f.endsWith(".test.ts"));
+
+describe("every test file is registered with the runner", () => {
+  test("no src/*.test.ts is missing from the npm test script", () => {
+    const unlisted = sources
+      .map((f) => `dist/${f.replace(/\.ts$/, ".js")}`)
+      .filter((entry) => !listed.has(entry));
+    assert.deepEqual(
+      unlisted,
+      [],
+      `${unlisted.length} test file(s) exist but are never run by CI. Add them ` +
+        `to the "test" script in plugin/package.json, or rename the file to ` +
+        `*.fixture.ts if it declares no tests.`,
+    );
+  });
+
+  test("the script names no entry whose source is gone", () => {
+    // The other direction. A rename or deletion leaves a stale entry that
+    // `node --test` fails on outright — but only once dist is clean, which it
+    // never is here, so it can sit unnoticed until someone else's CI breaks.
+    const expected = new Set(sources.map((f) => `dist/${f.replace(/\.ts$/, ".js")}`));
+    const orphaned = [...listed].filter((entry) => !expected.has(entry));
+    assert.deepEqual(orphaned, [], "stale entries in the test script");
+  });
+
+  test("the guard is reading a real list, not an empty one", () => {
+    // Guards the guard: if the script were reformatted so no token matched,
+    // both assertions above would go quiet in the passing direction.
+    assert.ok(listed.size >= 20, `only ${listed.size} entries parsed from the test script`);
+    assert.ok(sources.length >= 20, `only ${sources.length} test sources found`);
+  });
+});

--- a/plugin/src/tool-definitions.test.ts
+++ b/plugin/src/tool-definitions.test.ts
@@ -15,7 +15,7 @@ import { createToolFromSpec } from "./tool-definitions.js";
 import { TOOL_SPECS, TOOL_SPECS_BY_NAME, getSpec } from "./tool-specs.js";
 import { buildToolsMd } from "./educate.js";
 import { cauraPromptSectionText } from "./prompt-section.js";
-import { FROZEN_PLUGIN_ID } from "./legacy-contracts.test.js";
+import { FROZEN_PLUGIN_ID } from "./legacy-contracts.fixture.js";
 
 describe("tool-specs loader", () => {
   test("loads a non-empty ordered spec list from tools.json", () => {

--- a/tests/test_plugin_source_manifest.py
+++ b/tests/test_plugin_source_manifest.py
@@ -26,12 +26,23 @@ PLUGIN_SRC = REPO_ROOT / "plugin" / "src"
 def _expected_source_files() -> set[str]:
     """Every .ts file the install script needs to list.
 
-    Excludes only test files. `version.ts` is present on disk, served by
-    /api/plugin-source, AND listed in the bash loop (the install script
-    then overwrites it inline from the request's ``version`` parameter,
-    but the fetch still happens for parity with the manifest).
+    Excludes test files and `*.fixture.ts`, which is test-support source:
+    constants shared BETWEEN suites, imported by no runtime module, so an
+    install that never downloads the suites has nothing to resolve them for.
+    The suffix is the whole signal — a runtime module must not use it, or it
+    silently stops shipping and installs break with TS2307, which is the
+    failure this file was written for.
+
+    `version.ts` is present on disk, served by /api/plugin-source, AND listed
+    in the bash loop (the install script then overwrites it inline from the
+    request's ``version`` parameter, but the fetch still happens for parity
+    with the manifest).
     """
-    return {p.name for p in PLUGIN_SRC.glob("*.ts") if not p.name.endswith(".test.ts")}
+    return {
+        p.name
+        for p in PLUGIN_SRC.glob("*.ts")
+        if not (p.name.endswith(".test.ts") or p.name.endswith(".fixture.ts"))
+    }
 
 
 def test_python_allow_list_matches_plugin_src():
@@ -56,6 +67,37 @@ def _bash_fallback_src_files(src: str) -> set[str]:
         "when /api/plugin-manifest is unreachable or python3 is missing."
     )
     return set(match.group(1).split())
+
+
+def test_no_shipped_module_imports_a_test_fixture():
+    """The condition that makes excluding `*.fixture.ts` safe.
+
+    `_expected_source_files` leaves fixtures out of both install lists, so a
+    fresh install never downloads them. That is correct while only suites
+    import them and silently fatal the moment a shipped module does: the
+    install would fetch every file it lists and still fail to build, with the
+    same TS2307 this file's docstring records from 2026-04-16.
+
+    Checked by import, not by naming discipline, because the naming is the
+    thing being relied on.
+    """
+    shipped = _expected_source_files()
+    offenders = {}
+    for name in sorted(shipped):
+        text = (PLUGIN_SRC / name).read_text()
+        hits = [
+            line.strip()
+            for line in text.splitlines()
+            if ".fixture.js" in line or ".fixture.ts" in line
+        ]
+        if hits:
+            offenders[name] = hits
+
+    assert not offenders, (
+        "a module that ships to fresh installs imports a test fixture, which "
+        f"is excluded from both install lists: {offenders}. Move the shared "
+        "constants into a real module, or stop excluding fixtures."
+    )
 
 
 def test_install_script_srcfile_fallback_matches_plugin_src():


### PR DESCRIPTION
## The gap

`npm test` enumerates its inputs explicitly — `node --test dist/a.test.js dist/b.test.js …` — and the CI job is just `cd plugin && npm test`. So an unlisted `src/*.test.ts` compiles, ships, and is **silently never executed**. Nothing failed when that happened, because the suite that would have complained is the one that didn't run.

Measured: **24 files match `src/*.test.ts`, 23 were listed.**

The unlisted one is `legacy-contracts.test.ts`, and it turns out to declare **zero** tests — it's a fixture module holding two frozen identifiers, wearing a suffix that made it look like a forgotten suite. Renamed to `legacy-contracts.fixture.ts` with its eight importers updated, so the name states what it is and the guard has nothing to demand. The Python suites already use this distinction (`tests/_legacy_contracts.py` is imported, not collected).

## Two decisions that go against the obvious fix

**No `dist/*.test.js` glob.** Replacing the explicit list with a glob is the one-line version of this fix, and it's wrong: there's no clean step before `tsc`, so a glob also runs stale artifacts from deleted or renamed sources. This very rename produced such an orphan — `dist/legacy-contracts.test.js` sits on disk next to the new `dist/legacy-contracts.fixture.js`. A glob would have started running a file that no longer exists in `src`.

**Tokenised, not substring-matched.** This package contains both `identity.test.ts` and `tool-identity.test.ts`. Asking whether the script `includes("dist/identity.test.js")` answers **yes** when only the `tool-` one is listed — a guard built that way passes while a real suite goes unrun. There's a probe below for exactly this.

## The rename broke a second registration list, and that is the more interesting half

`plugin/src` filenames are also enumerated **from Python**: `core_api/routes/plugin.py`'s `_plugin_files` allow-list and the install script's `SRC_FILES` bash fallback both have to cover every non-test `.ts`, so fresh `curl … | bash` installs can download them. `tests/test_plugin_source_manifest.py` guards both, and its docstring records why: a 2026-04-16 refactor added two files, forgot both lists, and **every fresh install broke with `TS2307` until it was fixed three days later.**

My rename introduced a filename neither list knew, and that guard caught it — I had judged this change "plugin-only" and run only `npm test` plus the two naming gates, which is how it reached CI. A rename under `plugin/src` is never plugin-only.

The fix is not to add the fixture to those lists. Nothing outside the suites imports it, so listing it would assert a runtime dependency that doesn't exist and ship two frozen legacy identifiers into every install for no reason. Instead `_expected_source_files` now excludes `*.fixture.ts` as test-support source.

That exclusion is only safe while no shipped module imports a fixture — so that condition is now a test rather than a sentence in a docstring:

```
test_no_shipped_module_imports_a_test_fixture
```

It checks by import, not by naming discipline, because the naming is the thing being relied on.

## Verification

- **The guard fails on unmodified `main`**, naming `dist/legacy-contracts.test.js` and nothing else — the pre-existing gap, not a synthetic one.
- **Plugin suite: 438 pass** (435 before, plus three guard tests). **Root suite: green**, including the two manifest tests that caught the rename.
- **Three probes on the registration guard**, each naming exactly the right file:

| probe | guard names |
|---|---|
| a listed file dropped from the script | `dist/transport.test.js` |
| a script entry whose source is gone | `dist/deleted-suite.test.js` |
| `tool-identity` dropped while `identity` remains | `dist/tool-identity.test.js` |

- **Two probes on the manifest change**, confirming the exclusion opened no hole: an unregistered *runtime* module is still caught, and a shipped module importing a fixture is caught.
- Legacy-name ratchet recognises the rename as a move rather than reading two removed `legacy-name-ok` lines as progress; it and the do-not-touch sentinel both exit 0. Worth noting since the fixture holds the frozen `"memclaw"` plugin id.

## Scope note

Three lists enumerate these files: the `npm test` script, `_plugin_files`, and the install script's `SRC_FILES`. All three are now guarded. The Python suites need no equivalent — pytest discovers `tests/test_*.py` by collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
