### PR TITLE
feat(search): opt-in strict fleet scoping (C27)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -157,6 +157,7 @@ class ClassifyQuery:
                         status_filter=status_filter,
                         valid_at=valid_at,
                         readable_tenant_ids=readable_tenant_ids,
+                        strict_fleet_scoping=bool(ctx.data.get("strict_fleet_scoping")),
                         slot_acquired_marker=ctx.data,
                     )
 
@@ -379,6 +380,7 @@ class ClassifyQuery:
         valid_at: datetime | None = None,
         readable_tenant_ids: list[str] | None = None,
         slot_acquired_marker: dict | None = None,
+        strict_fleet_scoping: bool = False,
     ) -> list[types.SimpleNamespace]:
         """Load memories linked to graph-expanded entities, scored by hop distance."""
         all_entity_ids = list(entity_hops.keys())
@@ -487,6 +489,10 @@ class ClassifyQuery:
             "filter_agent_id": filter_agent_id,
             "memory_type_filter": memory_type_filter,
             "status_filter": status_filter,
+            # C27 — the ENTITY_LOOKUP short-circuit bypasses scored search
+            # entirely, so it needs the scope flag in its own right; inheriting
+            # it only on the scored path would leave this route permissive.
+            "strict_fleet_scoping": strict_fleet_scoping,
         }
         if valid_at is not None:
             search_data["valid_at"] = str(valid_at)

--- a/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
+++ b/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
@@ -126,6 +126,10 @@ class ExecuteScoredSearch:
         fleet_ids = data.get("fleet_ids")
         if fleet_ids:
             search_data["fleet_ids"] = fleet_ids
+            # C27 — only meaningful alongside fleet_ids; the storage predicate
+            # is built only when a fleet scope was requested.
+            if data.get("strict_fleet_scoping"):
+                search_data["strict_fleet_scoping"] = True
         if data.get("filter_agent_id"):
             search_data["filter_agent_id"] = data["filter_agent_id"]
         if data.get("caller_agent_id"):

--- a/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
+++ b/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
@@ -140,6 +140,10 @@ class LoadAndSerialize:
                         "supersedes_ids": [str(oid) for oid in outdated_ids],
                         "tenant_id": tenant_id,
                         "fleet_ids": data.get("fleet_ids"),
+                        # C27 — a successor is injected straight into the result
+                        # set, so an unscoped lookup here would reintroduce
+                        # exactly what the scored query just excluded.
+                        "strict_fleet_scoping": bool(data.get("strict_fleet_scoping")),
                         "caller_agent_id": data.get("caller_agent_id"),
                         "filter_agent_id": data.get("filter_agent_id"),
                         "memory_type_filter": data.get("memory_type_filter"),

--- a/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
+++ b/core-api/src/core_api/pipeline/steps/search/parallel_embed_entity_boost.py
@@ -44,6 +44,7 @@ async def _entity_boost_via_storage(
     graph_max_hops: int,
     use_union: bool = False,
     precomputed_hops: dict[UUID, tuple[int, float]] | None = None,
+    strict_fleet_scoping: bool = False,
 ) -> tuple[set[UUID], dict[UUID, float]]:
     """Entity FTS → graph expansion → link collection via storage client.
 
@@ -65,6 +66,8 @@ async def _entity_boost_via_storage(
             fts_data: dict = {"tokens": tokens, "tenant_id": tenant_id}
             if fleet_ids:
                 fts_data["fleet_ids"] = fleet_ids
+                if strict_fleet_scoping:
+                    fts_data["strict_fleet_scoping"] = True
             matched_id_strs = await sc.fts_search_entities(fts_data)
             matched_entity_ids = [UUID(eid) for eid in matched_id_strs]
 
@@ -210,6 +213,7 @@ class ParallelEmbedAndEntityBoost:
                     sp["graph_max_hops"],
                     use_union=True,
                     precomputed_hops=data.pop("_classified_entity_hops", None),
+                    strict_fleet_scoping=bool(data.get("strict_fleet_scoping")),
                 )
             )
         )

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -4105,6 +4105,7 @@ async def _entity_boost_pipeline(
     graph_max_hops: int,
     use_union: bool = False,
     precomputed_hops: dict[UUID, tuple[int, float]] | None = None,
+    strict_fleet_scoping: bool = False,
 ) -> tuple[set[UUID], dict[UUID, float]]:
     """Run entity FTS matching -> graph expansion -> link collection.
 
