### PR TITLE
docs: add a docs/ index and link plugin-upgrade.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ The plugin claims OpenClaw's `memory` slot and exposes the same agent-facing
 memory tools. Use the
 [agent installer's one-line setup](AGENT-INSTALL.md#connect-via-openclaw-plugin-alternative-to-mcp),
 then see the [OpenClaw integration guide](static/docs/integration-guide.md) for
-agent prompts and trust levels.
+agent prompts and trust levels. Already have nodes running? Keeping them current
+— auto-upgrade and the manual re-install — is covered in
+[`docs/plugin-upgrade.md`](docs/plugin-upgrade.md).
 
 ### Python client
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,54 @@
+# Documentation index
+
+Operator and integrator guides that ship with the repo. Start at the root
+[`README.md`](../README.md) for what Caura is and a first run;
+[`AGENT-INSTALL.md`](../AGENT-INSTALL.md) is the shortest path to a connected
+agent.
+
+## Operating a deployment
+
+- [`self-hosting.md`](self-hosting.md) — the complete self-hosted guide:
+  provider configuration, authentication modes, service topology, security,
+  offline operation, and tests.
+- [`local-embedder.md`](local-embedder.md) — serve embeddings from a TEI
+  sidecar instead of a hosted API, for semantic search with no cloud calls.
+- [`performance.md`](performance.md) — the benchmark numbers at operator scale:
+  what to expect in your own system, and what the numbers cannot tell you.
+- [`operator-forge-cron.md`](operator-forge-cron.md) — driving the Skill
+  Factory's Forge and promoter ticks from an external scheduler.
+
+## Building against the API
+
+- [`api-reference.md`](api-reference.md) — curated map of the REST and MCP
+  routes; a running deployment's own OpenAPI schema stays authoritative.
+- [`api-surfaces.md`](api-surfaces.md) — which operations belong on REST, MCP,
+  or the OpenClaw plugin, and who owns each surface.
+- [`public-api-stability.md`](public-api-stability.md) — the SemVer contract:
+  which surfaces are stable, and which are internal and free to change.
+- [`integration-without-plugin.md`](integration-without-plugin.md) — for
+  developers building an SDK client against a deployment with no plugin
+  runtime installed.
+- [`skills-inbox-api.md`](skills-inbox-api.md) — the operator-facing REST API
+  behind the human-in-the-loop review of Skill Factory candidates.
+
+## Upgrading
+
+- [`upgrading-from-v1.md`](upgrading-from-v1.md) — the v1.x to v2.x server
+  upgrade, including the destructive 768 → 1024 embedding migration and the
+  re-embed paths after it.
+- [`plugin-upgrade.md`](plugin-upgrade.md) — for operators upgrading the plugin
+  on OpenClaw nodes: when heartbeat-driven auto-upgrade runs, and the manual
+  re-install for the cases where it does not.
+
+## Skills over MCP
+
+- [`mcp-skill-delivery.md`](mcp-skill-delivery.md) — how a skill reaches an MCP
+  client (a read, not a push), and the rule that gates it.
+
+## Also in this directory
+
+- [`component-registry.yaml`](component-registry.yaml) — checked-in inventory of
+  the shipped cron ticks; `tests/test_component_registry.py` turns drift between
+  it and the scheduler into a test failure.
+- `contradiction-verification/`, `observability/`, `plans/` — findings,
+  measurement contracts, and decision records. Working notes, not guides.

--- a/docs/upgrading-from-v1.md
+++ b/docs/upgrading-from-v1.md
@@ -136,3 +136,10 @@ No public API changes. Code that reads memory embeddings via the search/recall
 endpoints is unaffected. External clients should not assume a vector width;
 custom integrations that directly handle the internal storage schema must
 migrate from 768 to 1024 dimensions with the database.
+
+## Upgrading the plugin
+
+Everything above is the server. Nodes running the OpenClaw plugin upgrade on
+their own path — heartbeat-driven auto-upgrade, with a manual re-install for
+the cases the server refuses to auto-deploy. See
+[`plugin-upgrade.md`](plugin-upgrade.md).


### PR DESCRIPTION
## Summary

`docs/` had twelve markdown files and no index, and `docs/plugin-upgrade.md` was
the one file with no inbound link from anywhere in the tree. This adds
`docs/README.md` and links `plugin-upgrade.md` from prose.

## Related Issue

Fixes #1407.

## Type of Change

- [x] Documentation update

## What's in it

**`docs/README.md`** — one line per file, grouped the way the `area/*` labels
group the repo: operating a deployment, building against the API, upgrading,
skills over MCP. Two extra entries so the index accounts for everything actually
in the directory rather than just the twelve: `component-registry.yaml`, and the
`plans/` · `observability/` · `contradiction-verification/` subdirectories,
flagged as working notes rather than guides.

**`plugin-upgrade.md` is current, not stale** — I read it before writing its
one-liner, as the issue asked. It documents the manifest-aware deploy gate
(`MIN_AUTO_DEPLOY_PLUGIN_VERSION`, `KNOWN_BROKEN_DEPLOY_VERSIONS`) from
CAURA-444 / #113, the identity-preserving manual re-install, and recovery from
the `ERR_MODULE_NOT_FOUND` partial-deploy state. Nothing in it reads as
superseded, so it is indexed as-is.

Linked from the two places its audience arrives:

- the **OpenClaw Plugin** section of the root `README.md` — the operator who
  just installed it is the one who later needs to upgrade it;
- the end of **`docs/upgrading-from-v1.md`**, which covers the server half of
  the same upgrade and stopped at the schema migration.

No existing doc content changed — only the two link sentences.

## How Has This Been Tested?

Every path in the new index resolves (the issue's snippet adjusted for
repo-convention relative links, which carry no `./` prefix):

```bash
cd docs && grep -oE '\]\([^)#][^)]*\)' README.md | sed 's/](//;s/)$//;s/#.*//' \
  | sort -u | while read -r f; do test -e "$f" || echo "BROKEN: $f"; done
```

15/15 resolve, nothing broken. Also ran the two gates that read markdown:

```
python3 scripts/legacy_name_ratchet.py --base origin/main   # No new lines.
python3 scripts/do_not_touch_sentinel.py                    # All 35 protected strings survive.
```

No tests added — the change is an index plus two links, and the link check above
is the verification.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes (or explained why none are needed)
- [x] I have updated relevant documentation (README, docs, etc.)
- [x] Every commit is signed off (DCO)

`ruff` / `mypy` / `pytest` are unaffected — no Python touched. Nothing
user-facing for `CHANGELOG.md`; the `docs:` commit type surfaces it there
already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
