### PR TITLE
feat(auth): give the caller identity its own type so stored data can't become one

### DIFF
--- a/core-api/src/core_api/agent_ids.py
+++ b/core-api/src/core_api/agent_ids.py
@@ -6,6 +6,28 @@ without importing each other — avoids the heavy/cross-private import that woul
 otherwise couple the route module to the whole MCP tool surface.
 """
 
+from typing import NewType
+
+# A caller identity that has been through authentication or resolution — not
+# merely a string that happens to hold an agent id. The distinction is
+# load-bearing rather than cosmetic: ``memory_access_allowed_for_agent`` decides
+# ``scope_agent`` access with ``owner_agent_id == caller_agent_id``, so a stored
+# row's own ``agent_id`` passed as the CALLER makes that comparison trivially
+# true and self-authorizes every access. Before this type both parameters were
+# ``str``, so nothing but review stopped it.
+#
+# Only the resolvers construct it, and ``tests/test_agent_identity_construction.py``
+# pins that list — a raw string cannot become an identity anywhere else. An
+# ``owner_agent_id`` read off a row deliberately stays ``str``: it is data, not
+# an identity, and giving the two the same type is what this prevents.
+#
+# NOT for audit attribution. ``AuthContext.effective_agent_id``'s docstring
+# draws that line and ``test_the_audit_attribution_is_not_bound_by_the_helper``
+# pins it: an attribution must record what the request carried even when
+# authorization ignored it, which is a different value from the identity
+# authorization used.
+AgentIdentity = NewType("AgentIdentity", str)
+
 # Reserved fallback identity used when a caller omits ``agent_id`` on the
 # single-tenant / standalone path. On the enterprise gateway this value is
 # explicitly refused (see ``mcp_server._refuse_default_agent_on_gateway``) so
@@ -66,7 +88,7 @@ ALWAYS_RESERVED_AGENT_IDS = frozenset({RESERVED_MAIN_AGENT_ID})
 _PLACEHOLDER_BODY_AGENT_IDS = frozenset({RESERVED_MAIN_AGENT_ID, DEFAULT_AGENT_ID})
 
 
-def effective_write_agent_id(verified_id: str | None, body_id: str | None) -> str | None:
+def effective_write_agent_id(verified_id: str | None, body_id: str | None) -> AgentIdentity | None:
     """Resolve the agent_id a WRITE is attributed to from the verified
     credential identity (gateway ``X-Agent-ID`` = ``home_agent_id``) and the
     client-supplied body id.
@@ -86,7 +108,31 @@ def effective_write_agent_id(verified_id: str | None, body_id: str | None) -> st
     write path, which already trusts the body unconditionally.
     """
     if verified_id and verified_id not in ALWAYS_RESERVED_AGENT_IDS:
-        return verified_id
+        return AgentIdentity(verified_id)
     if body_id and body_id not in _PLACEHOLDER_BODY_AGENT_IDS:
-        return body_id
-    return verified_id or body_id
+        return AgentIdentity(body_id)
+    # Reserved/placeholder fallthrough: still the resolved identity, and the
+    # write-path guard (policy=reject) is what refuses it downstream.
+    reserved = verified_id or body_id
+    # ``is not None`` so this stays a passthrough of the original
+    # ``return verified_id or body_id`` — truthiness here would turn an
+    # empty-string id into None and change what the write-path guard sees.
+    return AgentIdentity(reserved) if reserved is not None else None
+
+
+def effective_read_agent_id(verified_id: str | None, asserted_id: str) -> AgentIdentity:
+    """Resolve the identity a READ is authorized as, verified-id-first.
+
+    The read-side sibling of :func:`effective_write_agent_id`, and far simpler:
+    a read has no attribution to protect, so there is no reserved-placeholder
+    asymmetry — the gateway-verified id wins and the caller's asserted id is the
+    fallback. Total, because every MCP read tool defaults ``agent_id`` to
+    ``DEFAULT_AGENT_ID`` rather than accepting None.
+
+    Exists so the read path has ONE place that turns two strings into an
+    ``AgentIdentity``. It was written as ``_get_agent_id() or agent_id`` inline
+    at eight MCP call sites; the one that reaches ``enforce_fleet_read_many``
+    now routes through here instead. The remaining seven feed no authorization
+    sink and are deliberately left alone rather than swept.
+    """
+    return AgentIdentity(verified_id or asserted_id)

--- a/core-api/src/core_api/auth.py
+++ b/core-api/src/core_api/auth.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException, Request, Security
 from fastapi.security import APIKeyHeader
 
 from core_api import errors
+from core_api.agent_ids import AgentIdentity
 from core_api.config import settings
 from core_api.constants import API_KEY_HEADER
 from core_api.errors import coded_detail
@@ -54,7 +55,7 @@ class AuthContext:
         user_id: str | None = None,
         org_id: str | None = None,
         org_role: str | None = None,
-        agent_id: str | None = None,
+        agent_id: AgentIdentity | None = None,
         is_read_only: bool = False,
         is_install_credential: bool = False,
         install_uuid: str | None = None,
@@ -313,7 +314,7 @@ class AuthContext:
                 ),
             )
 
-    def effective_agent_id(self, requested_agent_id: str | None) -> str | None:
+    def effective_agent_id(self, requested_agent_id: str | None) -> AgentIdentity | None:
         """The agent this request ACTS AS: the authenticated identity, or the
         caller's assertion only when the credential authenticates none.
 