@@ -4133,6 +4134,7 @@ async def _entity_boost_pipeline(
                     "tenant_id": tenant_id,
                     "tokens": tokens,
                     "fleet_ids": fleet_ids,
+                    "strict_fleet_scoping": strict_fleet_scoping,
                 }
             )
             matched_entity_ids = [UUID(eid) for eid in matched_entity_ids_raw]
@@ -4534,6 +4536,11 @@ async def _search_memories_pipeline(
             # (skips hop-boosting). False ⇒ keyword/semantic reads only.
             "entity_retrieval": entity_retrieval,
             "tenant_config": tenant_config,
+            # C27 — resolved ONCE here rather than read off ``tenant_config`` in
+            # each step, so every fleet-scoped read in this request agrees. A
+            # step that forgot to look would silently fall back to permissive
+            # scoping, which is the failure A54 already paid for.
+            "strict_fleet_scoping": bool(getattr(tenant_config, "strict_fleet_scoping", False)),
             "search_profile": search_profile,
             "diagnostic": diagnostic,
             # D12 — per-request cosine floor; ResolveSearchProfile applies it
@@ -4649,7 +4656,14 @@ async def _search_memories_legacy(
     # deprecated legacy search honours the org switch exactly like the pipeline.
     emb_task = asyncio.ensure_future(_get_or_cache_embedding(query, tenant_id, tenant_config))
     ent_task = asyncio.ensure_future(
-        _entity_boost_pipeline(query, tenant_id, fleet_ids, graph_expand, sp["graph_max_hops"])
+        _entity_boost_pipeline(
+            query,
+            tenant_id,
+            fleet_ids,
+            graph_expand,
+            sp["graph_max_hops"],
+            strict_fleet_scoping=bool(getattr(tenant_config, "strict_fleet_scoping", False)),
+        )
         if entity_retrieval
         else _no_entity_boost()
     )
@@ -4691,6 +4705,10 @@ async def _search_memories_legacy(
         "embedding": embedding,
         "query": query,
         "fleet_ids": fleet_ids,
+        # C27 — the legacy path scopes fleets with the same storage predicate as
+        # the pipeline, so it takes the same switch. Leaving it out would make
+        # strict mode depend on which search implementation served the request.
+        "strict_fleet_scoping": bool(getattr(tenant_config, "strict_fleet_scoping", False)),
         "filter_agent_id": filter_agent_id,
         "caller_agent_id": caller_agent_id,
         "memory_type_filter": memory_type_filter,

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -99,6 +99,16 @@ DEFAULT_SETTINGS: dict = {
         "retention_days": 90,
     },
     "search": {
+        # C27 — opt-in STRICT fleet scoping. Wire contract D4 (RATIFIED) defines
+        # a NULL ``fleet_id`` as tenant-shared BY DESIGN, so a fleet-scoped read
+        # returns null-fleet rows too. That is deliberate and stays the default;
+        # ``True`` drops the null-fleet disjunct for a tenant that wants hard
+        # fleet isolation. Off by default for the same reason as
+        # ``recall_for_asserted_identity`` below: turning it on HIDES rows that
+        # are visible today, so it is a decision a tenant makes, never one
+        # inherited. ``scope_org`` rows stay visible in both modes — that is an
+        # explicit visibility tier, not an accident of a missing fleet.
+        "strict_fleet_scoping": None,
         "recall_boost": None,
         # Whether a caller-ASSERTED identity (SearchRequest.caller_agent_id from
         # a tenant-scoped key) may move recall_count, and so ranking. Off by
@@ -579,6 +589,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "security_audit.alert_score_below": (int, float),
     "security_audit.alert_critical_findings_min": int,
     "security_audit.alert_score_drop_delta": (int, float),
+    "search.strict_fleet_scoping": bool,
     "search.recall_boost": bool,
     "search.recall_for_asserted_identity": bool,
     "search.graph_retrieval": bool,
@@ -900,6 +911,18 @@ class ResolvedConfig:
         return self._ts.get("api_keys", {}).get("gemini_api_key") or global_settings.gemini_api_key
 
     # Search
+    @property
+    def strict_fleet_scoping(self) -> bool:
+        """Drop the null-fleet disjunct from fleet-scoped reads (default OFF).
+
+        Defaults FALSE like ``recall_for_asserted_identity``, and for a stronger
+        reason: every other search knob changes what RANKS, while this one
+        changes what is VISIBLE. Defaulting it on would retroactively hide rows
+        a tenant deliberately wrote fleet-less under contract D4.
+        """
+        val = self._ts.get("search", {}).get("strict_fleet_scoping")
+        return val if val is not None else False
+
     @property
     def recall_boost(self) -> bool:
         val = self._ts.get("search", {}).get("recall_boost")

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -109,6 +109,7 @@ async def fts_search_entities(request: Request) -> list[str]:
         tokens=body["tokens"],
         tenant_id=body["tenant_id"],
         fleet_ids=body.get("fleet_ids"),
+        strict_fleet_scoping=body.get("strict_fleet_scoping", False),
     )
     return [str(eid) for eid in ids]
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -211,6 +211,7 @@ async def scored_search(request: Request) -> list[dict]:
                 search_params=search_params,
                 temporal_window=temporal_window,
                 recall_boost_enabled=body.get("recall_boost_enabled", True),
+                strict_fleet_scoping=body.get("strict_fleet_scoping", False),
                 top_k=body.get("top_k", 10),
                 date_range_start=date_range_start,
                 date_range_end=date_range_end,
@@ -327,6 +328,7 @@ async def load_by_ids(request: Request) -> list[dict]:
                 status_filter=body.get("status_filter"),
                 valid_at=valid_at,
                 readable_tenant_ids=body.get("readable_tenant_ids") or None,
+                strict_fleet_scoping=body.get("strict_fleet_scoping", False),
             )
         out = [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
     except Exception:
@@ -458,6 +460,7 @@ async def find_successors(request: Request) -> list[dict]:
         filter_agent_id=body.get("filter_agent_id"),
         memory_type_filter=body.get("memory_type_filter"),
         valid_at=valid_at,
+        strict_fleet_scoping=body.get("strict_fleet_scoping", False),
     )
     return [orm_to_dict(m, MEMORY_FIELDS) for m in memories]
 

--- a/core-storage-api/src/core_storage_api/schemas.py
+++ b/core-storage-api/src/core_storage_api/schemas.py
@@ -282,6 +282,12 @@ class ScoredSearchRequest(BaseModel):
     search_params: dict
     temporal_window_seconds: float | None = None
     recall_boost_enabled: bool = True
+    # C27 — opt-in strict fleet scoping. Default False keeps wire contract D4
+    # (null fleet_id = tenant-shared BY DESIGN); True drops the null-fleet
+    # disjunct for tenants that want hard fleet isolation. Optional so a storage
+    # instance deployed ahead of core-api keeps serving callers that don't send
+    # it, the same independence A54's params were given.
+    strict_fleet_scoping: bool = False
     top_k: int = 10
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -230,6 +230,40 @@ async def get_read_session() -> AsyncIterator[AsyncSession]:
 # ---------------------------------------------------------------------------
 
 
+def _fleet_scope_clause(
+    model,
+    fleet_ids: Sequence[str],
+    *,
+    strict: bool,
+    include_org_visibility: bool = True,
+):
+    """The fleet predicate for a read, in one place (C27).
+
+    Wire contract D4 (RATIFIED) defines a NULL ``fleet_id`` as tenant-shared BY
+    DESIGN: a row written without a fleet is readable by every fleet in the
+    tenant. That is the default here and stays the default — this is an opt-in
+    strict mode, not a bug fix, and flipping the default would silently hide
+    rows that tenants deliberately wrote as shared.
+
+    ``strict=True`` drops ONLY the null-fleet disjunct. ``scope_org`` survives
+    in both modes: it is an explicit visibility TIER a writer chose, not an
+    accident of a missing fleet, so a tenant asking for fleet isolation is not
+    asking to revoke it. Narrowing that too would make the switch mean two
+    things at once.
+
+    Centralised because A54 established what happens otherwise — the identical
+    predicate lived in several queries, one was fixed, and the leak simply moved
+    to the next copy. Every fleet-scoped read builds its clause here so "strict"
+    cannot mean different things in different queries.
+    """
+    disjuncts = [model.fleet_id.in_(fleet_ids)]
+    if not strict:
+        disjuncts.append(model.fleet_id.is_(None))
+    if include_org_visibility:
+        disjuncts.append(model.visibility == "scope_org")
+    return or_(*disjuncts)
+
+
 def _scope_sql(
     tenant_id: str,
     fleet_id: str | None,
@@ -2318,6 +2352,7 @@ class PostgresService:
         date_range_end: str | None = None,
         readable_tenant_ids: list[str] | None = None,
         history_query: bool = False,
+        strict_fleet_scoping: bool = False,
     ) -> list[SimpleNamespace]:
         """Execute the full CTE-based scored search with entity-link JOIN.
 
@@ -2719,11 +2754,7 @@ class PostgresService:
 
         if fleet_ids:
             scored_stmt = scored_stmt.where(
-                or_(
-                    Memory.fleet_id.in_(fleet_ids),
-                    Memory.fleet_id.is_(None),
-                    Memory.visibility == "scope_org",
-                )
+                _fleet_scope_clause(Memory, fleet_ids, strict=strict_fleet_scoping)
             )
 
         if caller_agent_id:
@@ -2935,6 +2966,7 @@ class PostgresService:
         status_filter: str | None = None,
         valid_at: datetime | None = None,
         readable_tenant_ids: list[str] | None = None,
+        strict_fleet_scoping: bool = False,
     ) -> list[Memory]:
         """Load memories by ID with visibility/fleet/agent filters applied.
 
@@ -2975,13 +3007,7 @@ class PostgresService:
                 )
             )
             if fleet_ids:
