### PR TITLE
docs(settings): pin and document the reset shape and propagation contract (D17)

### DIFF
--- a/core-api/src/core_api/routes/settings.py
+++ b/core-api/src/core_api/routes/settings.py
@@ -42,6 +42,25 @@ async def update_tenant_settings(
 ):
     """Update tenant settings. Accepts partial updates. API keys are encrypted at rest.
 
+    **Resetting a setting.** Updates are a deep MERGE, so omitting a key leaves
+    it as it was — omission means "don't touch", never "clear". To return a
+    setting to its default, send it explicitly as ``null``:
+
+        {"search": {"recall_boost": null}}          # one leaf back to default
+        {"search": {"default_profile": null}}       # a whole section back to default
+
+    Sending ``{}`` for a section is a NO-OP, not a reset — an empty dict merges
+    nothing. That reads like a clear and is the shape operators reach for first,
+    so it is called out here rather than left to be discovered by a flip that
+    silently did not take.
+
+    **Propagation.** A write invalidates the handling worker's cache
+    immediately and broadcasts ``Org.SETTINGS_CHANGED`` so sibling workers drop
+    their copies (CAURA-571). Where the event bus is in-process — the default,
+    including local dev — that broadcast does not cross processes, and siblings
+    fall back to the 5-minute TTL. Expect propagation, not immediacy, when
+    flipping a flag and measuring the result.
+
     Audit attribution: honours ``X-Changed-By`` only when the caller is
     authenticated via the admin API key (i.e. the enterprise admin-api proxy).
     Regular user requests always use ``auth.user_id`` regardless of the header.

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -1284,6 +1284,13 @@ async def update_settings(
 ) -> dict:
     """Upsert tenant overrides + write an audit row with the flat diff.
 
+    Writes are a deep MERGE (``_deep_merge``), so an omitted key keeps its
+    current value. The reset shape is an explicit ``null``: ``_validate_leaf_types``
+    passes ``None`` through deliberately, every resolver property reads ``None``
+    as "no override", and a section set to ``None`` drops the whole group back to
+    defaults. ``{}`` for a section merges nothing and is a no-op — it looks like
+    a clear and is not one, which is the trap worth knowing about.
+
     Returns the merged display view (``DEFAULT_SETTINGS`` ⊕ tenant overrides)
     so callers can echo back the resulting state. No-ops when the submitted
     payload introduces no actual changes.

