### PR TITLE
fix(search): ENTITY_LOOKUP silently drops temporal hints — decline the short-circuit when one is present

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -6,8 +6,12 @@ matches are found the step MAY short-circuit to an *entity_lookup* strategy
 search can be skipped — but only when the linked-memory pool can fill the
 caller's ``top_k``.  That route replaces scoring rather than re-ranking it, so
 an under-filled pool falls through instead and the entity hits are applied as a
-hop boost over real scores (H-03).  Otherwise the query is routed to keyword or
-semantic search based on the adaptive FTS weight.
+hop boost over real scores (H-03).  A query carrying a temporal hint
+(``temporal_window`` / ``date_range_filter``) declines the short-circuit the
+same way: the hard date filter and freshness handling live in the scored
+search this route skips, so honouring the hint requires falling through.
+Otherwise the query is routed to keyword or semantic search based on the
+adaptive FTS weight.
 """
 
 from __future__ import annotations
@@ -132,6 +136,45 @@ class ClassifyQuery:
                     # lottery that buries rows pure scoring ranks first
                     # (S1 @K=10000: 11/25 vs rank-1 on unboosted score).
                     ctx.data["entity_match_declined"] = True
+                    matched_ids = []
+
+                # A temporal hint must not be silently dropped: the hard
+                # ``date_range_filter`` and the ``temporal_window`` freshness
+                # handling are applied only by ExecuteScoredSearch, and the
+                # entity_lookup short-circuit skips that step (and
+                # PostFilterResults) entirely — so a dated query ("what did
+                # Alice decide two weeks ago") would return linked memories
+                # from ANY date, with nothing recording that the constraint
+                # was discarded. Decline the short-circuit and fall through to
+                # the temporal / scored-search cascade, which applies both.
+                # Ordered AFTER the over-broad decline: an over-broad match on
+                # a dated query must still suppress hop-boosting (and must not
+                # pay for expanding a >threshold seed set here).
+                #
+                # Unlike over-broad, the entity match itself is good relevance
+                # signal — so ``entity_match_declined`` is NOT set; expand now
+                # and stash the hops so ParallelEmbedAndEntityBoost hop-boosts
+                # the scored results without re-deriving FTS + expansion.
+                if matched_ids and (
+                    ctx.data.get("temporal_window") is not None or ctx.data.get("date_range_filter")
+                ):
+                    entity_hops = await self._expand_per_fleet(
+                        sc,
+                        matched_ids,
+                        tenant_id,
+                        fleet_ids,
+                        graph_max_hops,
+                        use_union=True,
+                    )
+                    ctx.data["_classified_entity_hops"] = entity_hops
+                    # Distinct wording from the other declines — same
+                    # greppability contract as the fallthrough messages below.
+                    logger.info(
+                        "classify_query: entity_lookup declined — temporal hint present "
+                        "(window=%s, date_range=%s), falling through with hop boost",
+                        ctx.data.get("temporal_window"),
+                        ctx.data.get("date_range_filter"),
+                    )
                     matched_ids = []
 
                 if matched_ids:

--- a/tests/pipeline/test_classify_query.py
+++ b/tests/pipeline/test_classify_query.py
@@ -294,8 +294,15 @@ async def test_temporal_does_not_route_without_window(mock_get_sc):
 
 @pytest.mark.asyncio
 @patch("core_api.pipeline.steps.search.classify_query.get_storage_client")
-async def test_entity_lookup_takes_priority_over_temporal(mock_get_sc):
-    """Entity match + temporal_window set → ENTITY_LOOKUP wins."""
+async def test_temporal_window_declines_entity_short_circuit(mock_get_sc):
+    """Entity match + temporal_window set → TEMPORAL wins; hops preserved.
+
+    Inverts the pre-fix pin (``ENTITY_LOOKUP wins``): the short-circuit skips
+    the scored search, which is the only place the ``date_range_filter`` hard
+    filter and the temporal freshness handling are applied — so taking it on a
+    dated query silently returned linked memories from any date. The entity
+    match survives as a hop boost via ``_classified_entity_hops``.
+    """
     entity_id = uuid.uuid4()
     memory_id = uuid.uuid4()
     eid_str = str(entity_id)
@@ -325,7 +332,85 @@ async def test_entity_lookup_takes_priority_over_temporal(mock_get_sc):
     await step.execute(ctx)
 
     plan: RetrievalPlan = ctx.data["retrieval_plan"]
-    assert plan.strategy == RetrievalStrategy.ENTITY_LOOKUP
+    assert plan.strategy == RetrievalStrategy.TEMPORAL
+    assert plan.search_param_overrides["freshness_decay_days"] == 7
+    # The decline must happen BEFORE the pool load — no wasted storage
+    # roundtrip, no per-tenant slot spent on rows that would be discarded.
+    sc.get_memory_ids_by_entity_ids.assert_not_awaited()
+    sc.load_memories_by_ids.assert_not_awaited()
+    assert "filtered_rows" not in ctx.data
+    # Entity relevance is preserved for hop-boosting, NOT suppressed: this is
+    # a good match declined for temporal correctness, unlike over-broad.
+    assert ctx.data["_classified_entity_hops"] == {entity_id: (0, 1.0)}
+    assert "entity_match_declined" not in ctx.data
+
+
+@pytest.mark.asyncio
+@patch("core_api.pipeline.steps.search.classify_query.get_storage_client")
+async def test_date_range_filter_declines_entity_short_circuit(mock_get_sc):
+    """Entity match + hard date_range_filter (no soft window) → falls through.
+
+    The hard filter is applied only by the scored search, so the short-circuit
+    must decline even when no temporal_window was extracted ("two months ago"
+    style queries set only the date range). With no window the cascade lands on
+    keyword/semantic, where ExecuteScoredSearch applies the date range.
+    """
+    entity_id = uuid.uuid4()
+    memory_id = uuid.uuid4()
+    eid_str = str(entity_id)
+    mid_str = str(memory_id)
+
+    sc = _mock_sc()
+    sc.fts_search_entities = AsyncMock(return_value=[eid_str])
+    sc.expand_graph = AsyncMock(return_value={eid_str: {"hop": 0, "weight": 1.0}})
+    sc.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
+    )
+    mock_get_sc.return_value = sc
+
+    ctx = _make_ctx(
+        "Alice",
+        top_k=1,
+        date_range_filter={"start_date": "2026-07-06", "end_date": "2026-07-12"},
+    )
+
+    step = ClassifyQuery()
+    await step.execute(ctx)
+
+    plan: RetrievalPlan = ctx.data["retrieval_plan"]
+    assert plan.strategy == RetrievalStrategy.SEMANTIC_SEARCH
+    sc.load_memories_by_ids.assert_not_awaited()
+    assert "filtered_rows" not in ctx.data
+    assert ctx.data["_classified_entity_hops"] == {entity_id: (0, 1.0)}
+
+
+@pytest.mark.asyncio
+@patch("core_api.pipeline.steps.search.classify_query.get_storage_client")
+async def test_over_broad_decline_wins_over_temporal_decline(mock_get_sc):
+    """Over-broad match + temporal hint → over-broad handling, no expansion.
+
+    Ordering pin: the over-broad decline must run first, so a dated query with
+    a >threshold match still suppresses hop-boosting (``entity_match_declined``)
+    and never pays for expanding the over-broad seed set.
+    """
+    from core_api.constants import ENTITY_LOOKUP_MAX_MATCHES
+
+    sc = _mock_sc()
+    sc.fts_search_entities = AsyncMock(
+        return_value=[str(uuid.uuid4()) for _ in range(ENTITY_LOOKUP_MAX_MATCHES + 1)]
+    )
+    mock_get_sc.return_value = sc
+
+    ctx = _make_ctx("Alice", temporal_window=timedelta(days=7))
+
+    step = ClassifyQuery()
+    await step.execute(ctx)
+
+    plan: RetrievalPlan = ctx.data["retrieval_plan"]
+    assert plan.strategy == RetrievalStrategy.TEMPORAL
+    assert ctx.data["entity_match_declined"] is True
+    sc.expand_graph.assert_not_awaited()
+    assert "_classified_entity_hops" not in ctx.data
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Bug

`ExtractTemporalHint` sets three signals — `temporal_window` (soft freshness), `date_range_filter` (hard WHERE filter), `history_hint` — and **all three are consumed only by `ExecuteScoredSearch`**. The ENTITY_LOOKUP short-circuit in `ClassifyQuery` sets `skip_scored_search=True` (and `PostFilterResults` skips via its guard), so on a dated query that matched an entity:

- *"what did Alice decide two weeks ago"* → linked memories from **any date**, ranked only by hop boost + token overlap
- the hard date-range constraint is violated **silently** — the `entity_lookup` log line records only entity count and top_k
- `_collect_memories` forwards every other visibility filter (`valid_at`, status, agents, `readable_tenant_ids`) precisely to keep parity with the scored path ("drift is a cross-tenant leak risk"); `date_range_filter` was the one filter that drifted

## Fix

A decline gate after the CAURA-698 over-broad check: when `temporal_window` or `date_range_filter` is set and entities matched, expand the graph once, stash `_classified_entity_hops`, log a distinct grep-able decline reason, and fall through to the temporal / scored-search cascade — which applies both temporal signals, with the entity match surviving as a hop boost.

Placement details, each pinned by a test:

- **Declines before the pool load** — no `load_memories_by_ids` roundtrip or per-tenant storage slot spent on rows that would be discarded (H-03 spirit).
- **Ordered after the over-broad decline** — an over-broad match on a dated query still sets `entity_match_declined` (suppressing hop-boost) and never pays for expanding a >threshold seed set.
- **`entity_match_declined` NOT set** — unlike over-broad, this match is good relevance signal; only the exclusive route is declined.

## ⚠️ Deliberate behavior flip

`test_entity_lookup_takes_priority_over_temporal` pinned the old precedence ("entity + temporal → ENTITY_LOOKUP wins"). This PR inverts it — rewritten as `test_temporal_window_declines_entity_short_circuit` with the rationale in its docstring. If that pin encoded a product decision rather than an accident of ordering, flag it here.

**Out of scope on purpose:** RECENT_CONTEXT recency-regex queries ("what did we …") still lose to ENTITY_LOOKUP. That regex matches very common entity-query phrasing, so extending the decline there reroutes far more traffic and deserves its own decision.

## Testing

- 3 tests: the inverted precedence pin (asserts TEMPORAL plan, no pool load, hops preserved, no `entity_match_declined`), hard-date-range-only decline (falls to keyword/semantic where the scored search applies the range), over-broad-first ordering (no expansion, boost suppressed).
- Full unit suite: **5,951 passed** (`-m "not benchmark and not integration"`). The 4 failures in `test_recall_returns_memory_with_pending_embedding` / `test_fts_only_row_survives_a_saturated_candidate_window` fail identically on pristine `origin/main` — they need CI's migrated Postgres (`search_vector` generated column), not related to this change.
- `ruff` and `mypy` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)