### PR TITLE
fix(mcp): type-check mcp_server and drop it from the ignore_errors list

### DIFF
--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -206,7 +206,6 @@ module = [
     "core_api.routes.fleet",
     "core_api.routes.memories",
     "core_api.clients.storage_client",
-    "core_api.mcp_server",
     "core_api.app",
     "core_api.auth",
 ]

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1215,7 +1215,12 @@ async def caura_write(
     # case the body-supplied id is honored so the install self-identifies
     # rather than collapsing onto "main". Reads keep `_get_agent_id() or
     # agent_id` (visibility scoping is unaffected).
-    agent_id = effective_write_agent_id(_get_agent_id(), agent_id)
+    # ``or agent_id`` keeps this ``str``: the resolver returns None only when
+    # BOTH inputs are falsy, and this parameter defaults to DEFAULT_AGENT_ID,
+    # so the fallback is unreachable here. It states that instead of asserting
+    # it — and the resolver's ``str | None`` is correct on its own terms,
+    # exercised with a None body by tests/test_effective_write_agent_id.py.
+    agent_id = effective_write_agent_id(_get_agent_id(), agent_id) or agent_id
     if refuse := _refuse_default_agent_on_gateway(agent_id):
         return _with_latency(refuse, t0)
     # C3/C8 — reject reserved memory_types at the boundary before we
@@ -1306,7 +1311,10 @@ async def caura_write(
                         tenant_id=tenant_id,
                         fleet_id=fleet_id,
                         agent_id=agent_id,
-                        memory_type=memory_type,
+                        # MemoryCreate validates this against MemoryType and
+                        # raises on anything else; the parameter stays ``str``
+                        # because FastMCP publishes it to tools/list.
+                        memory_type=memory_type,  # type: ignore[arg-type]
                         content=content,
                         weight=weight,
                         source_uri=source_uri,
@@ -1314,26 +1322,31 @@ async def caura_write(
                         metadata=metadata,
                         status=status,
                         visibility=visibility,
-                        write_mode=write_mode,
+                        write_mode=write_mode,  # type: ignore[arg-type]
                     ),
                 )
                 return _with_latency(_serialize(result), t0)
-            # Batch path
-            if len(items) > 100:
+            # Batch path. ``items`` is populated: the guard near the top of
+            # this handler admits exactly one of {content, items} and the
+            # single-write path returned above. mypy cannot follow that through
+            # the XOR, so bind a narrowed name — an ``assert`` would vanish
+            # under -O and leave the invariant merely claimed.
+            batch = items or []
+            if len(batch) > 100:
                 return _with_latency(
                     json.dumps(
                         {
                             "error": {
                                 "code": "BATCH_TOO_LARGE",
-                                "message": f"items length {len(items)} exceeds maximum of 100.",
-                                "details": {"received": len(items), "max": 100},
+                                "message": f"items length {len(batch)} exceeds maximum of 100.",
+                                "details": {"received": len(batch), "max": 100},
                             }
                         }
                     ),
                     t0,
                 )
             try:
-                bulk_items = [BulkMemoryItem(**item) for item in items]
+                bulk_items = [BulkMemoryItem(**item) for item in batch]
             except (ValidationError, TypeError) as e:
                 return _with_latency(
                     json.dumps(
@@ -1341,7 +1354,7 @@ async def caura_write(
                             "error": {
                                 "code": "INVALID_BATCH_ITEM",
                                 "message": f"Invalid items — {e}",
-                                "details": {"received_count": len(items)},
+                                "details": {"received_count": len(batch)},
                             }
                         }
                     ),
@@ -1403,8 +1416,8 @@ async def caura_write(
             # to it; the trade-off is acceptable to keep this path
             # simple. If a use case needs MCP retry idempotency, the
             # client can pass an explicit token via metadata.
-            result = await create_memories_bulk(bulk_data, bulk_attempt_id=f"mcp:{uuid4()}")
-            return _with_latency(_serialize(result), t0)
+            bulk_result = await create_memories_bulk(bulk_data, bulk_attempt_id=f"mcp:{uuid4()}")
+            return _with_latency(_serialize(bulk_result), t0)
         except HTTPException as e:
             # Idempotent retry-safe duplicate: when create_memory raises 409
             # with the "Duplicate memory exists: <uuid>" detail (Stage 5's
@@ -2453,7 +2466,9 @@ async def caura_doc(
                 # credentials (home-only when single-tenant).
                 doc = await sc.get_document(
                     tenant_id=tenant_id,
-                    collection=collection,
+                    # Non-empty: the guard at the top of this handler refuses
+                    # any op outside {list_collections, search} without one.
+                    collection=collection,  # type: ignore[arg-type]
                     doc_id=doc_id,
                     readable_tenant_ids=readable,
                 )
@@ -2725,7 +2740,7 @@ async def caura_doc(
                 )
             deleted = await sc.delete_document(
                 tenant_id,
-                collection,
+                collection,  # type: ignore[arg-type]  # guaranteed by the op guard above
                 doc_id,
                 require_status=_AGENT_VISIBLE_SKILL_STATUS if skills_gate_on else None,
             )
@@ -3213,7 +3228,11 @@ async def caura_insights(
             if terr:
                 return _with_latency(_error_response("FORBIDDEN", parse_trust_error(terr)), t0)
             await check_and_increment(tenant_id, "insights")
-            memories_or_clusters = await _QUERY_DISPATCH[focus](tenant_id, fleet_id, agent_id, scope)
+            # Shape varies by focus — each dispatch entry returns its own, and
+            # ``discover`` returns a wrapper unpacked just below. Every
+            # consumer downstream is shape-agnostic, so ``Any`` states that
+            # rather than a union that would need narrowing at each use.
+            memories_or_clusters: Any = await _QUERY_DISPATCH[focus](tenant_id, fleet_id, agent_id, scope)
             if focus == "discover" and isinstance(memories_or_clusters, _DiscoverResult):
                 is_clustered = memories_or_clusters.is_clustered
                 memories_or_clusters = memories_or_clusters.data
@@ -3789,8 +3808,8 @@ async def caura_keystones_set(
                 payload: KeystoneUpsertPayload = {
                     "tenant_id": tenant_id,
                     "doc_id": doc_id,
-                    "title": title,
-                    "content": content,
+                    "title": title,  # type: ignore[typeddict-item]
+                    "content": content,  # type: ignore[typeddict-item]
                     "scope": scope,  # type: ignore[typeddict-item]
                     "weight": weight,  # type: ignore[typeddict-item]
                 }


### PR DESCRIPTION
## What

`core-api/pyproject.toml`'s `ignore_errors` list describes itself as **"a to-do, not a policy"** — delete a line, fix what mypy reports, and the gate tightens for good. This deletes `core_api.mcp_server`, the entry that hid 179 stale return annotations until #1383.

| | errors in `mcp_server` |
|---|---|
| before #1383, exemption removed | 195 |
| after #1383, exemption removed | 14 |
| **this PR** | **0** |

## The 14, and why none of them is mechanical

- **`caura_write`'s batch path** used `items` five times where mypy saw `list | None`. The invariant is real — the guard at the top admits exactly one of `{content, items}` and the single-write path returns first — so it's bound to a narrowed name rather than asserted. An `assert` disappears under `-O`, which would leave the invariant *claimed* rather than held.
- **`memory_type` / `write_mode`** reach Pydantic-validated `Literal`s as wire strings. Coded ignores, because narrowing the **parameters** would change what FastMCP publishes in `tools/list` — the schema is generated from those annotations. `MemoryCreate` already rejects anything else at runtime.
- **The bulk path** assigned a `BulkMemoryResponse` to the name the single-write path used for a `MemoryOut`. Given its own name.
- **`caura_doc`'s `collection`** is guaranteed by a guard that tests the **value** of `op` (`op not in {list_collections, search} and not collection` → refuse). No annotation expresses that, so coded ignores citing the guard. *The structural fix is per-op functions — the same shape as #1379's plugin dispatch — and is deliberately not attempted here.*
- **`caura_insights`'s `_QUERY_DISPATCH`** returns a different shape per focus, which mypy widened to `object`. Annotated `Any`, which is what it is; every downstream consumer is shape-agnostic.
- **`caura_keystones_set`** needed `title` and `content` ignored exactly as `scope` and `weight` already were, two lines below.
- **`effective_write_agent_id`** returns `str | None` and was assigned back to a `str` parameter. **Not** fixed by narrowing the resolver: its None-body behaviour is deliberate and `tests/test_effective_write_agent_id.py` pins `(None, None) -> None`. The call site takes `or agent_id` instead — unreachable in practice, since that parameter defaults to `DEFAULT_AGENT_ID` so both inputs cannot be falsy — and states the reason rather than asserting it.

## On the idiom

`assert` and `cast` are not house style here: **4 asserts across all of `core_api/src`** (none for narrowing) and **2 casts**, against **122 `type: ignore`, 121 of them with an explicit error code**. So narrowing where the invariant can become a fact, and a coded ignore with a reason where the guard depends on a value mypy cannot see. `caura_keystones_set` already had the exact ignore two lines from one of these errors.

## Verification

- `mypy src/` reports **zero** errors in `mcp_server`.
- **Two probes confirm the gate now fires** rather than merely being reconfigured:

| probe | errors surfaced |
|---|---|
| `_get_tenant` given an `int` return | **89** |
| one handler reverted to the pre-#147 `-> str` | **9** |

  The second matters: #1383's fix cannot regress silently now.

- Root suite **6328 passed, 4 skipped, 0 failed**. `ruff check` and `ruff format --check` clean on `core-api/src/`, run separately. Both naming gates exit 0.

The 2 remaining `import-untyped` errors are in `common/enrichment/service.py` — a stub package missing from a local venv, not this change. They appear identically with the exemption still in place, and main's CI is green.

## Note on the ratchet

This removes one of ~25 entries. The pyproject comment records how the `services.forge.*` recovery went: it found `forge/cron_handler.py` importing a name that had never existed, so the distill cron had raised on every tick and never once run (#955). Being inside an exempted tree is what kept that invisible. `mcp_server` was the largest remaining entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
