### PR TITLE
fix: narrow the Path C revert, drop three unreachable builders, clamp the interviewer flag

### DIFF
--- a/clients/python/src/caura_client/interviewer/cli.py
+++ b/clients/python/src/caura_client/interviewer/cli.py
@@ -65,6 +65,31 @@ def _read_env(*names: str, default: str = "") -> str:
     return "" if saw_blank else default
 
 
+# The server truncates each event's content at this many characters
+# (``INTERVIEW_EVENT_MAX_CHARS`` in core-api) and REJECTS a window whose events
+# exceed it. The CLI accepted any integer, so ``--max-event-chars 20000`` made
+# every submission 422 — and because a rejected window never advances the
+# cursor, the transcript stalled permanently rather than degrading. Clamped
+# here, loudly, because a silently-honoured flag that breaks every request is
+# worse than one that says it was overruled.
+_SERVER_MAX_EVENT_CHARS = 8_000
+
+
+def _event_chars(value: str) -> int:
+    """``--max-event-chars`` clamped to what the server will actually accept."""
+    n = int(value)
+    if n < 1:
+        raise argparse.ArgumentTypeError("--max-event-chars must be positive")
+    if n > _SERVER_MAX_EVENT_CHARS:
+        print(
+            f"caura-interviewer: --max-event-chars {n} exceeds the server limit "
+            f"of {_SERVER_MAX_EVENT_CHARS}; using {_SERVER_MAX_EVENT_CHARS}.",
+            file=sys.stderr,
+        )
+        return _SERVER_MAX_EVENT_CHARS
+    return n
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="caura-interviewer",
@@ -116,7 +141,7 @@ def _build_parser() -> argparse.ArgumentParser:
     run_p.add_argument("--max-windows", type=int, default=8)
     run_p.add_argument("--since-hours", type=float, default=168.0, help="only files modified in this window (0 = all)")
     run_p.add_argument("--min-events", type=int, default=10, help="dribble gate for the final window")
-    run_p.add_argument("--max-event-chars", type=int, default=4_000)
+    run_p.add_argument("--max-event-chars", type=_event_chars, default=4_000)
     run_p.add_argument("--flush", action="store_true", help="submit even below the dribble gate")
 
     status_p = sub.add_parser("status", help="show per-file cursor vs local line counts")
@@ -126,7 +151,7 @@ def _build_parser() -> argparse.ArgumentParser:
     hook_p = sub.add_parser("hook", help="Claude Code SessionEnd hook: drain the session transcript (stdin JSON)")
     common(hook_p)
     hook_p.add_argument("--max-windows", type=int, default=2)
-    hook_p.add_argument("--max-event-chars", type=int, default=4_000)
+    hook_p.add_argument("--max-event-chars", type=_event_chars, default=4_000)
 
     install_p = sub.add_parser("install", help="schedule a periodic `run` via cron (writes a 0600 env file it sources)")
     common(install_p)

