### PR TITLE
chore(plugin): classify installed-path aliases

### DIFF
--- a/plugin/e2e/interviewer-wet.mjs
+++ b/plugin/e2e/interviewer-wet.mjs
@@ -167,7 +167,7 @@ try {
       const { homedir } = await import("os");
       sidecar = JSON.parse(
         readFileSync(
-          join(homedir(), ".openclaw", "plugins", "memclaw", "interview-task-sync.json"),
+          join(homedir(), ".openclaw", "plugins", "memclaw", "interview-task-sync.json"), // legacy-name-ok: the published plugin id fixes the installed sidecar path
           "utf-8",
         ),
       );

--- a/plugin/e2e/interviewer-wet.sh
+++ b/plugin/e2e/interviewer-wet.sh
@@ -22,7 +22,7 @@ export CAURA_INTERVIEWER=true
 # The plugin modules log progress lines to stdout; the harness's JSON is
 # always the LAST line — capture just that.
 H() { node e2e/interviewer-wet.mjs "$@" | tail -1; }
-BUF="$HOME/.openclaw/plugins/memclaw/interview-buffer.jsonl"
+BUF="$HOME/.openclaw/plugins/memclaw/interview-buffer.jsonl" # legacy-name-ok: the published plugin id fixes the installed buffer path
 PASS=0; FAIL=0
 
 say()  { echo ">>> $*"; }


### PR DESCRIPTION
## What

Classify two installed-path references as deliberate legacy aliases by adding the existing `legacy-name-ok` marker.

This is intentionally a two-line PR. Independent review rejected broader plugin-runtime annotations where the external compatibility contract was not proven.

## Why these are permanent

- `plugin/e2e/interviewer-wet.mjs` reads `~/.openclaw/plugins/memclaw/interview-task-sync.json`. `memclaw` is the frozen published plugin id and therefore the installed directory name. Removing or renaming this segment makes the wet-test harness miss the sidecar written by existing installs.
- `plugin/e2e/interviewer-wet.sh` reads `~/.openclaw/plugins/memclaw/interview-buffer.jsonl` for the same installed plugin. Removing or renaming this segment makes the harness inspect a different buffer and misreport interview delivery.

The plugin manifest id itself is protected separately by the do-not-touch sentinel. These markers classify references to that fixed on-disk contract; they do not create a new alias.

## Deliberately not marked

Runtime `provider`, `backend`, and fallback labels, stale allowlist cleanup, and model-visible skill text remain unclassified. Review found that their external consumers or safe annotation mechanics were not proven strongly enough for a forever exemption.

## Census movement

Against the current refs immediately before this PR:

- `caura`: unclassified 135 -> 133; deliberate aliases 213 -> 215
- aggregate with `caura-enterprise@origin/dev`: unclassified 779 -> 777
- positive controls: `caura` matched 5,161 `caura` lines; enterprise matched 5,836

The original brief baseline remains 782 unclassified at `caura@8b634a96` plus `caura-enterprise@e97eea1e`; this PR accounts for two of those baseline lines.

## Verification

- `node --check e2e/interviewer-wet.mjs`
- `bash -n e2e/interviewer-wet.sh`
- `npm run build`
- focused plugin tests: 182 passed, 0 failed
- legacy-name ratchet: 2 annotated, 0 added/removed, net -2
- do-not-touch sentinel: all 35 protected strings survive
- staged diff check clean

No runtime behavior, live infrastructure, ratchet behavior, or protected gateway configuration changed.
