### PR TITLE
feat(conflicts): human review of detected conflicts — backend (D11)

### DIFF
--- a/common/models/memory_conflict.py
+++ b/common/models/memory_conflict.py
@@ -39,6 +39,13 @@ DIAGNOSES = (
     "unresolved",
 )
 EVIDENCE_STRENGTHS = ("explicit", "entailed", "probabilistic")
+
+# D11 — human review state. A row starts ``pending``; a reviewer moves it to
+# ``resolved`` (they chose an action) or ``dismissed`` (not a real conflict).
+# ``dismissed`` is the ground-truth signal that matters most: it is the only
+# record that the detector was WRONG, and nothing else in the system captures a
+# false positive.
+REVIEW_STATUSES = ("pending", "resolved", "dismissed")
 ACTIONS = (
     "replace",
     "supersede",
@@ -93,6 +100,19 @@ class MemoryConflict(Base):
     action: Mapped[str | None] = mapped_column(Text)
     audit_reason: Mapped[str | None] = mapped_column(Text)
 
+    # D11 — human review. Separate from ``action``/``audit_reason``, which record
+    # what the DETECTOR proposed; these record what a PERSON decided. Keeping the
+    # two apart is the point: comparing them is the precision measurement.
+    review_status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'pending'")
+    )
+    # The action the reviewer chose, from the same ACTIONS vocabulary the
+    # detector uses — so "did the human agree" is a direct comparison.
+    resolution_action: Mapped[str | None] = mapped_column(Text)
+    resolution_note: Mapped[str | None] = mapped_column(Text)
+    resolved_by: Mapped[str | None] = mapped_column(Text)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
     created_by: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=text("now()"), nullable=False
@@ -115,6 +135,23 @@ class MemoryConflict(Base):
         ),
         CheckConstraint(
             _one_of("action", ACTIONS, nullable=True), name="ck_memory_conflicts_action"
+        ),
+        CheckConstraint(
+            _one_of("review_status", REVIEW_STATUSES),
+            name="ck_memory_conflicts_review_status",
+        ),
+        CheckConstraint(
+            _one_of("resolution_action", ACTIONS, nullable=True),
+            name="ck_memory_conflicts_resolution_action",
+        ),
+        # D11 — the review queue is always "this tenant's pending rows, newest
+        # first". Without this the queue degrades to a seq scan as the table
+        # grows, and the table grows on every detected conflict.
+        Index(
+            "ix_memory_conflicts_review_queue",
+            "tenant_id",
+            "review_status",
+            "created_at",
         ),
         Index("ix_memory_conflicts_tenant", "tenant_id"),
         Index("ix_memory_conflicts_new", "new_memory_id"),

--- a/core-api/src/core_api/app.py
+++ b/core-api/src/core_api/app.py
@@ -48,6 +48,7 @@ from core_api.middleware.request_timeout import (
 )
 from core_api.routes.agents import router as agents_router
 from core_api.routes.audit import router as audit_router
+from core_api.routes.conflicts import router as conflicts_router
 from core_api.routes.crystallizer import router as crystallizer_router
 from core_api.routes.documents import router as documents_router
 from core_api.routes.entities import router as entities_router
@@ -1056,6 +1057,7 @@ app.include_router(stm_router, prefix="/api/v1")
 app.include_router(insights_router, prefix="/api/v1")
 app.include_router(interview_router, prefix="/api/v1")
 app.include_router(evolve_router, prefix="/api/v1")
+app.include_router(conflicts_router, prefix="/api/v1")
 app.include_router(lifecycle_router, prefix="/api/v1")
 app.include_router(org_deletion_router, prefix="/api/v1")
 

--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -974,6 +974,28 @@ class CoreStorageClient:
             idempotent=True,
         )
 
+    async def list_memory_conflicts(
+        self,
+        tenant_id: str,
+        review_status: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict]:
+        """D11 — the conflict review queue for a tenant."""
+        params: dict[str, Any] = {"tenant_id": tenant_id, "limit": limit, "offset": offset}
+        if review_status is not None:
+            params["review_status"] = review_status
+        return await self._get_list("/memories/memory-conflicts", **params)
+
+    async def get_memory_conflict(self, conflict_id: str, tenant_id: str) -> dict | None:
+        """One conflict row. ``None`` when absent or owned by another tenant."""
+        return await self._get(f"/memories/memory-conflicts/{conflict_id}", tenant_id=tenant_id, read=True)
+
+    async def resolve_memory_conflict(self, conflict_id: str, data: dict) -> dict:
+        """D11 — record a reviewer's decision. Raises on 409 (already reviewed),
+        which the route above turns into the caller's 409."""
+        return await self._patch(f"/memories/memory-conflicts/{conflict_id}/resolve", data)
+
     async def find_successors(self, data: dict) -> list[dict]:
         return await self._post("/memories/find-successors", data, read=True)  # type: ignore[return-value]
 

