### PR TITLE
fix(crystallizer): stop the sweep destroying knowledge, re-paying LLM calls, and mislabelling fleet scope

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -1260,8 +1260,11 @@ class CoreStorageClient:
             params["fleet_id"] = fleet_id
         return await self._get_list("/memories/recent", **params)
 
-    async def get_lifecycle_candidates(self, tenant_id: str) -> dict:
-        return await self._get("/memories/lifecycle-candidates", tenant_id=tenant_id) or {}
+    async def get_lifecycle_candidates(self, tenant_id: str, fleet_id: str | None = None) -> dict:
+        params: dict[str, Any] = {"tenant_id": tenant_id}
+        if fleet_id is not None:
+            params["fleet_id"] = fleet_id
+        return await self._get("/memories/lifecycle-candidates", **params) or {}
 
     async def check_near_duplicates(self, data: dict) -> dict:
         return await self._post("/memories/near-duplicates", data)  # type: ignore[return-value]
@@ -1694,11 +1697,17 @@ class CoreStorageClient:
         )
         return result  # type: ignore[return-value]
 
-    async def find_orphaned_entities(self, tenant_id: str) -> list[dict]:
-        return await self._get_list("/entities/orphaned", tenant_id=tenant_id)
+    async def find_orphaned_entities(self, tenant_id: str, fleet_id: str | None = None) -> list[dict]:
+        params: dict[str, Any] = {"tenant_id": tenant_id}
+        if fleet_id is not None:
+            params["fleet_id"] = fleet_id
+        return await self._get_list("/entities/orphaned", **params)
 
-    async def find_broken_entity_links(self, tenant_id: str) -> list[dict]:
-        return await self._get_list("/entities/broken-links", tenant_id=tenant_id)
+    async def find_broken_entity_links(self, tenant_id: str, fleet_id: str | None = None) -> list[dict]:
+        params: dict[str, Any] = {"tenant_id": tenant_id}
+        if fleet_id is not None:
+            params["fleet_id"] = fleet_id
+        return await self._get_list("/entities/broken-links", **params)
 
     # ---------------------------------------------------------------------
     # Entity-linking pipeline (Fix 2 Ph6) — thin wrappers over the coarse

--- a/core-api/src/core_api/routes/crystallizer.py
+++ b/core-api/src/core_api/routes/crystallizer.py
@@ -107,12 +107,35 @@ async def trigger_crystallization(
 async def trigger_crystallization_all(
     auth: AuthContext = Depends(get_auth_context),
 ):
-    """Trigger crystallization for ALL tenants (nightly batch)."""
+    """Trigger crystallization for ALL tenants (nightly batch).
+
+    Standalone-only. The fan-out needs a list of tenants and there is no tenant
+    enumeration on the storage client, so the single standalone tenant is the
+    only set this endpoint can build. On a multi-tenant deployment it therefore
+    cannot do what its name promises.
+
+    It used to say so with a 500: ``get_standalone_tenant_id()`` raises
+    ``RuntimeError`` when standalone was never initialised, nothing caught it,
+    and every hosted call returned "internal server error" — which reads as an
+    outage and sends whoever is on call looking for a broken crystallizer. The
+    condition is not a fault, it is a deployment mode, so it answers 501 with
+    the route that DOES work.
+    """
     auth.enforce_admin()
     # In OSS standalone mode, only one tenant exists
     from core_api.standalone import get_standalone_tenant_id
 
-    tenant_ids = [get_standalone_tenant_id()]
+    try:
+        tenant_ids = [get_standalone_tenant_id()]
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                "POST /crystallize/all is standalone-only: there is no tenant "
+                "enumeration to fan out over on a multi-tenant deployment. "
+                "Trigger each tenant with POST /crystallize?tenant_id=..."
+            ),
+        ) from exc
     reports = []
     for tid in tenant_ids:
         from core_api.services.organization_settings import resolve_config

