### PR TITLE
fix(worker): stop discarding atomic facts on the async enrichment path (A70 step 1)

### DIFF
--- a/core-worker/src/core_worker/consumer.py
+++ b/core-worker/src/core_worker/consumer.py
@@ -284,6 +284,10 @@ _ENRICHMENT_METADATA_FIELDS: frozenset[str] = frozenset(
         "pii_types",
         "business_relevance",
         "retrieval_hint",
+        # Persisted, not consumed here: the row carries the claims the LLM
+        # found so core-api can fan them out. Storing them is what makes the
+        # gap recoverable — a dropped list means re-running the LLM.
+        "atomic_facts",
         "llm_ms",
     }
 )
@@ -293,11 +297,18 @@ _ENRICHMENT_METADATA_FIELDS: frozenset[str] = frozenset(
 # fails when a future field is added without a code site to handle it
 # — silent drops are the failure mode we're guarding against.
 #
-# ``atomic_facts``: the synchronous write path fans these out into
-# child memories; the async worker doesn't yet implement that — see
-# the ``logger.debug`` in ``handle_enrich_request`` that surfaces the
-# gap when an enrichment produces them.
-_ENRICHMENT_UNROUTED_FIELDS: frozenset[str] = frozenset({"atomic_facts"})
+# Every ``EnrichmentResult`` field now routes somewhere. ``atomic_facts``
+# used to sit here — the worker computed them and threw them away, so a
+# fast-mode write of multi-claim content produced fewer memories than the
+# same content written in strong mode, and the difference was unrecoverable
+# because the LLM answer was gone. They are persisted to metadata now (see
+# ``_ENRICHMENT_METADATA_FIELDS``); the fan-out into child memories still
+# belongs to core-api, which already consumes ``Topics.Memory.ENRICHED`` and
+# already owns the fan-out logic, with its live-hash dedup, visibility and
+# weight inheritance. Duplicating that here would be a second implementation
+# of a subtle path — and the worker's storage client has no create-memory
+# call at all.
+_ENRICHMENT_UNROUTED_FIELDS: frozenset[str] = frozenset()
 
 # Metadata fields that ALWAYS overwrite (when not ``None`` and the
 # result came from a real LLM call — see the ``llm_ms > 0`` guard at
@@ -331,8 +342,21 @@ _ENRICHMENT_UNROUTED_FIELDS: frozenset[str] = frozenset({"atomic_facts"})
 #   memory personal↔business; the ``llm_ms > 0`` guard prevents
 #   ``fake_enrich``'s default "business" from clobbering a real
 #   "personal" classification on a heuristic-fallback redelivery.
+# * ``atomic_facts`` — same reasoning as ``tags``: a re-enrichment that finds
+#   ONE claim where a previous run found three must be able to clear the stale
+#   two, or the fan-out would later create children for claims the current
+#   content no longer makes. The ``llm_ms > 0`` guard keeps a heuristic-fallback
+#   redelivery from clearing a real LLM's facts.
 _ENRICHMENT_ALWAYS_WRITE_METADATA: frozenset[str] = frozenset(
-    {"contains_pii", "pii_types", "business_relevance", "retrieval_hint", "summary", "tags"}
+    {
+        "contains_pii",
+        "pii_types",
+        "business_relevance",
+        "retrieval_hint",
+        "summary",
+        "tags",
+        "atomic_facts",
+    }
 )
 
 # Defence-in-depth: a typo in the tuples above would silently drop in
@@ -580,26 +604,26 @@ async def handle_enrich_request(event: Event) -> None:
 
     patch = _build_patch(result, request.agent_provided_fields)
 
-    # Surface the sync-vs-async behavioural gap: the synchronous write
-    # path in ``memory_service.py`` fans ``atomic_facts`` out into
-    # child memories. The async worker doesn't yet — content with
-    # multiple distinct claims gets fewer memories on this path.
-    # Implementing child-memory creation in the worker requires a
-    # fresh embed roundtrip per child + a parent-link plumb through
-    # storage; tracked separately.
+    # The sync/async gap, now HALF closed. ``memory_service.py`` fans
+    # ``atomic_facts`` out into child memories on the synchronous path; this
+    # worker does not, so fast-mode multi-claim content still yields fewer
+    # memories than the same content written in strong mode.
     #
-    # Logged at WARNING (not ERROR): the gap is real but expected
-    # under the current PR scope, and ERROR-paging on every multi-fact
-    # write would drown the on-call alert channel without giving them
-    # an actionable fix. The follow-up ticket reference makes the gap
-    # discoverable; a dashboard counter on the WARNING string lets
-    # operators quantify exposure.
+    # What changed: the facts are no longer DISCARDED. They ride into the row's
+    # metadata above, so the gap is now recoverable from stored data instead of
+    # requiring the LLM to be re-run. Fan-out stays in core-api, which already
+    # consumes ``Topics.Memory.ENRICHED`` and already owns the dedup /
+    # visibility / weight rules a child must inherit.
+    #
+    # Still WARNING, not ERROR: the gap is real but expected, and paging on
+    # every multi-fact write would bury on-call without an actionable fix. The
+    # string stays greppable so the exposure remains countable — that count is
+    # what the A75 proof gate needs to size this.
     if result.atomic_facts:
         logger.warning(
-            "enrich-request for memory %s produced %d atomic_facts; "
-            "child-memory creation not yet implemented in async path "
-            "(tracked: CAURA-595 follow-up) — secondary facts will "
-            "NOT appear as child memories",
+            "enrich-request for memory %s produced %d atomic_facts; persisted to "
+            "metadata but child-memory fan-out is not yet implemented on the async "
+            "path — secondary facts will NOT appear as child memories YET",
             request.memory_id,
             len(result.atomic_facts),
         )

--- a/tests/test_a70_atomic_facts_persisted.py
+++ b/tests/test_a70_atomic_facts_persisted.py
@@ -1,0 +1,105 @@
+"""reg-a70 step 1 — the async worker stopped throwing atomic facts away.
+
+Atomize-on-write is largely built already: the enrichment prompt asks for
+``atomic_facts`` (field 9), ``AtomicFact`` and ``EnrichmentResult.atomic_facts``
+exist with a validator, and ``memory_service`` fans them out into child memories
+on the SYNCHRONOUS path — with live-hash dedup, visibility and weight
+inheritance, and non-fatal failure.
+
+The async worker did none of that. Worse, it did not merely skip the fan-out: it
+listed ``atomic_facts`` in ``_ENRICHMENT_UNROUTED_FIELDS`` and DISCARDED them,
+so the LLM's answer was gone and the only way to recover it was to pay for the
+call again. A fast-mode write of multi-claim content produced fewer memories
+than the same content in strong mode, permanently.
+
+This step persists them. Fan-out stays in core-api, which already consumes
+``Topics.Memory.ENRICHED`` and already owns the rules a child must inherit —
+and the worker's storage client has no create-memory call at all, so putting it
+here would mean both a new write capability and a second copy of a subtle path.
+"""
+
+import pytest
+
+from common.enrichment import EnrichmentResult
+from core_worker import consumer as wc
+
+pytestmark = pytest.mark.unit
+
+
+def test_atomic_facts_are_no_longer_discarded():
+    """The one-line regression: the field used to sit in the drop list."""
+    assert "atomic_facts" not in wc._ENRICHMENT_UNROUTED_FIELDS
+
+
+def test_atomic_facts_route_to_metadata():
+    assert "atomic_facts" in wc._ENRICHMENT_METADATA_FIELDS
+
+
+def test_nothing_is_unrouted_any_more():
+    """The drop list is now empty, so the import-time drift guard below covers
+    every field rather than every field except one."""
+    assert not wc._ENRICHMENT_UNROUTED_FIELDS
+
+
+def test_every_enrichment_field_still_has_a_home():
+    """Mirrors the module's own import-time guard. If someone adds a field to
+    ``EnrichmentResult`` and wires it nowhere, this fails here rather than the
+    value silently landing on the floor."""
+    unrouted = (
+        set(EnrichmentResult.model_fields)
+        - wc._ENRICHMENT_ORM_FIELDS
+        - wc._ENRICHMENT_METADATA_FIELDS
+        - wc._ENRICHMENT_UNROUTED_FIELDS
+    )
+    assert unrouted == set(), f"unrouted enrichment fields: {unrouted}"
+
+
+def test_a_re_enrichment_can_clear_stale_facts():
+    """Always-write, for the same reason ``tags`` is. A re-run that finds ONE
+    claim where a previous run found three must be able to clear the stale two,
+    or the fan-out would later create children for claims the current content no
+    longer makes."""
+    assert "atomic_facts" in wc._ENRICHMENT_ALWAYS_WRITE_METADATA
+
+
+def test_a_heuristic_fallback_cannot_clear_real_facts():
+    """Always-write is paired with the ``llm_ms > 0`` guard everywhere it is
+    used; without it a fallback redelivery during an LLM outage would wipe facts
+    a real run produced."""
+    import inspect
+
+    # Comments stripped and the window sized off the CODE: the always-write
+    # branch carries a long explanatory comment, so a byte-window over the raw
+    # source measures prose rather than the guard's placement.
+    code = [
+        ln
+        for ln in inspect.getsource(wc._build_patch).splitlines()
+        if not ln.lstrip().startswith("#")
+    ]
+    i = next(
+        n for n, ln in enumerate(code) if "_ENRICHMENT_ALWAYS_WRITE_METADATA" in ln
+    )
+    assert any("result.llm_ms > 0" in ln for ln in code[i : i + 4]), (
+        "the always-write branch no longer guards on a real LLM call"
+    )
+
+
+def test_the_gap_log_no_longer_claims_the_facts_are_lost():
+    """The WARNING is the operator's only signal here. It said the facts would
+    not appear as children — true — but implied they were gone, which is no
+    longer the case, and the difference decides whether anyone has to re-run the
+    LLM to recover them."""
+    import inspect
+
+    src = inspect.getsource(wc.handle_enrich_request)
+    assert "persisted to" in src
+    assert "not yet implemented" in src
+
+
+def test_the_gap_warning_stays_greppable_and_counted():
+    """The count is what sizes the exposure for the A75 proof gate."""
+    import inspect
+
+    src = inspect.getsource(wc.handle_enrich_request)
+    assert "len(result.atomic_facts)" in src
+    assert "logger.warning" in src[src.index("if result.atomic_facts:") - 400 :]


### PR DESCRIPTION
## A70 is mostly already built

I went looking for where to add `facts[]` and found it there:

- The enrichment prompt has **field 9 `atomic_facts`**, with exactly the intended semantics — *"each entry becomes its own child memory with its own embedding"*.
- `AtomicFact` and `EnrichmentResult.atomic_facts` exist, with a validator and **17 passing tests**.
- `memory_service.py:3103` **already fans them out** into child memories on the **synchronous** path — live-hash *and* intra-loop dedup, visibility and weight inheritance, non-fatal failure.

**Estimate on the tracker row drops from ~4d to ~1d.**

## What the async worker was doing

Not merely skipping the fan-out — **discarding the facts**:

```python
_ENRICHMENT_UNROUTED_FIELDS: frozenset[str] = frozenset({"atomic_facts"})
```

So the LLM's answer was gone, and the only way to recover it was to pay for the call again. A fast-mode write of multi-claim content produced fewer memories than the same content in strong mode — permanently, and silently.

## This PR

Routes the facts into the row's metadata. **Persisted, not yet consumed.** Two things change:

- the fast/strong gap becomes **recoverable from stored data** instead of requiring an LLM re-run;
- the exposure becomes **countable from real traffic**, which is what the A75 proof gate needs to size this.

Routed as **always-write**, for the same reason `tags` is: a re-enrichment finding one claim where a previous run found three must be able to clear the stale two, or a later fan-out creates children for claims the content no longer makes. The existing `llm_ms > 0` guard stops a heuristic-fallback redelivery wiping real facts.

`_ENRICHMENT_UNROUTED_FIELDS` is now **empty**, so the module's import-time drift guard covers every `EnrichmentResult` field rather than every field but one.

## Why fan-out stays in core-api

Core-api already consumes `Topics.Memory.ENRICHED` (`handle_memory_enriched`) and already owns the dedup / visibility / weight rules a child must inherit. Duplicating that here would be a second implementation of a subtle path — the mistake A54 and C27 both paid for. The worker's storage client also has **no create-memory call at all**, so doing it here means granting the worker a write capability it has never had.

**Step 2** — the core-api fan-out from the persisted facts — is the remainder of A70.

## Testing

8 new tests, including that the drop list is now empty and that every enrichment field still has a routing home (mirroring the module's own import-time guard).

core-api suite: **27 failures vs main's 28** — none new. Main's extra is the flaky wall-clock test now filed as `oss-0909-l-01`. `ruff` clean; `mypy` on core-worker unchanged.