--- a/core-api/src/core_api/openapi_responses.py
+++ b/core-api/src/core_api/openapi_responses.py
@@ -532,3 +532,24 @@ class HealthResponse(BaseModel):
         default=None,
         description="Only on 503: names of failing dependencies.",
     )
+
+
+class ConflictOut(BaseModel):
+    """D11 — a detected conflict with its human-review state."""
+
+    id: str
+    tenant_id: str
+    new_memory_id: str
+    old_memory_id: str
+    relationship: str
+    diagnosis: str | None = None
+    action: str | None = Field(default=None, description="What the detector proposed.")
+    review_status: str = Field(description="pending | resolved | dismissed")
+    resolution_action: str | None = Field(default=None, description="What the reviewer chose.")
+    resolution_note: str | None = None
+    resolved_by: str | None = None
+    resolved_at: str | None = None
+
+
+class ConflictListResponse(BaseModel):
+    items: list[ConflictOut]

--- a/core-api/src/core_api/routes/conflicts.py
+++ b/core-api/src/core_api/routes/conflicts.py
@@ -1,0 +1,148 @@
+"""D11 — human review of detected conflicts.
+
+``memory_conflicts`` has recorded what the DETECTOR concluded since A55, and
+nothing recorded what a PERSON concluded. That gap is why detector precision has
+never been measurable: a false positive looks exactly like a true one in storage.
+
+These routes are the read + decide half. They deliberately keep the detector's
+proposal (``action``, ``audit_reason``) and the reviewer's decision
+(``resolution_action``, ``resolution_note``) as separate fields, because
+comparing them is the measurement — a ``dismissed`` row is the only record in the
+system that detection was wrong.
+
+Read-only listing plus one state transition; no memory row is touched here.
+Applying a resolution to the memories themselves stays with the contradiction
+engine, which already owns the CAS-guarded status/supersedes writes.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from core_api import openapi_responses as _oar
+from core_api.agent_ids import DEFAULT_AGENT_ID
+from core_api.auth import AuthContext, get_auth_context
+from core_api.clients.storage_client import get_storage_client
+from core_api.schemas import ConflictListResponse, ConflictOut, ConflictResolveRequest
+from core_api.services.audit_service import log_action
+from core_api.services.trust_service import require_trust as _require_trust
+
+router = APIRouter(tags=["Conflicts"])
+
+# Mirrors common.models.memory_conflict.REVIEW_STATUSES minus the implicit
+# initial state, for the query-param filter.
+_REVIEW_STATUSES = ("pending", "resolved", "dismissed")
+
+
+@router.get("/conflicts", responses={200: {"model": _oar.ConflictListResponse}})
+async def list_conflicts(
+    tenant_id: str,
+    review_status: str | None = Query(
+        default=None,
+        description="Filter by review state: pending | resolved | dismissed. Omit for all.",
+    ),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    auth: AuthContext = Depends(get_auth_context),
+) -> ConflictListResponse:
+    """The conflict review queue, oldest first.
+
+    Oldest-first is deliberate: a queue worked newest-first leaves its oldest
+    entries permanently at the bottom, which is precisely the backlog a reviewer
+    needs to clear.
+    """
+    auth.enforce_tenant(tenant_id)
+    if review_status is not None and review_status not in _REVIEW_STATUSES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid review_status '{review_status}'. Must be one of: " + ", ".join(_REVIEW_STATUSES),
+        )
+    rows = await get_storage_client().list_memory_conflicts(
+        tenant_id=tenant_id, review_status=review_status, limit=limit, offset=offset
+    )
+    return ConflictListResponse(items=[ConflictOut(**r) for r in rows])
+
+
+@router.get("/conflicts/{conflict_id}", responses={200: {"model": _oar.ConflictOut}})
+async def get_conflict(
+    conflict_id: str,
+    tenant_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+) -> ConflictOut:
+    auth.enforce_tenant(tenant_id)
+    row = await get_storage_client().get_memory_conflict(conflict_id, tenant_id)
+    if row is None:
+        # One 404 for "no such conflict" and "not your conflict" alike, so the
+        # route cannot be used to probe which ids exist in other tenants.
+        raise HTTPException(status_code=404, detail="Conflict not found")
+    return ConflictOut(**row)
+
+
+@router.patch("/conflicts/{conflict_id}/resolve", responses={200: {"model": _oar.ConflictOut}})
+async def resolve_conflict(
+    conflict_id: str,
+    body: ConflictResolveRequest,
+    auth: AuthContext = Depends(get_auth_context),
+) -> ConflictOut:
+    """Record a reviewer's decision on one conflict.
+
+    409 when the row is no longer ``pending``. Two people working the same queue
+    is the ordinary case, not the edge case: the storage-side compare-and-set is
+    what stops the second decision silently overwriting the first, and this is
+    the status code that tells the caller their queue entry was stale rather
+    than pretending the write landed.
+    """
+    auth.enforce_tenant(body.tenant_id)
+    # Blocks demo-sandbox and read-only credentials before any state moves — a
+    # review decision is a write, even though no memory row changes.
+    auth.enforce_read_only()
+    # TRUST-plane, not admin-plane. ``enforce_admin`` admits only the super-admin
+    # key, which would put review out of reach of the people who actually run a
+    # tenant. But leaving this at tenant scope alone would let ANY agent
+    # credential dismiss the contradictions it caused — and a dismissal is the
+    # system's only record of the detector being wrong, so a self-serving one
+    # corrupts the exact ground truth this surface exists to collect. Trust >= 2
+    # matches the keystone-author bar: a privileged action inside a tenant.
+    reviewer = auth.agent_id or DEFAULT_AGENT_ID
+    _trust, not_found, terr = await _require_trust(body.tenant_id, reviewer, min_level=2)
+    if not_found or terr:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"Agent '{reviewer}' cannot review conflicts. Reviewing records ground "
+                "truth about detector accuracy, so it requires a registered agent at "
+                "trust >= 2 — call with X-Agent-ID or an agent-scoped credential."
+            ),
+        )
+    payload = {
+        "tenant_id": body.tenant_id,
+        "review_status": body.review_status,
+        "resolution_action": body.resolution_action,
+        "resolution_note": body.resolution_note,
+        # Attribution comes from the verified identity, never the body — a
+        # reviewer must not be able to file a decision under someone else's name.
+        "resolved_by": reviewer,
+    }
+    try:
+        row = await get_storage_client().resolve_memory_conflict(conflict_id, payload)
+    except HTTPException:
+        raise
+    except Exception as exc:  # storage 4xx surfaced with its own status
+        status = getattr(exc, "status_code", None) or getattr(
+            getattr(exc, "response", None), "status_code", None
+        )
+        if status in (400, 404, 409):
+            raise HTTPException(status_code=status, detail=str(exc)) from exc
+        raise
+    await log_action(
+        tenant_id=body.tenant_id,
+        agent_id=auth.agent_id,
+        action="conflict.review",
+        resource_type="memory_conflict",
+        resource_id=conflict_id,
+        detail={
+            "review_status": body.review_status,
+            "resolution_action": body.resolution_action,
+        },
+    )
+    return ConflictOut(**row)

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -619,6 +619,63 @@ class SearchDiagnostic(BaseModel):
     all_candidates: list[dict] = []
 
 
+class ConflictOut(BaseModel):
+    """D11 — a detected conflict plus its human-review state.
+
+    The detector's own fields (``relationship`` / ``diagnosis`` / ``action``)
+    and the reviewer's (``resolution_action`` / ``resolution_note``) are kept
+    side by side on purpose: comparing them IS the precision measurement, and
+    collapsing them into one field would destroy the only record of the
+    detector being wrong.
+    """
+
+    id: UUID
+    tenant_id: str
+    fleet_id: str | None = None
+    new_memory_id: UUID
+    old_memory_id: UUID
+    relationship: str
+    relationship_confidence: float | None = None
+    diagnosis: str | None = None
+    diagnosis_confidence: float | None = None
+    evidence_strength: str | None = None
+    action: str | None = Field(default=None, description="What the DETECTOR proposed.")
+    audit_reason: str | None = None
+    created_by: str | None = None
+    created_at: datetime | None = None
+    review_status: str = Field(description="pending | resolved | dismissed")
+    resolution_action: str | None = Field(
+        default=None, description="What the REVIEWER chose, from the same vocabulary as `action`."
+    )
+    resolution_note: str | None = None
+    resolved_by: str | None = None
+    resolved_at: datetime | None = None
+
+
+class ConflictListResponse(BaseModel):
+    """Envelope for the review queue — ``items`` per the ratified wire contract."""
+
+    items: list[ConflictOut]
+
+
+class ConflictResolveRequest(BaseModel):
+    model_config = STRICT_WRITE_BODY
+
+    tenant_id: str
+    review_status: Literal["resolved", "dismissed"] = Field(
+        description=(
+            "Terminal state only. 'pending' is rejected: this endpoint records a "
+            "decision, and re-opening a reviewed conflict would erase the audit trail "
+            "of who decided what."
+        )
+    )
+    resolution_action: str | None = Field(
+        default=None,
+        description="Optional; the action the reviewer chose. Validated against the shared vocabulary.",
+    )
+    resolution_note: str | None = Field(default=None, max_length=2000)
+
+
 class SearchWarning(BaseModel):
     """A28 — a coded, non-fatal caveat about the result set.
 