--- a/clients/python/tests/test_interviewer_cli_clamp.py
+++ b/clients/python/tests/test_interviewer_cli_clamp.py
@@ -1,0 +1,62 @@
+"""oss-0902-l-09 — ``--max-event-chars`` could be set past what the server takes.
+
+The flag accepted any integer. The server truncates each event at
+``INTERVIEW_EVENT_MAX_CHARS`` (8000) and REJECTS a window whose events exceed
+it, and a rejected window never advances the cursor — so an over-large value did
+not degrade the transcript, it stalled it permanently, 422 after 422.
+
+Clamping is announced on stderr rather than applied quietly: a flag that is
+silently overruled leaves the operator believing a setting that is not in force,
+which is how this stayed unnoticed.
+"""
+
+import argparse
+
+import pytest
+
+from caura_client.interviewer import cli
+
+
+def test_a_value_over_the_server_limit_is_clamped(capsys):
+    assert cli._event_chars("20000") == cli._SERVER_MAX_EVENT_CHARS
+    assert "exceeds the server limit" in capsys.readouterr().err
+
+
+def test_clamping_names_both_the_asked_and_the_used_value(capsys):
+    cli._event_chars("999999")
+    err = capsys.readouterr().err
+    assert "999999" in err and str(cli._SERVER_MAX_EVENT_CHARS) in err
+
+
+def test_values_within_the_limit_pass_through_silently(capsys):
+    assert cli._event_chars("4000") == 4_000
+    assert cli._event_chars(str(cli._SERVER_MAX_EVENT_CHARS)) == cli._SERVER_MAX_EVENT_CHARS
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize("bad", ["0", "-5"])
+def test_a_nonsense_value_is_refused_rather_than_clamped(bad):
+    """Zero or negative is a mistake, not an over-ask. Clamping it upward would
+    invent a value the caller never asked for."""
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._event_chars(bad)
+
+
+def test_both_subcommands_use_the_clamp():
+    """``run`` and ``hook`` both take the flag; clamping one leaves the other
+    able to stall a transcript."""
+    import inspect
+
+    src = inspect.getsource(cli)
+    assert src.count('"--max-event-chars", type=_event_chars') == 2
+
+
+def test_the_limit_is_documented_as_mirroring_the_server():
+    """``caura_client`` is a separate distribution and cannot import core-api, so
+    this constant is a COPY of ``INTERVIEW_EVENT_MAX_CHARS`` and can drift. The
+    comment naming its source is the only link between them; keep it."""
+    import inspect
+
+    src = inspect.getsource(cli)
+    i = src.index("_SERVER_MAX_EVENT_CHARS = 8_000")
+    assert "INTERVIEW_EVENT_MAX_CHARS" in src[max(0, i - 700) : i]

--- a/core-api/src/core_api/pipeline/compositions/entity_linking.py
+++ b/core-api/src/core_api/pipeline/compositions/entity_linking.py
@@ -22,32 +22,10 @@ def build_full_entity_linking_pipeline() -> Pipeline:
     )
 
 
