### PR TITLE
chore(installer): classify frozen plugin id

### DIFF
--- a/core-api/src/core_api/routes/plugin.py
+++ b/core-api/src/core_api/routes/plugin.py
@@ -504,10 +504,10 @@ const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
 
 if (!config.plugins) config.plugins = {{}};
 if (!Array.isArray(config.plugins.allow)) config.plugins.allow = [];
-if (!config.plugins.allow.includes('memclaw')) config.plugins.allow.push('memclaw');
+if (!config.plugins.allow.includes('memclaw')) config.plugins.allow.push('memclaw'); // legacy-name-ok: frozen plugin id; changing it makes restrictive allowlists refuse to load the plugin
 
 if (!config.plugins.entries) config.plugins.entries = {{}};
-config.plugins.entries.memclaw = {{ enabled: true, config: {{}} }};
+config.plugins.entries.memclaw = {{ enabled: true, config: {{}} }}; // legacy-name-ok: frozen plugin id; changing it leaves the manifest-id plugin disabled
 
 // Disable memory-core — OpenClaw only loads one kind:"memory" plugin at a time.
 // Without this, the memory slot stays with memory-core and register() is never called.
@@ -524,8 +524,8 @@ if (config.plugins.entries['memory-core']) {{
 // even though the tool surface is registered. Confirmed against
 // OpenClaw 2026.5.4 dist/registry-DFFgCbcm.js:241 resolveContextEngine.
 if (!config.plugins.slots) config.plugins.slots = {{}};
-config.plugins.slots.memory = 'memclaw';
-config.plugins.slots.contextEngine = 'memclaw';
+config.plugins.slots.memory = 'memclaw'; // legacy-name-ok: frozen plugin id; changing it loses the memory slot
+config.plugins.slots.contextEngine = 'memclaw'; // legacy-name-ok: frozen plugin id; changing it stops keystone injection
 
 if (!config.plugins.load) config.plugins.load = {{}};
 if (!Array.isArray(config.plugins.load.paths)) config.plugins.load.paths = [];


### PR DESCRIPTION
## What

Classify four emitted installer assignments as deliberate aliases for the frozen OpenClaw plugin id `memclaw`.

This PR is limited to the generated setup JavaScript. Transitional `skills/memclaw` paths and explanatory prose remain unclassified.

## Why these are permanent

The published manifest id is `memclaw` and is protected by the repository sentinel. The generated installer must write that same id into every id-keyed OpenClaw configuration surface:

- `plugins.allow`: with a restrictive allowlist, changing the value makes OpenClaw refuse to load the plugin.
- `plugins.entries.memclaw`: changing the key leaves the manifest-id plugin disabled.
- `plugins.slots.memory`: changing the value loses the memory runtime slot.
- `plugins.slots.contextEngine`: changing the value stops context-engine assembly and keystone injection.

Independent simplify review checked these statements against the manifest, `PLUGIN_ID` sentinel/test, and slot contract tests. The marker comments are emitted as valid JavaScript comments and do not change behavior.

## Census movement

Against current `caura@origin/main` immediately before this PR:

- unclassified: 135 -> 131
- deliberate aliases: 213 -> 217
- aggregate with current `caura-enterprise@origin/dev`: 779 -> 775
- cumulative aggregate if paired with caura#1388 and enterprise#1583: 779 -> 771
- positive controls: OSS 5,161 and enterprise 5,836 matching `caura` lines

The original brief baseline remains 782 unclassified at `caura@8b634a96` plus `caura-enterprise@e97eea1e`; this PR accounts for four of those baseline lines.

## Verification

- Ruff lint passed
- Ruff format check passed
- generated Bash and embedded ESM JavaScript syntax checks passed
- legacy-name ratchet: four annotated, zero added/removed, net -4
- do-not-touch sentinel: all 35 protected strings survive
- diff check clean

The three targeted integration-test modules were collected, but their shared session fixture could not authenticate to this host's local PostgreSQL test database. No credential or database state was changed; CI is the authoritative test run.

No ratchet behavior, lockfile, infrastructure, deployment, or gateway configuration changed.
