### PR TITLE
refactor(routes): pass the write identity down instead of re-reading a nullable field

### DIFF
--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -1067,9 +1067,17 @@ async def write_memory(
     # anonymous write would collapse onto one shared identity — the same footgun
     # mcp_server._refuse_default_agent_on_gateway guards against. Keep that as an
     # explicit 422 rather than a silent default.
-    if not body.agent_id:
+    #
+    # Bound to a local so the narrowing SURVIVES: ``model_copy`` rebinds
+    # ``body`` and the field stays ``str | None`` on the model, so re-reading
+    # ``body.agent_id`` in the inner function threw the guarantee away and
+    # needed a ``type: ignore`` there. Passed down instead — see
+    # ``_write_memory_inner``'s ``chosen_agent_id``.
+    chosen_agent_id = body.agent_id
+    if not chosen_agent_id:
         if app_settings.is_standalone:
-            body = body.model_copy(update={"agent_id": DEFAULT_AGENT_ID})
+            chosen_agent_id = DEFAULT_AGENT_ID
+            body = body.model_copy(update={"agent_id": chosen_agent_id})
         else:
             raise _missing_agent_id_error()
     # Idempotency replay is short-circuited BEFORE the per-tenant slot —
@@ -1101,7 +1109,7 @@ async def write_memory(
     # queueing requests until they time out at the worker layer. Only
     # the new-write path is gated; replays returned above bypass it.
     async with per_tenant_slot("write", body.tenant_id):
-        return await _write_memory_inner(body, response, auth, _idem)
+        return await _write_memory_inner(body, response, auth, _idem, chosen_agent_id)
 
 
 async def _write_memory_inner(
@@ -1109,6 +1117,11 @@ async def _write_memory_inner(
     response: Response,
     auth: AuthContext,
     idem: IdempotencyGuard | None,
+    # The write identity the caller asked for, already guarded non-None by
+    # ``write_memory``. Deliberately ``str``, not ``AgentIdentity``: this is
+    # the caller's CLAIM, and ``resolve_write_agent`` is what turns a
+    # claim into an identity.
+    chosen_agent_id: str,
 ):
     from core_api.services.organization_settings import resolve_config
 
@@ -1117,22 +1130,13 @@ async def _write_memory_inner(
     # ignoring a client-supplied body override. Enable ONLY after reserved-
     # `main` creds are re-identified, else it pins them back onto `main`.
     if app_settings.bind_write_identity_to_auth and auth.agent_id:
+        chosen_agent_id = auth.agent_id
         body.agent_id = auth.agent_id
     # Ownership boundary (gate + owner stamp + post-create re-check), shared
     # with the bulk path so a broker single-write can't attribute a memory to
     # an agent owned by a different install.
-    #
-    # ``body.agent_id`` is non-None here: write_memory either filled the
-    # reserved standalone identity or raised ``_missing_agent_id_error``. The
-    # guard is in that outer function, so no narrowing reaches this one.
-    #
-    # Deliberately not ``or DEFAULT_AGENT_ID``: outside standalone that would
-    # silently attribute an anonymous write to the one shared identity, which
-    # is the exact footgun the guard raises to prevent. An ignore keeps the
-    # refusal where it belongs; the structural fix is for this function to take
-    # the resolved id as a parameter instead of re-reading a nullable field.
     agent, body.agent_id = await resolve_write_agent(
-        body.agent_id,  # type: ignore[arg-type]
+        chosen_agent_id,
         body.tenant_id,
         body.fleet_id,
         is_install_credential=auth.is_install_credential,
@@ -1282,9 +1286,17 @@ async def write_memories_bulk(
     # reserved standalone identity or must name a real agent. Defaulting
     # outside standalone would silently collapse anonymous writes onto one
     # shared identity — see mcp_server._refuse_default_agent_on_gateway.
-    if not body.agent_id:
+    #
+    # Bound to a local so the narrowing SURVIVES: ``model_copy`` rebinds
+    # ``body`` and the field stays ``str | None`` on the model, so re-reading
+    # ``body.agent_id`` in the inner function threw the guarantee away and
+    # needed a ``type: ignore`` there. Passed down instead — see
+    # ``_write_memories_bulk_inner``'s ``chosen_agent_id``.
+    chosen_agent_id = body.agent_id
+    if not chosen_agent_id:
         if app_settings.is_standalone:
-            body = body.model_copy(update={"agent_id": DEFAULT_AGENT_ID})
+            chosen_agent_id = DEFAULT_AGENT_ID
+            body = body.model_copy(update={"agent_id": chosen_agent_id})
         else:
             raise _missing_agent_id_error()
     if not bulk_attempt_id:
@@ -1312,7 +1324,7 @@ async def write_memories_bulk(
         # carry on the cached response.
         return JSONResponse(content=_body, status_code=_status)
     async with per_tenant_slot("write", body.tenant_id):
-        return await _write_memories_bulk_inner(body, response, auth, _idem, bulk_attempt_id)
+        return await _write_memories_bulk_inner(body, response, auth, _idem, bulk_attempt_id, chosen_agent_id)
 
 
 def _broker_write_agent_id(items: list[BulkMemoryItem], install_uuid: str | None) -> str:
@@ -1371,11 +1383,17 @@ async def _write_memories_bulk_inner(
     auth: AuthContext,
     idem: IdempotencyGuard | None,
     bulk_attempt_id: str,
+    # The write identity the caller asked for, already guarded non-None by
+    # ``write_memories_bulk``. Deliberately ``str``, not ``AgentIdentity``: this is
+    # the caller's CLAIM, and ``resolve_write_agent`` is what turns a
+    # claim into an identity.
+    chosen_agent_id: str,
 ):
     # Phase 2 (dark, default off): bind to the verified credential identity
     # (see _write_memory_inner). Enabled only post-re-identification. Runs
     # before resolve_write_agent so the gate/stamp apply to the bound identity.
     if app_settings.bind_write_identity_to_auth and auth.agent_id:
+        chosen_agent_id = auth.agent_id
         body.agent_id = auth.agent_id
     # Ownership boundary (gate + owner stamp + post-create re-check), shared
     # with the single-write path.
@@ -1387,18 +1405,8 @@ async def _write_memories_bulk_inner(
     # auto-registers many agents from item metadata; gating each on admin
     # approval would create trust-0 rows and 403 whole batches, breaking capture.
     # Per-agent approval is an interactive / single-agent concern.
-    #
-    # ``body.agent_id`` is non-None here: write_memories_bulk either filled the
-    # reserved standalone identity or raised ``_missing_agent_id_error``. The
-    # guard is in that outer function, so no narrowing reaches this one.
-    #
-    # Deliberately not ``or DEFAULT_AGENT_ID``: outside standalone that would
-    # silently attribute an anonymous write to the one shared identity, which
-    # is the exact footgun the guard raises to prevent. An ignore keeps the
-    # refusal where it belongs; the structural fix is for this function to take
-    # the resolved id as a parameter instead of re-reading a nullable field.
     agent, body.agent_id = await resolve_write_agent(
-        body.agent_id,  # type: ignore[arg-type]
+        chosen_agent_id,
         body.tenant_id,
         body.fleet_id,
         is_install_credential=auth.is_install_credential,

--- a/tests/test_broker_write_ownership.py
+++ b/tests/test_broker_write_ownership.py
@@ -29,6 +29,7 @@ import pytest
 from fastapi import Response
 
 from core_api import mcp_server
+from core_api.agent_ids import AgentIdentity
 from core_api.auth import AuthContext
 from core_api.config import settings as app_settings
 from core_api.routes import memories
@@ -39,12 +40,16 @@ pytestmark = pytest.mark.unit
 
 
 def _broker_auth(
-    install_uuid: str | None = "install-1", *, is_install: bool = True
+    install_uuid: str | None = "install-1",
+    *,
+    is_install: bool = True,
+    agent_id: str | None = None,
 ) -> AuthContext:
     return AuthContext(
         tenant_id="tenant-1",
         is_install_credential=is_install,
         install_uuid=install_uuid,
+        agent_id=AgentIdentity(agent_id) if agent_id is not None else None,
     )
 
 
@@ -180,10 +185,12 @@ async def test_resolve_passes_require_approval(monkeypatch):
 # ── REST end-to-end: both routes attribute through resolve_write_agent ───
 
 
-async def _drive_single(monkeypatch, *, agent_id, auth, gate_owner, created_owner):
+async def _drive_single(
+    monkeypatch, *, agent_id, auth, gate_owner, created_owner, bind_identity=False
+):
     """Drive ``_write_memory_inner`` with storage/metering mocked; return the
     agent id that reaches ``create_memory``."""
-    monkeypatch.setattr(app_settings, "bind_write_identity_to_auth", False)
+    monkeypatch.setattr(app_settings, "bind_write_identity_to_auth", bind_identity)
     monkeypatch.setattr(
         "core_api.services.organization_settings.resolve_config",
         AsyncMock(return_value=SimpleNamespace(require_agent_approval=False)),
@@ -220,14 +227,16 @@ async def _drive_single(monkeypatch, *, agent_id, auth, gate_owner, created_owne
     monkeypatch.setattr(memories, "create_memory", _create)
     body = MemoryCreate(tenant_id="tenant-1", agent_id=agent_id, content="hello world")
     with pytest.raises(_Sentinel):
-        await memories._write_memory_inner(body, Response(), auth, None)
+        await memories._write_memory_inner(body, Response(), auth, None, agent_id)
     return captured["agent_id"]
 
 
-async def _drive_bulk(monkeypatch, *, agent_id, auth, gate_owner, created_owner):
+async def _drive_bulk(
+    monkeypatch, *, agent_id, auth, gate_owner, created_owner, bind_identity=False
+):
     """Drive ``_write_memories_bulk_inner`` with storage/metering mocked; return
     the agent id that reaches ``create_memories_bulk``."""
-    monkeypatch.setattr(app_settings, "bind_write_identity_to_auth", False)
+    monkeypatch.setattr(app_settings, "bind_write_identity_to_auth", bind_identity)
     monkeypatch.setattr(
         agent_service,
         "lookup_agent",
@@ -260,7 +269,7 @@ async def _drive_bulk(monkeypatch, *, agent_id, auth, gate_owner, created_owner)
     )
     with pytest.raises(_Sentinel):
         await memories._write_memories_bulk_inner(
-            body, Response(), auth, None, "attempt-1"
+            body, Response(), auth, None, "attempt-1", agent_id
         )
     return captured["agent_id"]
 
@@ -399,3 +408,48 @@ async def test_mcp_write_passes_credential_identity(mcp_env, monkeypatch):
         await mcp_server.caura_write(content="x", agent_id="a1")
     assert captured["is_install"] is True
     assert captured["install_uuid"] == "install-7"
+
+
+# ── Phase 2: bind_write_identity_to_auth ─────────────────────────────────────
+# The flag ships dark, and nothing exercised it ENABLED — every other reference
+# in the suite sets it False or discusses it in prose. So the override could
+# have silently become a no-op and the suite would have stayed green. It is a
+# spoof-hardening control: when on, the verified credential identity wins over
+# whatever the body named, so what these pin is that the BODY's id does not
+# reach ``resolve_write_agent``.
+
+
+async def test_phase2_binds_the_verified_identity_over_the_body_single(monkeypatch):
+    agent_id = await _drive_single(
+        monkeypatch,
+        agent_id="body-claimed-agent",
+        auth=_broker_auth(None, is_install=False, agent_id="verified-agent"),
+        gate_owner=None,
+        created_owner=None,
+        bind_identity=True,
+    )
+    assert agent_id == "verified-agent"
+
+
+async def test_phase2_binds_the_verified_identity_over_the_body_bulk(monkeypatch):
+    agent_id = await _drive_bulk(
+        monkeypatch,
+        agent_id="body-claimed-agent",
+        auth=_broker_auth(None, is_install=False, agent_id="verified-agent"),
+        gate_owner=None,
+        created_owner=None,
+        bind_identity=True,
+    )
+    assert agent_id == "verified-agent"
+
+
+async def test_phase2_off_leaves_the_body_identity_alone_single(monkeypatch):
+    """The other half of the flag: dark by default, so the body still wins."""
+    agent_id = await _drive_single(
+        monkeypatch,
+        agent_id="body-claimed-agent",
+        auth=_broker_auth(None, is_install=False, agent_id="verified-agent"),
+        gate_owner=None,
+        created_owner=None,
+    )
+    assert agent_id == "body-claimed-agent"


### PR DESCRIPTION
## What

Removes both `type: ignore[arg-type]` that #1387 added, by doing what its own comment said the fix was: have the inner write functions **take** the resolved identity instead of re-reading `body.agent_id`.

## Why the ignores existed

The invariant was always true — `write_memory` / `write_memories_bulk` either fill the reserved standalone identity or raise `_missing_agent_id_error`. It just could not be *checked*: the guard is in the outer function and the call is in the inner one, the field stays `str | None` on the model, and the standalone branch rebinds `body` via `model_copy`.

Binding the guarded value to a local is what fixes it — the narrowing then survives both the rebind and the function boundary:

```python
chosen_agent_id = body.agent_id
if not chosen_agent_id:
    if app_settings.is_standalone:
        chosen_agent_id = DEFAULT_AGENT_ID
        body = body.model_copy(update={"agent_id": chosen_agent_id})
    else:
        raise _missing_agent_id_error()
```

The parameter is deliberately `str` and **not** `AgentIdentity`. At that point it is still the caller's *claim*; `resolve_write_agent` is what turns a claim into an identity. Typing it `AgentIdentity` would assert the opposite of what is true there.

The long comment at each call site is **gone rather than moved**. It warned against "fixing" the ignore with `or DEFAULT_AGENT_ID`; with a non-optional parameter there is no ignore to fix, and the reason the outer guard raises instead of defaulting is already stated in the outer function where that decision is made.

Worth knowing: `warn_unused_ignores = false`, so nothing would have flagged those ignores as stale. Removing them was deliberate, not prompted by a failure.

## A gap this refactor exposed

Both inner functions apply a dark Phase 2 override, and the new local has to be rebound there too:

```python
if app_settings.bind_write_identity_to_auth and auth.agent_id:
    chosen_agent_id = auth.agent_id   # <- added here
    body.agent_id = auth.agent_id
```

Forgetting that line would leave `body.agent_id` assigned — so the flag would still **look** applied — while `resolve_write_agent` received the body's original claim. The spoof-hardening control would be a no-op.

**Nothing in the suite exercised this flag enabled.** Every existing reference sets it `False` or discusses it in prose, so that regression would have been silent and green.

Three tests now cover it:

| test | pins |
|---|---|
| `..._over_the_body_single` | verified identity beats the body's claim, single write |
| `..._over_the_body_bulk` | same on the bulk path |
| `test_phase2_off_leaves_the_body_identity_alone_single` | dark by default — the body's claim still wins |

Both "enabled" tests fail without the rebind, asserting `'body-claimed-agent' == 'verified-agent'` — the no-op made visible. The flag ships dark, so this is the first coverage it has had.

## Verification

- `mypy src/` clean **with both ignores removed** (local baseline is 2 pre-existing `import-untyped` errors in `common/enrichment/service.py`).
- **Two structural probes, from a baseline of 0 errors:** re-reading the field at the call site errors, and so does passing `body.agent_id` from the *outer* function. The second is the one that matters — it shows the guarded local, not the parameter by itself, is doing the work.
- **Both new "enabled" tests fail without the rebind** they cover.
- Root suite green.
- `ruff check` and `ruff format --check` clean on `core-api/src/` and `tests/`, each scope run separately.
- `scripts/legacy_name_ratchet.py --base origin/main` and `scripts/do_not_touch_sentinel.py` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
