### PR TITLE
refactor(doc-search): give the document top_k cap one source of truth

### DIFF
--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -270,6 +270,27 @@ assert DOC_MEMORY_MAX_CHARS <= MAX_CONTENT_LENGTH, (
     f"({MAX_CONTENT_LENGTH}) — an over-cap spec would fail schema validation."
 )
 
+# ── Document search (``caura_doc op=search`` / ``POST /documents/search``) ──
+# Deliberately NOT ``MAX_SEARCH_TOP_K``, which bounds MEMORY search. A memory
+# row is an enriched, summarised row; a document row is the caller's own body,
+# returned whole and bounded only by ``MAX_CONTENT_LENGTH``, so a page of 50
+# can already be ~500 KB. The two ceilings have never been equal and coupling
+# them would import a limit chosen for a different payload — but each was a
+# bare literal repeated across its surfaces, which is the drift both constants
+# exist to remove. Raise this only alongside a projected result shape
+# (``summary`` + ``doc_id``); on the current shape a bigger page is a bigger
+# blob, not better retrieval.
+#
+# Both surfaces must agree on the number and enforce it DIFFERENTLY: REST
+# rejects an over-cap ``top_k`` (422, via ``DocSearchRequest``'s ``le=``) while
+# MCP clamps silently, because a tool signature is read by a model that never
+# sees the validation error. Same ceiling, two behaviours — so the ceiling has
+# to come from one place, and the MCP parameter description (published to
+# callers in ``plugin/tools.json``) is interpolated from it rather than typed
+# out beside it.
+DEFAULT_DOC_SEARCH_TOP_K = 5
+MAX_DOC_SEARCH_TOP_K = 50
+
 # ── Tool surface bookkeeping ──
 # Tool descriptions live inline in `core_api/tools/caura_*.py` spec
 # modules (the SoT). Nothing else should hold a copy.

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -36,9 +36,11 @@ from core_api.agent_ids import (
 from core_api.auth import get_admin_key
 from core_api.clients.storage_client import KeystoneUpsertPayload, get_storage_client
 from core_api.constants import (
+    DEFAULT_DOC_SEARCH_TOP_K,
     DEFAULT_SEARCH_TOP_K,
     EVOLVE_OUTCOME_TYPES,
     INSIGHTS_FOCUS_MODES,
+    MAX_DOC_SEARCH_TOP_K,
     MAX_SEARCH_TOP_K,
     MEMORY_STATUSES,
     MEMORY_TYPES,
@@ -2120,7 +2122,10 @@ async def caura_doc(
         Field(description="op=write; optional scoping filter for op=list_collections|search."),
     ] = None,
     query: Annotated[str | None, Field(description="op=search: natural-language query.")] = None,
-    top_k: Annotated[int, Field(description="op=search: max results (1-50).")] = 5,
+    top_k: Annotated[
+        int,
+        Field(description=f"op=search: max results (1-{MAX_DOC_SEARCH_TOP_K})."),
+    ] = DEFAULT_DOC_SEARCH_TOP_K,
 ) -> ToolReply:
     """Structured-document CRUD. Op-dispatched. Replaces the 4 prior
     `caura_doc_*` tools."""
@@ -2635,7 +2640,7 @@ async def caura_doc(
                         ),
                         t0,
                     )
-                capped_top_k = max(1, min(top_k, 50))
+                capped_top_k = max(1, min(top_k, MAX_DOC_SEARCH_TOP_K))
                 # Active-only gate for a SCOPED skills search: push the
                 # status filter into the SQL so top_k stays exact (a
                 # post-filter alone would silently shrink the result

--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -13,6 +13,7 @@ from common.embedding import get_embedding
 from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
+from core_api.constants import DEFAULT_DOC_SEARCH_TOP_K, MAX_DOC_SEARCH_TOP_K
 from core_api.middleware.idempotency import IDEMPOTENCY_HEADER, idempotency_for
 from core_api.middleware.rate_limit import write_limit
 from core_api.schemas import STRICT_WRITE_BODY
@@ -150,7 +151,7 @@ class DocSearchRequest(BaseModel):
     fleet_id: str | None = None
     collection: str | None = Field(default=None, min_length=1, max_length=200)
     query: str = Field(min_length=1)
-    top_k: int = Field(default=5, ge=1, le=50)
+    top_k: int = Field(default=DEFAULT_DOC_SEARCH_TOP_K, ge=1, le=MAX_DOC_SEARCH_TOP_K)
 
 
 class DocOut(BaseModel):

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -22,7 +22,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from core_api import mcp_server
-from core_api.constants import VECTOR_DIM
+from core_api.constants import (
+    DEFAULT_DOC_SEARCH_TOP_K,
+    MAX_DOC_SEARCH_TOP_K,
+    VECTOR_DIM,
+)
 from tests._mcp_test_helpers import parse_envelope, strip_latency, stub_storage_client
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
@@ -457,15 +461,57 @@ async def test_doc_search_empty_results(mcp_env, monkeypatch):
     assert payload["results"] == []
 
 
-async def test_doc_search_top_k_capped_at_50(mcp_env, monkeypatch):
-    """top_k above 50 is capped server-side."""
+async def test_doc_search_top_k_capped_at_the_ceiling(mcp_env, monkeypatch):
+    """top_k above the ceiling is clamped server-side, not rejected.
+
+    MCP clamps where REST 422s (see ``test_doc_search_top_k_has_one_source_of
+    _truth``): a tool signature is read by a model that never sees the
+    validation error, so the useful behaviour is to serve the capped page.
+    """
     monkeypatch.setattr(
         "common.embedding.get_embedding", _async_return([0.1] * VECTOR_DIM)
     )
     sc = stub_storage_client(monkeypatch, search_documents_vector=[])
 
     await mcp_server.caura_doc(op="search", collection="c", query="q", top_k=9999)
