### PR TITLE
fix(routes): type-check routes.memories and drop it from the ignore_errors list

### DIFF
--- a/core-api/pyproject.toml
+++ b/core-api/pyproject.toml
@@ -204,7 +204,6 @@ module = [
     "core_api.pipeline.steps.write.parallel_embed_enrich",
     "core_api.pipeline.steps.write.schedule_background_tasks",
     "core_api.routes.fleet",
-    "core_api.routes.memories",
     "core_api.clients.storage_client",
     "core_api.app",
     "core_api.auth",

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1116,8 +1116,18 @@ async def _write_memory_inner(
     # Ownership boundary (gate + owner stamp + post-create re-check), shared
     # with the bulk path so a broker single-write can't attribute a memory to
     # an agent owned by a different install.
+    #
+    # ``body.agent_id`` is non-None here: write_memory either filled the
+    # reserved standalone identity or raised ``_missing_agent_id_error``. The
+    # guard is in that outer function, so no narrowing reaches this one.
+    #
+    # Deliberately not ``or DEFAULT_AGENT_ID``: outside standalone that would
+    # silently attribute an anonymous write to the one shared identity, which
+    # is the exact footgun the guard raises to prevent. An ignore keeps the
+    # refusal where it belongs; the structural fix is for this function to take
+    # the resolved id as a parameter instead of re-reading a nullable field.
     agent, body.agent_id = await resolve_write_agent(
-        body.agent_id,
+        body.agent_id,  # type: ignore[arg-type]
         body.tenant_id,
         body.fleet_id,
         is_install_credential=auth.is_install_credential,
@@ -1372,8 +1382,18 @@ async def _write_memories_bulk_inner(
     # auto-registers many agents from item metadata; gating each on admin
     # approval would create trust-0 rows and 403 whole batches, breaking capture.
     # Per-agent approval is an interactive / single-agent concern.
+    #
+    # ``body.agent_id`` is non-None here: write_memories_bulk either filled the
+    # reserved standalone identity or raised ``_missing_agent_id_error``. The
+    # guard is in that outer function, so no narrowing reaches this one.
+    #
+    # Deliberately not ``or DEFAULT_AGENT_ID``: outside standalone that would
+    # silently attribute an anonymous write to the one shared identity, which
+    # is the exact footgun the guard raises to prevent. An ignore keeps the
+    # refusal where it belongs; the structural fix is for this function to take
+    # the resolved id as a parameter instead of re-reading a nullable field.
     agent, body.agent_id = await resolve_write_agent(
-        body.agent_id,
+        body.agent_id,  # type: ignore[arg-type]
         body.tenant_id,
         body.fleet_id,
         is_install_credential=auth.is_install_credential,


### PR DESCRIPTION
## What

Removes `core_api.routes.memories` from the mypy `ignore_errors` list in
`core-api/pyproject.toml` and fixes what that surfaces. Second entry off the
ratchet after #1384, and far smaller: **two errors, both the same call.**

Both are `Argument 1 to "resolve_write_agent" has incompatible type "str | None"; expected "str"` — at `memories.py:1120` (`_write_memory_inner`) and `:1376` (`_write_memories_bulk_inner`).

## Why it isn't a bug

`resolve_write_agent(chosen_agent_id: str, …)` is the write-identity boundary —
its own docstring calls it the one that "can't be bypassed by a caller's choice
of endpoint". Both write paths pass `body.agent_id`, declared `str | None` on the
request model, and it is genuinely non-None at both calls. The caller guards it:

```python
if not body.agent_id:
    if app_settings.is_standalone:
        body = body.model_copy(update={"agent_id": DEFAULT_AGENT_ID})
    else:
        raise _missing_agent_id_error()
```

Three things stop mypy carrying that, and the third is the one that matters:

1. the field is declared optional on the model;
2. the standalone branch **rebinds** `body` via `model_copy`;
3. the guard sits in the **outer** function (`write_memory` / `write_memories_bulk`)
   while the call is in the **inner** one.

No local narrowing recovers a caller's invariant across a function boundary, so
this cannot be fixed in place by restructuring a condition.

## Why not the tidier one-liner

`body.agent_id or DEFAULT_AGENT_ID` reads as the obvious fix and is the one thing
this code must not do: outside standalone it would silently attribute an
anonymous write to the one shared identity — exactly the footgun the guard raises
to prevent. A coded ignore leaves the refusal where it belongs. Each call site
carries a comment saying so, because both are equally tempting places for a
future editor to "clean up" the ignore.

The structural fix is for the two inner functions to **take** the resolved
identity as a parameter instead of re-reading a nullable model field. That is
what an `AgentIdentity` sink type would formalise, and these are its first two
real customers — worth noting because before #1384 this module held **13 of the
32** identity call sites such a NewType would have bound, all of them invisible
while the module was exempt.

## Verification

- `mypy src/` clean for this module (local baseline is 2 pre-existing
  `import-untyped` errors in `common/enrichment/service.py`, a stub package
  missing from the local venv — identical with the exemption in place).
- **Two mutation probes confirm the gate fires** rather than having been
  reconfigured, from a baseline of 0 errors in this file:
  - a fresh type error introduced anywhere in the module is reported → 1 error;
  - removing either of the two ignores brings its original error back → 1 error.
    So what silences these is the annotation, not the exemption line.
- Root suite green: 6337 passed, 4 skipped.
- `ruff check core-api/src/` and `ruff format --check core-api/src/` clean, run
  separately at CI's scopes.
- `scripts/legacy_name_ratchet.py --base origin/main` and
  `scripts/do_not_touch_sentinel.py` both exit 0.

**24 entries remain** on the `ignore_errors` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