--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -293,6 +293,52 @@ async def run_crystallization(
     return report_id
 
 
+async def _type_ii_watermark(sc, tenant_id: str, fleet_id: str | None, report_id) -> str | None:
+    """The previous crystallization run's completion time, or None.
+
+    ``run_shadow`` takes a ``since`` watermark and ``select_candidates`` uses it
+    to skip any subject with nothing new since the last sweep. Nobody passed it,
+    so every nightly run re-asked the LLM about every subject with >=2 live
+    memories — re-paying, in full, for answers about subjects that had not
+    changed since the previous night.
+
+    The watermark has to come from the LAST COMPLETED run, which is why this
+    cannot just read ``get_latest_report``: the current run has ALREADY reserved
+    its own row with ``status="running"`` (see ``_reserve_report``), so the
+    "latest" report is frequently this run itself. Using that would stamp the
+    watermark at now and skip every subject — turning an overspend into a sweep
+    that silently does nothing, which is the worse failure.
+
+    Guards, in order: it must not be this run's row; it must be terminal
+    (``completed_at`` set — a crashed 'running' row from a previous attempt has
+    none); and it must be a non-empty string, because ``select_candidates``
+    compares it to ``created_at`` with ``>`` and a non-string would raise inside
+    the sweep.
+
+    Returns None on ANY doubt, and None means "scan everything" — the behaviour
+    this fix exists to reduce. That asymmetry is deliberate: paying twice is a
+    cost bug, skipping a changed subject is a correctness bug, and only one of
+    those is recoverable on the next run.
+    """
+    try:
+        latest = await sc.get_latest_report(tenant_id, fleet_id, report_type="crystallization")
+    except Exception:
+        logger.warning(
+            "type_ii watermark lookup failed for tenant %s; scanning all subjects",
+            tenant_id,
+            exc_info=True,
+        )
+        return None
+    if not isinstance(latest, dict):
+        return None
+    if str(latest.get("id", "")) == str(report_id):
+        return None
+    completed = latest.get("completed_at")
+    if not isinstance(completed, str) or not completed:
+        return None
+    return completed
+
+
 async def _execute_crystallization(
     sc,
     report_id,
@@ -417,6 +463,7 @@ async def _execute_crystallization(
                     subject_rows,
                     tenant_id,
                     await resolve_config(tenant_id),
+                    since=await _type_ii_watermark(sc, tenant_id, fleet_id, report_id),
                 )
             except Exception:
                 logger.warning("type_ii shadow phase failed for %s", tenant_id, exc_info=True)
@@ -691,12 +738,41 @@ async def _run_crystallization(
         # sweep — same isolation the per-row loop gave us, just at
         # cluster granularity (K HTTPs instead of K x M).
         archived_ids: list[str] = []
-        cluster_ids_to_archive = [
-            {"memory_id": str(mem.get("id")), "status": "archived"} for mem in cluster_memories
-        ]
+        # Archive ONLY if this cluster actually produced a replacement.
+        #
+        # The archive used to be unconditional, which quietly destroyed
+        # knowledge in the exact case the loop above treats as routine. A
+        # crystallized fact is a near-verbatim merge of cluster members that are
+        # >=0.95 similar and STILL ACTIVE at this point, so ``create_memory``'s
+        # dedup gate 409s against a cluster member — the very row the next block
+        # was about to archive. An all-409 cluster therefore ended with every
+        # source archived and nothing crystallized to stand in their place: the
+        # facts left the live corpus and no replacement entered it.
+        #
+        # ``new_ids`` is the right condition, not ``duplicate_facts == 0``: what
+        # licenses the archive is that a replacement EXISTS, not that nothing was
+        # rejected. A cluster that created one fact and skipped two duplicates is
+        # still safe to archive; a cluster that created none never is.
+        if not new_ids:
+            logger.info(
+                "Crystallizer kept %d source(s) live: cluster produced no new memory "
+                "(duplicates=%d failed=%d)",
+                len(cluster_memories),
+                duplicate_facts,
+                failed_facts,
+            )
+            cluster_ids_to_archive = []
+        else:
+            cluster_ids_to_archive = [
+                {"memory_id": str(mem.get("id")), "status": "archived"} for mem in cluster_memories
+            ]
         try:
-            batch_result = await sc.batch_update_status(
-                {"updates": cluster_ids_to_archive}, tenant_id=tenant_id
+            batch_result = (
+                await sc.batch_update_status({"updates": cluster_ids_to_archive}, tenant_id=tenant_id)
+                # No replacement was created, so there is nothing to retire and
+                # no reason to spend a storage round-trip saying so.
+                if cluster_ids_to_archive
+                else {}
             )
             skipped_set = set(batch_result.get("skipped") or [])
             for item in cluster_ids_to_archive:
@@ -853,7 +929,7 @@ async def _check_orphaned_entities(
 ) -> dict:
     """Entities with zero memory_entity_links."""
     sc = get_storage_client()
-    rows = await sc.find_orphaned_entities(tenant_id)
+    rows = await sc.find_orphaned_entities(tenant_id, fleet_id)
     ids = [str(r.get("id")) for r in rows]
     return {
         "count": len(rows),
@@ -956,7 +1032,7 @@ async def _check_expired_still_active(
     had something to report, and nothing at all when it didn't.
     """
     sc = get_storage_client()
-    candidates = await sc.get_lifecycle_candidates(tenant_id)
+    candidates = await sc.get_lifecycle_candidates(tenant_id, fleet_id)
     expired = candidates.get("expired_still_active", [])
     return {"count": len(expired), "affected_ids": [str(r) for r in expired][:MAX_AFFECTED_IDS]}
 
@@ -972,7 +1048,7 @@ async def _check_stale_memories(
     Values are bare UUID strings — see ``_check_expired_still_active``.
     """
     sc = get_storage_client()
-    candidates = await sc.get_lifecycle_candidates(tenant_id)
+    candidates = await sc.get_lifecycle_candidates(tenant_id, fleet_id)
     stale = candidates.get("stale_low_weight", [])
     return {"count": len(stale), "affected_ids": [str(r) for r in stale][:MAX_AFFECTED_IDS]}
 
@@ -989,7 +1065,7 @@ async def _check_short_content(
     ``_check_expired_still_active``.
     """
     sc = get_storage_client()
-    candidates = await sc.get_lifecycle_candidates(tenant_id)
+    candidates = await sc.get_lifecycle_candidates(tenant_id, fleet_id)
     short = candidates.get("short_content", [])
     return {"count": len(short), "affected_ids": [str(r) for r in short][:MAX_AFFECTED_IDS]}
 
@@ -1000,7 +1076,7 @@ async def _check_broken_entity_links(
 ) -> dict:
     """Entity links pointing to soft-deleted memories."""
     sc = get_storage_client()
-    rows = await sc.find_broken_entity_links(tenant_id)
+    rows = await sc.find_broken_entity_links(tenant_id, fleet_id)
     ids = [str(r.get("id")) for r in rows]
     return {"count": len(rows), "affected_ids": list(set(ids))[:MAX_AFFECTED_IDS]}
 

--- a/core-storage-api/src/core_storage_api/routers/entities.py
+++ b/core-storage-api/src/core_storage_api/routers/entities.py
@@ -471,14 +471,18 @@ async def count_memories_per_entity(request: Request) -> dict:
 
 
 @router.get("/orphaned")
-async def find_orphaned_entities(tenant_id: str) -> list[dict]:
-    rows = await _svc.entity_find_orphaned(tenant_id, fleet_id=None)
+async def find_orphaned_entities(tenant_id: str, fleet_id: str | None = None) -> list[dict]:
+    # ``fleet_id`` was hardcoded None here while the service below has always
+    # taken it, so a fleet-scoped crystallizer report carried TENANT-WIDE
+    # counts. Optional with a None default, so a storage instance deployed
+    # ahead of core-api keeps serving callers that don't send it.
+    rows = await _svc.entity_find_orphaned(tenant_id, fleet_id=fleet_id)
     return [{"id": str(row[0]), "canonical_name": row[1]} for row in rows]
 
 
 @router.get("/broken-links")
-async def find_broken_entity_links(tenant_id: str) -> list[dict]:
-    rows = await _svc.entity_find_broken_links(tenant_id, fleet_id=None)
+async def find_broken_entity_links(tenant_id: str, fleet_id: str | None = None) -> list[dict]:
+    rows = await _svc.entity_find_broken_links(tenant_id, fleet_id=fleet_id)
     return [{"memory_id": str(row[0]), "entity_id": str(row[1])} for row in rows]
 
 

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -1002,7 +1002,7 @@ async def get_recent_memories(
 
 
 @router.get("/lifecycle-candidates")
-async def get_lifecycle_candidates(tenant_id: str) -> dict:
+async def get_lifecycle_candidates(tenant_id: str, fleet_id: str | None = None) -> dict:
     """Id lists for the crystallizer's lifecycle hygiene checks.
 
     Every list is bare stringified ids, not row dicts — callers index them
@@ -1010,9 +1010,12 @@ async def get_lifecycle_candidates(tenant_id: str) -> dict:
     but was never exposed, so ``_check_short_content`` read a key that was
     never returned and reported zero for every tenant.
     """
-    expired = await _svc.memory_find_expired_still_active(tenant_id, None)
-    stale = await _svc.memory_find_stale_count(tenant_id, None, stale_days=90, max_weight=0.3)
-    short = await _svc.memory_find_short_content(tenant_id, None, CRYSTALLIZER_SHORT_CONTENT_CHARS)
+    # All three service calls have always taken a fleet argument; the route
+    # passed None positionally, so every fleet-scoped lifecycle count was
+    # actually tenant-wide.
+    expired = await _svc.memory_find_expired_still_active(tenant_id, fleet_id)
+    stale = await _svc.memory_find_stale_count(tenant_id, fleet_id, stale_days=90, max_weight=0.3)
+    short = await _svc.memory_find_short_content(tenant_id, fleet_id, CRYSTALLIZER_SHORT_CONTENT_CHARS)
     return {
         "expired_still_active": [str(r[0]) for r in expired],
         "stale_low_weight": [str(r[0]) for r in stale],

--- a/tests/test_low_crystallizer_archive_and_fanout.py
+++ b/tests/test_low_crystallizer_archive_and_fanout.py
@@ -1,0 +1,109 @@
+"""oss-0902-l-30 and oss-0814-l-09 — two crystallizer defects on the same sweep.
+
+l-30: the source-archive step ran UNCONDITIONALLY after the fact-creation loop,
+so a cluster whose every crystallized fact was rejected as a duplicate ended
+with all its sources archived and nothing standing in their place. The code's
+own comment explains why that is the routine case, not an edge one: a
+crystallized fact is a near-verbatim merge of cluster members that are >=0.95
+similar and STILL ACTIVE at that point, so ``create_memory``'s dedup gate 409s
+against a cluster member — the very row about to be archived. Knowledge left the
+live corpus and none entered it.
+
+l-09: ``POST /crystallize/all`` answered 500 on every multi-tenant deployment.
+``get_standalone_tenant_id()`` raises when standalone was never initialised and
+nothing caught it. The endpoint is standalone-only by construction — there is no
+tenant enumeration to fan out over — so the condition is a deployment mode, not
+a fault, and 500 sends whoever is on call hunting a crystallizer outage.
+"""
+
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ── l-30 ──────────────────────────────────────────────────────────────────
+
+
+def _archive_block() -> str:
+    from core_api.services import crystallizer_service as cs
+
+    src = inspect.getsource(cs)
+    i = src.index("archived_ids: list[str] = []")
+    return src[i : src.index("batch_result", i) + 600]
+
+
+def test_archive_is_gated_on_a_replacement_existing():
+    b = _archive_block()
+    assert "if not new_ids:" in b, "the archive step is unconditional again"
+
+
+def test_gate_is_new_ids_not_absence_of_duplicates():
+    """What licenses retiring the sources is that a replacement EXISTS — not
+    that nothing was rejected. A cluster that created one fact and skipped two
+    duplicates is still safe to archive; one that created none never is.
+
+    Comments are stripped first: the code comment names the rejected condition
+    in prose to explain why it is wrong, and matching that would fail on the
+    explanation rather than on the behaviour."""
+    code = "\n".join(
+        line
+        for line in _archive_block().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    assert "duplicate_facts == 0" not in code
+    assert "failed_facts == 0" not in code
+    assert "if not new_ids:" in code
+
+
+def test_nothing_created_means_nothing_is_queued_for_archive():
+    b = _archive_block()
+    i = b.index("if not new_ids:")
+    assert "cluster_ids_to_archive = []" in b[i : b.index("else:", i)]
+
+
+def test_keeping_sources_live_is_logged_with_the_reason():
+    """Silence here would look identical to a cluster that had no sources."""
+    b = _archive_block()
+    assert "kept" in b and "duplicates=%d failed=%d" in b
+
+
+def test_empty_cluster_skips_the_storage_round_trip():
+    """No replacement means nothing to retire — and no reason to spend a call
+    telling storage so."""
+    b = _archive_block()
+    assert "if cluster_ids_to_archive" in b and "else {}" in b
+
+
+# ── l-09 ──────────────────────────────────────────────────────────────────
+
+
+def test_fanout_answers_501_not_500_outside_standalone():
+    from core_api.routes import crystallizer as cr
+
+    src = inspect.getsource(cr.trigger_crystallization_all)
+    assert "except RuntimeError" in src, "the RuntimeError still escapes as a 500"
+    assert "status_code=501" in src
+
+
+def test_the_501_names_the_route_that_does_work():
+    """An error that only says 'no' costs the caller another round trip to find
+    out what to do instead."""
+    from core_api.routes import crystallizer as cr
+
+    src = inspect.getsource(cr.trigger_crystallization_all)
+    assert "POST /crystallize?tenant_id=" in src
+
+
+def test_standalone_path_is_untouched():
+    """The fan-out must still work where it is meaningful — the guard is only
+    reached when the tenant id cannot be resolved at all."""
+    from core_api.routes import crystallizer as cr
+
+    src = inspect.getsource(cr.trigger_crystallization_all)
+    body = src[src.index("try:") :]
+    assert "tenant_ids = [get_standalone_tenant_id()]" in body
+    assert body.index("tenant_ids = [get_standalone_tenant_id()]") < body.index(
+        "except RuntimeError"
+    )

--- a/tests/test_low_oss_0902_l_31_hygiene_fleet_scope.py
+++ b/tests/test_low_oss_0902_l_31_hygiene_fleet_scope.py
@@ -1,0 +1,94 @@
+"""oss-0902-l-31 — fleet-scoped crystallizer reports carried tenant-wide counts.
+
+Five hygiene checks took a ``fleet_id`` parameter and never applied it, so a
+report generated for one fleet reported every other fleet's orphans, expired
+rows, stale rows, short content and broken links as its own.
+
+The parameter was not the hard part — the STORAGE layer has always accepted a
+fleet argument for all five. The scoping was thrown away in transit: the two
+entity routes hardcoded ``fleet_id=None``, and ``/lifecycle-candidates`` passed
+a positional ``None`` to three service calls that each take one. So the fix is a
+thread, not a rewrite, and these tests pin every link in it — a fix at one layer
+is silently undone by the next.
+"""
+
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        "_check_orphaned_entities",
+        "_check_broken_entity_links",
+        "_check_expired_still_active",
+        "_check_stale_memories",
+        "_check_short_content",
+    ],
+)
+def test_every_fleet_blind_check_now_forwards_its_fleet(fn):
+    """All five took the parameter and dropped it. Reading the source is the
+    point: each one has exactly one storage call, and it must carry fleet_id."""
+    from core_api.services import crystallizer_service as cs
+
+    src = inspect.getsource(getattr(cs, fn))
+    assert "fleet_id" in src.split("-> dict:", 1)[1], f"{fn} still ignores fleet_id"
+
+
+def test_storage_client_sends_fleet_only_when_set():
+    """Omitted rather than sent as None, so a storage instance running ahead of
+    core-api keeps its existing behaviour instead of seeing an explicit null."""
+    from core_api.clients.storage_client import CoreStorageClient
+
+    for m in (
+        "find_orphaned_entities",
+        "find_broken_entity_links",
+        "get_lifecycle_candidates",
+    ):
+        sig = inspect.signature(getattr(CoreStorageClient, m))
+        assert sig.parameters["fleet_id"].default is None, m
+        src = inspect.getsource(getattr(CoreStorageClient, m))
+        assert "if fleet_id is not None:" in src, m
+        assert 'params["fleet_id"] = fleet_id' in src, m
+
+
+def test_entity_routes_no_longer_hardcode_none():
+    """This is where the scoping was actually lost — the service call below has
+    always taken the argument."""
+    from core_storage_api.routers import entities
+
+    src = inspect.getsource(entities)
+    assert "entity_find_orphaned(tenant_id, fleet_id=None)" not in src
+    assert "entity_find_broken_links(tenant_id, fleet_id=None)" not in src
+    assert "entity_find_orphaned(tenant_id, fleet_id=fleet_id)" in src
+    assert "entity_find_broken_links(tenant_id, fleet_id=fleet_id)" in src
+
+
+def test_lifecycle_route_forwards_fleet_to_all_three_queries():
+    """One route feeds three of the five checks, so a miss here re-breaks three
+    of them at once."""
+    from core_storage_api.routers import memories
+
+    # Whitespace-normalised: the formatter is free to rewrap these calls, and a
+    # line-exact assertion would fail on reformatting rather than on a regression.
+    src = " ".join(inspect.getsource(memories.get_lifecycle_candidates).split())
+    assert "memory_find_expired_still_active(tenant_id, fleet_id)" in src
+    assert "memory_find_stale_count(tenant_id, fleet_id" in src
+    assert "memory_find_short_content(tenant_id, fleet_id" in src
+    assert "(tenant_id, None" not in src
+
+
+def test_route_signatures_accept_an_optional_fleet():
+    from core_storage_api.routers import entities, memories
+
+    for fn in (
+        entities.find_orphaned_entities,
+        entities.find_broken_entity_links,
+        memories.get_lifecycle_candidates,
+    ):
+        p = inspect.signature(fn).parameters
+        assert "fleet_id" in p, fn.__name__
+        assert p["fleet_id"].default is None, fn.__name__

--- a/tests/test_low_oss_0902_l_43_type_ii_watermark.py
+++ b/tests/test_low_oss_0902_l_43_type_ii_watermark.py
@@ -1,0 +1,107 @@
+"""oss-0902-l-43 — the Type-II nightly sweep re-paid for unchanged subjects.
+
+``run_shadow`` accepts a ``since`` watermark and ``select_candidates`` uses it to
+skip subjects with nothing new since the previous sweep. The crystallizer never
+passed it, so ``since`` was always None and every run issued one LLM call per
+subject with >=2 live memories — the same answers, re-bought nightly.
+
+The trap this fix has to avoid is bigger than the bug. The current run reserves
+its OWN report row with ``status="running"`` before the sweep body executes, so
+``get_latest_report`` frequently returns THIS run. Using that as the watermark
+would stamp it at now and skip every subject: an overspend would become a sweep
+that silently does nothing. Every guard below exists for that, and every
+uncertain case resolves to None ("scan everything") because paying twice is
+recoverable on the next run and skipping a changed subject is not.
+"""
+
+import pytest
+
+from core_api.services import crystallizer_service as cs
+
+pytestmark = pytest.mark.unit
+
+
+class _SC:
+    def __init__(self, latest):
+        self._latest = latest
+        self.calls = []
+
+    async def get_latest_report(self, tenant_id, fleet_id=None, report_type=None):
+        self.calls.append((tenant_id, fleet_id, report_type))
+        if isinstance(self._latest, Exception):
+            raise self._latest
+        return self._latest
+
+
+async def _wm(latest, report_id="cur"):
+    return await cs._type_ii_watermark(_SC(latest), "t1", None, report_id)
+
+
+async def test_previous_completed_run_supplies_the_watermark():
+    got = await _wm({"id": "prev", "completed_at": "2026-09-08T02:00:00Z"})
+    assert got == "2026-09-08T02:00:00Z"
+
+
+async def test_this_runs_own_row_is_never_the_watermark():
+    """The reserved 'running' row is usually the latest report. Taking it would
+    set the watermark to now and skip every subject."""
+    assert await _wm({"id": "cur", "completed_at": "2026-09-09T02:00:00Z"}) is None
+
+
+async def test_a_crashed_running_row_is_not_terminal():
+    """A previous attempt that died leaves status='running' and no
+    ``completed_at``; it proves nothing was swept."""
+    assert await _wm({"id": "prev", "status": "running", "completed_at": None}) is None
+
+
+async def test_non_string_completed_at_is_refused():
+    """``select_candidates`` compares the watermark to ``created_at`` with ``>``.
+    A non-string would raise inside the sweep rather than here."""
+    assert await _wm({"id": "prev", "completed_at": 1757376000}) is None
+    assert await _wm({"id": "prev", "completed_at": ""}) is None
+
+
+async def test_no_reports_at_all_scans_everything():
+    assert await _wm(None) is None
+    assert await _wm("not-a-dict") is None
+
+
+async def test_lookup_failure_scans_everything_rather_than_skipping():
+    """The safe direction. A storage blip must not be able to silence the sweep."""
+    assert await _wm(RuntimeError("storage down")) is None
+
+
+async def test_watermark_is_scoped_to_this_fleet_and_report_type():
+    """A different fleet's (or a non-crystallization) report would be the wrong
+    clock — it says nothing about when THESE subjects were last swept."""
+    sc = _SC({"id": "prev", "completed_at": "2026-09-08T02:00:00Z"})
+    await cs._type_ii_watermark(sc, "t1", "fleet-a", "cur")
+    assert sc.calls == [("t1", "fleet-a", "crystallization")]
+
+
+def test_the_sweep_actually_passes_the_watermark():
+    """The whole defect was a parameter nobody supplied, so pin the call site —
+    the helper being correct is worth nothing if it is not wired in."""
+    import inspect
+
+    src = inspect.getsource(cs._execute_crystallization)
+    assert "since=await _type_ii_watermark(" in src
+
+
+def test_select_candidates_still_honours_since():
+    """Pins the contract this fix depends on: with a watermark, an unchanged
+    subject costs no LLM call; without one, everything is scanned."""
+    from core_api.services.type_ii_materializer import select_candidates
+
+    bundles = {
+        "stale": [
+            {"id": "1", "created_at": "2026-09-01T00:00:00Z"},
+            {"id": "2", "created_at": "2026-09-02T00:00:00Z"},
+        ],
+        "fresh": [
+            {"id": "3", "created_at": "2026-09-01T00:00:00Z"},
+            {"id": "4", "created_at": "2026-09-09T00:00:00Z"},
+        ],
+    }
+    assert select_candidates(bundles, "2026-09-08T00:00:00Z") == ["fresh"]
+    assert set(select_candidates(bundles, None)) == {"stale", "fresh"}


### PR DESCRIPTION
Four low-severity audit findings on the same nightly sweep. From the shared remediation tracker: `oss-0902-l-43`, `oss-0902-l-30`, `oss-0902-l-31`, `oss-0814-l-09`.

## `oss-0902-l-43` — the Type-II sweep re-paid for unchanged subjects

`run_shadow` takes a `since` watermark and `select_candidates` uses it to skip subjects with nothing new. Nobody passed it, so every nightly run re-asked the LLM about **every** subject with ≥2 live memories, buying the same answers again.

It now takes the last **completed** run's timestamp. That can't be `get_latest_report` alone: this run has already reserved its own `status="running"` row, so the "latest" report is frequently *this* run — using it would stamp the watermark at now and skip every subject, turning an overspend into a sweep that silently does nothing.

The helper refuses its own row, non-terminal rows, and non-string timestamps, and resolves every doubt to `None` ("scan everything"). That asymmetry is deliberate: **paying twice is recoverable on the next run; skipping a changed subject is not.**

## `oss-0902-l-30` — sources archived with nothing to replace them

The archive step ran unconditionally after the fact-creation loop. Per the loop's own comment, a crystallized fact is a near-verbatim merge of cluster members that are ≥0.95 similar and **still active** at that point — so `create_memory`'s dedup gate 409s against a cluster member, *the very row about to be archived*. A cluster whose facts were all rejected ended with every source archived and nothing in their place.

Gated on `new_ids`, deliberately **not** on the absence of duplicates: what licenses retiring the sources is that a replacement exists. One fact created and two duplicates skipped is still safe to archive; zero created never is.

## `oss-0902-l-31` — fleet-scoped reports carried tenant-wide counts

Five hygiene checks took `fleet_id` and never applied it. The parameter was never the hard part — **the storage layer has always accepted a fleet argument for all five.** The scoping was thrown away in transit:

```python
rows = await _svc.entity_find_orphaned(tenant_id, fleet_id=None)   # hardcoded
expired = await _svc.memory_find_expired_still_active(tenant_id, None)  # positional None
```

Threaded through route, client and caller; optional with `None` defaults so storage can deploy ahead of core-api.

*Note on the count:* the audit says five checks. Four ignore the parameter outright; the fifth (`_check_broken_entity_links`) passes it to a client that drops it. The audit was right.

## `oss-0814-l-09` — `POST /crystallize/all` answered 500 off standalone

`get_standalone_tenant_id()` raises when standalone was never initialised, nothing caught it, and every hosted call returned "internal server error" — which reads as an outage and sends on-call hunting a broken crystallizer. The endpoint is standalone-only by construction (no tenant enumeration to fan out over), so this is a deployment mode, not a fault. Now 501, naming the route that does work.

## Testing

- 26 new unit tests across the four findings.
- Full suite: **27 failures, name-for-name identical to main's 27** — none new.
- `ruff check` / `ruff format --check` clean; `mypy` clean on core-storage-api, unchanged on core-api.

Tracker rows move to done on merge.