--- a/core-storage-api/src/core_storage_api/database/migrations/versions/043_memory_conflicts_review.py
+++ b/core-storage-api/src/core_storage_api/database/migrations/versions/043_memory_conflicts_review.py
@@ -1,0 +1,92 @@
+"""Human review state on ``memory_conflicts`` (D11).
+
+``memory_conflicts`` records what the DETECTOR concluded — the relationship, the
+diagnosis, the action it proposed. Nothing records what a PERSON concluded, so
+there is no way to ask the only question that matters for precision: how often
+was the detector right?
+
+These columns keep the two apart deliberately. ``action``/``audit_reason`` stay
+the detector's proposal; ``resolution_action``/``resolution_note`` are the
+reviewer's decision, drawn from the SAME ``ACTIONS`` vocabulary so "did the human
+agree" is a direct comparison rather than a mapping exercise. A ``dismissed`` row
+is the most valuable of the three states: it is the only place in the system that
+records a FALSE POSITIVE.
+
+``review_status`` is NOT NULL DEFAULT 'pending'. On PostgreSQL 11+ adding a
+column with a non-volatile default is a catalog-only change — no table rewrite —
+so this is safe without the NOT VALID / VALIDATE two-step, and
+``memory_conflicts`` is not one of the repo's declared large tables in any case.
+
+The queue index is ``(tenant_id, review_status, created_at)`` in that order: the
+review queue is always "this tenant's pending rows, oldest first", so tenant and
+status are equality predicates and created_at supplies the ordering. Without it
+the queue degrades to a seq scan, and this table grows on every detected
+conflict.
+
+Revision ID: 043
+Revises: 042
+Create Date: 2026-09-08
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "043"
+down_revision: str | None = "042"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CK_STATUS = "ck_memory_conflicts_review_status"
+_CK_ACTION = "ck_memory_conflicts_resolution_action"
+_IX_QUEUE = "ix_memory_conflicts_review_queue"
+
+_REVIEW_STATUSES = ("pending", "resolved", "dismissed")
+# Mirrors common.models.memory_conflict.ACTIONS. Duplicated as a literal on
+# purpose: a migration must describe the schema at ITS point in history, not
+# import a constant that a later release can change underneath it.
+_ACTIONS = (
+    "replace",
+    "supersede",
+    "scope",
+    "merge",
+    "split_entity",
+    "downweight",
+    "mark_disputed",
+    "ask",
+    "no_op",
+)
+
+
+def _in_list(col: str, values: tuple[str, ...]) -> str:
+    return ", ".join(f"'{v}'" for v in values) and f"{col} IN (" + ", ".join(f"'{v}'" for v in values) + ")"
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE memory_conflicts ADD COLUMN IF NOT EXISTS review_status TEXT NOT NULL DEFAULT 'pending'"
+    )
+    for col in ("resolution_action", "resolution_note", "resolved_by"):
+        op.execute(f"ALTER TABLE memory_conflicts ADD COLUMN IF NOT EXISTS {col} TEXT")
+    op.execute("ALTER TABLE memory_conflicts ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMPTZ")
+
+    op.execute(
+        f"ALTER TABLE memory_conflicts ADD CONSTRAINT {_CK_STATUS} "
+        f"CHECK ({_in_list('review_status', _REVIEW_STATUSES)})"
+    )
+    # Nullable: a pending row has no resolution_action yet.
+    op.execute(
+        f"ALTER TABLE memory_conflicts ADD CONSTRAINT {_CK_ACTION} "
+        f"CHECK (resolution_action IS NULL OR {_in_list('resolution_action', _ACTIONS)})"
+    )
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS {_IX_QUEUE} ON memory_conflicts (tenant_id, review_status, created_at)"
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP INDEX IF EXISTS {_IX_QUEUE}")
+    op.execute(f"ALTER TABLE memory_conflicts DROP CONSTRAINT IF EXISTS {_CK_ACTION}")
+    op.execute(f"ALTER TABLE memory_conflicts DROP CONSTRAINT IF EXISTS {_CK_STATUS}")
+    for col in ("resolved_at", "resolved_by", "resolution_note", "resolution_action", "review_status"):
+        op.execute(f"ALTER TABLE memory_conflicts DROP COLUMN IF EXISTS {col}")

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1169,6 +1169,12 @@ _MEMORY_CONFLICT_FIELDS = [
     "created_by",
     "created_at",
     "metadata_",
+    # D11 — human review state.
+    "review_status",
+    "resolution_action",
+    "resolution_note",
+    "resolved_by",
+    "resolved_at",
 ]
 
 
@@ -1206,6 +1212,72 @@ async def record_memory_conflict(request: Request) -> dict:
         row = await _svc.memory_conflict_record(body)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    return orm_to_dict(row, _MEMORY_CONFLICT_FIELDS)
+
+
+@router.get("/memory-conflicts")
+async def list_memory_conflicts(
+    tenant_id: str,
+    review_status: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict]:
+    """D11 — the review queue. Tenant-scoped; see the service docstring for why
+    that is a boundary rather than a filter."""
+    try:
+        rows = await _svc.memory_conflicts_list(
+            tenant_id=tenant_id, review_status=review_status, limit=limit, offset=offset
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return [orm_to_dict(r, _MEMORY_CONFLICT_FIELDS) for r in rows]
+
+
+@router.get("/memory-conflicts/{conflict_id}")
+async def get_memory_conflict(conflict_id: str, tenant_id: str) -> dict:
+    try:
+        row = await _svc.memory_conflict_get(UUID(conflict_id), tenant_id)
+    except (ValueError, TypeError):
+        row = None
+    if row is None:
+        # Same 404 for "no such conflict" and "not your conflict" — the route
+        # must not answer "does this id exist?" for another tenant.
+        raise HTTPException(status_code=404, detail="Conflict not found")
+    return orm_to_dict(row, _MEMORY_CONFLICT_FIELDS)
+
+
+@router.patch("/memory-conflicts/{conflict_id}/resolve")
+async def resolve_memory_conflict(conflict_id: str, request: Request) -> dict:
+    """D11 — record a reviewer's decision.
+
+    409 when the row is no longer pending. Two reviewers working the same queue
+    is the ordinary case, and the CAS in the service is what stops the second
+    write silently overwriting the first's decision.
+    """
+    body: dict = await request.json()
+    tenant_id = _require(body, "tenant_id")
+    try:
+        moved = await _svc.memory_conflict_resolve(
+            conflict_id=UUID(str(conflict_id)),
+            tenant_id=tenant_id,
+            review_status=_require(body, "review_status"),
+            resolution_action=body.get("resolution_action"),
+            resolution_note=body.get("resolution_note"),
+            resolved_by=body.get("resolved_by"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if not moved:
+        # Distinguish "gone/not yours" from "already reviewed" so the caller can
+        # tell a stale queue entry from a permissions problem.
+        existing = await _svc.memory_conflict_get(UUID(str(conflict_id)), tenant_id)
+        if existing is None:
+            raise HTTPException(status_code=404, detail="Conflict not found")
+        raise HTTPException(
+            status_code=409,
+            detail=f"Conflict already reviewed (review_status={existing.review_status})",
+        )
+    row = await _svc.memory_conflict_get(UUID(str(conflict_id)), tenant_id)
     return orm_to_dict(row, _MEMORY_CONFLICT_FIELDS)
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2093,7 +2093,9 @@ class PostgresService:
             )
             result = await session.execute(stmt)
             await session.commit()
-            return bool(result.rowcount)
+            # ``rowcount`` lives on CursorResult; the async ``execute`` is typed
+            # as Result. Same ignore the sibling CAS updates in this file use.
+            return (result.rowcount or 0) > 0  # type: ignore[attr-defined]
 
     async def memory_conflict_record(self, payload: dict) -> MemoryConflict:
         """Insert an A55 ``memory_conflicts`` classification record.

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2008,6 +2008,93 @@ class PostgresService:
             await session.flush()
             return row
 
