### PR TITLE
fix(events): contract the org enum so dual_subscribe=False works again

### DIFF
--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -41,14 +41,14 @@ class Org(enum.StrEnum):
     # so the OSS boundary guard (core-api) can reject reads/writes for
     # affected tenants synchronously, even while the durable mirror
     # eventually catches up.
-    SUPPRESSION_CHANGED = "memclaw.org.suppression-changed"
+    SUPPRESSION_CHANGED = "caura.org.suppression-changed"
     # CAURA-571: core-api publishes this after an org's settings are written so
     # every process drops its per-process settings cache promptly — without it,
     # a tightened governance control keeps applying its looser prior value on
     # sibling workers for up to the cache TTL (5 min). Subscribe with
     # ``broadcast=True`` (every process must receive it), not the work-queue
     # default.
-    SETTINGS_CHANGED = "memclaw.org.settings-changed"
+    SETTINGS_CHANGED = "caura.org.settings-changed"
 
 
 class Lifecycle(enum.StrEnum):
@@ -236,6 +236,24 @@ def family(topic: str) -> str:
 # behind the 47 subscriptions on the legacy prod topic, two per instance.
 # Bounded and reaping. Recorded as measured, not as an investigation
 # closed: that pool is still the reason the OLD topic cannot be deleted here.
+#
+# ``org`` CONTRACTED 2026-09-08, the same day it flipped, and the short gap was
+# not tidiness. Contraction is what repairs ``dual_subscribe=False``, which is
+# the DEFAULT: between the flip and this edit ``unbound_publish_topics(dual=False)``
+# reported both org topics, so every standalone and on-prem process constructing
+# a ``PubSubEventBus`` at the default RAISED on construction. ``memory`` sat in
+# that same state for four days (2026-09-01 to 2026-09-05, contracted by #1307);
+# this family did not have to. The guard is fleet-wide by design, so the blast
+# radius of a flip-without-contract is every deployable that never runs the
+# Terraform the flag is gated on -- not merely the family that moved.
+#
+# Contracting BEFORE the legacy topics are drained is safe and is the documented
+# order: publishers already emit only the twin (confirmed by delivery, not by
+# configuration -- first post-promote prod publish landed on
+# ``prod--caura.org.suppression-changed`` at 06:23:13Z), so nothing new arrives
+# on the legacy name. What contraction changes is that subscribers stop BINDING
+# it, which is the precondition for draining it, not a substitute for having
+# drained it. The legacy topics stay until the drain gate passes.
 #
 # ``pipeline`` must NOT enter this set while it has zero live topics in either
 # environment: publishing to a topic that does not exist is silent loss, so

--- a/core-api/src/core_api/suppression.py
+++ b/core-api/src/core_api/suppression.py
@@ -1,7 +1,7 @@
 """Boundary guard for soft-deleted org tenants (CAURA-694).
 
 When an enterprise org is soft-deleted, ``platform-admin-api`` publishes
-``memclaw.org.suppression-changed`` with the list of tenant_ids the
+``caura.org.suppression-changed`` with the list of tenant_ids the
 action covers. Core-worker mirrors that into
 ``public.tenant_suppression`` (CAURA-694 storage migration). This module
 is the synchronous read side: core-api's auth layer asks

--- a/tests/test_events/test_topic_rename_cutover.py
+++ b/tests/test_events/test_topic_rename_cutover.py
@@ -29,12 +29,14 @@ identity for them and neither can demonstrate a mismatch. A test that reaches
 for a real family to show the silent-failure state this file exists to pin would
 therefore go VACUOUS on those two, which is why such tests use ``PRE_CONTRACT``.
 
-``org`` flipped 2026-09-08 and is NOT yet contracted, so it is currently the one
-real family for which ``publish_name`` and ``subscribe_names(dual=False)``
-disagree. That makes a default-constructed (``dual=False``) Pub/Sub bus illegal
-again until ``org`` contracts — the same window memory passed through between
-2026-09-01 and 2026-09-05. ``PRE_CONTRACT`` stays regardless: it must not depend
-on a real family happening to be mid-cutover.
+``org`` flipped AND contracted 2026-09-08, so it joins them: every real flipped
+family now carries the current name, and a default-constructed (``dual=False``)
+Pub/Sub bus is legal again. The window where it was not — between the flip and
+the contract — is the same one memory passed through between 2026-09-01 and
+2026-09-05, and it is why ``PRE_CONTRACT`` exists at all: with no real family
+mid-cutover, a test that reached for one to demonstrate the mismatch would assert
+nothing. ``PRE_CONTRACT`` stays regardless: it must not depend on a real family
+happening to be mid-cutover.
 
 Tests about *the flag's parse rule* still take the ``nothing_flipped`` fixture so
 their precondition cannot depend on cutover state.
@@ -219,17 +221,18 @@ def test_exactly_the_flipped_families_are_flipped() -> None:
     progress.
 
     ``org`` joined on 2026-09-08 — the third SHARED family, mirrored into
-    caura-enterprise in the same cycle. It is flipped but NOT yet contracted, so
-    it is the family that currently makes ``unbound_publish_topics(dual=False)``
-    non-empty; see the module docstring.
+    caura-enterprise in the same cycle — and was contracted the same day. Its
+    publisher flip was confirmed by DELIVERY rather than configuration: the first
+    post-promote production publish landed on
+    ``prod--caura.org.suppression-changed``, with zero on the legacy name.
 
     ``memory`` joined on 2026-09-01 — the second SHARED family, mirrored into
     caura-enterprise in the same cycle. Its absent ``.created`` declaration had
     already been removed. The live re-measurement found 12/12 running Pub/Sub
     deployables dual-subscribing and 16/16 active durable twins attached to the
-    matching twin topics (8 per environment), with no ephemerals. Its enum
-    members remain on the legacy names because contraction is the next step,
-    not part of this flip.
+    matching twin topics (8 per environment), with no ephemerals. It was
+    contracted on 2026-09-05 by #1307, four days after the flip — the window in
+    which ``dual=False`` was illegal fleet-wide.
     """
     assert topics_mod.FLIPPED_FAMILIES == FLIPPED
     assert "audit" not in topics_mod.FLIPPED_FAMILIES
