### PR TITLE
fix(ingest): stop dropping CJK facts, honour the cache contract, delete a dead constant

### DIFF
--- a/core-api/src/core_api/services/ingest_service.py
+++ b/core-api/src/core_api/services/ingest_service.py
@@ -123,14 +123,6 @@ _CLOUD_METADATA_IPS = frozenset({"169.254.169.254", "fd00:ec2::254"})
 # latency.
 _PREVIEW_CONCURRENCY = 4
 
-# Maximum content length the LLM sees. Inputs longer than this get
-# truncated; ``ingest_preview`` reports the post-truncate length as
-# ``content_length`` and sets ``truncated: true`` + ``original_length``
-# so callers know the input was clipped. (Previously ``content_length``
-# returned the pre-truncate length, lying about what the LLM actually
-# processed.)
-_INGEST_MAX_CONTENT_CHARS = 50_000
-
 # Minimum content length before we'll even call the LLM. Whitespace-only
 # inputs and trivially short ones ("hi") used to burn a real LLM call
 # producing useless meta-facts ("The content begins with the greeting
@@ -174,6 +166,38 @@ _SALIENCE_FLOOR = 0.5
 # the validator drops them. "≥ 5 words" is the boundary — anything shorter
 # is almost always a heading, label, or one-word fragment.
 _MIN_FACT_WORDS = 5
+
+# Scripts that do not put spaces between words. A whitespace split reports 1
+# for an entire Chinese or Japanese sentence, so ``len(body.split())`` dropped
+# every CJK fact as a "sub-5-word fragment" — the filter deleted the content it
+# was meant to protect, and only for those languages.
+#
+# Hangul is deliberately EXCLUDED: Korean is space-delimited, so counting each
+# syllable as a word would over-count it and let real fragments through.
+_CJK_RE = re.compile(
+    "["
+    "\u3040-\u309f"  # hiragana
+    "\u30a0-\u30ff"  # katakana
+    "\u3400-\u4dbf"  # CJK unified ext A
+    "\u4e00-\u9fff"  # CJK unified
+    "\uf900-\ufaff"  # CJK compatibility
+    "\uff66-\uff9f"  # halfwidth katakana
+    "]"
+)
+
+
+def _fact_word_count(text: str) -> int:
+    """Word count that survives a script without spaces.
+
+    Each CJK character counts as one unit and the remainder is split on
+    whitespace, so mixed text ("Acme の売上は 12% 増加した") is counted once,
+    not twice. One character per unit is deliberately generous — a CJK word is
+    typically one to two characters, so this errs toward KEEPING a short fact
+    rather than silently dropping a real one, which is the failure being fixed.
+    """
+    cjk = len(_CJK_RE.findall(text))
+    return len(_CJK_RE.sub(" ", text).split()) + cjk
+
 
 # Drop facts that describe the input itself rather than extracting from it.
 # These show up when the LLM has nothing real to chunk — typical on short
@@ -346,7 +370,7 @@ async def _chunk_content(
 
         # A5: drop sub-5-word fragments. Prompt forbids them but the LLM
         # still emits short headings/labels on noisy inputs.
-        if len(body.split()) < _MIN_FACT_WORDS:
+        if _fact_word_count(body) < _MIN_FACT_WORDS:
             dropped_short += 1
             continue
 
@@ -998,6 +1022,15 @@ async def ingest_preview(request: IngestRequest) -> dict:
             "chunk_ms": 0,
             "cached": True,
             "run_id": prior_run_id,
+            # The contract this response documents: the caller echoes
+            # ``doc_hash`` to commit so the NEXT preview can hit this cache. The
+            # cache-hit branch omitted it, so a client that followed the
+            # documented flow lost the hash precisely when the cache was
+            # working — the second ingest of a document could never cache.
+            "doc_hash": doc_hash,
+            # Zero LLM calls were made, for the same reason ``chunk_ms`` is 0.
+            # Absent would read as "unknown"; 0 is the true count.
+            "sections": 0,
         }
 
     # ---- P2.3: whitespace / too-short short-circuit ----