+    async def memory_conflicts_list(
+        self,
+        tenant_id: str,
+        review_status: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[MemoryConflict]:
+        """D11 — the review queue for one tenant.
+
+        Tenant scoping is not a filter here, it is the boundary: a conflict row
+        names two memory ids and their contents are reachable from it, so an
+        unscoped read would hand one tenant another's memories. Ordered oldest
+        first — a review queue is worked front to back, and newest-first would
+        leave the oldest unreviewed rows permanently at the bottom.
+        """
+        from common.models.memory_conflict import REVIEW_STATUSES
+
+        if review_status is not None and review_status not in REVIEW_STATUSES:
+            raise ValueError(f"review_status {review_status!r} must be one of {REVIEW_STATUSES}")
+        async with get_session() as session:
+            stmt = select(MemoryConflict).where(MemoryConflict.tenant_id == tenant_id)
+            if review_status:
+                stmt = stmt.where(MemoryConflict.review_status == review_status)
+            stmt = (
+                stmt.order_by(MemoryConflict.created_at.asc())
+                .limit(max(1, min(limit, 200)))
+                .offset(max(0, offset))
+            )
+            return list((await session.execute(stmt)).scalars().all())
+
+    async def memory_conflict_get(self, conflict_id: UUID, tenant_id: str) -> MemoryConflict | None:
+        """One conflict row, scoped to its tenant. ``None`` when absent OR owned
+        by another tenant — the caller cannot distinguish the two, which is the
+        point: a bare 404 leaks nothing about what exists elsewhere."""
+        async with get_session() as session:
+            stmt = select(MemoryConflict).where(
+                MemoryConflict.id == conflict_id,
+                MemoryConflict.tenant_id == tenant_id,
+            )
+            return (await session.execute(stmt)).scalar_one_or_none()
+
+    async def memory_conflict_resolve(
+        self,
+        conflict_id: UUID,
+        tenant_id: str,
+        review_status: str,
+        resolution_action: str | None = None,
+        resolution_note: str | None = None,
+        resolved_by: str | None = None,
+    ) -> bool:
+        """D11 — record a reviewer's decision. Returns True iff a row moved.
+
+        CAS on ``review_status = 'pending'``. Two reviewers opening the same
+        queue is the normal case, not the edge case: without the compare the
+        second write silently overwrites the first's decision and the audit trail
+        records only the loser's disappearance. The False return is what lets the
+        route answer 409 instead of pretending it worked.
+        """
+        from common.models.memory_conflict import ACTIONS, REVIEW_STATUSES
+
+        if review_status not in REVIEW_STATUSES or review_status == "pending":
+            raise ValueError(
+                f"review_status {review_status!r} must be a terminal state "
+                f"({[s for s in REVIEW_STATUSES if s != 'pending']})"
+            )
+        if resolution_action is not None and resolution_action not in ACTIONS:
+            raise ValueError(f"resolution_action {resolution_action!r} must be one of {ACTIONS}")
+        async with get_session() as session:
+            stmt = (
+                sql_update(MemoryConflict)
+                .where(
+                    MemoryConflict.id == conflict_id,
+                    MemoryConflict.tenant_id == tenant_id,
+                    MemoryConflict.review_status == "pending",
+                )
+                .values(
+                    review_status=review_status,
+                    resolution_action=resolution_action,
+                    resolution_note=resolution_note,
+                    resolved_by=resolved_by,
+                    resolved_at=func.now(),
+                )
+            )
+            result = await session.execute(stmt)
+            await session.commit()
+            return bool(result.rowcount)
+
     async def memory_conflict_record(self, payload: dict) -> MemoryConflict:
         """Insert an A55 ``memory_conflicts`` classification record.
 

--- a/tests/test_authz_gate_inventory.py
+++ b/tests/test_authz_gate_inventory.py
@@ -264,6 +264,12 @@ NON_ADMIN_PLANE_ROUTERS: dict[str, str] = {
     # close a hole. Named explicitly because an earlier draft omitted it from
     # both sets and nothing failed.
     "keystones": "trust-plane: agents author their own rules, gated by require_trust",
+    # Reviewing is privileged INSIDE a tenant, not super-admin-only: enforce_admin
+    # would put it out of reach of the people who run the tenant. But plain tenant
+    # scope would let any agent dismiss the contradictions it caused, and a
+    # dismissal is the only record that detection was wrong — so the resolve route
+    # gates on require_trust(min_level=2), the keystone-author bar.
+    "conflicts": "trust-plane: human review of detector output, gated by require_trust",
 }
 
 # Routers that exist ONLY under an explicit env flag, and so are not part of

--- a/tests/test_d11_conflict_review.py
+++ b/tests/test_d11_conflict_review.py
@@ -83,8 +83,13 @@ def test_resolve_is_compare_and_set_on_pending():
     from core_storage_api.services.postgres_service import PostgresService
 
     src = inspect.getsource(PostgresService.memory_conflict_resolve)
+    # the compare half: only a still-pending row may move
     assert 'MemoryConflict.review_status == "pending"' in src
-    assert "return bool(result.rowcount)" in src
+    # the set half: the caller learns whether it won, which is what lets the
+    # route answer 409 instead of pretending the write landed. Asserted on
+    # rowcount rather than an exact expression so a typing fix cannot silently
+    # look like a behaviour change.
+    assert "rowcount" in src.split("await session.commit()")[1]
 
 
 def test_every_conflict_query_is_tenant_scoped():

--- a/tests/test_d11_conflict_review.py
+++ b/tests/test_d11_conflict_review.py
@@ -1,0 +1,158 @@
+"""D11 — human review of detected conflicts.
+
+``memory_conflicts`` recorded what the DETECTOR concluded and nothing recorded
+what a PERSON concluded, so detector precision was unmeasurable: in storage a
+false positive is indistinguishable from a true one.
+
+The design point these tests protect is the SEPARATION. ``action`` stays the
+detector's proposal and ``resolution_action`` is the reviewer's decision, drawn
+from the same vocabulary so the two can be compared directly. Collapsing them
+into one field would destroy the only record of the detector being wrong.
+"""
+
+import inspect
+
+import pytest
+from pydantic import ValidationError
+
+from common.models.memory_conflict import REVIEW_STATUSES
+from core_api.schemas import ConflictListResponse, ConflictOut, ConflictResolveRequest
+
+pytestmark = pytest.mark.unit
+
+
+# ── vocabulary ────────────────────────────────────────────────────────────
+
+
+def test_review_states_are_pending_resolved_dismissed():
+    assert REVIEW_STATUSES == ("pending", "resolved", "dismissed")
+
+
+def test_reviewer_reuses_the_detector_action_vocabulary():
+    """The comparison "did the human agree" only works if both sides speak the
+    same words. A separate reviewer vocabulary would make precision a mapping
+    exercise instead of an equality check."""
+    src = inspect.getsource(__import__("common.models.memory_conflict", fromlist=["x"]))
+    assert '_one_of("resolution_action", ACTIONS' in src
+
+
+# ── the resolve contract ──────────────────────────────────────────────────
+
+
+def test_resolve_refuses_to_reopen_a_reviewed_conflict():
+    """'pending' is not an accepted target. Re-opening would erase the record of
+    who decided what, which is the only thing this table is for."""
+    with pytest.raises(ValidationError):
+        ConflictResolveRequest(tenant_id="t", review_status="pending")
+
+
+@pytest.mark.parametrize("state", ["resolved", "dismissed"])
+def test_resolve_accepts_both_terminal_states(state):
+    r = ConflictResolveRequest(tenant_id="t", review_status=state)
+    assert r.review_status == state
+
+
+def test_dismissed_is_reachable_without_an_action():
+    """A dismissal is 'this was not a real conflict' — there is no action to
+    record, and requiring one would push reviewers into inventing a verdict."""
+    r = ConflictResolveRequest(tenant_id="t", review_status="dismissed")
+    assert r.resolution_action is None
+
+
+def test_resolve_body_rejects_unknown_fields():
+    with pytest.raises(ValidationError):
+        ConflictResolveRequest(tenant_id="t", review_status="resolved", reviewer="me")
+
+
+def test_reviewer_identity_is_never_taken_from_the_body():
+    """resolved_by comes from the verified identity. A reviewer must not be able
+    to file a decision under someone else's name."""
+    assert "resolved_by" not in ConflictResolveRequest.model_fields
+    src = inspect.getsource(__import__("core_api.routes.conflicts", fromlist=["x"]))
+    # attribution is the gated identity, resolved before the trust check
+    assert '"resolved_by": reviewer' in src
+    assert "reviewer = auth.agent_id or DEFAULT_AGENT_ID" in src
+
+
+# ── storage-side guarantees ───────────────────────────────────────────────
+
+
+def test_resolve_is_compare_and_set_on_pending():
+    """Two reviewers working one queue is the ordinary case. Without the CAS the
+    second decision silently overwrites the first."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_conflict_resolve)
+    assert 'MemoryConflict.review_status == "pending"' in src
+    assert "return bool(result.rowcount)" in src
+
+
+def test_every_conflict_query_is_tenant_scoped():
+    """A conflict row names two memory ids whose contents are reachable from it,
+    so an unscoped read hands one tenant another's memories."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    for fn in (
+        "memory_conflicts_list",
+        "memory_conflict_get",
+        "memory_conflict_resolve",
+    ):
+        src = inspect.getsource(getattr(PostgresService, fn))
+        assert "MemoryConflict.tenant_id == tenant_id" in src, (
+            f"{fn} is not tenant-scoped"
+        )
+
+
+def test_queue_is_oldest_first():
+    """Newest-first leaves the oldest unreviewed rows permanently at the bottom
+    — which is exactly the backlog a reviewer is trying to clear."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_conflicts_list)
+    assert "MemoryConflict.created_at.asc()" in src
+
+
+def test_resolve_rejects_a_non_terminal_target_at_the_storage_layer_too():
+    """Defence in depth: the schema blocks it at the edge, the service blocks it
+    for any internal caller that bypasses the route."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_conflict_resolve)
+    assert 'review_status == "pending"' in src and "must be a terminal state" in src
+
+
+# ── wire shape ────────────────────────────────────────────────────────────
+
+
+def test_list_uses_the_items_envelope():
+    assert "items" in ConflictListResponse.model_fields
+
+
+def test_conflict_out_keeps_detector_and_reviewer_fields_apart():
+    f = ConflictOut.model_fields
+    for name in (
+        "action",
+        "audit_reason",
+        "resolution_action",
+        "resolution_note",
+        "review_status",
+    ):
+        assert name in f, f"{name} missing from the wire model"
+
+
+def test_missing_and_foreign_conflicts_answer_identically():
+    """Ownership is never signalled by a distinct status: a 403-for-foreign would
+    turn the endpoint into an existence oracle for other tenants' conflict ids.
+    The one 403 in this module is the TRUST gate, which fires before any lookup
+    and so reveals nothing about which ids exist."""
+    src = inspect.getsource(__import__("core_api.routes.conflicts", fromlist=["x"]))
+    assert src.count('status_code=404, detail="Conflict not found"') >= 1
+    trust_403 = src.count("cannot review conflicts")
+    assert src.count("status_code=403") == trust_403 == 1
+
+
+def test_review_requires_elevated_trust():
+    """Plain tenant scope would let any agent dismiss the contradictions it
+    caused — and a dismissal is the only record that detection was wrong."""
+    src = inspect.getsource(__import__("core_api.routes.conflicts", fromlist=["x"]))
+    assert "_require_trust(body.tenant_id, reviewer, min_level=2)" in src