-def build_quick_entity_linking_pipeline() -> Pipeline:
-    """Hourly: just resolution (assumes embeddings are mostly populated)."""
-    return Pipeline(
-        "entity_linking_quick",
-        [
-            ResolveEntities(),
-        ],
-    )
-
-
-def build_link_discovery_pipeline() -> Pipeline:
-    """On-demand: backfill embeddings then discover new cross-links."""
-    return Pipeline(
-        "entity_linking_discovery",
-        [
-            BackfillEntityEmbeddings(),
-            DiscoverCrossLinks(),
-        ],
-    )
-
-
-def build_relation_inference_pipeline() -> Pipeline:
-    """On-demand: just co-occurrence relation inference."""
-    return Pipeline(
-        "entity_linking_relations",
-        [
-            InferRelations(),
-        ],
-    )
+# ``build_quick_entity_linking_pipeline``, ``build_link_discovery_pipeline`` and
+# ``build_relation_inference_pipeline`` were removed 2026-09-09 (audit
+# oss-0814-l-48): three profiles for schedules that were never wired up, with no
+# reference anywhere in the repo — not a caller, not an export, not a test. Only
+# the nightly full pipeline is used (``lifecycle_audit``). They are recoverable
+# from git if an hourly or on-demand schedule is ever built; keeping unreachable
+# profiles around implied a choice of pipeline that callers did not actually have.

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -2221,7 +2221,36 @@ async def _attempt_entity_retraction(
     # pre-existing candidate, and the loser is new_memory itself. Writing these
     # the canonical way round in a flipped chain would revert the wrong row and
     # leave the real edge dangling.
-    await sc.update_memory_status(str(candidate.get("id")), "active", tenant_id=cand_tenant)
+    # Revert ONLY a status detection itself set. The literal "active" used to be
+    # written unconditionally, so whatever the row held at this moment was
+    # overwritten — including a status this path never assigned. Detection marks
+    # a losing candidate "outdated" or "conflicted"; anything else means another
+    # writer has moved the row since (confirmed by a human, archived by the
+    # crystallizer, superseded by a different chain), and stamping "active" over
+    # that discards someone else's decision to undo our own.
+    #
+    # Mirrors the guard the content-edit reset already applies for exactly this
+    # reason (``memory_service``: reset to "active" only ``if mem["status"] in
+    # ("outdated", "conflicted")``); the two paths clear the same state and had
+    # no business disagreeing.
+    #
+    # NOTE this restores "active", not the status the row held BEFORE detection.
+    # A row that was "confirmed" and got marked "conflicted" comes back as
+    # "active", because nothing records what was overwritten — neither
+    # ``memories`` nor ``memory_conflicts`` has a prior-status column. Narrowing
+    # the write is the part that can be fixed without a migration; recovering the
+    # original value cannot.
+    cand_status = candidate.get("status")
+    if cand_status in ("outdated", "conflicted"):
+        await sc.update_memory_status(str(candidate.get("id")), "active", tenant_id=cand_tenant)
+    else:
+        logger.info(
+            "PATH_C_RETRACTION candidate_revert_skipped memory=%s candidate=%s status=%s "
+            "(not a status detection set; leaving it to its current owner)",
+            new_memory.get("id"),
+            candidate.get("id"),
+            cand_status,
+        )
     try:
         await sc.update_memory_status(
             str(edge_owner.get("id")),

--- a/tests/test_low_assorted_batch.py
+++ b/tests/test_low_assorted_batch.py
@@ -1,0 +1,104 @@
+"""Two unrelated low-severity findings, grouped only by size.
+
+oss-0902-l-29: the Path C retraction wrote the literal "active" over whatever
+  status the candidate held at that moment, including one this path never set.
+
+oss-0814-l-48: three entity-linking pipeline builders with no reference anywhere
+  in the repo.
+
+(oss-0902-l-09, the interviewer CLI clamp, is covered in the client package's
+own suite — ``clients/python/tests/test_interviewer_cli_clamp.py`` — because
+``caura_client`` is a separate distribution and is not importable from here.)
+"""
+
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ── oss-0902-l-29 ─────────────────────────────────────────────────────────
+
+
+def _revert_block() -> str:
+    from core_api.services import contradiction_detector as cd
+
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    i = src.index('cand_status = candidate.get("status")')
+    return src[i : i + 900]
+
+
+def test_revert_only_touches_a_status_detection_set():
+    """Detection marks a loser "outdated" or "conflicted". Anything else means
+    another writer moved the row, and stamping "active" over that undoes their
+    decision to undo ours."""
+    b = _revert_block()
+    assert 'if cand_status in ("outdated", "conflicted"):' in b
+
+
+def test_the_unconditional_write_is_gone():
+    from core_api.services import contradiction_detector as cd
+
+    src = inspect.getsource(cd._attempt_entity_retraction)
+    code = "\n".join(ln for ln in src.splitlines() if not ln.lstrip().startswith("#"))
+    assert (
+        'update_memory_status(str(candidate.get("id")), "active", tenant_id=cand_tenant)'
+        in code
+    )
+    # ...but only inside the guard, never at the function's own indent level.
+    for line in code.splitlines():
+        if "update_memory_status(str(candidate.get" in line:
+            assert line.startswith("        "), "revert is still unconditional"
+
+
+def test_a_skipped_revert_is_logged_with_the_status_it_found():
+    """Silence would make "another writer owns this row" indistinguishable from
+    "the retraction never ran"."""
+    b = _revert_block()
+    assert "candidate_revert_skipped" in b and "status=%s" in b
+
+
+def test_it_matches_the_content_edit_reset_guard():
+    """The two paths clear the same state and had no business disagreeing — the
+    content-edit reset has always been guarded, which is why only this site was
+    losing statuses."""
+    from core_api.services import memory_service as ms
+
+    src = inspect.getsource(ms)
+    assert 'if mem.get("status") in ("outdated", "conflicted"):' in src
+
+
+# ── oss-0814-l-48 ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "build_quick_entity_linking_pipeline",
+        "build_link_discovery_pipeline",
+        "build_relation_inference_pipeline",
+    ],
+)
+def test_the_unreachable_builders_are_gone(name):
+    from core_api.pipeline.compositions import entity_linking
+
+    assert not hasattr(entity_linking, name)
+
+
+def test_the_one_live_builder_survives():
+    """``lifecycle_audit`` calls this nightly — deleting the wrong one of the
+    four would take entity linking down entirely."""
+    from core_api.pipeline.compositions.entity_linking import (
+        build_full_entity_linking_pipeline,
+    )
+
+    p = build_full_entity_linking_pipeline()
+    assert p._name == "entity_linking_full"
+    assert len(p._steps) == 4
+
+
+def test_the_live_builder_still_has_its_caller():
+    from core_api.services import lifecycle_audit
+
+    assert "build_full_entity_linking_pipeline" in inspect.getsource(lifecycle_audit)


