### PR TITLE
feat(scripts): add ref-only legacy-name census

### DIFF
--- a/scripts/legacy_name_census.py
+++ b/scripts/legacy_name_census.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Count legacy-name lines in explicit git refs across repositories.
+
+The census is deliberately ref-only. It resolves every supplied ref to a commit
+and runs ``git grep`` against that commit; modified and untracked working-tree
+files cannot affect the result.
+
+Usage::
+
+    scripts/legacy_name_census.py \
+      --repo caura . origin/main \
+      --repo caura-enterprise ../caura-enterprise origin/dev
+    scripts/legacy_name_census.py --repo caura . origin/main --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Literal, NotRequired, TypedDict
+
+import legacy_name_ratchet as ratchet
+
+CountField = Literal[
+    "all_match_lines",
+    "unclassified_lines",
+    "deliberate_alias_lines",
+    "deliberate_floor_lines",
+    "marker_metadata_lines",
+]
+
+_COUNT_FIELDS: tuple[CountField, ...] = (
+    "all_match_lines",
+    "unclassified_lines",
+    "deliberate_alias_lines",
+    "deliberate_floor_lines",
+    "marker_metadata_lines",
+)
+
+# Ref scans cannot see untracked worktrees in the first place. These pathspecs
+# also make the exclusion explicit for a ref that accidentally committed a
+# worktree copy, at the repository root or below another directory.
+_NESTED_CHECKOUT_EXCLUSIONS = (
+    ":(exclude,glob,top).claude/worktrees/**",
+    ":(exclude,glob,top)**/.claude/worktrees/**",
+    ":(exclude,glob,top).worktrees/**",
+    ":(exclude,glob,top)**/.worktrees/**",
+)
+
+
+class Counts(TypedDict):
+    all_match_lines: int
+    unclassified_lines: int
+    deliberate_alias_lines: int
+    deliberate_floor_lines: int
+    marker_metadata_lines: int
+
+
+class Match(TypedDict):
+    path: str
+    text: str
+
+
+class ControlReport(TypedDict):
+    pattern: str
+    matched_lines: int
+    query_shape: str
+
+
+class RepositoryReport(TypedDict):
+    name: str
+    ref: str
+    commit: str
+    counts: Counts
+    top_level: dict[str, Counts]
+    control: ControlReport
+
+
+class BaselineComparison(TypedDict):
+    remaining: int
+    cleared: int
+    cleared_percent: float
+
+
+class BaselineReport(TypedDict):
+    original: int
+    provenance_verified: bool
+    note: str
+    raw_matches: BaselineComparison
+
+
+class CensusPayload(TypedDict):
+    schema: str
+    query: dict[str, object]
+    repositories: list[RepositoryReport]
+    aggregate: Counts
+    baseline: NotRequired[BaselineReport]
+
+
+class CensusError(RuntimeError):
+    """The requested ref could not be measured safely."""
+
+
+def _empty_counts() -> Counts:
+    return {
+        "all_match_lines": 0,
+        "unclassified_lines": 0,
+        "deliberate_alias_lines": 0,
+        "deliberate_floor_lines": 0,
+        "marker_metadata_lines": 0,
+    }
+
+
+def _git(
+    repo: Path,
+    args: list[str],
+    *,
+    no_match_is_empty: bool = False,
+) -> bytes:
+    command = ["git", "-C", str(repo), *args]
+    result = subprocess.run(command, capture_output=True, check=False)
+    if result.returncode == 0:
+        return result.stdout
+    if no_match_is_empty and result.returncode == 1:
+        return b""
+    detail = result.stderr.decode("utf-8", errors="replace").strip()
+    raise CensusError(f"{' '.join(command)} failed ({result.returncode}): {detail}")
+
+
+def _repo_root(path: str) -> Path:
+    requested = Path(path).expanduser().resolve()
+    root = _git(requested, ["rev-parse", "--show-toplevel"])
+    return Path(root.decode("utf-8", errors="strict").strip())
+
+
+def _validated_ref(value: str) -> str:
+    if not value.strip() or value != value.strip():
+        raise CensusError("ref must be non-empty and have no outer whitespace")
+    if value.startswith("-") or "\0" in value:
+        raise CensusError(f"ref must not be a git option: {value!r}")
+    return value
+
+
+def _resolve_commit(repo: Path, ref: str) -> str:
+    value = _validated_ref(ref)
+    resolved = _git(
+        repo,
+        ["rev-parse", "--verify", "--end-of-options", f"{value}^{{commit}}"],
+    )
+    return resolved.decode("ascii", errors="strict").strip()
+
+
+def _grep_lines(repo: Path, commit: str, pattern: str) -> list[Match]:
+    """Run the census query and parse git's NUL-delimited line records."""
+    output = _git(
+        repo,
+        [
+            "grep",
+            "-I",
+            "-i",
+            "-n",
+            "-z",
+            "--full-name",
+            "-e",
+            pattern,
+            commit,
+            "--",
+            ":/",
+            *_NESTED_CHECKOUT_EXCLUSIONS,
+        ],
+        no_match_is_empty=True,
+    )
+    prefix = f"{commit}:".encode()
+    matches: list[Match] = []
+    cursor = 0
+    while cursor < len(output):
+        path_end = output.find(b"\0", cursor)
+        line_end = output.find(b"\0", path_end + 1)
+        text_end = output.find(b"\n", line_end + 1)
+        if min(path_end, line_end, text_end) < 0:
+            raise CensusError("git grep returned a malformed NUL-delimited record")
+        raw_path = output[cursor:path_end]
+        raw_text = output[line_end + 1 : text_end]
+        if not raw_path.startswith(prefix):
+            raise CensusError("git grep returned a path outside the requested ref")
+        matches.append(
+            {
+                "path": raw_path[len(prefix) :].decode(
+                    "utf-8", errors="surrogateescape"
+                ),
+                "text": raw_text.decode("utf-8", errors="replace"),
+            }
+        )
+        cursor = text_end + 1
+    return matches
+
+
+def _top_level(path: str) -> str:
+    parts = PurePosixPath(path).parts
+    return parts[0] if len(parts) > 1 else "."
+
+
+def _marker_meta_paths(repo: Path, commit: str) -> frozenset[str]:
+    """Read analytics-only marker paths from the same ref being counted."""
+    path = "scripts/legacy_name_ratchet.json"
+    result = subprocess.run(
+        ["git", "-C", str(repo), "show", f"{commit}:{path}"],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return frozenset(ratchet._MARKER_SYSTEM_PATHS)
+    try:
+        config = json.loads(result.stdout)
+        configured = config.get("marker_inventory_meta_paths", [])
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise CensusError(f"cannot read {path} from {commit}: {exc}") from exc
+    if not isinstance(configured, list) or not all(
+        isinstance(item, str) for item in configured
+    ):
+        raise CensusError(
+            f"marker_inventory_meta_paths in {path} at {commit} must be a string list"
+        )
+    return frozenset(ratchet._MARKER_SYSTEM_PATHS) | frozenset(configured)
+
+
+def _classification(
+    match: Match, marker_meta_paths: frozenset[str]
+) -> tuple[CountField, ...]:
+    text = match["text"]
+    kind = ratchet._kind(text)
+    if match["path"] in marker_meta_paths and kind is not None:
+        return ("all_match_lines", "marker_metadata_lines")
+    if kind == ratchet.EXEMPT_MARKER:
+        return ("all_match_lines", "deliberate_alias_lines")
+    if kind == ratchet.FLOOR_MARKER:
+        return ("all_match_lines", "deliberate_floor_lines")
+    return ("all_match_lines", "unclassified_lines")
+
+
+def _increment(counts: Counts, fields: tuple[CountField, ...]) -> None:
+    for field in fields:
+        counts[field] += 1
+
+
+def _sum_counts(items: list[Counts]) -> Counts:
+    total = _empty_counts()
+    for item in items:
+        for field in _COUNT_FIELDS:
+            total[field] += item[field]
+    return total
+
+
+def _census_repo(name: str, path: str, ref: str) -> RepositoryReport:
+    repo = _repo_root(path)
+    commit = _resolve_commit(repo, ref)
+    matches = _grep_lines(repo, commit, ratchet.LEGACY_NAME)
+    control = _grep_lines(repo, commit, ratchet.NEW_NAME)
+    if not control:
+        raise CensusError(
+            f"{name} @ {ref}: positive control {ratchet.NEW_NAME!r} matched no "
+            "lines through the census query; refusing to trust the result"
+        )
+
+    marker_meta_paths = _marker_meta_paths(repo, commit)
+    counts = _empty_counts()
+    top_level: dict[str, Counts] = {}
+    for match in matches:
+        fields = _classification(match, marker_meta_paths)
+        _increment(counts, fields)
+        directory = _top_level(match["path"])
+        _increment(top_level.setdefault(directory, _empty_counts()), fields)
+
+    return {
+        "name": name,
+        "ref": ref,
+        "commit": commit,
+        "counts": counts,
+        "top_level": dict(sorted(top_level.items())),
+        "control": {
+            "pattern": ratchet.NEW_NAME,
+            "matched_lines": len(control),
+            "query_shape": "same git grep options, ref, pathspec, and exclusions",
+        },
+    }
+
+
+def _baseline_comparison(baseline: int, remaining: int) -> BaselineComparison:
+    cleared = baseline - remaining
+    return {
+        "remaining": remaining,
+        "cleared": cleared,
+        "cleared_percent": round(cleared * 100 / baseline, 1),
+    }
+
+
+def _payload(
+    repositories: list[RepositoryReport], baseline: int | None
+) -> CensusPayload:
+    aggregate = _sum_counts([repo["counts"] for repo in repositories])
+    definition_path = Path(ratchet.__file__)
+    result: CensusPayload = {
+        "schema": "legacy-name-census/v1",
+        "query": {
+            "method": "git grep against each resolved commit",
+            "case_insensitive": True,
+            "unit": "matching lines",
+            "definition_source": {
+                "repository": "caura-ai/caura",
+                "module": "scripts/legacy_name_ratchet.py",
+                "sha256": hashlib.sha256(definition_path.read_bytes()).hexdigest(),
+                "symbols": ["LEGACY_NAME", "NEW_NAME", "_kind"],
+                "note": "The org-required gate uses this canonical OSS engine.",
+            },
+            "excluded_paths": list(_NESTED_CHECKOUT_EXCLUSIONS),
+            "aggregation_note": (
+                "Raw per-repository counts are summed for baseline comparison; "
+                "vendored/generated content can overlap between repositories."
+            ),
+        },
+        "repositories": repositories,
+        "aggregate": aggregate,
+    }
+    if baseline is not None:
+        result["baseline"] = {
+            "original": baseline,
+            "provenance_verified": False,
+            "note": "The historical query, refs, and exclusions were not supplied.",
+            "raw_matches": _baseline_comparison(baseline, aggregate["all_match_lines"]),
+        }
+    return result
+
+
+def _print_counts(prefix: str, counts: Counts) -> None:
+    print(
+        f"{prefix}{counts['all_match_lines']:,} raw matches; "
+        f"{counts['unclassified_lines']:,} unclassified candidate debt; "
+        f"{counts['deliberate_alias_lines']:,} deliberate aliases; "
+        f"{counts['deliberate_floor_lines']:,} deliberate floor mentions; "
+        f"{counts['marker_metadata_lines']:,} marker metadata"
+    )
+
+
+def _print_human(payload: CensusPayload) -> None:
+    print("Legacy-name census (matching lines in named git refs)")
+    for repo in payload["repositories"]:
+        print(f"\n{repo['name']} @ {repo['ref']} ({repo['commit'][:12]})")
+        control = repo["control"]
+        print(
+            f"Control: {control['matched_lines']:,} line(s) matched "
+            f"{control['pattern']!r} with the same query shape."
+        )
+        _print_counts("Total: ", repo["counts"])
+        print("By top-level directory:")
+        for directory, counts in repo["top_level"].items():
+            _print_counts(f"  {directory}: ", counts)
+
+    print("\nAggregate")
+    _print_counts("Total: ", payload["aggregate"])
+    baseline = payload.get("baseline")
+    if baseline is not None:
+        print(
+            f"Baseline {baseline['original']:,} comparison only; historical query "
+            "provenance was not supplied:"
+        )
+        comparison = baseline["raw_matches"]
+        print(
+            f"  raw matches: {comparison['remaining']:,} remaining, "
+            f"{comparison['cleared']:,} cleared "
+            f"({comparison['cleared_percent']:.1f}%)"
+        )
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Count legacy-name lines in one or more named git refs."
+    )
+    parser.add_argument(
+        "--repo",
+        action="append",
+        nargs=3,
+        required=True,
+        metavar=("NAME", "PATH", "REF"),
+        help="repository label, local checkout path, and ref to scan; repeatable",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    parser.add_argument(
+        "--baseline",
+        type=_positive_int,
+        help="show arithmetic comparisons to an unverified historical baseline",
+    )
+    args = parser.parse_args()
+
+    names = [spec[0] for spec in args.repo]
+    if len(names) != len(set(names)):
+        parser.error("--repo NAME values must be unique")
+
+    try:
+        repositories = [_census_repo(*spec) for spec in args.repo]
+    except (CensusError, OSError, UnicodeError, ValueError) as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    payload = _payload(repositories, args.baseline)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_human(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_legacy_name_census.py
+++ b/tests/test_legacy_name_census.py
@@ -1,0 +1,278 @@
+"""Integration tests for the ref-only legacy-name census."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "legacy_name_census.py"
+LEGACY = "mem" + "claw"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "t")
+
+    (root / "src").mkdir()
+    (root / "docs").mkdir()
+    (root / "src" / "debt.py").write_text(
+        f'OLD_URL = "https://{LEGACY}.example"\nOLD_TOPIC = "{LEGACY}-events"\n'
+    )
+    (root / "src" / "aliases.py").write_text(
+        f'OLD_TOOL = "{LEGACY}_write"  # legacy-name-ok: permanent wire alias\n'
+    )
+    (root / "docs" / "floor.md").write_text(
+        f"Run `{LEGACY} status`. <!-- legacy-name-floor: frozen command -->\n"
+    )
+    (root / "docs" / "programme.md").write_text(
+        f"Example: {LEGACY}_write  # legacy-name-ok: marker documentation\n"
+        f"Unmarked programme debt: {LEGACY}-later\n"
+    )
+    (root / "scripts").mkdir()
+    (root / "scripts" / "legacy_name_ratchet.json").write_text(
+        json.dumps({"marker_inventory_meta_paths": ["docs/programme.md"]})
+    )
+    (root / "README.md").write_text("Caura is the current product name.\n")
+    _git(
+        root,
+        "add",
+        "README.md",
+        "docs/floor.md",
+        "docs/programme.md",
+        "scripts/legacy_name_ratchet.json",
+        "src/aliases.py",
+        "src/debt.py",
+    )
+    _git(root, "commit", "-qm", "base")
+    return root
+
+
+def _run(repo: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            "sample",
+            str(repo),
+            "main",
+            *extra,
+        ],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_json_counts_debt_and_permanent_lines_by_top_level(repo: Path) -> None:
+    result = _run(repo, "--json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    report = payload["repositories"][0]
+    assert report["ref"] == "main"
+    assert report["commit"] == _git(repo, "rev-parse", "main")
+    assert report["counts"] == {
+        "all_match_lines": 6,
+        "unclassified_lines": 3,
+        "deliberate_alias_lines": 1,
+        "deliberate_floor_lines": 1,
+        "marker_metadata_lines": 1,
+    }
+    assert report["top_level"] == {
+        "docs": {
+            "all_match_lines": 3,
+            "unclassified_lines": 1,
+            "deliberate_alias_lines": 0,
+            "deliberate_floor_lines": 1,
+            "marker_metadata_lines": 1,
+        },
+        "src": {
+            "all_match_lines": 3,
+            "unclassified_lines": 2,
+            "deliberate_alias_lines": 1,
+            "deliberate_floor_lines": 0,
+            "marker_metadata_lines": 0,
+        },
+    }
+    assert report["control"]["pattern"] == "caura"
+    assert report["control"]["matched_lines"] == 1
+    assert payload["aggregate"] == report["counts"]
+
+
+def test_named_ref_is_scanned_instead_of_the_working_tree(repo: Path) -> None:
+    (repo / "src" / "debt.py").write_text(
+        "\n".join(f"{LEGACY}-{index}" for index in range(20))
+    )
+    (repo / "working-tree-only.txt").write_text(f"{LEGACY}-untracked\n")
+    (repo / "scripts" / "legacy_name_ratchet.json").write_text(
+        json.dumps({"marker_inventory_meta_paths": []})
+    )
+
+    report = json.loads(_run(repo, "--json").stdout)["repositories"][0]
+
+    assert report["counts"]["all_match_lines"] == 6
+    assert report["counts"]["unclassified_lines"] == 3
+    assert report["counts"]["marker_metadata_lines"] == 1
+
+
+def test_nested_checkout_paths_are_excluded(repo: Path) -> None:
+    hidden = repo / ".claude" / "worktrees" / "stale"
+    hidden.mkdir(parents=True)
+    (hidden / "copy.py").write_text(f"{LEGACY}-stale\n")
+    generic = repo / ".worktrees" / "other"
+    generic.mkdir(parents=True)
+    (generic / "copy.py").write_text(f"{LEGACY}-other\n")
+    nested = repo / "vendor" / ".claude" / "worktrees" / "third"
+    nested.mkdir(parents=True)
+    (nested / "copy.py").write_text(f"{LEGACY}-third\n")
+    gitlink = repo / "vendor" / "external"
+    gitlink.mkdir()
+    _git(gitlink, "init", "-q", "-b", "main")
+    _git(gitlink, "config", "user.email", "t@example.com")
+    _git(gitlink, "config", "user.name", "t")
+    (gitlink / "copy.py").write_text(f"{LEGACY}-gitlink\n")
+    _git(gitlink, "add", "copy.py")
+    _git(gitlink, "commit", "-qm", "nested checkout")
+    _git(repo, "add", "-f", ".claude/worktrees/stale/copy.py")
+    _git(repo, "add", "-f", ".worktrees/other/copy.py")
+    _git(repo, "add", "-f", "vendor/.claude/worktrees/third/copy.py")
+    _git(repo, "add", "vendor/external")
+    _git(repo, "commit", "-qm", "add nested checkout fixtures")
+
+    report = json.loads(_run(repo, "--json").stdout)["repositories"][0]
+
+    assert report["counts"]["all_match_lines"] == 6
+    assert ".claude" not in report["top_level"]
+    assert ".worktrees" not in report["top_level"]
+    assert "vendor" not in report["top_level"]
+
+
+def test_human_summary_names_ref_commit_control_and_baseline(repo: Path) -> None:
+    result = _run(repo, "--baseline", "3635")
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        f"sample @ main ({_git(repo, 'rev-parse', '--short=12', 'main')})"
+        in result.stdout
+    )
+    assert "Control: 1 line(s) matched 'caura'" in result.stdout
+    assert "Baseline 3,635" in result.stdout
+    assert "raw matches" in result.stdout
+    assert "unclassified candidate debt" in result.stdout
+    assert "  docs: 3 raw matches" in result.stdout
+
+    payload = json.loads(_run(repo, "--baseline", "3635", "--json").stdout)
+    assert payload["baseline"] == {
+        "original": 3635,
+        "provenance_verified": False,
+        "note": "The historical query, refs, and exclusions were not supplied.",
+        "raw_matches": {
+            "remaining": 6,
+            "cleared": 3629,
+            "cleared_percent": 99.8,
+        },
+    }
+
+
+def test_repeated_repositories_have_individual_and_aggregate_counts(
+    repo: Path,
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            "first",
+            str(repo),
+            "main",
+            "--repo",
+            "second",
+            str(repo),
+            "main",
+            "--json",
+        ],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert [item["name"] for item in payload["repositories"]] == ["first", "second"]
+    assert payload["aggregate"] == {
+        key: value * 2 for key, value in payload["repositories"][0]["counts"].items()
+    }
+
+
+def test_root_files_are_reported_under_dot(repo: Path) -> None:
+    name = "odd\nname.txt"
+    (repo / name).write_text(f"{LEGACY}-root\n")
+    _git(repo, "add", name)
+    _git(repo, "commit", "-qm", "add root legacy line")
+
+    report = json.loads(_run(repo, "--json").stdout)["repositories"][0]
+
+    assert report["top_level"]["."]["all_match_lines"] == 1
+    assert report["top_level"]["."]["unclassified_lines"] == 1
+
+
+def test_missing_ref_is_an_error_not_a_false_zero(repo: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            "sample",
+            str(repo),
+            "no-such-ref",
+            "--json",
+        ],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "no-such-ref" in result.stderr
+    assert result.stdout == ""
+
+
+def test_missing_control_is_an_error_despite_legacy_matches(repo: Path) -> None:
+    (repo / "README.md").write_text("The current product name is absent.\n")
+    hidden = repo / ".claude" / "worktrees" / "control"
+    hidden.mkdir(parents=True)
+    (hidden / "README.md").write_text("Caura exists only in an excluded path.\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "add", "-f", ".claude/worktrees/control/README.md")
+    _git(repo, "commit", "-qm", "remove the positive control")
+
+    result = _run(repo, "--json")
+
+    assert result.returncode == 2
+    assert "positive control 'caura' matched no lines" in result.stderr
+    assert result.stdout == ""


### PR DESCRIPTION
## Summary

- add a ref-only census that accepts repeatable `NAME PATH REF` repository inputs, resolves each ref to a commit, and runs `git grep` against that commit rather than the working tree
- reuse the canonical ratchet's `LEGACY_NAME`, positive-control name, and marker parser directly; the ratchet gate is unchanged
- separate marked deliberate aliases, permanent floor mentions, marker-system metadata, and unclassified candidate debt per repository and top-level directory
- emit a versioned JSON report and the same information as a human-readable summary
- exclude `.claude/worktrees/`, `.worktrees/`, nested instances of those paths, and gitlinks; run a same-query-shape `caura` control before trusting a small or zero result

## Current census

Fetched immediately before measurement:

| repository | ref | commit | raw lines | unclassified | marked aliases | floor mentions | marker metadata | control (`caura`) |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| `caura-ai/caura` | `origin/main` | `091f9f05e0cb` | 541 | 138 | 213 | 152 | 38 | 5,141 |
| `caura-ai/caura-enterprise` | `origin/dev` | `e97eea1ec00e` | 966 | 644 | 87 | 112 | 123 | 5,722 |
| **sum** | | | **1,507** | **782** | **300** | **264** | **161** | |

This does **not** reproduce the reported 2,143 remaining of 3,635. The historical refs, exact query, repository set, and exclusions were not supplied, so the script records baseline provenance as unverified. The current ref-only raw count gives the arithmetic comparison 1,507 / 3,635 (2,128 fewer, 58.5%), but this PR does not claim that as a verified trend from the outside report. Raw cross-repository sums can also overlap vendored/generated content; JSON says so explicitly.

The existing marker convention is sufficient, so this PR adds no convention. `legacy-name-ok` identifies compat aliases and `legacy-name-floor` identifies permanent textual/wire references. However, marker coverage is incomplete: some known permanent `memclaw_*` behavior and bridge prose remains unmarked. Therefore the script deliberately calls the remaining 782 lines **unclassified candidate debt**, not “not-yet-done.” Proposed follow-up for review: annotate confirmed permanent aliases with the existing `legacy-name-ok` marker in a separate audited PR; do not silently infer permanence in this census.

Example:

```bash
python3 scripts/legacy_name_census.py \
  --repo caura /path/to/caura origin/main \
  --repo caura-enterprise /path/to/caura-enterprise origin/dev \
  --baseline 3635 --json
```

## Verification

- new tests were run before the implementation and failed because `scripts/legacy_name_census.py` did not exist
- `uv run pytest --noconftest tests/test_legacy_name_census.py -q` — 8 passed
- `uv run pytest --noconftest tests/test_legacy_name_census.py tests/test_legacy_name_ratchet.py -q` — passed
- `uv run ruff check scripts/` and `uv run ruff check tests/` — passed
- `uv run ruff format --check scripts/` and `uv run ruff format --check tests/` — passed
- `uv run mypy --config-file scripts/mypy.ini scripts/` — passed

The ordinary root pytest invocation was not used for this isolated script suite because the repository's autouse fixture requires a local PostgreSQL instance; `--noconftest` keeps this ref-only integration suite independent of unrelated database setup.
