### PR TITLE
feat(clients): claim the unscoped npm aliases for the client

### DIFF
--- a/.github/workflows/publish-npm-caura-client.yml
+++ b/.github/workflows/publish-npm-caura-client.yml
@@ -1,0 +1,137 @@
+name: Publish the caura-client alias
+
+# Publishes `clients/npm-caura-client` — UNSCOPED `caura-client`, an alias that
+# re-exports the canonical implementation package `@caura/client`.
+#
+# WHY THIS PACKAGE EXISTS. The Python client is `pip install caura-client`, so
+# `npm install caura-client` is a name people will guess — and an UNSCOPED npm
+# name is publishable by any third party, which makes an unclaimed one the
+# npm half of the supply-chain hole the PyPI aliases already closed. Owning it
+# keeps a guessed install line resolving to the canonical package instead of
+# to whoever claims it first. (The bare name `caura` needs no such defense:
+# npm's name-similarity filter blocks it against `csurf` for EVERY publisher,
+# no exception process — npm support, 2026-08-28. Recorded as not-happening;
+# `@caura/client` is canonical.)
+#
+# GATES. Same shape as publish-npm-sdk.yml: credential present, tag agrees
+# with package.json, dependencies already on the registry, publish, verify the
+# registry actually serves it. Consolidating this shape into a reusable
+# `workflow_call` remains the right end state, just not done yet.
+#
+# One-time setup by a maintainer:
+#   1. `NPM_TOKEN` repository secret — an npm automation token with publish
+#      rights. Reusing the token from `publish-npm-client.yml` satisfies this.
+#
+# Release: bump the version in clients/npm-caura-client/package.json, then
+# push a tag `npm-caura-client-v<version>` (or run this workflow manually).
+# v1.0.0 was published manually by a maintainer on 2026-09-08.
+
+on:
+  push:
+    tags:
+      - "npm-caura-client-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      # `contents: read` is not redundant — declaring a permissions block sets
+      # every unlisted scope to `none`, which would leave `actions/checkout`
+      # unable to read the repo.
+      contents: read
+      id-token: write # npm provenance
+    defaults:
+      run:
+        working-directory: clients/npm-caura-client
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: The publish credential must exist
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -z "${NPM_TOKEN}" ]]; then
+            echo "::error::NPM_TOKEN repository secret is not set. Add an npm automation token with publish rights to the @caura scope; nothing here can publish without it."
+            exit 1
+          fi
+
+      - name: The tag must agree with package.json
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#npm-caura-client-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::tag ${GITHUB_REF_NAME} says ${TAG_VERSION} but package.json says ${PKG_VERSION}"
+            exit 1
+          fi
+          echo "publishing $(node -p "require('./package.json').name")@${PKG_VERSION}"
+
+      # npm does not resolve dependencies at publish time: publishing against a
+      # version that is not on the registry SUCCEEDS and produces a package that
+      # fails for the first person who installs it.
+      - name: Every dependency must already be on the registry
+        run: |
+          node -p "Object.entries(require('./package.json').dependencies || {}).map(([n, r]) => n + '@' + r).join('\n')" \
+            > /tmp/deps.txt
+          while read -r SPEC; do
+            [[ -z "$SPEC" ]] && continue
+            RESOLVED=""
+            for attempt in 1 2 3 4 5; do
+              # `|| true` is load-bearing: steps run under `bash -eo pipefail`,
+              # so an unresolvable spec would abort the step on attempt 1 and
+              # the retry would be decorative. The type check matters too —
+              # npm prints its E404 as valid JSON on stdout under `--json`, so
+              # a successful parse proves nothing about existence.
+              RESOLVED=$(npm view "$SPEC" version --json 2>/dev/null | node -e '
+                let s = "";
+                process.stdin.on("data", d => s += d).on("end", () => {
+                  try {
+                    const j = JSON.parse(s);
+                    const a = Array.isArray(j) ? j : [j];
+                    const last = a[a.length - 1];
+                    console.log(typeof last === "string" ? last : "");
+                  } catch { console.log(""); }
+                });' || true)
+              [[ -n "$RESOLVED" ]] && break
+              echo "attempt ${attempt}: ${SPEC} not visible yet, waiting"
+              sleep 10
+            done
+            if [[ -z "$RESOLVED" ]]; then
+              echo "::error::${SPEC} is not on the registry. Publish it first (publish-npm-client.yml) — npm would accept this package anyway and it would be uninstallable."
+              exit 1
+            fi
+            echo "${SPEC} -> ${RESOLVED}"
+          done < /tmp/deps.txt
+
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # A green publish step is not evidence the registry serves it.
+      - name: The registry must serve what we just published
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          for attempt in 1 2 3 4 5; do
+            SERVED=$(npm view "${PKG_NAME}@${PKG_VERSION}" version --json 2>/dev/null | node -e '
+              let s = "";
+              process.stdin.on("data", d => s += d).on("end", () => {
+                try {
+                  const j = JSON.parse(s);
+                  const a = Array.isArray(j) ? j : [j];
+                  const last = a[a.length - 1];
+                  console.log(typeof last === "string" ? last : "");
+                } catch { console.log(""); }
+              });' || true)
+            [[ -n "$SERVED" ]] && { echo "registry serves ${PKG_NAME}@${SERVED}"; exit 0; }
+            echo "attempt ${attempt}: not served yet, waiting"
+            sleep 10
+          done
+          echo "::error::${PKG_NAME}@${PKG_VERSION} is not being served after publish."
+          exit 1

--- a/.github/workflows/publish-npm-caura-sdk.yml
+++ b/.github/workflows/publish-npm-caura-sdk.yml
@@ -1,0 +1,137 @@
+name: Publish the caura-sdk alias
+
+# Publishes `clients/npm-caura-sdk` — UNSCOPED `caura-sdk`, an alias that
+# re-exports the canonical implementation package `@caura/client`.
+#
+# WHY THIS PACKAGE EXISTS. The Python client is `pip install caura-sdk`, so
+# `npm install caura-sdk` is a name people will guess — and an UNSCOPED npm
+# name is publishable by any third party, which makes an unclaimed one the
+# npm half of the supply-chain hole the PyPI aliases already closed. Owning it
+# keeps a guessed install line resolving to the canonical package instead of
+# to whoever claims it first. (The bare name `caura` needs no such defense:
+# npm's name-similarity filter blocks it against `csurf` for EVERY publisher,
+# no exception process — npm support, 2026-08-28. Recorded as not-happening;
+# `@caura/client` is canonical.)
+#
+# GATES. Same shape as publish-npm-sdk.yml: credential present, tag agrees
+# with package.json, dependencies already on the registry, publish, verify the
+# registry actually serves it. Consolidating this shape into a reusable
+# `workflow_call` remains the right end state, just not done yet.
+#
+# One-time setup by a maintainer:
+#   1. `NPM_TOKEN` repository secret — an npm automation token with publish
+#      rights. Reusing the token from `publish-npm-client.yml` satisfies this.
+#
+# Release: bump the version in clients/npm-caura-sdk/package.json, then
+# push a tag `npm-caura-sdk-v<version>` (or run this workflow manually).
+# v1.0.0 was published manually by a maintainer on 2026-09-08.
+
+on:
+  push:
+    tags:
+      - "npm-caura-sdk-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      # `contents: read` is not redundant — declaring a permissions block sets
+      # every unlisted scope to `none`, which would leave `actions/checkout`
+      # unable to read the repo.
+      contents: read
+      id-token: write # npm provenance
+    defaults:
+      run:
+        working-directory: clients/npm-caura-sdk
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: The publish credential must exist
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -z "${NPM_TOKEN}" ]]; then
+            echo "::error::NPM_TOKEN repository secret is not set. Add an npm automation token with publish rights to the @caura scope; nothing here can publish without it."
+            exit 1
+          fi
+
+      - name: The tag must agree with package.json
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#npm-caura-sdk-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::tag ${GITHUB_REF_NAME} says ${TAG_VERSION} but package.json says ${PKG_VERSION}"
+            exit 1
+          fi
+          echo "publishing $(node -p "require('./package.json').name")@${PKG_VERSION}"
+
+      # npm does not resolve dependencies at publish time: publishing against a
+      # version that is not on the registry SUCCEEDS and produces a package that
+      # fails for the first person who installs it.
+      - name: Every dependency must already be on the registry
+        run: |
+          node -p "Object.entries(require('./package.json').dependencies || {}).map(([n, r]) => n + '@' + r).join('\n')" \
+            > /tmp/deps.txt
+          while read -r SPEC; do
+            [[ -z "$SPEC" ]] && continue
+            RESOLVED=""
+            for attempt in 1 2 3 4 5; do
+              # `|| true` is load-bearing: steps run under `bash -eo pipefail`,
+              # so an unresolvable spec would abort the step on attempt 1 and
+              # the retry would be decorative. The type check matters too —
+              # npm prints its E404 as valid JSON on stdout under `--json`, so
+              # a successful parse proves nothing about existence.
+              RESOLVED=$(npm view "$SPEC" version --json 2>/dev/null | node -e '
+                let s = "";
+                process.stdin.on("data", d => s += d).on("end", () => {
+                  try {
+                    const j = JSON.parse(s);
+                    const a = Array.isArray(j) ? j : [j];
+                    const last = a[a.length - 1];
+                    console.log(typeof last === "string" ? last : "");
+                  } catch { console.log(""); }
+                });' || true)
+              [[ -n "$RESOLVED" ]] && break
+              echo "attempt ${attempt}: ${SPEC} not visible yet, waiting"
+              sleep 10
+            done
+            if [[ -z "$RESOLVED" ]]; then
+              echo "::error::${SPEC} is not on the registry. Publish it first (publish-npm-client.yml) — npm would accept this package anyway and it would be uninstallable."
+              exit 1
+            fi
+            echo "${SPEC} -> ${RESOLVED}"
+          done < /tmp/deps.txt
+
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # A green publish step is not evidence the registry serves it.
+      - name: The registry must serve what we just published
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          for attempt in 1 2 3 4 5; do
+            SERVED=$(npm view "${PKG_NAME}@${PKG_VERSION}" version --json 2>/dev/null | node -e '
+              let s = "";
+              process.stdin.on("data", d => s += d).on("end", () => {
+                try {
+                  const j = JSON.parse(s);
+                  const a = Array.isArray(j) ? j : [j];
+                  const last = a[a.length - 1];
+                  console.log(typeof last === "string" ? last : "");
+                } catch { console.log(""); }
+              });' || true)
+            [[ -n "$SERVED" ]] && { echo "registry serves ${PKG_NAME}@${SERVED}"; exit 0; }
+            echo "attempt ${attempt}: not served yet, waiting"
+            sleep 10
+          done
+          echo "::error::${PKG_NAME}@${PKG_VERSION} is not being served after publish."
+          exit 1

--- a/clients/npm-caura-client/README.md
+++ b/clients/npm-caura-client/README.md
@@ -1,0 +1,26 @@
+# caura-client
+
+Unscoped alias for [`@caura/client`](https://www.npmjs.com/package/@caura/client),
+the official TypeScript client for [Caura](https://caura.ai) — governed shared
+memory for AI agent fleets.
+
+```bash
+npm install caura-client
+```
+
+```ts
+import { Caura } from 'caura-client';
+```
+
+`@caura/client` is the canonical name. This alias exists because the Python
+client is installed as `pip install caura-client` on PyPI, so
+`npm install caura-client` is a name people will guess — and unlike a scoped npm
+name, an unscoped one is publishable by any third party. Owning it keeps that
+install line resolving to the canonical implementation instead of to whoever
+claims it first. It depends directly on `@caura/client` rather than chaining
+through another alias.
+
+The bare name `caura` is not publishable on npm at all: the registry's
+name-similarity filter blocks it (against `csurf`) for every publisher, with
+no exception process — npm support confirmed 2026-08-28. That applies to
+everyone equally, so the bare name needs no defensive registration.

--- a/clients/npm-caura-client/index.d.ts
+++ b/clients/npm-caura-client/index.d.ts
@@ -1,0 +1,1 @@
+export * from '@caura/client';

--- a/clients/npm-caura-client/index.js
+++ b/clients/npm-caura-client/index.js
@@ -1,0 +1,1 @@
+export * from '@caura/client';

--- a/clients/npm-caura-client/package.json
+++ b/clients/npm-caura-client/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "caura-client",
+  "version": "1.0.0",
+  "description": "Caura \u2014 governed shared memory for AI agent fleets. Unscoped alias for @caura/client.",
+  "license": "Apache-2.0",
+  "author": "Caura <hello@caura.ai>",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "README.md"
+  ],
+  "dependencies": {
+    "@caura/client": "^1.0.1"
+  },
+  "homepage": "https://caura.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/caura-ai/caura.git",
+    "directory": "clients/npm-caura-client"
+  },
+  "keywords": [
+    "caura",
+    "agent-memory",
+    "ai-agents",
+    "mcp",
+    "multi-agent"
+  ]
+}

--- a/clients/npm-caura-sdk/README.md
+++ b/clients/npm-caura-sdk/README.md
@@ -1,0 +1,26 @@
+# caura-sdk
+
+Unscoped alias for [`@caura/client`](https://www.npmjs.com/package/@caura/client),
+the official TypeScript client for [Caura](https://caura.ai) — governed shared
+memory for AI agent fleets.
+
+```bash
+npm install caura-sdk
+```
+
+```ts
+import { Caura } from 'caura-sdk';
+```
+
+`@caura/client` is the canonical name. This alias exists because the Python
+client is installed as `pip install caura-sdk` on PyPI, so
+`npm install caura-sdk` is a name people will guess — and unlike a scoped npm
+name, an unscoped one is publishable by any third party. Owning it keeps that
+install line resolving to the canonical implementation instead of to whoever
+claims it first. It depends directly on `@caura/client` rather than chaining
+through another alias.
+
+The bare name `caura` is not publishable on npm at all: the registry's
+name-similarity filter blocks it (against `csurf`) for every publisher, with
+no exception process — npm support confirmed 2026-08-28. That applies to
+everyone equally, so the bare name needs no defensive registration.

--- a/clients/npm-caura-sdk/index.d.ts
+++ b/clients/npm-caura-sdk/index.d.ts
@@ -1,0 +1,1 @@
+export * from '@caura/client';

--- a/clients/npm-caura-sdk/index.js
+++ b/clients/npm-caura-sdk/index.js
@@ -1,0 +1,1 @@
+export * from '@caura/client';

--- a/clients/npm-caura-sdk/package.json
+++ b/clients/npm-caura-sdk/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "caura-sdk",
+  "version": "1.0.0",
+  "description": "Caura \u2014 governed shared memory for AI agent fleets. Unscoped alias for @caura/client.",
+  "license": "Apache-2.0",
+  "author": "Caura <hello@caura.ai>",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "README.md"
+  ],
+  "dependencies": {
+    "@caura/client": "^1.0.1"
+  },
+  "homepage": "https://caura.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/caura-ai/caura.git",
+    "directory": "clients/npm-caura-sdk"
+  },
+  "keywords": [
+    "caura",
+    "agent-memory",
+    "ai-agents",
+    "mcp",
+    "multi-agent"
+  ]
+}


### PR DESCRIPTION
Adds `clients/npm-caura-client` + `clients/npm-caura-sdk` — unscoped **`caura-client`** and **`caura-sdk`**, thin re-export aliases of `@caura/client`, mirroring the `@caura/sdk` alias pattern file for file (same 4-file shape, same publish-workflow gates; tags `npm-caura-client-v*` / `npm-caura-sdk-v*`).

**Why**: PyPI installs are `caura-client`/`caura-sdk`, so the same unscoped npm names are what users will guess — and unscoped names are publishable by any third party (the npm half of the supply-chain hole the PyPI aliases closed; see publish-npm-sdk.yml's own header for the scoped/unscoped asymmetry). Both pin `@caura/client ^1.0.1`, the version where `@caura/client` became the full implementation (13.8 kB, zero deps), so they can never resolve to the retired forwarder chain.

**Decision record** (closes work-order 0.8): bare npm `caura` is not happening — the registry's similarity filter (vs `csurf`) blocks it for every publisher, no exception process, per npm support 2026-08-28. `@caura/client` is canonical.

v1.0.0 of both aliases is being published manually by the maintainer (the granular CI token cannot create new packages); the workflows cover future bumps.