### PR TITLE
chore(installer): classify remaining plugin identities

### DIFF
--- a/core-api/src/core_api/services/agent_identity.py
+++ b/core-api/src/core_api/services/agent_identity.py
@@ -41,10 +41,10 @@ RESERVED_WRITE_ID_MESSAGE = (
     'agent_id "{agent_id}" is reserved and no longer accepts writes — it is the '
     "unset plugin default and collides across every install. Retry with a "
     "unique, STABLE agent_id for THIS install: (1) set CAURA_AGENT_ID in "
-    '~/.openclaw/plugins/memclaw/.env to a stable name (e.g. "webclaw") and '
+    '~/.openclaw/plugins/memclaw/.env to a stable name (e.g. "webclaw") and '  # legacy-name-floor: existing installed path; migrate before changing recovery guidance
     "restart the plugin; (2) or pass a unique agent_id argument on each write "
     'call now; (3) if you have no name, use "main-<install_id>" with '
-    "<install_id> from ~/.openclaw/plugins/memclaw/install.json. The id must "
+    "<install_id> from ~/.openclaw/plugins/memclaw/install.json. The id must "  # legacy-name-floor: existing installed path; migrate before changing recovery guidance
     "not be reserved and must be identical on every run. Recall and existing "
     "memories are unaffected."
 )

--- a/scripts/wet-test-install.sh
+++ b/scripts/wet-test-install.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 # ── Defaults ──
 BRANCH="main"
 REPO="git@github.com:caura-ai/caura.git"
-PLUGIN_DIR="$HOME/.openclaw/plugins/memclaw"
+PLUGIN_DIR="$HOME/.openclaw/plugins/memclaw"  # legacy-name-floor: standard install path; changing it creates a second copy instead of updating existing installs
 CAURA_API_URL=""
 CAURA_API_KEY=""
 CAURA_FLEET_ID=""
@@ -152,10 +152,10 @@ if [[ -f "$OPENCLAW_CONFIG" ]]; then
     // Ensure plugins section
     if (!config.plugins) config.plugins = {};
     if (!Array.isArray(config.plugins.allow)) config.plugins.allow = [];
-    if (!config.plugins.allow.includes('memclaw')) config.plugins.allow.push('memclaw');
+    if (!config.plugins.allow.includes('memclaw')) config.plugins.allow.push('memclaw'); // legacy-name-ok: frozen plugin id; restrictive allowlists require it
 
     if (!config.plugins.entries) config.plugins.entries = {};
-    config.plugins.entries.memclaw = { enabled: true };
+    config.plugins.entries.memclaw = { enabled: true }; // legacy-name-ok: frozen plugin id; this entry enables the manifest-id plugin
 
     if (!config.plugins.load) config.plugins.load = {};
     if (!Array.isArray(config.plugins.load.paths)) config.plugins.load.paths = [];


### PR DESCRIPTION
## Summary

- classify three exact installed-plugin path references as `legacy-name-floor`
- classify two OpenClaw configuration keys as `legacy-name-ok`
- reduce the OSS unclassified census from 129 to 124 on the refreshed branch

## Classification rationale

The two `agent_identity.py` paths are not aliases: they name the existing on-disk `.env` and `install.json` files used in recovery guidance. Renaming the text before migrating installations would direct users away from the real files, so they belong on the migration floor.

The wet installer default path is likewise a live installed path. Changing it would create or update a second plugin copy instead of the existing standard installation, so it is also a floor mention.

The two `memclaw` JavaScript keys are permanent aliases because the plugin manifest ID remains `memclaw`. Removing the allowlist value would make restrictive OpenClaw configurations reject the plugin; removing the `plugins.entries.memclaw` entry would stop enabling that manifest-ID plugin.

The remaining permanent aliases that cannot safely carry inline markers in Dockerfile ARG syntax, strict JSON, or the shipped skill hash remain explicitly classified in the brief-D ledger rather than being hidden from review.

## Verification

- `uv run --frozen ruff check core-api/src/core_api/services/agent_identity.py`
- `uv run --frozen ruff format --check core-api/src/core_api/services/agent_identity.py`
- `bash -n scripts/wet-test-install.sh`
- extracted embedded Node.js snippet parsed successfully
- `python3 scripts/do_not_touch_sentinel.py` — all 35 protected strings survive
- legacy-name census: 129 → 124 unclassified; same-shape `caura` control 5,242

The focused agent-identity pytest is locally blocked during setup by the checkout's PostgreSQL authentication; no credentials or database state were changed. CI is the authoritative integration check.