@@ -341,7 +342,12 @@ class AuthContext:
         ``test_the_audit_attribution_is_not_bound_by_the_helper``, so this
         paragraph is a rule rather than a request.
         """
-        return self.agent_id or requested_agent_id
+        resolved = self.agent_id or requested_agent_id
+        # ``is not None``, not truthiness: an explicit ``""`` assertion is
+        # PRESERVED here (pinned by test_auth_context.py), because
+        # ``enforce_self_agent`` treats it as an assertion and refuses it.
+        # Collapsing it to None would read as "no assertion" instead.
+        return AgentIdentity(resolved) if resolved is not None else None
 
     def enforce_tenant(self, requested_tenant: str | None) -> None:
         """Raise if the caller may not write to ``requested_tenant``.
@@ -522,8 +528,15 @@ async def get_auth_context(
 ) -> AuthContext:
     admin_key = get_admin_key()
     # Enterprise gateway injects X-Agent-ID when the caller's credential
-    # is agent-scoped (kind=agent_key).
-    agent_id = request.headers.get("x-agent-id") or None
+    # is agent-scoped (kind=agent_key). Constructed here rather than left a bare
+    # string because this header IS the REST plane's authentication boundary —
+    # the twin of ``mcp_server``'s ``_agent_id_var`` — and every ``AuthContext``
+    # built below carries this one value. This module is still on the mypy
+    # ``ignore_errors`` list, so nothing here would have forced the step; making
+    # it explicit is what keeps the boundary visible (and recorded in
+    # ``tests/test_agent_identity_construction.py``) until the exemption goes.
+    _agent_header = request.headers.get("x-agent-id") or None
+    agent_id = AgentIdentity(_agent_header) if _agent_header else None
     # Enterprise gateway injects X-Org-Read-Only: true when the org has
     # exceeded plan limits after a subscription cancellation. In standalone
     # and OSS-direct paths the header is absent, so enforcement is a no-op.

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -27,7 +27,12 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from common import duplicate_memory
 from common.enrichment.constants import SERVER_RESERVED_MEMORY_TYPES