--- a/tests/test_low_ingest_batch.py
+++ b/tests/test_low_ingest_batch.py
@@ -1,0 +1,119 @@
+"""Three low-severity ingest findings.
+
+oss-0902-l-37: ``len(body.split()) < 5`` dropped every fact written in a script
+  that does not put spaces between words. A whole Chinese or Japanese sentence
+  is one whitespace token, so the fragment filter deleted exactly the content it
+  exists to protect — and only for those languages.
+
+oss-0814-l-28: the doc-hash cache-hit branch omitted ``doc_hash`` (and
+  ``sections``) from its response. The response's own docstring tells callers to
+  echo ``doc_hash`` to commit so the NEXT preview can hit the cache, so a client
+  following the documented flow lost the hash precisely when the cache was
+  working.
+
+oss-0814-l-49: ``_INGEST_MAX_CONTENT_CHARS`` was defined, never read, and
+  carried a comment describing truncation ("sets ``truncated: true`` +
+  ``original_length``") that the function's own docstring contradicts ("no
+  longer truncated post-PR#7"). Dead code that documents behaviour the service
+  does not have is worse than no comment.
+"""
+
+import inspect
+
+import pytest
+
+from core_api.services import ingest_service as ing
+
+pytestmark = pytest.mark.unit
+
+
+# ── oss-0902-l-37 ─────────────────────────────────────────────────────────
+
+
+def test_english_counting_is_unchanged():
+    """The fix must not move the boundary for space-delimited text."""
+    assert ing._fact_word_count("Acme raised its revenue target") == 5
+    assert ing._fact_word_count("Quarterly revenue rose") == 3
+
+
+def test_a_cjk_sentence_is_no_longer_one_word():
+    """The defect in one assertion: this is a real fact, and a whitespace split
+    calls it a one-word fragment."""
+    jp = "売上は前年比で12パーセント増加した"
+    assert len(jp.split()) == 1
+    assert ing._fact_word_count(jp) >= ing._MIN_FACT_WORDS
+
+
+def test_mixed_script_counts_each_half_once():
+    """A latin token inside CJK text must not be counted twice — once as a
+    whitespace word and again as characters."""
+    assert ing._fact_word_count("Acme の売上は増加した") == 1 + len("の売上は増加した")
+
+
+def test_hangul_is_excluded_because_korean_uses_spaces():
+    """Counting each syllable would over-count Korean and let genuine fragments
+    through — the opposite failure."""
+    ko = "제목"  # a two-syllable heading: still a fragment
+    assert ing._fact_word_count(ko) == 1
+
+
+def test_a_short_cjk_fragment_is_still_dropped():
+    """The filter must keep working for the case it was written for."""
+    assert ing._fact_word_count("概要") < ing._MIN_FACT_WORDS
+
+
+def test_the_validator_uses_the_script_aware_count():
+    """A correct helper is worth nothing if the call site still splits on
+    whitespace."""
+    src = inspect.getsource(ing)
+    assert "_fact_word_count(body) < _MIN_FACT_WORDS" in src
+    assert "len(body.split()) < _MIN_FACT_WORDS" not in src
+
+
+# ── oss-0814-l-28 ─────────────────────────────────────────────────────────
+
+
+def _cache_branch() -> str:
+    src = inspect.getsource(ing)
+    i = src.index("if cached_memories:")
+    return src[i : src.index("whitespace / too-short", i)]
+
+
+def test_cache_hit_returns_the_doc_hash_it_tells_callers_to_echo():
+    assert '"doc_hash": doc_hash,' in _cache_branch()
+
+
+def test_cache_hit_reports_zero_sections_rather_than_omitting_it():
+    """Absent reads as "unknown"; zero is the true number of LLM calls made on a
+    cache hit, for the same reason ``chunk_ms`` is 0."""
+    b = _cache_branch()
+    assert '"sections": 0,' in b
+    assert '"chunk_ms": 0,' in b
+
+
+def test_both_preview_returns_carry_the_cache_contract_keys():
+    """The two exits must agree, or the contract depends on which branch ran."""
+    src = inspect.getsource(ing.ingest_preview)
+    assert src.count('"doc_hash"') >= 2
+    assert src.count('"sections"') >= 2
+
+
+# ── oss-0814-l-49 ─────────────────────────────────────────────────────────
+
+
+def test_the_dead_truncation_constant_is_gone():
+    assert not hasattr(ing, "_INGEST_MAX_CONTENT_CHARS")
+
+
+def test_no_comment_still_claims_truncation_that_does_not_happen():
+    """The constant's comment promised ``truncated: true`` and
+    ``original_length`` fields the service never sets."""
+    src = inspect.getsource(ing)
+    assert "truncated: true" not in src
+    assert "original_length" not in src
+
+
+def test_the_live_minimum_length_guard_is_untouched():
+    """The neighbouring constant is real and load-bearing — deleting the wrong
+    one would send trivial inputs to the LLM."""
+    assert ing._INGEST_MIN_CONTENT_CHARS == 20


### PR DESCRIPTION
Three low-severity findings in `ingest_service`, from the shared remediation tracker: `oss-0902-l-37`, `oss-0814-l-28`, `oss-0814-l-49`.

## `oss-0902-l-37` — the fragment filter deleted every CJK fact

```python
if len(body.split()) < _MIN_FACT_WORDS:   # 5
```

That assumes words are separated by spaces. A whole Chinese or Japanese sentence is **one** whitespace token, so the guard written to drop headings and one-word labels was dropping complete, useful facts — silently, counted as `dropped_short`, and only for those languages.

`_fact_word_count` counts each CJK character as one unit and splits the remainder on whitespace, so mixed text (`"Acme の売上は増加した"`) is counted once rather than twice.

Two deliberate calls:

- **One character per unit is generous.** A CJK word is typically one to two characters, so this errs toward *keeping* a short fact rather than dropping a real one — the failure being fixed. A genuine two-character heading (`概要`) is still below the floor.
- **Hangul is excluded.** Korean *is* space-delimited, so counting syllables would over-count it and let real fragments through — the opposite bug.

## `oss-0814-l-28` — the cache hit broke the contract it documents

`ingest_preview`'s own docstring says:

> `doc_hash` — sha256 of (tenant, content); caller echoes to commit for cache

The cache-hit branch didn't return it. So a client following the documented flow lost the hash **precisely when the cache was working**, and the second ingest of a document could never cache. Both exits now return it.

The branch also reports `sections: 0`, for the same reason it already reports `chunk_ms: 0` — zero LLM calls is the true count, while an absent key reads as "unknown".

## `oss-0814-l-49` — a dead constant documenting behaviour that doesn't exist

`_INGEST_MAX_CONTENT_CHARS` was defined once, never read, and its comment promised truncation with `truncated: true` and `original_length` response fields — which the same function's docstring flatly contradicts ("no longer truncated post-PR#7"). A comment describing behaviour the service doesn't have is worse than no comment. Removed; the live `_INGEST_MIN_CONTENT_CHARS` is untouched, and a test pins that.

## Testing

- 12 new unit tests, including that English counting is unchanged, that a short CJK fragment is *still* dropped, and that the call site actually uses the new helper.
- Full suite: **27 failures, name-for-name identical to main's 27** — none new.
- `ruff check` / `ruff format --check` clean; `mypy` unchanged from main.

Tracker rows move to done on merge.