--- a/tests/test_d17_settings_reset_contract.py
+++ b/tests/test_d17_settings_reset_contract.py
@@ -1,0 +1,129 @@
+"""reg-d17 — tenant-settings operability.
+
+Two behaviours were reported as silently corrupting any flip-then-measure
+workflow. Investigating them changed the task:
+
+* **Cross-worker invalidation already ships.** ``update_settings`` publishes
+  ``Org.SETTINGS_CHANGED``, ``consumer.register_consumers`` subscribes
+  ``handle_org_settings_changed`` with ``broadcast=True``, and ``app`` calls
+  that at startup (CAURA-571). What is true is narrower: the bus defaults to
+  ``inprocess``, where a broadcast cannot cross processes, so on that backend —
+  local dev included — siblings still wait out the TTL.
+
+* **Resetting a setting already works**, via an explicit ``null``. It was simply
+  undocumented, so the shape operators reach for first (``{}``) looks like a
+  clear, silently merges nothing, and the flip appears not to have taken.
+
+So the fix is to PIN and DOCUMENT the mechanism rather than build a second one.
+These tests exist because an undocumented behaviour is one refactor away from
+being an unintentional one.
+"""
+
+import inspect
+
+import pytest
+
+from common.organization_settings_merge import deep_merge
+from core_api.services.organization_settings import (
+    ResolvedConfig,
+    _validate_leaf_types,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ── the reset shape ───────────────────────────────────────────────────────
+
+
+def test_null_is_accepted_by_validation():
+    """``_validate_leaf_types`` skips ``None`` deliberately (``v is not None``).
+    If that guard ever tightens to reject null, the only reset shape goes with
+    it — hence this test rather than a comment."""
+    _validate_leaf_types(
+        {"search": {"recall_boost": None, "strict_fleet_scoping": None}}
+    )
+
+
+def test_null_returns_a_leaf_to_its_default():
+    stored = {"search": {"recall_boost": False}}
+    assert ResolvedConfig(tenant_settings=stored).recall_boost is False
+    reset = deep_merge(stored, {"search": {"recall_boost": None}})
+    assert ResolvedConfig(tenant_settings=reset).recall_boost is True  # the default
+
+
+def test_null_returns_a_whole_section_to_its_default():
+    stored = {"search": {"default_profile": {"score_formula": 1, "fts_weight": 0.4}}}
+    reset = deep_merge(stored, {"search": {"default_profile": None}})
+    assert reset["search"]["default_profile"] is None
+
+
+def test_an_empty_dict_is_a_no_op_not_a_clear():
+    """The documented trap. This is the shape an operator tries first, and it
+    leaves every key in place — the flip appears not to have taken."""
+    stored = {"search": {"default_profile": {"score_formula": 1, "fts_weight": 0.4}}}
+    after = deep_merge(stored, {"search": {"default_profile": {}}})
+    assert after["search"]["default_profile"] == {"score_formula": 1, "fts_weight": 0.4}
+
+
+def test_omitting_a_key_keeps_it():
+    """Merge semantics: omission means "don't touch", never "clear"."""
+    stored = {"search": {"recall_boost": False, "graph_retrieval": False}}
+    after = deep_merge(stored, {"search": {"recall_boost": True}})
+    assert after["search"]["graph_retrieval"] is False
+
+
+# ── the contract is written down where callers look ───────────────────────
+
+
+def test_the_route_documents_the_reset_shape():
+    """An undocumented reset is why this was filed as "can never be reset"."""
+    from core_api.routes import settings as route
+
+    doc = inspect.getdoc(route.update_tenant_settings) or ""
+    assert "null" in doc
+    assert "NO-OP" in doc or "no-op" in doc
+
+
+def test_the_route_documents_propagation_rather_than_promising_immediacy():
+    from core_api.routes import settings as route
+
+    doc = inspect.getdoc(route.update_tenant_settings) or ""
+    assert "SETTINGS_CHANGED" in doc
+    assert "TTL" in doc
+
+
+def test_the_service_documents_the_same_contract():
+    """Two layers, one contract — the merge happens here, so the rule belongs
+    here too."""
+    from core_api.services.organization_settings import update_settings
+
+    doc = inspect.getdoc(update_settings) or ""
+    assert "null" in doc and "no-op" in doc
+
+
+# ── the cross-worker path the row assumed was missing ─────────────────────
+
+
+def test_the_settings_changed_broadcast_is_published_on_write():
+    from core_api.services.organization_settings import update_settings
+
+    src = inspect.getsource(update_settings)
+    assert "Topics.Org.SETTINGS_CHANGED" in src
+    assert "invalidate_cache(tenant_id)" in src
+
+
+def test_a_subscriber_exists_and_is_registered_broadcast():
+    """Publishing to nobody would look identical to not publishing at all."""
+    from core_api import consumer
+
+    src = inspect.getsource(consumer.register_consumers)
+    assert "Topics.Org.SETTINGS_CHANGED" in src
+    assert "broadcast=True" in src
+    assert callable(consumer.handle_org_settings_changed)
+
+
+def test_the_handler_evicts_the_local_cache():
+    src = inspect.getsource(
+        __import__("core_api.consumer", fromlist=["x"]).handle_org_settings_changed
+    )
+    assert "invalidate_cache" in src


### PR DESCRIPTION
D17 was filed as two behaviours that "silently corrupt any flip-then-measure workflow". Investigating both changed the task, so this PR is smaller than the row — and the row needs correcting.

## Cross-worker invalidation already ships

`update_settings` publishes `Org.SETTINGS_CHANGED` after invalidating locally, `register_consumers` subscribes `handle_org_settings_changed` with `broadcast=True`, and `app` calls that at startup. All of it cites CAURA-571 by name.

What's true is narrower: `EVENT_BUS_BACKEND` defaults to `inprocess`, where a broadcast can't cross processes — so on that backend, **local dev included**, siblings still wait out the 5-minute TTL.

**This also corrects something I recorded on C27 (#1410).** I saw a flag take ~30s and three polls to take effect locally and wrote it up as production behaviour. It was the in-process bus, not a missing mechanism.

## Resetting already works — via `null`

`_validate_leaf_types` passes `None` through deliberately (`v is not None`), every resolver property reads `None` as "no override", and a section set to `None` drops the group back to defaults. Measured, not assumed:

| payload | result |
|---|---|
| leaf → `null` | `recall_boost False` → resolver reads the default (`True`) |
| section → `null` | `default_profile {…}` → `None` |
| section → `{}` | `default_profile {…}` → **unchanged** |

So the reported defect is real but mis-stated. The reset exists; what fails is that `{}` — the shape an operator reaches for first — merges nothing and silently no-ops, so the flip looks like it never took.

## Why documenting, not building

`{}` is deliberately left as a no-op. It's a legitimate "nothing to change in this section", and reinterpreting it as a clear would turn a harmless payload into one that wipes settings — a worse failure than the one being fixed.

Both the route and the service now state the merge semantics, the `null` reset shape, the `{}` trap, and that propagation is expected rather than immediate.

## Testing

11 tests pin all of it — including that validation still admits `null`, because if that guard ever tightens the only reset shape goes with it, and that a subscriber actually exists (publishing to nobody looks identical to not publishing).

Full suite: **27 failures, identical to main's 27** — none new. `ruff` clean; `mypy` unchanged.

Tracker row `reg-d17` should be narrowed on merge: the invalidation half is already shipped.