-from core_api.agent_ids import DEFAULT_AGENT_ID, effective_write_agent_id
+from core_api.agent_ids import (
+    DEFAULT_AGENT_ID,
+    AgentIdentity,
+    effective_read_agent_id,
+    effective_write_agent_id,
+)
 from core_api.auth import get_admin_key
 from core_api.clients.storage_client import KeystoneUpsertPayload, get_storage_client
 from core_api.constants import (
@@ -114,7 +119,12 @@ logger = logging.getLogger(__name__)
 # ── Auth via context vars ──
 
 _tenant_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("mcp_tenant_id")
-_agent_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("mcp_agent_id", default=None)
+# Holds the gateway-verified ``X-Agent-ID``, so this ContextVar is the MCP
+# plane's twin of ``AuthContext.agent_id`` and its single construction point
+# for ``AgentIdentity``.
+_agent_id_var: contextvars.ContextVar[AgentIdentity | None] = contextvars.ContextVar(
+    "mcp_agent_id", default=None
+)
 # True iff X-Tenant-ID arrived as a request header (gateway-routed). On that
 # path the gateway is the source of truth for identity; falling back to the
 # literal "mcp-agent" tool-param default would silently attribute every write
@@ -388,7 +398,7 @@ class MCPAuthMiddleware:
             # and the delete trust gate. Use the value the resolution above
             # decided; only Path 4 sets it True.
             agent_header = headers.get(b"x-agent-id", b"").decode() if via_gateway else ""
-            _agent_id_var.set(agent_header or None)
+            _agent_id_var.set(AgentIdentity(agent_header) if agent_header else None)
 
             readable_header = headers.get(b"x-readable-tenant-ids", b"").decode() if via_gateway else ""
             if readable_header:
@@ -447,7 +457,7 @@ def _get_tenant() -> str:
     return _tenant_id_var.get(_UNAUTH)
 
 
-def _get_agent_id() -> str | None:
+def _get_agent_id() -> AgentIdentity | None:
     """Return the verified agent_id from X-Agent-ID header, or None."""
     return _agent_id_var.get(None)
 
@@ -988,7 +998,10 @@ async def caura_recall(
             t0,
         )
     tenant_id = _get_tenant()
-    agent_id = _get_agent_id() or agent_id  # prefer gateway-verified identity
+    # Gateway-verified identity wins. Routed through the shared resolver
+    # rather than inline because this one reaches ``enforce_fleet_read_many``
+    # below, so it must be an ``AgentIdentity`` and not a bare string.
+    agent_id = effective_read_agent_id(_get_agent_id(), agent_id)
     if refuse := _refuse_default_agent_on_gateway(agent_id):
         return _with_latency(refuse, t0)
     capped_top_k = min(top_k, MAX_SEARCH_TOP_K)

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -25,7 +25,7 @@ from fastapi.responses import JSONResponse
 from common import permanent_failure
 from common.enrichment.constants import SERVER_RESERVED_MEMORY_TYPES
 from core_api import openapi_responses as _oar
-from core_api.agent_ids import DEFAULT_AGENT_ID
+from core_api.agent_ids import DEFAULT_AGENT_ID, AgentIdentity
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import PermanentStorageWriteError, get_storage_client
 from core_api.config import settings as app_settings
@@ -519,7 +519,12 @@ async def memory_stats(
         agent_id,
         message=f"agent_id must be omitted or match the authenticated agent ('{auth.agent_id}').",
     )
-    caller_agent_id = auth.agent_id or agent_id
+    # Was the bare ``auth.agent_id or agent_id``. That is exactly the
+    # expression ``effective_agent_id`` exists to name (see its docstring:
+    # the bare form is indistinguishable from an audit-attribution line of
+    # the same shape), and this is the authorization identity — it gates
+    # ``enforce_fleet_read`` below. Same value, via the audited helper.
+    caller_agent_id = auth.effective_agent_id(agent_id)
     effective_agent_id = agent_id
     if scope is not None:
         # scope='fleet'/'all' drops the per-caller filter so cross-agent
@@ -1799,7 +1804,7 @@ async def update_memory_endpoint(
     )
 
 
-def _resolve_read_identity(auth: AuthContext, body: SearchRequest) -> tuple[str | None, bool]:
+def _resolve_read_identity(auth: AuthContext, body: SearchRequest) -> tuple[AgentIdentity | None, bool]:
     """Resolve the identity a search-shaped read runs as, refusing a spoof.
 
     Returns ``(eff_agent_id, identity_asserted)``.
@@ -1840,7 +1845,10 @@ def _resolve_read_identity(auth: AuthContext, body: SearchRequest) -> tuple[str 
     # callers are untouched. The filter itself is passed separately at the
     # callsite and is unchanged — it was already a distinct parameter all the way
     # down to the storage predicate; only the identity was derived from it.
-    eff_agent_id = auth.agent_id or body.caller_agent_id or body.filter_agent_id
+    asserted = body.caller_agent_id or body.filter_agent_id
+    # ``is not None`` keeps this an exact passthrough of the original
+    # ``auth.agent_id or body.caller_agent_id or body.filter_agent_id``.
+    eff_agent_id = auth.agent_id or (AgentIdentity(asserted) if asserted is not None else None)
     # True when the identity was ASSERTED by a tenant-scoped caller rather than
     # authenticated. Gates the recall_count bump — see the note at the callsite.
     identity_asserted = bool(not auth.agent_id and body.caller_agent_id)

--- a/core-api/src/core_api/services/agent_service.py
+++ b/core-api/src/core_api/services/agent_service.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from fastapi import HTTPException
 
+from core_api.agent_ids import AgentIdentity
 from core_api.clients.storage_client import get_storage_client
 from core_api.constants import DEFAULT_TRUST_LEVEL
 from core_api.services.audit_service import log_action
@@ -143,7 +144,7 @@ def _owned_by_other_install(owner_install_uuid: str | None, install_uuid: str | 
     return owner_install_uuid is not None and owner_install_uuid != install_uuid
 
 
-async def broker_owned_agent_id(chosen: str, install_uuid: str | None, tenant_id: str) -> str:
+async def broker_owned_agent_id(chosen: str, install_uuid: str | None, tenant_id: str) -> AgentIdentity:
     """Lenient ownership gate over a broker write's chosen agent id.
 
     A broker write may be attributed to an agent named by the caller (REST item
@@ -178,10 +179,10 @@ async def broker_owned_agent_id(chosen: str, install_uuid: str | None, tenant_id
             chosen,
             tenant_id,
         )
-        return chosen
+        return AgentIdentity(chosen)
     fallback = broker_label(install_uuid)
     if chosen == fallback:
-        return chosen
+        return AgentIdentity(chosen)
     # The ``broker:<install>`` namespace is RESERVED — an install may only ever
     # write as its OWN bare-install identity. A chosen id in that namespace that
     # isn't this install's own fallback (handled above) is *another* install's
@@ -190,13 +191,13 @@ async def broker_owned_agent_id(chosen: str, install_uuid: str | None, tenant_id
     # attacker could first-touch ``broker:<victim>`` (stamping itself as owner)
     # and thereby capture the victim's later degraded writes.
     if chosen.startswith(_BROKER_LABEL_PREFIX):
-        return fallback
+        return AgentIdentity(fallback)
     owner = await lookup_agent(tenant_id, chosen)
     if owner is None:
-        return chosen
+        return AgentIdentity(chosen)
     if _owned_by_other_install(owner.get("owner_install_uuid"), install_uuid):
-        return fallback
-    return chosen
+        return AgentIdentity(fallback)
+    return AgentIdentity(chosen)
 
 
 async def resolve_write_agent(
@@ -207,7 +208,7 @@ async def resolve_write_agent(
     is_install_credential: bool,
     install_uuid: str | None,
     require_approval: bool = False,
-) -> tuple[dict, str]:
+) -> tuple[dict, AgentIdentity]:
     """Resolve the agent a write is attributed to, enforcing the broker
     ownership boundary, and return ``(agent_row, safe_agent_id)``.
 
@@ -254,7 +255,7 @@ async def resolve_write_agent(
             require_approval=require_approval,
             owner_install_uuid=install_uuid,
         )
-    return agent, chosen_agent_id
+    return agent, AgentIdentity(chosen_agent_id)
 
 
 async def enforce_fleet_write(
@@ -281,7 +282,7 @@ async def enforce_fleet_write(
 
 async def enforce_fleet_read(
     tenant_id: str,
-    agent_id: str,
+    agent_id: AgentIdentity,
     fleet_id: str | None,
 ) -> None:
     """Enforce read permissions for search/list (read-only — never creates agents)."""
@@ -290,7 +291,7 @@ async def enforce_fleet_read(
 
 async def enforce_fleet_read_many(
     tenant_id: str,
-    agent_id: str,
+    agent_id: AgentIdentity,
     fleet_ids: Sequence[str | None],
 ) -> None:
     """Enforce read permissions for EVERY requested fleet.
@@ -421,9 +422,12 @@ async def resolve_read_fleet_gate(
 
 async def authorize_memory_access(
     tenant_id: str,
-    caller_agent_id: str | None,
+    caller_agent_id: AgentIdentity | None,
     *,
     visibility: str | None,
+    # Stays ``str``: this is the row's stored owner, i.e. data. Typing it
+    # ``AgentIdentity`` would let a caller identity and a stored value be used
+    # interchangeably, which is what the type exists to prevent.
     owner_agent_id: str | None,
     fleet_id: str | None,
     write: bool = False,
@@ -477,7 +481,7 @@ async def authorize_memory_access(
 
 def memory_access_allowed_for_agent(
     agent: dict | None,
-    caller_agent_id: str,
+    caller_agent_id: AgentIdentity,
     *,
     visibility: str | None,
     owner_agent_id: str | None,
@@ -507,7 +511,7 @@ def memory_access_allowed_for_agent(
 
 async def enforce_memory_read(
     tenant_id: str,
-    caller_agent_id: str | None,
+    caller_agent_id: AgentIdentity | None,
     memory: Any,
 ) -> None:
     """Raise 404 if ``caller_agent_id`` may not read ``memory`` (an ORM row).
@@ -529,7 +533,7 @@ async def enforce_memory_read(
 
 async def enforce_delete(
     tenant_id: str,
-    agent_id: str,
+    agent_id: AgentIdentity,
 ) -> None:
     """Enforce delete permissions for an AGENT credential.
 

--- a/core-api/src/core_api/services/caller_identity.py
+++ b/core-api/src/core_api/services/caller_identity.py
@@ -20,7 +20,7 @@ import logging
 
 from fastapi import HTTPException
 
-from core_api.agent_ids import DEFAULT_AGENT_ID
+from core_api.agent_ids import DEFAULT_AGENT_ID, AgentIdentity
 from core_api.auth import AuthContext
 from core_api.config import settings as app_settings
 from core_api.services.agent_service import broker_owned_agent_id
@@ -36,7 +36,7 @@ async def resolve_caller_and_gate(
     body_agent_id: str | None,
     scope: str,
     action: str,
-) -> str:
+) -> AgentIdentity:
     """Resolve the caller's ``agent_id`` and gate the write on trust.
 
     Precedence: gateway-verified ``auth.agent_id`` > ``body_agent_id`` >
@@ -66,7 +66,10 @@ async def resolve_caller_and_gate(
             auth.agent_id,
             body_agent_id,
         )
-    caller_agent_id = auth.agent_id or body_agent_id or DEFAULT_AGENT_ID
+    # The single construction point for this resolver: all three returns
+    # below hand back this value (or a broker-degraded one, itself already an
+    # AgentIdentity), so the identity is minted once, here.
+    caller_agent_id = AgentIdentity(auth.agent_id or body_agent_id or DEFAULT_AGENT_ID)
 
     if auth.is_admin:
         return caller_agent_id

--- a/tests/test_agent_identity_construction.py
+++ b/tests/test_agent_identity_construction.py
@@ -1,0 +1,190 @@
+"""``AgentIdentity`` is only worth having if a raw string cannot become one.
+
+The type marks a caller identity that has been through authentication or
+resolution. What makes that more than documentation is the pair of invariants
+below, and they cover each other:
+
+* **Construction is confined to the resolvers.** Without this, every call site
+  could write ``AgentIdentity(whatever)`` and the type would be a cast ritual
+  that reads as a guarantee.
+
+* **The sinks still ask for it.** An allow-list alone passes trivially if
+  someone widens a sink's parameter back to ``str`` — nothing would be
+  constructed, nothing would be violated, and the guarantee would be gone with
+  every test still green. (Same mutual-coverage shape as the two error-code
+  invariants in ``tests/test_tool_error_codes_inventory.py``: a narrowing scan
+  satisfies one invariant silently and is caught only by the other.)
+
+The property being protected is concrete. ``memory_access_allowed_for_agent``
+decides ``scope_agent`` access with ``owner_agent_id == caller_agent_id``, so a
+stored row's own ``agent_id`` passed as the CALLER makes that comparison
+trivially true and self-authorizes every access. Before this type both
+parameters were ``str | None`` and the swap type-checked; the third test below
+pins the asymmetry that keeps them distinguishable.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import core_api
+
+SRC = pathlib.Path(core_api.__file__).parent
+
+# Every place a raw string may legitimately become an identity: the gateway /
+# header boundary, and the resolvers that apply a precedence rule. Adding an
+# entry here is a deliberate act — it is a new place where an unvalidated
+# string is asserted to be an authenticated identity, which is exactly the
+# decision that should not be made silently in review.
+ALLOWED_CONSTRUCTORS: frozenset[tuple[str, str]] = frozenset(
+    {
+        # Write-side precedence (verified id wins unless reserved).
+        ("agent_ids.py", "effective_write_agent_id"),
+        # Read-side precedence (verified id wins, asserted id falls back).
+        ("agent_ids.py", "effective_read_agent_id"),
+        # REST: the authenticated identity, or a caller's assertion when the
+        # credential authenticates none.
+        ("auth.py", "AuthContext.effective_agent_id"),
+        # REST: the gateway-verified X-Agent-ID header boundary. ``core_api.auth``
+        # is still mypy-exempt, so this construction is what makes the boundary
+        # explicit rather than an unchecked bare string.
+        ("auth.py", "get_auth_context"),
+        # MCP: the gateway-verified X-Agent-ID header boundary — the MCP plane's
+        # twin of AuthContext.agent_id.
+        ("mcp_server.py", "MCPAuthMiddleware.__call__"),
+        # REST read identity (auth > body.caller_agent_id > body.filter_agent_id).
+        ("routes/memories.py", "_resolve_read_identity"),
+        # Broker ownership boundary: degrades a foreign id to this install's own.
+        ("services/agent_service.py", "broker_owned_agent_id"),
+        # Write attribution, after the ownership boundary.
+        ("services/agent_service.py", "resolve_write_agent"),
+        # Evolve/insights caller resolution + trust gate.
+        ("services/caller_identity.py", "resolve_caller_and_gate"),
+    }
+)
+
+# The authorization sinks, and the parameter that must be an identity rather
+# than any string. ``owner_agent_id`` is deliberately absent — see
+# ``test_owner_agent_id_is_not_an_identity``.
+IDENTITY_SINKS: dict[str, str] = {
+    "enforce_fleet_read": "agent_id",
+    "enforce_fleet_read_many": "agent_id",
+    "enforce_delete": "agent_id",
+    "enforce_memory_read": "caller_agent_id",
+    "authorize_memory_access": "caller_agent_id",
+    "memory_access_allowed_for_agent": "caller_agent_id",
+}
+
+
+def _qualname_stack(tree: ast.AST) -> list[tuple[str, ast.Call]]:
+    """Every ``AgentIdentity(...)`` call with its dotted enclosing scope."""
+    found: list[tuple[str, ast.Call]] = []
+    stack: list[str] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "AgentIdentity":
+                found.append((".".join(stack) or "<module>", node))
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return found
+
+
+def _sources() -> list[tuple[str, ast.Module]]:
+    out = []
+    for path in sorted(SRC.rglob("*.py")):
+        try:
+            out.append((str(path.relative_to(SRC)), ast.parse(path.read_text())))
+        except SyntaxError:  # pragma: no cover - a syntax error fails elsewhere
+            continue
+    return out
+
+
+def test_agent_identity_is_constructed_only_by_the_resolvers() -> None:
+    actual = {
+        (rel, scope) for rel, tree in _sources() for scope, _ in _qualname_stack(tree)
+    }
+    unexpected = actual - ALLOWED_CONSTRUCTORS
+    assert not unexpected, (
+        "AgentIdentity is constructed outside the identity resolvers:\n  "
+        + "\n  ".join(f"{rel}::{scope}" for rel, scope in sorted(unexpected))
+        + "\n\nA raw string became an authenticated identity here. Either route the "
+        "value through an existing resolver, or — if this really is a new identity "
+        "boundary — add it to ALLOWED_CONSTRUCTORS with a comment saying why."
+    )
+
+
+def test_the_authorization_sinks_still_require_an_identity() -> None:
+    """Without this, widening a sink back to ``str`` would pass silently."""
+    seen: dict[str, str] = {}
+    for _rel, tree in _sources():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            if node.name not in IDENTITY_SINKS:
+                continue
+            want = IDENTITY_SINKS[node.name]
+            args = node.args.posonlyargs + node.args.args + node.args.kwonlyargs
+            for arg in args:
+                if arg.arg == want:
+                    seen[node.name] = (
+                        ast.unparse(arg.annotation) if arg.annotation else "<none>"
+                    )
+
+    missing = set(IDENTITY_SINKS) - set(seen)
+    assert not missing, f"sink(s) not found — renamed or removed? {sorted(missing)}"
+
+    widened = {name: anno for name, anno in seen.items() if "AgentIdentity" not in anno}
+    assert not widened, (
+        "authorization sink(s) no longer require an AgentIdentity:\n  "
+        + "\n  ".join(
+            f"{n}({IDENTITY_SINKS[n]}: {a})" for n, a in sorted(widened.items())
+        )
+        + "\n\nWidening these to ``str`` removes the guarantee without failing "
+        "anything else: nothing would be constructed, so the allow-list test "
+        "above would still pass."
+    )
+
+
+def test_owner_agent_id_is_not_an_identity() -> None:
+    """The asymmetry IS the security property, so it is pinned explicitly.
+
+    ``owner_agent_id`` is read off a stored row: it is data. Giving it the same
+    type as the caller would make the two interchangeable again — and
+    ``scope_agent`` access is decided by comparing them.
+    """
+    checked = 0
+    for _rel, tree in _sources():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            args = node.args.posonlyargs + node.args.args + node.args.kwonlyargs
+            for arg in args:
+                if arg.arg != "owner_agent_id":
+                    continue
+                anno = ast.unparse(arg.annotation) if arg.annotation else "<none>"
+                checked += 1
+                assert "AgentIdentity" not in anno, (
+                    f"{node.name}(owner_agent_id: {anno}) — a stored row's owner is "
+                    "data, not an authenticated identity. Typing it the same as "
+                    "caller_agent_id makes them interchangeable, and scope_agent "
+                    "access is decided by comparing the two."
+                )
+    assert checked >= 2, (
+        f"expected to check at least the two authorize/predicate parameters, saw {checked}"
+    )


### PR DESCRIPTION
## The bug class this closes

`authorize_memory_access` takes two agent ids, and they are different *kinds* of thing:

| parameter | where it comes from |
|---|---|
| `caller_agent_id` | `auth.agent_id`, `_get_agent_id()`, a resolver — **authenticated** |
| `owner_agent_id` | `memory.get("agent_id")`, `mem.get("agent_id")`, `getattr(memory, "agent_id", None)` — **a stored row** |

Both were `str | None`. And `memory_access_allowed_for_agent` decides `scope_agent` access with:

```python
if visibility == "scope_agent":
    return owner_agent_id == caller_agent_id
```

Pass a row's own `agent_id` as the **caller** and this returns `True` unconditionally — every access self-authorizes. A full silent bypass, and the signatures permitted it exactly.

`AgentIdentity` is a `NewType` over `str` for the authenticated caller. `owner_agent_id` **deliberately stays `str`** — it is data, and giving the two the same type is the confusion being prevented.

`NewType` is the identity function at runtime, so the *type* is runtime-neutral. The **rewrite was not**, and that is worth reading closely: constructing the type needs a None test, and the obvious `if resolved else None` turns an empty-string id into `None` in three resolvers.

`effective_agent_id` is pinned for exactly that input — `(None, "", "")` — because `enforce_self_agent` treats an explicit `""` as an **assertion** and refuses it, so collapsing it to `None` reads as *no assertion*. An existing test caught that one. `_resolve_read_identity` takes `caller_agent_id` straight off the request body with no `min_length`, so `""` is reachable there **from the wire** and was not covered by any test. All three now test `is not None` and are exact passthroughs.

> Note on what was *already* safe: transposing the two arguments was impossible before this change, because `owner_agent_id` is keyword-only. The `*` was already doing that job. This closes the other direction — a stored value passed *as* the caller.

## Why producers and sinks are one commit

Typing the five sinks alone leaves **20 mypy errors** (measured, not assumed), so a split would be red in CI. Nine `(file, function)` pairs may construct an identity; everything else receives one. `tests/test_agent_identity_construction.py` pins that list.

## Two corrections to the original plan

**`resolve_caller_and_gate` was on the sink list; it is a producer.** Its parameter is `body_agent_id` — the client's own claim — and it *returns* the resolved id. Typing that parameter `AgentIdentity` would have asserted that client input is authenticated, exactly backwards. Five sinks, not six.

**The MCP plane needed no design decision.** Its producer is `_agent_id_var`, the ContextVar holding the gateway-verified `X-Agent-ID` — the structural twin of `AuthContext.agent_id`. Typing it binds all eight MCP sites at once rather than needing eight casts.

## What the type found

Two sites resolved identity inline rather than through a resolver, so neither could be typed without a cast:

- **`routes/memories.py`** wrote the bare `auth.agent_id or agent_id` and fed it to `enforce_fleet_read`. That is *verbatim* the expression `AuthContext.effective_agent_id` exists to name — its docstring says the bare form "could not be told from an audit-log line of the same shape", and that `tests/test_authz_gate_inventory.py` **had to delete the rule that credited it**. Now calls the helper: identical value, one fewer bypass.
- **`mcp_server`** wrote `_get_agent_id() or agent_id` at eight sites. The one reaching `enforce_fleet_read_many` now routes through a new `effective_read_agent_id`, the read-side sibling of the existing `effective_write_agent_id`. The other seven feed no authorization sink and are **deliberately left alone** rather than swept.

## What was deliberately NOT typed

Three bare-form sites are **audit attributions**: `attribution_agent_id`, `conflicts.reviewer`, `skills_inbox.rejected_by_agent`. `effective_agent_id`'s docstring draws that line and `test_the_audit_attribution_is_not_bound_by_the_helper` pins it — an attribution records what the request carried *even when authorization ignored it*, which is a different value. Sweeping them would have broken that test and changed what the audit log records.

## One honest limitation

`core_api.auth` is still on the `ignore_errors` list, so nothing there forces the header-to-identity step. It is written explicitly anyway, at the single place `X-Agent-ID` is read, so the REST boundary is visible and recorded rather than an unchecked bare string. The signature still binds every *consumer* outside that module — which is why the REST sites type-check at all.

## Payoff, measured before starting

**32 of 34** sink call sites (94%) are now mypy-checked, against **7 of 32** before #1384 un-exempted `mcp_server`. The two blind ones are `routes.fleet:807` and `services.memory_service:3425` — un-exempting those first would have bought 2 sites of 34, so it was not worth doing first.

## Verification

- `mypy src/` clean (local baseline is 2 pre-existing `import-untyped` errors in `common/enrichment/service.py`, a stub package missing from the local venv).
- **Three mutation probes, all firing from a green baseline:** a construction outside the allow-list; a sink widened back to `str`; `owner_agent_id` given the caller's type. The last two matter because the allow-list alone passes trivially if the type is removed — nothing is constructed, so nothing is violated. Same mutual-coverage shape as the two error-code invariants in #1378.
- Root suite green.
- `ruff check` and `ruff format --check` clean on `core-api/src/` and `tests/`, each scope run separately.
- `scripts/legacy_name_ratchet.py --base origin/main` and `scripts/do_not_touch_sentinel.py` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