-                stmt = stmt.where(
-                    or_(
-                        Memory.fleet_id.in_(fleet_ids),
-                        Memory.fleet_id.is_(None),
-                        Memory.visibility == "scope_org",
-                    )
-                )
+                stmt = stmt.where(_fleet_scope_clause(Memory, fleet_ids, strict=strict_fleet_scoping))
             if caller_agent_id:
                 stmt = stmt.where(
                     or_(
@@ -3109,6 +3135,7 @@ class PostgresService:
         filter_agent_id: str | None = None,
         memory_type_filter: str | None = None,
         valid_at: datetime | None = None,
+        strict_fleet_scoping: bool = False,
     ) -> list[Memory]:
         """Find active/confirmed memories that supersede the given memory IDs."""
         async with get_session() as session:
@@ -3123,13 +3150,7 @@ class PostgresService:
                 )
             )
             if fleet_ids:
-                stmt = stmt.where(
-                    or_(
-                        Memory.fleet_id.in_(fleet_ids),
-                        Memory.fleet_id.is_(None),
-                        Memory.visibility == "scope_org",
-                    )
-                )
+                stmt = stmt.where(_fleet_scope_clause(Memory, fleet_ids, strict=strict_fleet_scoping))
             if caller_agent_id:
                 stmt = stmt.where(
                     or_(
@@ -6334,6 +6355,7 @@ class PostgresService:
         tokens: list[str],
         tenant_id: str,
         fleet_ids: list[str] | None = None,
+        strict_fleet_scoping: bool = False,
     ) -> list[UUID]:
         """Full-text search against the entity tsvector index.
 
@@ -6365,7 +6387,11 @@ class PostgresService:
                 or_(*per_token),
             )
             if fleet_ids:
-                stmt = stmt.where(or_(Entity.fleet_id.in_(fleet_ids), Entity.fleet_id.is_(None)))
+                stmt = stmt.where(
+                    _fleet_scope_clause(
+                        Entity, fleet_ids, strict=strict_fleet_scoping, include_org_visibility=False
+                    )
+                )
             result = await session.execute(stmt)
             return [row[0] for row in result.all()]
 

--- a/tests/test_c27_strict_fleet_scoping.py
+++ b/tests/test_c27_strict_fleet_scoping.py
@@ -1,0 +1,153 @@
+"""C27 — opt-in strict fleet scoping.
+
+Wire contract D4 (RATIFIED) defines a NULL ``fleet_id`` as tenant-shared BY
+DESIGN: a row written without a fleet is readable by every fleet in the tenant.
+This is NOT a bug being fixed. It is an opt-in mode for tenants that want hard
+fleet isolation, and the default must stay permissive — flipping it would
+retroactively hide rows that tenants deliberately wrote as shared.
+
+Two things are easy to get wrong here and both are pinned below.
+
+**The predicate must live in ONE place.** A54 is the precedent: the identical
+visibility clause was copied across several candidate queries, one copy was
+fixed as filed, and the live leak simply reproduced through the next copy. Any
+query that hand-rolls ``fleet_id.is_(None)`` is outside the switch and silently
+permissive, so ``test_no_query_builds_the_fleet_predicate_by_hand`` fails on the
+copy rather than waiting for the leak.
+
+**``scope_org`` survives in both modes.** It is a visibility TIER a writer chose
+explicitly, not an accident of a missing fleet. A tenant asking for fleet
+isolation is not asking to revoke org-wide sharing, and folding the two together
+would make one switch mean two things.
+"""
+
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _sql(strict: bool, include_org: bool = True, entity: bool = False) -> str:
+    """Compile the real clause to SQL text.
+
+    Deliberately compiled rather than asserted against fake column objects: the
+    thing that matters is the predicate Postgres actually receives, and a stub
+    that merely records method calls would keep passing if the helper stopped
+    returning a usable clause at all.
+    """
+    from common.models.entity import Entity
+    from common.models.memory import Memory
+    from core_storage_api.services.postgres_service import _fleet_scope_clause
+
+    model = Entity if entity else Memory
+    clause = _fleet_scope_clause(
+        model, ["f1"], strict=strict, include_org_visibility=include_org
+    )
+    return str(clause.compile(compile_kwargs={"literal_binds": True}))
+
+
+# ── the switch ────────────────────────────────────────────────────────────
+
+
+def test_default_keeps_null_fleet_rows_visible():
+    """Contract D4. The permissive branch is the DEFAULT, not a legacy path."""
+    sql = _sql(strict=False)
+    assert "IS NULL" in sql, (
+        "default scoping dropped tenant-shared rows — this silently hides data "
+        "written fleet-less on purpose"
+    )
+
+
+def test_strict_drops_only_the_null_fleet_disjunct():
+    sql = _sql(strict=True)
+    assert "IS NULL" not in sql
+    assert "f1" in sql and "IN " in sql, "strict mode dropped the fleet match itself"
+
+
+def test_scope_org_survives_strict_mode():
+    """The switch means "stop inheriting null-fleet rows", not "revoke org-wide
+    visibility". Conflating them would make one flag do two jobs."""
+    assert "scope_org" in _sql(strict=True)
+    assert "scope_org" in _sql(strict=False)
+
+
+def test_entities_have_no_visibility_column_and_say_so():
+    """``Entity`` carries no ``visibility``; asking for it would raise rather
+    than quietly widen. The caller opts out explicitly."""
+    sql = _sql(strict=True, include_org=False, entity=True)
+    assert "scope_org" not in sql and "visibility" not in sql
+    assert "IS NULL" not in sql and "f1" in sql
+
+
+# ── the A54 lesson: one predicate, one place ──────────────────────────────
+
+
+def test_every_fleet_scoped_read_goes_through_the_helper():
+    """Fails on a COPY of the predicate, not on the leak it later causes.
+
+    Counts hand-rolled ``fleet_id.is_(None)`` disjuncts in the storage service.
+    The legitimate uses are single-fleet equality lookups (``fleet_id == x OR
+    fleet_id IS NULL`` for a write path), not the multi-fleet READ predicate
+    this switch governs — so what is asserted is that no read builds an
+    ``in_(fleet_ids)``/``is_(None)`` pair outside the helper.
+    """
+    from core_storage_api.services import postgres_service as ps
+
+    src = inspect.getsource(ps)
+    # every place fleet_ids is turned into a disjunction
+    # The ONLY legitimate ``in_(fleet_ids)`` is the one inside the helper.
+    hand_rolled = src.count("fleet_id.in_(fleet_ids)")
+    assert hand_rolled == 1, (
+        f"{hand_rolled} sites build the multi-fleet predicate inline (expected only "
+        "the one inside _fleet_scope_clause); an inline copy sits outside the "
+        "strict switch and is silently permissive — this is exactly how A54 leaked"
+    )
+    # definition + the four fleet-scoped reads
+    assert src.count("_fleet_scope_clause(") == 5
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        "memory_scored_search",
+        "memory_load_by_ids",
+        "memory_find_successors",
+        "entity_fts_search",
+    ],
+)
+def test_storage_reads_accept_the_flag_and_default_permissive(fn):
+    """Optional with a permissive default at the storage boundary, so a storage
+    instance deployed AHEAD of core-api keeps serving callers that don't send
+    it — the same independence A54's params were given."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    sig = inspect.signature(getattr(PostgresService, fn))
+    assert "strict_fleet_scoping" in sig.parameters, f"{fn} cannot be scoped strictly"
+    assert sig.parameters["strict_fleet_scoping"].default is False
+
+
+# ── the tenant switch ─────────────────────────────────────────────────────
+
+
+def test_setting_defaults_off():
+    """Turning this on HIDES rows that are visible today, so it is a decision a
+    tenant makes rather than one inherited from a deploy."""
+    from core_api.services.organization_settings import ResolvedConfig
+
+    assert ResolvedConfig(tenant_settings={}).strict_fleet_scoping is False
+
+
+def test_setting_is_readable_when_set():
+    from core_api.services.organization_settings import ResolvedConfig
+
+    cfg = ResolvedConfig(tenant_settings={"search": {"strict_fleet_scoping": True}})
+    assert cfg.strict_fleet_scoping is True
+
+
+def test_setting_is_a_declared_writable_key():
+    """Undeclared keys are rejected on write, so without this the switch could
+    be read but never turned on."""
+    from core_api.services.organization_settings import _LEAF_TYPES
+
+    assert _LEAF_TYPES["search.strict_fleet_scoping"] is bool


### PR DESCRIPTION
## What this is — and is not

Wire contract **D4 (RATIFIED)** defines a NULL `fleet_id` as tenant-shared **by design**: a row written without a fleet is readable by every fleet in the tenant. This PR does **not** change that, and does not treat it as a bug. It adds the switch for tenants that want hard fleet isolation, and leaves the contract's behaviour as the default.

`search.strict_fleet_scoping` — per tenant, **default `False`**.

Off by default for the same reason as `recall_for_asserted_identity`: turning it on **hides rows that are visible today**, so it is a decision a tenant makes, never one inherited from a deploy. Every other search knob changes what *ranks*; this one changes what is *visible*.

`scope_org` survives in **both** modes — an explicit visibility tier a writer chose, not an accident of a missing fleet. A tenant asking for fleet isolation isn't asking to revoke org-wide sharing.

## One predicate, one place

A54 is why. The identical clause was copied across several candidate queries, the copy named in the task was fixed, and the live leak reproduced through the next copy. Everything now builds its clause in `_fleet_scope_clause`, and `test_every_fleet_scoped_read_goes_through_the_helper` fails on a hand-rolled **copy** rather than waiting for the leak it would cause.

Threaded through **every** fleet-scoped read, not just the obvious one:

| Read | Why it matters |
|---|---|
| `memory_scored_search` | the main recall |
| `memory_load_by_ids` | the `ENTITY_LOOKUP` short-circuit — bypasses scored search entirely, so it needs the flag in its own right |
| `memory_find_successors` | a successor is injected straight into the result set; an unscoped lookup reintroduces exactly what the scored query just excluded |
| `entity_fts_search` | entity route (no `visibility` column, so the caller opts out explicitly) |

On the pipeline **and** the legacy search path, so the mode can't depend on which implementation served the request.

Storage params are optional with a permissive default, so a storage instance deployed ahead of core-api keeps serving callers that don't send them — the same independence A54's params were given.

## Wet test

Storage predicate, isolated:

```
strict=False -> in_fleet=YES  null_fleet=YES
strict=True  -> in_fleet=YES  null_fleet=NO
```

End to end through `/api/v1/search` with a genuinely null-fleet row: **PASS** in both modes.

⚠️ The switch took **~30s** to take effect. Settings are cached per worker (5-min TTL) and a `PUT` only invalidates the worker that served it, so a tenant flipping this should expect propagation, not immediacy. Worth knowing before someone reports it as broken.

Two things the wet test caught that would otherwise have produced a false pass: a null-fleet row **cannot** be created through the write API (an agent's home fleet is frozen at first write, so omitting `fleet_id` inherits it), and my first attempt used contradicting contents, so contradiction detection marked one row `conflicted` and default status filtering hid it.

## Testing

- 12 new unit tests, compiling the **real** clause to SQL rather than asserting against stub columns.
- Full suite: **27 failures, name-for-name identical to main's 27** — none new.
- `ruff check` / `ruff format --check` clean. `mypy src/` clean on core-storage-api; core-api matches main.

Closes C27.