### PR TITLE
fix(extraction): keep bracketed qualifiers in canonical_name (A67)

### DIFF
--- a/core-api/src/core_api/services/entity_extraction.py
+++ b/core-api/src/core_api/services/entity_extraction.py
@@ -51,6 +51,20 @@ Rules:
   statement about a different subject, and the update would never supersede the
   value it replaces. Exactly one entity carries role=subject unless the content
   genuinely asserts facts about two independent subjects.
+- KEEP a bracketed qualifier the content attaches to a name. "Acme (Delaware)"
+  and "Acme (Ohio)" are two different organizations, so they are "acme
+  (delaware)" and "acme (ohio)" — never a bare "acme". Dropping the qualifier
+  collapses them into one entity, and every later statement about either is then
+  attributed to both. Each example below is a COMPLETE entity: the qualifier
+  rule changes the name, it never lets you omit entity_type or role.
+    "Acme (Delaware) filed in March."
+      {{"canonical_name": "acme (delaware)", "entity_type": "organization", "role": "subject"}}
+    "Acme (Ohio) filed in June."
+      {{"canonical_name": "acme (ohio)", "entity_type": "organization", "role": "subject"}}
+  Only qualifiers the CONTENT brackets. Do not invent one, and do not fold in
+  surrounding context that merely happens to be nearby — "Priya at AcmeCorp" is
+  still "priya", because the next mention of her may not carry the company and
+  the two must still resolve to one person.
 - relation_type: short verb phrase like works_on, uses, belongs_to, created_by, depends_on, manages, located_in
 - Extract every distinct named subject. Include identifiers (PR-2025-A, build-734), product codes (Vermillion-7), model names (gpt-5.4-nano), and version strings as entity_type=identifier or entity_type=artifact when they refer to a specific named thing.
 - Job titles (ceo, engineer, manager, director, officer) classify as entity_type=role — NOT person. Use entity_type=person only when a named individual is referenced (e.g., "Anna Bergstrom"). "the CEO" alone is a role; "Anna, the CEO" is one person entity plus one role entity.

--- a/tests/test_a67_bracketed_qualifiers_survive.py
+++ b/tests/test_a67_bracketed_qualifiers_survive.py
@@ -1,0 +1,106 @@
+"""A67 — a bracketed qualifier was dropped from the canonical name, so two
+different things with the same base name collapsed into one entity.
+
+``EXTRACTION_PROMPT`` said ``canonical_name: lowercase, no articles`` and
+nothing about qualifiers, so "Zylo (Delaware)" and "Zylo (Ohio)" both extracted
+as ``zylo``. Once they share an entity, every later statement about either is
+attributed to both, and a contradiction between two unrelated organizations
+looks like one organization contradicting itself.
+
+Measured against the live Vertex model, same seven sentences through both
+prompts, nothing else changed:
+
+    before   "Zylo (Delaware)"  -> zylo            "Zylo (Ohio)"  -> zylo
+             "Orbiter (v2)"     -> orbiter859085   "Orbiter (v3)" -> orbiter859085
+             -> 2/2 in-scope cases merged
+    after    -> zylo859085 (delaware) / (ohio), orbiter859085 (v2) / (v3)
+             -> 0/2 merged, and end-to-end 0/3 wrong with 0 fake fallbacks
+
+The NEGATIVE control matters as much as the fix: "Priya at AcmeCorp" and "Priya
+at BetaIndustries" must BOTH stay bare ``priya``. The qualifier has to be one
+the content brackets — folding in nearby context would split a single person
+across every employer she is ever mentioned alongside, which is the opposite
+failure and a worse one.
+
+One trap this rule already fell into once, hence
+``test_examples_are_complete_entities`` below: the first draft wrote its
+examples as ``-> canonical_name: acme (delaware)``, naming a single field. The
+model read that as the output shape and stopped emitting ``role``, which is a
+required ``str`` on ``ExtractedEntity`` — so ``_parse_graph_lenient`` dropped
+EVERY entity, ``_do_extract`` raised on the total loss, and extraction fell
+through to the regex heuristic. That heuristic emits bare canonical names, which
+is indistinguishable from the very bug under test. Examples in this block must
+therefore show a whole entity object.
+"""
+
+import json
+import re
+
+import pytest
+
+from core_api.services.entity_extraction import EXTRACTION_PROMPT, ExtractedEntity
+
+pytestmark = pytest.mark.unit
+
+
+def test_prompt_tells_the_model_to_keep_the_qualifier():
+    """The bug was the absence of any rule here, so its presence is the fix."""
+    assert "KEEP a bracketed qualifier" in EXTRACTION_PROMPT
+
+
+def test_prompt_explains_the_consequence_of_dropping_it():
+    """Keeps the next editor from trimming the paragraph as verbose: removing it
+    silently re-merges distinct entities."""
+    assert "collapses them into one entity" in EXTRACTION_PROMPT
+    assert "attributed to both" in EXTRACTION_PROMPT
+
+
+def test_prompt_carries_both_sides_of_a_worked_pair():
+    """A single example does not show that the qualifier DISCRIMINATES — the
+    pair does."""
+    assert "acme (delaware)" in EXTRACTION_PROMPT
+    assert "acme (ohio)" in EXTRACTION_PROMPT
+
+
+def test_rule_is_scoped_to_qualifiers_the_content_brackets():
+    """Without this bound the rule over-captures: "Priya at AcmeCorp" would
+    become a different person from "Priya at BetaIndustries", splitting one
+    human across every employer she is mentioned near."""
+    assert "Only qualifiers the CONTENT brackets" in EXTRACTION_PROMPT
+    assert "Do not invent one" in EXTRACTION_PROMPT
+    assert 'still "priya"' in EXTRACTION_PROMPT
+
+
+def test_examples_are_complete_entities():
+    """The regression that cost a full measurement round. Every JSON example in
+    the qualifier block must carry all three REQUIRED fields of
+    ``ExtractedEntity`` — an example listing only ``canonical_name`` teaches the
+    model to omit ``role``, and a payload missing a required field is dropped
+    item-by-item until nothing is left and extraction degrades to regex.
+
+    Required fields are read off the model rather than hard-coded, so adding a
+    required field to ``ExtractedEntity`` fails here instead of silently
+    reintroducing the same collapse.
+    """
+    block = EXTRACTION_PROMPT[EXTRACTION_PROMPT.index("KEEP a bracketed qualifier") :]
+    block = block[: block.index("- relation_type")]
+
+    # The prompt is a .format() template, so its literal braces are doubled.
+    examples = re.findall(r"\{\{(.*?)\}\}", block, re.S)
+    assert examples, "the qualifier rule lost its worked examples"
+
+    required = {
+        name for name, f in ExtractedEntity.model_fields.items() if f.is_required()
+    }
+    for raw in examples:
+        parsed = json.loads("{" + raw + "}")
+        missing = required - parsed.keys()
+        assert not missing, f"example omits required field(s) {missing}: {parsed}"
+
+
+def test_examples_use_a_role_the_prompt_offers():
+    """An example is only safe to copy if the value it demonstrates is legal."""
+    block = EXTRACTION_PROMPT[EXTRACTION_PROMPT.index("KEEP a bracketed qualifier") :]
+    block = block[: block.index("- relation_type")]
+    for raw in re.findall(r"\{\{(.*?)\}\}", block, re.S):
+        assert json.loads("{" + raw + "}")["role"] in {"subject", "object", "mentioned"}