-    assert sc.search_documents_vector.await_args.args[0]["top_k"] == 50
+    assert (
+        sc.search_documents_vector.await_args.args[0]["top_k"] == MAX_DOC_SEARCH_TOP_K
+    )
+
+
+def test_doc_search_top_k_has_one_source_of_truth():
+    """REST (``le=``), the MCP clamp and the MCP description read one constant.
+
+    The ceiling was a bare literal 50 in three places — the ``DocSearchRequest``
+    bound, the clamp in ``caura_doc``, and that tool's own parameter description,
+    which is also what ``plugin/tools.json`` publishes to callers. A cap the
+    description contradicts is worse than no description: the model plans around
+    the number it was told. This pins them together, and pins the published
+    string to the same constant so a change has to move all four at once.
+
+    ``MAX_DOC_SEARCH_TOP_K`` is deliberately NOT ``MAX_SEARCH_TOP_K``: document
+    rows are caller-supplied blobs ranked on one cosine distance, memory rows
+    carry enrichment and graph expansion. The two limits have never been equal.
+    """
+    import inspect
+
+    from core_api import constants as core_constants
+    from core_api.routes.documents import DocSearchRequest
+
+    le = [
+        m
+        for m in DocSearchRequest.model_fields["top_k"].metadata
+        if getattr(m, "le", None) is not None
+    ]
+    assert le and le[0].le == MAX_DOC_SEARCH_TOP_K
+    assert DocSearchRequest.model_fields["top_k"].default == DEFAULT_DOC_SEARCH_TOP_K
+
+    doc_top_k = inspect.get_annotations(mcp_server.caura_doc, eval_str=True)["top_k"]
+    desc = next(getattr(item, "description", "") for item in doc_top_k.__metadata__)
+    assert desc == f"op=search: max results (1-{MAX_DOC_SEARCH_TOP_K})."
+
+    assert core_constants.MAX_DOC_SEARCH_TOP_K == 50
+    assert core_constants.MAX_DOC_SEARCH_TOP_K != core_constants.MAX_SEARCH_TOP_K
 
 
 async def test_doc_search_embedding_provider_failure_aborts(mcp_env, monkeypatch):


### PR DESCRIPTION
## Summary

`caura_doc op=search` and `POST /documents/search` share a ceiling of **50**, and it was a bare literal in three places. This names it once — `MAX_DOC_SEARCH_TOP_K` (and `DEFAULT_DOC_SEARCH_TOP_K = 5`) in `core_api.constants` — and has all three read it. #1411 did exactly this for memory search; this is the same fix on the surface it did not cover.

**No value changes.** 50 stays 50, the default stays 5. `scripts/export_tool_specs.py` regenerates `plugin/tools.json` byte-identical, so the baseline fixture and `tool-definitions.ts` stay correct without edits.

## Why

The third copy is the one that matters: the MCP **parameter description**, `"op=search: max results (1-50)."`, is what `plugin/tools.json` publishes to callers. A model plans around the number it is told, so a cap whose own docs contradict it is worse than an undocumented one — and a description typed out beside the limit it describes is the copy most likely to be missed when the limit moves. That is not hypothetical: the stale `caura_recall` description was a review finding on #1411 twice.

## Why not 200

`MAX_DOC_SEARCH_TOP_K` is deliberately **not** `MAX_SEARCH_TOP_K`, which #1411 just raised to 200. The two bound different payloads:

| | memory search | document search |
|---|---|---|
| what a row is | enriched, summarised row | the caller's own body, returned whole |
| per-row bound | enrichment/graph budget | `MAX_CONTENT_LENGTH` = 10,000 chars |
| a full page | 200 rows, sized by measured retrieval quality | 50 rows ≈ **~500 KB**; 200 would be **~2 MB** |
| why the number | AMB slot count — 20 forced 8k-char chunking | response size on the current result shape |

Raising this one would also make the silent MCP clamp worse: a model asking `caura_doc` for 200 gets a 2 MB tool result with no error and no signal. The constant's comment records the precondition for ever raising it — a projected result shape (`summary` + `doc_id`), not a bigger page of full blobs.

## What changed

| file | change |
|---|---|
| `core-api/src/core_api/constants.py` | `DEFAULT_DOC_SEARCH_TOP_K` / `MAX_DOC_SEARCH_TOP_K`, placed with the other `DOC_*` constants (clear of #1411's `Search / ranking` block) |
| `core-api/src/core_api/routes/documents.py` | `DocSearchRequest.top_k` `default=` / `le=` read the constants |
| `core-api/src/core_api/mcp_server.py` | description interpolated from the constant; clamp reads it; default reads it |
| `tests/test_mcp_doc.py` | existing cap test reads the constant and is renamed; new source-of-truth test |

## Tests

`test_doc_search_top_k_has_one_source_of_truth` pins the REST bound, the REST default, the MCP clamp and the published description string together, and asserts the two ceilings stay distinct (50 ≠ 200).

I could not run pytest locally — the suite needs Postgres and Docker was not available on this machine — so I verified the wiring by importing the modules and asserting the same conditions directly (REST `le=50`, MCP description `"op=search: max results (1-50)."`, default 5, `tools.json` no drift). Ruff check and format clean. CI runs the real suite.

## Follow-up, not in scope

The two surfaces enforce this differently on purpose — REST 422s, MCP clamps, because a tool signature is read by a model that never sees a validation error. But `caura_recall` **reports** its clamp (`truncated`, `requested_top_k`, `effective_top_k`, `warning`) while `caura_doc` clamps **silently**. Worth closing; it is a behaviour change and did not belong in a no-op refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