--- a/tests/test_skill_schema_v1.py
+++ b/tests/test_skill_schema_v1.py
@@ -1084,7 +1084,7 @@ class TestMigrationChain:
         """
         chain = self._load()
         heads = set(chain) - {dr for dr in chain.values() if dr is not None}
-        assert heads == {"042"}, f"Expected single head '042', got {sorted(heads)}"
+        assert heads == {"043"}, f"Expected single head '043', got {sorted(heads)}"
 
     def test_skill_factory_chain_links(self):
         chain = self._load()
@@ -1134,6 +1134,10 @@ class TestMigrationChain:
         # 042: tenant_usage_counters.count >= 0 — a negative counter reads as
         # under-limit and disables plan enforcement for the tenant
         assert chain.get("042") == "041", "042 must follow 041"
+        # 043: human review state on memory_conflicts — the detector records what
+        # it concluded, nothing recorded what a person concluded, so precision was
+        # unmeasurable (D11).
+        assert chain.get("043") == "042", "043 must follow 042"
 
     def test_no_plain_set_not_null_on_large_tables(self):
         """Tightening a column to NOT NULL on a large table must not full-scan


### PR DESCRIPTION
## Detector precision has never been measurable

`memory_conflicts` has recorded what the **detector** concluded since A55. Nothing recorded what a **person** concluded — so in storage, a false positive is indistinguishable from a true one.

