### PR TITLE
fix(embedding): cache LocalEmbedding per model so the local provider stops reloading the model on every request

### DIFF
--- a/common/embedding/_registry.py
+++ b/common/embedding/_registry.py
@@ -33,6 +33,24 @@ logger = logging.getLogger(__name__)
 # could never have worked against this schema.
 DEFAULT_LOCAL_EMBEDDING_MODEL = "BAAI/bge-large-en-v1.5"
 
+# Cache ``LocalEmbedding`` instances by model name. The loaded
+# ``SentenceTransformer`` lives on the *instance* (``self._model``), and
+# ``get_embedding_provider`` runs on every embed/search request — so a
+# fresh instance per call meant every request paid a full model load
+# from disk (seconds, plus its own copy of the weights in RAM until GC)
+# instead of hitting the already-warm model. This is the "registry's
+# per-model instance cache" that ``LocalEmbedding.dedup_scope`` was
+# already written against.
+#
+# Unlike ``_openai_provider_cache`` there is no eviction: nothing to
+# close (no connection pool, no credential to rotate), and the key space
+# is env-driven (``LOCAL_EMBEDDING_MODEL``), so a process realistically
+# holds one entry. No lock either — there is no await between lookup and
+# insert, so coroutines can't interleave a double-construct, and
+# construction is cheap anyway (the model load is lazy and
+# single-flighted behind the instance's ``_load_lock``).
+_local_provider_cache: dict[str, LocalEmbedding] = {}
+
 # Cache OpenAI provider instances by (api_key, model). Each instance
 # holds a long-lived ``AsyncOpenAI`` (and therefore a long-lived
 # ``httpx.AsyncClient`` connection pool); without the cache, every
@@ -351,8 +369,13 @@ def get_embedding_provider(
         # config. pydantic-settings maps core-api's ``local_embedding_model`` to
         # this same var, so the two stay in step. ``or`` (not a default=) so an
         # empty value falls back rather than loading a model named "".
-        return LocalEmbedding(
+        model_name = (
             os.environ.get("LOCAL_EMBEDDING_MODEL") or DEFAULT_LOCAL_EMBEDDING_MODEL
         )
+        provider = _local_provider_cache.get(model_name)
+        if provider is None:
+            provider = LocalEmbedding(model_name)
+            _local_provider_cache[model_name] = provider
+        return provider
 
     raise ValueError(f"Unknown embedding provider: {name}")

--- a/tests/test_local_embedder_instance_cache.py
+++ b/tests/test_local_embedder_instance_cache.py
@@ -1,0 +1,54 @@
+"""The registry must reuse ``LocalEmbedding`` instances across calls.
+
+The loaded ``SentenceTransformer`` is cached on the instance
+(``self._model``), and ``get_embedding_provider`` runs on every
+embed/search request. A fresh instance per call therefore reloaded the
+model from disk on every request — seconds of latency per embed, and one
+extra copy of the weights in RAM per in-flight request. Follow-up to C38,
+which made the model configurable but kept per-call construction.
+
+These tests never touch sentence-transformers: ``LocalEmbedding.__init__``
+is lazy (the import and load happen in ``_ensure_model``), which is also
+why identity — not equality — is the thing to assert.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from common.embedding import _registry
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache():
+    """Module-level cache — keep entries from leaking between tests."""
+    with patch.dict(_registry._local_provider_cache, clear=True):
+        yield
+
+
+def test_same_model_returns_the_same_instance():
+    first = _registry.get_embedding_provider("local")
+    second = _registry.get_embedding_provider("local")
+    assert first is second
+
+
+def test_env_override_is_cached_too():
+    with patch.dict(os.environ, {"LOCAL_EMBEDDING_MODEL": "custom/model-x"}):
+        first = _registry.get_embedding_provider("local")
+        second = _registry.get_embedding_provider("local")
+    assert first is second
+    assert first.model == "custom/model-x"
+
+
+def test_distinct_models_get_distinct_instances():
+    """Keyed by model name, not a process-wide singleton: a cached default
+    must not be handed to a caller whose env now names another model."""
+    default = _registry.get_embedding_provider("local")
+    with patch.dict(os.environ, {"LOCAL_EMBEDDING_MODEL": "custom/model-x"}):
+        other = _registry.get_embedding_provider("local")
+    assert default is not other
+    assert default.model == _registry.DEFAULT_LOCAL_EMBEDDING_MODEL
+    assert other.model == "custom/model-x"


### PR DESCRIPTION
## `EMBEDDING_PROVIDER=local` reloaded the sentence-transformers model on every request

`get_embedding_provider` runs on every embed/search request (`_service.py` resolves the provider per call), and the LOCAL branch constructed a fresh `LocalEmbedding()` each time. The loaded `SentenceTransformer` is cached on the **instance** (`self._model`), so every request paid a full model load — seconds of latency per embed, plus one copy of the weights in RAM per in-flight request until GC. `LocalEmbedding.dedup_scope` already documented "the registry's per-model instance cache"; the cache didn't exist.

Dormant, not a live outage — same caveat as C38 (#1342), which revived this path but kept per-call construction: staging/prod embed via TEI/bge-m3 through the OpenAI-compatible client.

## Fix

Module-level `_local_provider_cache: dict[str, LocalEmbedding]` keyed by model name, mirroring `_openai_provider_cache` minus what doesn't apply:

- **no eviction** — nothing to close (no connection pool, no credential to rotate), and the key space is env-driven (`LOCAL_EMBEDDING_MODEL`), so a process realistically holds one entry;
- **no lock** — no await between lookup and insert, so coroutines can't interleave a double-construct; construction is cheap regardless (the model load is lazy and single-flighted behind the instance's `_load_lock`).

## Tests

`tests/test_local_embedder_instance_cache.py`: same model → same instance (default and env-override), distinct models → distinct instances. Existing C38 suite unaffected (9 passed together). `ruff check common/` and `mypy --config-file common/mypy.ini common/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)