### PR TITLE
fix(embedding): unify the EMBEDDING_PROVIDER default and stop silent fake-vector persistence

### DIFF
--- a/common/embedding/_service.py
+++ b/common/embedding/_service.py
@@ -24,6 +24,7 @@ from common.embedding.constants import (
     EMBEDDING_RETRY_DELAY_S,
 )
 from common.embedding.protocols import EmbeddingProvider, InstructionAwareEmbedder
+from common.provider_names import DEFAULT_EMBEDDING_PROVIDER
 
 logger = logging.getLogger(__name__)
 
@@ -492,12 +493,24 @@ def is_blank_text(text: str) -> bool:
 
 
 def _resolve_provider_name(tenant_config: object | None) -> str:
-    """Tenant override first, else ``EMBEDDING_PROVIDER`` env, else ``"fake"``."""
+    """Tenant override first, else ``EMBEDDING_PROVIDER`` env, else the shared default.
+
+    The fallback is ``DEFAULT_EMBEDDING_PROVIDER`` — the same constant
+    behind core-api's ``Settings.embedding_provider`` — NOT ``"fake"``.
+    The old ``"fake"`` fallback meant a tenant-config-less caller in a
+    process without ``EMBEDDING_PROVIDER`` in its env silently persisted
+    fake vectors while tenant-aware callers in the same process used the
+    real provider (pydantic's ``env_file`` loads ``.env`` into Settings
+    only, never into ``os.environ``, so bare-metal runs hit exactly that
+    split). Falling back to the real-provider name is still safe with no
+    keys configured: the registry degrades to ``FakeEmbeddingProvider``
+    at construction, but through a path that WARNS.
+    """
     if tenant_config is not None:
         name = getattr(tenant_config, "embedding_provider", None)
         if name:
             return name