@@ -660,6 +663,31 @@ def test_the_guard_does_not_fire_once_lifecycle_is_fully_contracted(
     monkeypatch.setattr(topics_mod, "FLIPPED_FAMILIES", frozenset({"lifecycle"}))
     assert topics_mod.unbound_publish_topics(dual=False) == ()
     PubSubEventBus(project_id="proj", subscription_prefix="test")
+
+
+def test_every_flipped_family_is_contracted_so_the_default_bus_is_legal() -> None:
+    """The REAL set, unmonkeypatched: no flipped family may sit uncontracted.
+
+    Every other assertion about the construction guard in this file isolates a
+    single family with ``monkeypatch``, which answers "does the guard work?" but
+    not "is the fleet currently in the state the guard permits?". Those are
+    different questions, and only the second one catches a flip that shipped
+    without its contraction.
+
+    That gap is not hypothetical. ``memory`` sat flipped-but-uncontracted from
+    2026-09-01 to 2026-09-05 and ``org`` did the same on 2026-09-08. In both
+    windows ``dual_subscribe=False`` -- the DEFAULT -- raised on construction for
+    every standalone and on-prem process, because the guard is fleet-wide by
+    design rather than scoped to the family that moved. No test failed either
+    time; the breakage was found by reading the module.
+
+    Deliberately no monkeypatch: the value under test is the shipped one.
+    """
+    unbound = topics_mod.unbound_publish_topics(dual=False)
+    assert unbound == (), (
+        "a flipped family is not contracted, so a default-constructed "
+        f"PubSubEventBus raises fleet-wide: {sorted(unbound)}"
+    )
 
 
 def test_inprocess_bus_can_never_reach_the_guarded_state(


### PR DESCRIPTION
Contracts the `Org` enum onto the current names. Companion to #1372, which flipped
the family this morning.

## This closes a live breakage, it is not tidy-up

`dual_subscribe=False` is the **default**. Between #1372 and this PR:

```
unbound_publish_topics(dual=False) -> ['memclaw.org.suppression-changed',
                                       'memclaw.org.settings-changed']
```

Non-empty there means a default-constructed `PubSubEventBus` **raises on
construction**. And the guard is fleet-wide by design — `unbound_publish_topics` is
computed over every topic the module declares, so the moment one family is flipped
without being contracted, *every* process at the default fails, whether or not it
touches `org`. That is precisely the standalone and on-prem deployments that never
run the Terraform the flag is gated on.

`memory` sat in that state for four days (2026-09-01 → 2026-09-05, closed by #1307).
`org`'s window closes the day it opened.

After this change: `unbound_publish_topics(dual=False) == ()`.

## Why contracting before the drain is correct, not premature

Contraction stops subscribers **binding** the legacy name. That is the precondition
for draining it — not a substitute for having drained it. It is safe here because
publishers have already moved, and that is established **by delivery, not by
configuration**:

```
prod, first publish after the promote, 06:23:13Z
  prod--caura.org.suppression-changed   1
  prod--memclaw.org.*                   0
```

The legacy topics stay. They come out when the drain gate passes — currently
**not** before 2026-09-09 06:13Z, since a >24h post-flip window does not exist yet.

## The test both windows were missing

Every existing assertion about the construction guard monkeypatches a single family:

```python
monkeypatch.setattr(topics_mod, "FLIPPED_FAMILIES", frozenset({"lifecycle"}))
assert topics_mod.unbound_publish_topics(dual=False) == ()
```

That asks *"does the guard work?"*. It never asks *"is the shipped set in a state the
guard permits?"* — which is the question that catches a flip that shipped without its
contraction. **Neither the `memory` window nor the `org` window failed a test.** Both
were found by reading the module.

`test_every_flipped_family_is_contracted_so_the_default_bus_is_legal` asks the second
question, deliberately with no monkeypatch, so the value under test is the shipped one.

Confirmed load-bearing: reverting the two enum literals fails it and nothing else.

## Scope

| file | change |
|---|---|
| `common/events/topics.py` | two enum members; the comment records why the gap was closed same-day |
| `core-api/src/core_api/suppression.py` | docstring named the legacy topic |
| `tests/.../test_topic_rename_cutover.py` | new test; two stale docstring paragraphs |

**`019_tenant_suppression.py` deliberately keeps the legacy name.** It is a historical
record of what the topic was called when the migration ran, and
`do_not_touch_sentinel.py` pins it with the reason *"the migration stops naming the
topic it documents"*. Changing it would have been wrong and the sentinel would have
caught it.

## Gates

- `tests/test_events/`: failure set **byte-identical to `origin/main`** (18 known
  environment-only failures, diffed against a pristine control worktree, not assumed
  from a matching count)
- Do-not-touch sentinel: 35/35
- Legacy-name ratchet: `No new lines. 0 annotated, 3 removed, 0 excused moves (-3 net)`
- `ruff check` clean; `ruff format --check` clean on all three changed files. The repo
  has 12 pre-existing format-dirty files — verified identical on `origin/main`, so they
  are not from this change and are not touched here.

## Next

`org` still needs its >24h drained window before Terraform contraction. `audit` remains
last, unconditionally — those rows are hash-chained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