### PR DESCRIPTION
## The bug

`EXTRACTION_PROMPT` specified `canonical_name: lowercase, no articles` and said nothing about qualifiers. A qualifier the content **brackets** — there precisely to say *which* thing is meant — was dropped, so two different things sharing a base name collapsed into one entity. Every later statement about either was then attributed to both, and a disagreement between two unrelated organizations reads as one organization contradicting itself.

## Measurement

Same sentences through both prompts against the live Vertex model, nothing else changed:

| Case | before (main) | after |
|---|---|---|
| `Zylo (Delaware)` / `Zylo (Ohio)` | `zylo` / `zylo` — **merged** | `zylo (delaware)` / `zylo (ohio)` |
| `Orbiter (v2)` / `Orbiter (v3)` | `orbiter` / `orbiter` — **merged** | `orbiter (v2)` / `orbiter (v3)` |
| `Priya at AcmeCorp` / `at BetaIndustries` (control) | `priya` / `priya` | `priya` / `priya` — unchanged |

End-to-end on a rebuilt stack: **0/3 cases wrong, 0 fake fallbacks, 0 dropped entities.**

## The bound is part of the fix

The rule covers only qualifiers the **content brackets**. Folding in nearby context would be the opposite failure and a worse one: `Priya at AcmeCorp` and `Priya at BetaIndustries` must both stay bare `priya`, because her next mention may carry no employer at all and all of them must still resolve to one person. That case is a negative control in both the repro and the tests.

## Why the examples are complete objects

Load-bearing, not stylistic. A first draft wrote them as `-> canonical_name: acme (delaware)`, naming a single field. The model read that as the output shape and **stopped emitting `role`** — a required `str` on `ExtractedEntity` — so `_parse_graph_lenient` dropped *every* entity, `_do_extract` raised on the total loss, and extraction fell through to the regex heuristic. That heuristic emits bare canonical names, which is indistinguishable from the very bug under test; it cost a full measurement round before the payload was captured. `test_examples_are_complete_entities` reads the required fields off the model, so adding a required field fails there rather than silently reintroducing the collapse.

## Testing

- 6 new unit tests pinning the rule, its bound, and the complete-example contract.
- Full suite: **27 failures, byte-identical to main's 27** (diffed by name) — none new.
- `ruff check` / `ruff format --check` clean on the changed files; `mypy src/` from `core-api/` matches main exactly.
- Wet-tested end to end on a rebuilt local stack with real Vertex extraction, with fake-fallback and dropped-entity counts verified at zero before trusting any number.

Closes **A68**, not A67.

A67 as filed is the **contextual** case — `Priya at AcmeCorp` vs `Priya at BetaIndustries`, where the discriminator is nearby context. That is exactly the case this change deliberately does *not* split, for the reason above, and it is the negative control here. A68 was split out for the bracketed variant this PR fixes; A67 stays open.

Also filed **A69** while measuring this: `ExtractedEntity.role` is a required `str`, so a payload omitting it on every entity collapses the whole extraction to the regex heuristic silently. Observed on `main` independently of this change (`"The billing service owner is Dana."` → `dropped={'entities': 2}`), same class as the `Mention.cluster_id` incident (#788).