-    return os.environ.get("EMBEDDING_PROVIDER", "fake")
+    return os.environ.get("EMBEDDING_PROVIDER", DEFAULT_EMBEDDING_PROVIDER)
 
 
 async def get_embeddings_batch(

--- a/common/provider_names.py
+++ b/common/provider_names.py
@@ -37,3 +37,17 @@ class ProviderName(StrEnum):
     # Sentinels
     FAKE = "fake"
     NONE = "none"
+
+
+# Single source of truth for the embedding-provider default. Two resolution
+# paths read ``EMBEDDING_PROVIDER``: core-api's pydantic ``Settings``
+# (tenant-aware callers, via ``ResolvedConfig``) and
+# ``common.embedding._service._resolve_provider_name`` (tenant-config-less
+# callers — doc/skill writes, MCP doc ops, entity embeddings, the storage
+# backfill CLI). They historically carried different fallbacks ("openai" vs
+# "fake"), so with the env var unset the same process embedded memories with
+# a real provider while silently persisting fake vectors everywhere else.
+# Both defaults MUST come from here. Lives in this leaf module (not
+# ``common.embedding.constants``) so ``core_api.config`` can import it
+# without pulling the whole embedding package at settings-import time.
+DEFAULT_EMBEDDING_PROVIDER: str = ProviderName.OPENAI.value

--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -4,6 +4,7 @@ from typing import Any, Literal, Self
 from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
+from common.provider_names import DEFAULT_EMBEDDING_PROVIDER
 from common.storage_auth import read_shared_secret_file
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,11 @@ class Settings(BaseSettings):
     # (bypassing the gateway via its public run.app URL) cannot impersonate a
     # tenant by setting identity headers itself. Unset (OSS/standalone/dev) = no-op.
     gateway_shared_secret: str | None = None
-    embedding_provider: str = "openai"  # fake | openai | local
+    # fake | openai | local. The default is the shared constant so this
+    # field can never drift from ``_resolve_provider_name``'s env fallback
+    # again (they disagreed once — "openai" here vs "fake" there — and
+    # tenant-config-less paths silently persisted fake vectors).
+    embedding_provider: str = DEFAULT_EMBEDDING_PROVIDER
     # C38 — model for ``embedding_provider="local"`` (sentence-transformers).
     # MUST emit VECTOR_DIM dimensions; the provider now refuses a mismatch at
     # load rather than failing later at INSERT. Maps to LOCAL_EMBEDDING_MODEL,

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -2411,8 +2411,23 @@ async def caura_doc(
                 if source is not None:
                     from common.embedding import get_embedding
 
+                    # Tenant config so provider resolution matches the memory
+                    # paths and per-tenant embedding keys/models apply — see
+                    # routes/documents.py (same rationale, same degrade-to-
+                    # process-provider idiom on resolution failure).
+                    try:
+                        tenant_config = await resolve_config(tenant_id)
+                    except Exception:
+                        logger.warning(
+                            "caura_doc write: failed to resolve tenant config "
+                            "(tenant=%s); falling back to process-level "
+                            "embedding provider",
+                            tenant_id,
+                            exc_info=True,
+                        )
+                        tenant_config = None
                     # Synchronous write — see routes/documents.py.
-                    embedding = await get_embedding(source, background=False)
+                    embedding = await get_embedding(source, tenant_config, background=False)
                     if embedding is None:
                         return _with_latency(
                             _error_response(
@@ -2629,8 +2644,22 @@ async def caura_doc(
                     )
                 from common.embedding import get_embedding
 
+                # Same-provider query embedding — see routes/documents.py
+                # search: the query vector must come from the provider that
+                # embedded this tenant's stored documents.
+                try:
+                    tenant_config = await resolve_config(tenant_id)
+                except Exception:
+                    logger.warning(
+                        "caura_doc search: failed to resolve tenant config "
+                        "(tenant=%s); falling back to process-level embedding "
+                        "provider",
+                        tenant_id,
+                        exc_info=True,
+                    )
+                    tenant_config = None
                 # Interactive search — see documents.py: not background.
-                query_embedding = await get_embedding(query, background=False)
+                query_embedding = await get_embedding(query, tenant_config, background=False)
                 if query_embedding is None:
                     return _with_latency(
                         _error_response(

--- a/core-api/src/core_api/routes/documents.py
+++ b/core-api/src/core_api/routes/documents.py
@@ -27,6 +27,7 @@ from core_api.services.audit_service import log_action, log_cross_tenant_read
 from core_api.services.organization_settings import (
     get_raw_settings,
     get_settings_for_display,
+    resolve_config,
 )
 from core_api.services.skill_lifecycle import (
     SkillWriteContext,
@@ -380,10 +381,26 @@ async def upsert_document(
 
     embedding: list[float] | None = None
     if source is not None:
+        # Tenant config so provider resolution matches the memory paths
+        # (tenant override → env → shared default) and per-tenant embedding
+        # keys/models apply — without it, resolution fell to the raw env
+        # fallback, which historically diverged from the Settings default.
+        # Resolution failure degrades to the process-level provider rather
+        # than failing the write (same idiom as memory_service re-embeds).
+        try:
+            tenant_config = await resolve_config(body.tenant_id)
+        except Exception:
+            logger.warning(
+                "doc write: failed to resolve tenant config (tenant=%s); "
+                "falling back to process-level embedding provider",
+                body.tenant_id,
+                exc_info=True,
+            )
+            tenant_config = None
         # Synchronous write: the client blocks on this and gets the 502
         # below if it returns None, so it must not sit on the reduced
         # deferred budget. See EMBEDDING_INTERACTIVE_RESERVED_SLOTS.
-        embedding = await get_embedding(source, background=False)
+        embedding = await get_embedding(source, tenant_config, background=False)
         if embedding is None:
             raise HTTPException(
                 status_code=502,
@@ -705,9 +722,22 @@ async def search_documents(
         # the search-budget cost for the widened query.
         await check_and_increment(auth.tenant_id, "search")
 
+    # Resolve for the SEARCHED tenant (body.tenant_id, not auth.tenant_id):
+    # the query vector must come from the same provider that embedded that
+    # tenant's stored documents or the spaces split and similarity is noise.
+    try:
+        tenant_config = await resolve_config(body.tenant_id)
+    except Exception:
+        logger.warning(
+            "doc search: failed to resolve tenant config (tenant=%s); "
+            "falling back to process-level embedding provider",
+            body.tenant_id,
+            exc_info=True,
+        )
+        tenant_config = None
     # A user is waiting on this search: keep it off the background budget
     # so a bulk-ingest flood can't throttle it into the 503 below.
-    query_embedding = await get_embedding(body.query, background=False)
+    query_embedding = await get_embedding(body.query, tenant_config, background=False)
     if query_embedding is None:
         raise HTTPException(
             status_code=503,

--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -366,8 +366,12 @@ async def process_entity_extraction(
             # carries the prior skip-on-failure semantics — a single
             # entity that fails to embed becomes ``None`` in its slot
             # rather than aborting the whole batch.
+            # ``tenant_cfg`` (resolved above for the extraction call) also
+            # routes the embeds: tenant provider/key overrides apply, and
+            # resolution can't fall to the raw env default — entity vectors
+            # must live in the same space as this tenant's memory vectors.
             embed_results = await asyncio.gather(
-                *(get_embedding(name, background=True) for name, _et, _role in filtered),
+                *(get_embedding(name, tenant_cfg, background=True) for name, _et, _role in filtered),
                 return_exceptions=True,
             )
             name_embeddings: dict[str, list[float] | None] = {}

--- a/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
+++ b/core-storage-api/src/core_storage_api/scripts/backfill_embeddings.py
@@ -38,6 +38,11 @@ each row's tenant config (DB lookup or proxy call) inside the embed
 loop, which conflicts with the "standalone, no service deps" design
 goal of this CLI.
 
+A startup preflight refuses live (non ``--dry-run``) runs whose
+process-level provider resolves to the FAKE provider — fake "repairs"
+permanently poison NULL-embedding rows. Override for dev/test
+databases with ``--allow-fake-provider``.
+
 If your deployment uses per-tenant embedding overrides, **stop and
 use the event-driven backfill task in core-worker instead**:
 
@@ -684,6 +689,17 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Limit to a single table (memories or entities). Default: both.",
     )
     p.add_argument(
+        "--allow-fake-provider",
+        action="store_true",
+        help=(
+            "Permit a live run against the FAKE embedding provider (dev/test "
+            "databases only). Without this flag the preflight refuses to run "
+            "when the process-level provider resolves to fake — a fake "
+            "'repair' writes hash-based vectors into rows that then stop "
+            "being NULL, so no later real backfill will ever revisit them."
+        ),
+    )
+    p.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -698,13 +714,50 @@ async def _amain(argv: list[str]) -> int:
         format="%(asctime)s %(levelname)s %(name)s | %(message)s",
     )
 
-    # Sanity: does an embedding provider key resolve to anything?
-    if not os.environ.get("OPENAI_API_KEY") and (os.environ.get("EMBEDDING_PROVIDER", "fake") in ("openai",)):
-        logger.error(
-            "EMBEDDING_PROVIDER=openai but OPENAI_API_KEY is unset. "
-            "Set the key or change the provider before running backfill."
-        )
-        return 1
+    # Preflight: refuse a live run whose rows would be "repaired" with fake
+    # vectors. Two roads lead there — ``EMBEDDING_PROVIDER=fake`` set
+    # explicitly, and provider ``openai`` with no key resolving anywhere
+    # (the registry then degrades to ``FakeEmbeddingProvider``, logging a
+    # warning per call but never failing). Either way the poisoned rows
+    # stop being NULL, so the selector never revisits them: permanent
+    # damage, hence a hard refusal rather than a warning. Overridable with
+    # ``--allow-fake-provider`` for dev/test databases.
+    #
+    # Replaces the older openai-without-OPENAI_API_KEY check, which had
+    # both a false negative (unset EMBEDDING_PROVIDER used to fall back to
+    # "fake" and sail through) and a false positive (platform-tier
+    # ``PLATFORM_EMBEDDING_*`` credentials satisfy the openai path without
+    # ``OPENAI_API_KEY``). Constructing the provider once and inspecting
+    # what actually resolved answers the real question. ``local`` is
+    # exempted from construction — it never silently degrades to fake, and
+    # building it here could eagerly load the sentence-transformers model.
+    # Dry runs skip the preflight: they make no provider calls.
+    if not args.dry_run:
+        from common.embedding import get_embedding_provider
+        from common.provider_names import DEFAULT_EMBEDDING_PROVIDER, ProviderName
+
+        provider_name = os.environ.get("EMBEDDING_PROVIDER", DEFAULT_EMBEDDING_PROVIDER)
+        resolved_fake = provider_name == ProviderName.FAKE
+        if provider_name not in (ProviderName.FAKE, ProviderName.LOCAL):
+            try:
+                provider = get_embedding_provider(provider_name)
+            except ValueError:
+                logger.exception(
+                    "Embedding provider misconfigured (EMBEDDING_PROVIDER=%r); "
+                    "fix the environment before running backfill.",
+                    provider_name,
+                )
+                return 1
+            resolved_fake = provider.provider_name == ProviderName.FAKE
+        if resolved_fake and not args.allow_fake_provider:
+            logger.error(
+                "Embedding provider resolved to FAKE (EMBEDDING_PROVIDER=%r). "
+                "A live backfill would permanently poison NULL-embedding rows "
+                "with hash-based vectors. Configure a real provider (or its "
+                "API key), or pass --allow-fake-provider for a dev/test DB.",
+                provider_name,
+            )
+            return 1
 
     # --rewrite-hint-prefixed is intentionally non-idempotent: the
     # selector keys on metadata.retrieval_hint, which the rewrite

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -253,6 +253,11 @@ async def test_amain_returns_2_on_runtime_error(
         "core_storage_api.scripts.backfill_embeddings.run_backfill",
         _runtime_explode,
     )
+    # A real provider name + key so the fake-provider preflight passes and
+    # the test reaches the exit-code mapping under scrutiny (the suite-wide
+    # conftest default is EMBEDDING_PROVIDER=fake, which the preflight
+    # refuses on live runs).
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     code = await _amain([])
@@ -281,6 +286,9 @@ async def test_amain_returns_1_on_unexpected_exception(
         "core_storage_api.scripts.backfill_embeddings.run_backfill",
         _value_explode,
     )
+    # See test_amain_returns_2_on_runtime_error: get past the fake-provider
+    # preflight to reach the exit-code mapping.
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     with caplog.at_level(
@@ -502,6 +510,8 @@ async def test_amain_warns_on_non_idempotent_rewrite(
         "core_storage_api.scripts.backfill_embeddings.asyncio.sleep",
         _record_sleep,
     )
+    # Past the fake-provider preflight (conftest pins EMBEDDING_PROVIDER=fake).
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     code = await _amain(["--rewrite-hint-prefixed"])
@@ -581,6 +591,8 @@ async def test_amain_no_warning_on_default_mode(
         "core_storage_api.scripts.backfill_embeddings.asyncio.sleep",
         _record_sleep,
     )
+    # Past the fake-provider preflight (conftest pins EMBEDDING_PROVIDER=fake).
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     code = await _amain([])
@@ -589,6 +601,131 @@ async def test_amain_no_warning_on_default_mode(
     assert code == 0
     assert "NOT idempotent" not in captured.err
     assert sleeps == []
+
+
+# ---------------------------------------------------------------------------
+# Fake-provider preflight
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_refuses_live_run_on_fake_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """EMBEDDING_PROVIDER=fake + live run → exit 1 before any backfill
+    work. A fake 'repair' flips rows out of the NULL selector forever, so
+    the refusal must fire before ``run_backfill``."""
+    import logging
+
+    from core_storage_api.scripts.backfill_embeddings import _amain
+
+    called: list[bool] = []
+
+    async def _must_not_run(**_kw):
+        called.append(True)
+        return []
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.run_backfill", _must_not_run
+    )
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "fake")
+
+    with caplog.at_level(
+        logging.ERROR, logger="core_storage_api.scripts.backfill_embeddings"
+    ):
+        code = await _amain([])
+
+    assert code == 1
+    assert called == []
+    assert "resolved to FAKE" in caplog.text
+    assert "--allow-fake-provider" in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_refuses_openai_that_degrades_to_fake(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider "openai" with no key anywhere (tenant, env, platform)
+    degrades to FakeEmbeddingProvider inside the registry — the preflight
+    must catch what actually RESOLVED, not just the name. This is the case
+    the old openai-without-OPENAI_API_KEY guard checked, now subsumed."""
+    from core_storage_api.scripts.backfill_embeddings import _amain
+
+    called: list[bool] = []
+
+    async def _must_not_run(**_kw):
+        called.append(True)
+        return []
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.run_backfill", _must_not_run
+    )
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    # conftest pins PLATFORM_EMBEDDING_PROVIDER="" so the platform tier is
+    # off; make it explicit here since it is what this test is about.
+    monkeypatch.setenv("PLATFORM_EMBEDDING_PROVIDER", "")
+
+    code = await _amain([])
+
+    assert code == 1
+    assert called == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_allow_fake_provider_overrides_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--allow-fake-provider is the dev/test escape hatch: same fake
+    environment as the refusal test, but the run proceeds."""
+    from core_storage_api.scripts.backfill_embeddings import _amain
+
+    called: list[bool] = []
+
+    async def _record_run(**_kw):
+        called.append(True)
+        return []
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.run_backfill", _record_run
+    )
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "fake")
+
+    code = await _amain(["--allow-fake-provider"])
+
+    assert code == 0
+    assert called == [True]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_dry_run_skips_fake_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--dry-run makes no provider calls and writes nothing, so it must
+    work in keyless/fake environments — that is the scope-estimation use
+    case."""
+    from core_storage_api.scripts.backfill_embeddings import _amain
+
+    called: list[bool] = []
+
+    async def _record_run(**_kw):
+        called.append(True)
+        return []
+
+    monkeypatch.setattr(
+        "core_storage_api.scripts.backfill_embeddings.run_backfill", _record_run
+    )
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "fake")
+
+    code = await _amain(["--dry-run"])
+
+    assert code == 0
+    assert called == [True]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_doc.py
+++ b/tests/test_mcp_doc.py
@@ -259,8 +259,9 @@ async def test_doc_write_summary_embeds_and_forwards(mcp_env, monkeypatch):
 
     # ``**kwargs`` tolerates get_embedding's keyword-only ``background``:
     # the doc write is synchronous, so it opts out of the deferred budget.
-    async def fake_embed(text, **_kwargs):
+    async def fake_embed(text, tenant_config=None, **_kwargs):
         captured["embed_text"] = text
+        captured["embed_tenant_config"] = tenant_config
         return [0.1] * VECTOR_DIM
 
     sc = stub_storage_client(monkeypatch, upsert_document_xmax={"xmax": 0})

--- a/tests/test_platform_providers.py
+++ b/tests/test_platform_providers.py
@@ -726,3 +726,59 @@ class TestPlatformEmbeddingSelfHosted:
         monkeypatch.setenv("PLATFORM_EMBEDDING_TRUNCATE_TO_DIM", "not-an-int")
 
         _init_and_assert_rejected()
+
+
+# ---------------------------------------------------------------------------
+# Group 6: EMBEDDING_PROVIDER default unification
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultProviderNameUnification:
+    """The env fallback must match core-api's ``Settings`` default.
+
+    Regression for the split default: ``Settings.embedding_provider`` said
+    ``"openai"`` while ``_resolve_provider_name`` fell back to ``"fake"``,
+    so tenant-config-less callers (doc/skill writes, MCP doc ops, entity
+    embeddings, the storage backfill CLI) silently persisted fake vectors
+    in processes whose env lacked ``EMBEDDING_PROVIDER`` while memory
+    paths in the same process embedded for real. Both now read
+    ``common.provider_names.DEFAULT_EMBEDDING_PROVIDER``.
+    """
+
+    def test_env_unset_falls_back_to_shared_default(self, monkeypatch):
+        from common.embedding._service import _resolve_provider_name
+        from common.provider_names import DEFAULT_EMBEDDING_PROVIDER
+
+        monkeypatch.delenv("EMBEDDING_PROVIDER", raising=False)
+        assert _resolve_provider_name(None) == DEFAULT_EMBEDDING_PROVIDER
+        # The default is the REAL provider: with no keys configured the
+        # registry still degrades to fake, but through a path that warns.
+        assert DEFAULT_EMBEDDING_PROVIDER == "openai"
+
+    def test_env_wins_over_default(self, monkeypatch):
+        from common.embedding._service import _resolve_provider_name
+
+        monkeypatch.setenv("EMBEDDING_PROVIDER", "fake")
+        assert _resolve_provider_name(None) == "fake"
+
+    def test_tenant_config_wins_over_env(self, monkeypatch):
+        from common.embedding._service import _resolve_provider_name
+
+        monkeypatch.setenv("EMBEDDING_PROVIDER", "fake")
+
+        class _Cfg:
+            embedding_provider = "openai"
+
+        assert _resolve_provider_name(_Cfg()) == "openai"
+
+    def test_settings_field_default_is_the_shared_constant(self):
+        # Introspect the FIELD default rather than constructing Settings():
+        # construction reads .env / process env and would test the machine,
+        # not the code.
+        from common.provider_names import DEFAULT_EMBEDDING_PROVIDER
+        from core_api.config import Settings
+
+        assert (
+            Settings.model_fields["embedding_provider"].default
+            == DEFAULT_EMBEDDING_PROVIDER
+        )


### PR DESCRIPTION
## The bug (validated, then prod-verified)

The embedding-provider default lived in two places and disagreed: core-api's pydantic `Settings.embedding_provider` said **`"openai"`** while `common.embedding._resolve_provider_name`'s env fallback said **`"fake"`**. Any caller without a `tenant_config`, in a process whose env lacked `EMBEDDING_PROVIDER`, silently embedded and persisted FAKE hash vectors while memory paths in the same process embedded for real.

Affected tenant-config-less paths: doc/skill writes + doc search (REST and MCP `caura_doc`), entity-name embeddings, and the storage backfill CLI. The fake provider always succeeds, so every `embedding is None` guard passed — no error, no log. Live repro: bare-metal `.env`-file runs (pydantic's `env_file` loads into Settings, never `os.environ`; there is no `load_dotenv` anywhere) and the backfill CLI. Prod SaaS was verified safe on 2026-09-09 only because `EMBEDDING_PROVIDER=openai` is set out-of-band on the service (companion pin: caura-enterprise PR on `promote-to-prod.yml`).

## The fix

- **One default.** `common.provider_names.DEFAULT_EMBEDDING_PROVIDER = "openai"`, read by both `Settings.embedding_provider` and `_resolve_provider_name`'s env fallback. Keyless dev still degrades to the fake provider, but through the registry path that WARNS — never silently.
- **Tenant config at every embed site.** Doc/skill write + search (REST and MCP) resolve the tenant's config (cache-first, 5-min TTL; degrade-to-`None` on failure, same idiom as memory_service), so per-tenant provider/key/model overrides now apply on those paths too. The entity-extraction worker passes the `tenant_cfg` it already resolves for extraction (A5c).
- **Backfill CLI preflight.** A live (non `--dry-run`) run now refuses to start when the process-level provider *resolves* to fake — explicit `EMBEDDING_PROVIDER=fake`, or `openai` degrading with no key anywhere — unless `--allow-fake-provider`. A fake "repair" flips rows out of the NULL selector forever, hence hard refusal. This replaces the old openai-without-`OPENAI_API_KEY` check, which had a false negative (unset provider fell back to `"fake"` and sailed through) and a false positive (platform-tier `PLATFORM_EMBEDDING_*` credentials satisfy openai without `OPENAI_API_KEY`). `local` is exempt from preflight construction so we never eagerly load the sentence-transformers model.

## Tests

- New `TestDefaultProviderNameUnification` (tests/test_platform_providers.py): env-unset → shared default, env wins, tenant wins, and `Settings.model_fields` default == the constant.
- New preflight tests (tests/test_backfill_embeddings.py): fake refusal fires before `run_backfill`, openai-degrading-to-fake refusal, `--allow-fake-provider` override, `--dry-run` exemption. Existing `_amain` tests updated to set a real provider (they previously leaned on the buggy fallback).
- Full root suite: 6,400+ passed. core-storage-api suite: 371 passed. (31 root failures are pre-existing on clean `origin/main` — local-DB schema staleness, verified by stash-and-rerun.)

## Behavior-change note

A bare-metal run with `OPENAI_API_KEY` exported but `EMBEDDING_PROVIDER` unset previously embedded fake; it now embeds real (matching what the Settings default always claimed). Docker/compose, onprem, staging, and prod all set `EMBEDDING_PROVIDER` explicitly and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)