### PR DESCRIPTION
Three unrelated low-severity findings from the shared remediation tracker, grouped only by size: `oss-0902-l-29`, `oss-0814-l-48`, `oss-0902-l-09`. Closes the 10-item low-priority batch.

## `oss-0902-l-29` — the retraction overwrote statuses it never set

Step 1 of the two-step retraction wrote the literal `"active"` over whatever the candidate held at that moment. Detection marks a losing candidate `outdated` or `conflicted`; **anything else means another writer has moved the row since** — confirmed by a human, archived by the crystallizer, superseded by a different chain — and stamping `"active"` over that discards someone else's decision in order to undo our own.

Now guarded on the statuses detection actually assigns, with a skipped revert logged alongside what it found. That mirrors the guard the content-edit reset has always had:

```python
if mem.get("status") in ("outdated", "conflicted"):
    patch["status"] = "active"
```

**The audit is half wrong here, and it's worth saying:** it claims the content-edit reset shares this bug. It doesn't — it was already guarded, which is exactly why only the retraction was losing statuses.

**What this does not do:** it restores `active`, not the status the row held *before* detection. A `confirmed` row marked `conflicted` still returns as `active`, because nothing records what was overwritten — neither `memories` nor `memory_conflicts` has a prior-status column. Narrowing the write is the part fixable without a migration; recovering the original value isn't.

## `oss-0814-l-48` — three builders nothing could reach

`build_quick_entity_linking_pipeline`, `build_link_discovery_pipeline` and `build_relation_inference_pipeline` had **zero references anywhere in the repo** — not a caller, not an export, not a test. Only the nightly `build_full_entity_linking_pipeline` is used (by `lifecycle_audit`), and a test pins that the live one survived, because deleting the wrong one of the four would take entity linking down entirely.

## `oss-0902-l-09` — a flag that could stall a transcript permanently

`--max-event-chars` accepted any integer. The server truncates each event at `INTERVIEW_EVENT_MAX_CHARS` (8000) and **rejects** a window exceeding it — and a rejected window never advances the cursor, so an over-large value didn't degrade the transcript, it stalled it, 422 after 422.

Clamped on both subcommands and announced on stderr: a silently-overruled flag leaves the operator believing a setting that isn't in force. Zero and negative are refused rather than clamped upward, which would invent a value nobody asked for.

Tests live in the client package's own suite — `caura_client` is a separate distribution and isn't importable from the core-api tests. The client constant is necessarily a *copy* of the server's, so a test pins the comment naming its source; nothing else links them.

## Testing

- 9 new core-api tests + 7 in the client suite.
- core-api: **27 failures, identical to main's 27** — none new.
- client: **145 passed**, with the same single pre-existing failure as main.
- `ruff check` clean on both (client CI's exact command). `mypy` unchanged.
- `cli.py` is deliberately left unformatted: it already drifts from `ruff format` on main, and reformatting would rewrite untouched `legacy-name-ok` lines.