This is the read + decide half. No UI yet, deliberately: the API is verifiable on its own.

## What's here

| layer | change |
|---|---|
| model + migration `043` | `review_status`, `resolution_action`, `resolution_note`, `resolved_by`, `resolved_at`, + a `(tenant_id, review_status, created_at)` queue index |
| storage | `memory_conflicts_list` / `_get` / `_resolve` |
| core-api | `GET /conflicts`, `GET /conflicts/{id}`, `PATCH /conflicts/{id}/resolve` |

The detector's proposal (`action`, `audit_reason`) and the reviewer's decision (`resolution_action`, `resolution_note`) are **separate fields drawn from the same `ACTIONS` vocabulary**, so *"did the human agree"* is an equality check rather than a mapping exercise. Collapsing them would destroy the only record of the detector being wrong — a `dismissed` row is the system's sole false-positive signal.

## Design decisions worth your review

**Trust-plane, not admin-plane.** `enforce_admin` admits only the super-admin key, which would put review out of reach of the people who actually run a tenant. But plain tenant scope would let **any agent dismiss the contradictions it caused** — corrupting the exact ground truth this surface exists to collect. Gated on `require_trust(min_level=2)` (the keystone-author bar) plus `enforce_read_only`.

**Resolve is compare-and-set** on `review_status='pending'`, returning **409** when the row has moved. Two reviewers working one queue is the ordinary case, not the edge case; without the compare, the second decision silently overwrites the first and the audit trail records only the loser's disappearance.

**`pending` is rejected as a resolve target** — re-opening would erase the record of who decided what.

**Missing and foreign conflicts both answer 404**, so the route can't be used to probe which ids exist in other tenants. The single `403` is the trust gate, which fires *before* any lookup and so reveals nothing.

**Queue is oldest-first.** Newest-first leaves the oldest unreviewed rows permanently at the bottom — precisely the backlog a reviewer is trying to clear.

## Testing

16 unit tests. Full suite **6,326 passed**; **26 failures, identical to clean main with these changes stashed** (verified by stashing — local test-DB seeding, not this change).

The `authz_gate_inventory` and migration-chain guards both caught real omissions during development — an unclassified router and an unpinned head — and both are now satisfied rather than suppressed.

## ⚠ Deploy prerequisite

`contradiction_write_conflict_record` is **default OFF**, so `memory_conflicts` is empty in every environment. The queue renders empty until that flag is enabled. **Not flipped here** — that's a separate decision.

Refs: canonical D11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)