### PR TITLE
perf(search): compute scored-search primitives once via a fenced ingredients CTE (HNSW plan PR1)

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -2381,6 +2381,19 @@ class PostgresService:
         _score_formula = int(sp.get("score_formula", 0) or 0)
 
         # -- Scoring expressions --
+        #
+        # Two-layer build. The per-row primitives that are expensive to
+        # evaluate — the pgvector cosine distance and ``ts_rank_cd`` — are
+        # projected exactly ONCE into a fenced ``ingredients`` CTE, and every
+        # derived factor (similarity, freshness, boosts, penalties, score) is
+        # computed in the branch layer above it from those columns. This is the
+        # inner-projection work ``_saturate_rank``'s note promised: before it,
+        # SQLAlchemy inlined the ``vec_sim`` CASE at every site that named it
+        # and the compiled statement paid SIX cosine distance computations per
+        # candidate row (427ms -> 90ms for this change alone on a 50k-row,
+        # 1024-dim rig; the ratchet in test_fts_score_single_render pins the
+        # counts in both directions).
+        #
         # CAURA-594: pgvector's `<=>` is strict — NULL in → NULL out. A
         # bare `1 - cosine_distance` would therefore propagate NULL up
         # through the similarity blend into `score`, and PostgreSQL's
@@ -2416,6 +2429,195 @@ class PostgresService:
         scaled_keyword_rank = _fts_rank_scale * raw_keyword_rank
         fts_score = _saturate_rank(scaled_keyword_rank).label("fts_score")
 
+        # CAURA-594 admission guard + exact-lexical-match gate share ONE
+        # expression. `plainto_tsquery('english', '')` (and any whitespace-only
+        # or stop-word-only input it normalises down to empty) returns the
+        # empty `tsquery`, which `@@`-matches every non-NULL `tsvector` — that
+        # would silently re-admit every NULL-embedding row when callers pass
+        # `query=""` or `query="   "` (e.g. entity-only / vector-only search
+        # modes), bringing back the displacement-by-weight bug. Gate on the
+        # Python-side query string so the operator is only emitted when there's
+        # actual text to match.
+        #
+        # ``_fts_guard`` is used in WHERE clauses (admission, the conflicted
+        # carve-out, and its projection below); the ``fts_match`` COLUMN it
+        # projects is what the derived layer reads for the status-penalty gate
+        # and the FTS-reserve filter — the exact-lexical-match signal and the
+        # fts-match signal are the same expression, so one column serves both.
+        _fts_guard = Memory.search_vector.op("@@")(ts_query) if query and query.strip() else false()
+        _exact_lexical_match = _fts_guard
+        fts_match = _fts_guard.label("fts_match")
+
+        # -- Layer 0: the ``ingredients`` CTE --
+        # Row filters are identical to the pre-split statement; only the select
+        # list changed. Raw row fields ride along so the derived layer never
+        # touches ``memories`` again before the final top_k join.
+        ingredients_stmt = (
+            select(
+                Memory.id.label("mem_id"),
+                vec_sim,
+                has_embedding,
+                fts_score,
+                fts_match,
+                Memory.created_at.label("created_at"),
+                Memory.ts_valid_start.label("ts_valid_start"),
+                Memory.ts_valid_end.label("ts_valid_end"),
+                Memory.memory_type.label("memory_type"),
+                Memory.weight.label("weight"),
+                Memory.status.label("status"),
+                Memory.recall_count.label("recall_count"),
+                Memory.last_recalled_at.label("last_recalled_at"),
+            )
+            # Multi-tenant read predicate: when ``readable_tenant_ids``
+            # is provided (cross-tenant agent key), reads widen across
+            # the full set; otherwise we stay single-tenant for the
+            # common case. Result rows still carry ``Memory.tenant_id``
+            # so the caller can attribute each row to its source tenant.
+            .where(
+                Memory.tenant_id.in_(readable_tenant_ids)
+                if readable_tenant_ids
+                else Memory.tenant_id == tenant_id
+            )
+            .where(Memory.deleted_at.is_(None))
+            # CAURA-594: NULL-embedding rows are admitted only if they also
+            # match the FTS query — otherwise they'd rank on `Memory.weight *
+            # freshness * ...` alone and could fill top_k slots with rows
+            # that have no relationship to the query during a large backfill
+            # window. `search_vector @@ ts_query` is GIN-indexed, so the
+            # extra predicate is free for rows that already had to scan
+            # the tenant/fleet slice.
+            # Other paths (find_semantic_duplicate, find_similar_candidates,
+            # find_neighbors_by_embedding, compute_health_stats) keep their
+            # NULL guards — vector-pure operations where a NULL operand has
+            # no comparable semantics.
+            .where(
+                or_(
+                    Memory.embedding.is_not(None),
+                    _fts_guard,
+                )
+            )
+        )
+
+        if fleet_ids:
+            ingredients_stmt = ingredients_stmt.where(
+                _fleet_scope_clause(Memory, fleet_ids, strict=strict_fleet_scoping)
+            )
+
+        if caller_agent_id:
+            visibility_filter = or_(
+                Memory.visibility == "scope_org",
+                Memory.visibility == "scope_team",
+                and_(
+                    Memory.visibility == "scope_agent",
+                    Memory.agent_id == caller_agent_id,
+                ),
+            )
+            ingredients_stmt = ingredients_stmt.where(visibility_filter)
+        else:
+            ingredients_stmt = ingredients_stmt.where(Memory.visibility != "scope_agent")
+
+        if filter_agent_id:
+            ingredients_stmt = ingredients_stmt.where(Memory.agent_id == filter_agent_id)
+        if memory_type_filter:
+            ingredients_stmt = ingredients_stmt.where(Memory.memory_type == memory_type_filter)
+        if status_filter:
+            ingredients_stmt = ingredients_stmt.where(Memory.status == status_filter)
+        elif history_query:
+            # A63 — a history question ("what was…", "did I switch…",
+            # "how long have I been…") needs the superseded value: the
+            # older side of an update is EXACTLY what the caller asked
+            # for, so neither the exclusion below nor the status_penalty
+            # applies. Ranking is pure relevance; present-state queries
+            # keep both protections.
+            pass
+        else:
+            # Exclude superseded memories from default search results. The
+            # contradiction detector marks the older row ``outdated`` (RDF
+            # path) or ``conflicted`` (semantic path) and points the newer
+            # one at it via ``supersedes_id``. Surfacing both would dilute
+            # ranking with stale claims agents shouldn't act on. Callers
+            # that need to inspect superseded rows pass an explicit
+            # ``status_filter`` to override.
+            #
+            # Carve-out: a ``conflicted`` row that is an EXACT lexical match
+            # for the query is kept. ``conflicted`` (unlike ``outdated``) means
+            # "a competing claim exists", not "definitively retracted" — and the
+            # semantic contradiction path mismarks near-duplicate-but-distinct
+            # entities (e.g. ``Wayne #0000`` vs ``Wayne #0704``), so a blanket
+            # exclusion silently drops the very row the caller named. The
+            # exact-match gate scopes the carve-out to rows the caller clearly
+            # asked for; status_penalty above keeps a surfaced exact-match
+            # conflicted row un-demoted, and load_and_serialize still injects its
+            # supersedes successor so both sides are visible. ``outdated`` stays
+            # fully excluded.
+            ingredients_stmt = ingredients_stmt.where(
+                or_(
+                    Memory.status.notin_(("outdated", "conflicted")),
+                    and_(Memory.status == "conflicted", _exact_lexical_match),
+                )
+            )
+        if valid_at:
+            from datetime import date as _date_type
+
+            from sqlalchemy import Date as _Date
+            from sqlalchemy import cast as _cast
+            from sqlalchemy import literal as _literal
+
+            # Hard filter on the START side, compared at DAY granularity.
+            # Future-dated memories can't answer past questions — but strict
+            # timestamp comparison also excludes same-day memories written a
+            # few hours after the query was asked, which is too aggressive
+            # for workflows where the question + its evidence share a day.
+            # We cast both sides to DATE so same-day-later memories pass.
+            _valid_at_date = (
+                valid_at.date() if hasattr(valid_at, "date") else _date_type.fromisoformat(str(valid_at)[:10])
+            )
+            ingredients_stmt = ingredients_stmt.where(
+                or_(
+                    Memory.ts_valid_start.is_(None),
+                    _cast(Memory.ts_valid_start, _Date) <= _cast(_literal(_valid_at_date), _Date),
+                ),
+            )
+            # NOTE: the END side (`ts_valid_end >= valid_at`) is NO LONGER
+            # a hard filter.  A past ts_valid_end now triggers the soft
+            # ``currency_factor`` below (default 0.5x) — so an over-eager
+            # enrichment date can't silently hide a semantically strong
+            # memory from historical-question queries.
+
+        # NOTE: date_range_start/end no longer produces a hard WHERE filter;
+        # the multiplier ``date_range_boost`` below handles it softly.
+
+        # ``AS MATERIALIZED`` is a deliberate optimisation fence. With the
+        # FTS-reserved branch present the CTE is referenced twice and
+        # PostgreSQL materialises it anyway; but on blank-query paths
+        # (entity-only / vector-only search) only the main branch remains, a
+        # single-reference CTE is inlined back into its consumer, and inlining
+        # substitutes the defining expression at every column reference —
+        # putting the repeated cosine evaluations straight back.
+        #
+        # The modifier is the documented PostgreSQL 12+ contract for exactly
+        # this ("MATERIALIZED ... prevents folding into the parent query"),
+        # unlike the earlier ``.offset(0)`` draft of this fence, which leaned
+        # on the incidental planner rule that a set limitOffset disqualifies a
+        # subquery from pull-up. PG < 12 would reject the syntax, but the
+        # schema already floors on 12+ (pgvector, HNSW). SQLAlchemy 2.0 has no
+        # ``materialized=`` argument on ``cte()``; ``CTE.prefix_with`` is the
+        # documented way to emit the modifier and renders
+        # ``WITH ingredients AS MATERIALIZED (...)``.
+        #
+        # Guarded twice: test_fts_score_single_render pins the compiled text
+        # (modifier present, one ``<=>`` render), and
+        # test_scored_search_materialized_plan pins the PLAN — EXPLAIN must
+        # show the CTE as its own node on the single-branch statement, so a
+        # future PostgreSQL/SQLAlchemy behaviour change surfaces in CI rather
+        # than as a silent ~6x hot-path regression.
+        ing = ingredients_stmt.cte("ingredients").prefix_with("MATERIALIZED")
+
+        # -- Layer 1: derived factors over ingredient columns --
+        # Everything below is CASE/arithmetic over already-computed columns, so
+        # SQLAlchemy re-rendering an expression at another naming site costs a
+        # few flops per row, not another 1024-dim distance or rank call.
+        #
         # CAURA-679: NULL-embedding rows fall back to `fts_score` alone
         # rather than the `(1 - w) * 0 + w * fts_score` haircut that
         # the unconditional blend would apply. The haircut multiplies
@@ -2429,32 +2631,32 @@ class PostgresService:
         # than silently undiscoverable.
         similarity = case(
             (
-                Memory.embedding.is_not(None),
-                (1.0 - _fts_weight) * vec_sim + _fts_weight * fts_score,
+                ing.c.has_embedding,
+                (1.0 - _fts_weight) * ing.c.vec_sim + _fts_weight * ing.c.fts_score,
             ),
-            else_=fts_score,
+            else_=ing.c.fts_score,
         ).label("similarity")
 
         anchor = func.greatest(
-            Memory.created_at,
-            func.coalesce(Memory.ts_valid_start, Memory.created_at),
+            ing.c.created_at,
+            func.coalesce(ing.c.ts_valid_start, ing.c.created_at),
         )
         age_days = func.extract("epoch", func.now() - anchor) / 86400.0
 
         type_decay = case(
-            *[(Memory.memory_type == mt, float(days)) for mt, days in TYPE_DECAY_DAYS.items()],
+            *[(ing.c.memory_type == mt, float(days)) for mt, days in TYPE_DECAY_DAYS.items()],
             else_=float(_freshness_decay_days),
         ).label("type_decay_days")
 
         freshness = case(
             (
                 and_(
-                    Memory.ts_valid_end.is_not(None),
-                    Memory.ts_valid_end < func.now(),
+                    ing.c.ts_valid_end.is_not(None),
+                    ing.c.ts_valid_end < func.now(),
                 ),
                 _freshness_floor,
             ),
-            (Memory.ts_valid_end.is_not(None), 1.0),
+            (ing.c.ts_valid_end.is_not(None), 1.0),
             (
                 age_days < type_decay,
                 # Clamp age to >= 0 so a FUTURE anchor (e.g. an enrichment-set
@@ -2472,7 +2674,7 @@ class PostgresService:
             days_since_recall = (
                 func.extract(
                     "epoch",
-                    func.now() - func.coalesce(Memory.last_recalled_at, Memory.created_at),
+                    func.now() - func.coalesce(ing.c.last_recalled_at, ing.c.created_at),
                 )
                 / 86400.0
             )
@@ -2481,20 +2683,20 @@ class PostgresService:
                 1.0
                 + (_recall_boost_cap - 1.0)
                 * recency_factor
-                * Memory.recall_count
-                / (Memory.recall_count + RECALL_BOOST_SCALE)
+                * ing.c.recall_count
+                / (ing.c.recall_count + RECALL_BOOST_SCALE)
             ).label("recall_boost")
         else:
             recall_boost_expr = literal_column("1.0").label("recall_boost")
 
-        base_score = (_similarity_blend * similarity + (1.0 - _similarity_blend) * Memory.weight).label(
+        base_score = (_similarity_blend * similarity + (1.0 - _similarity_blend) * ing.c.weight).label(
             "base_score"
         )
 
         if temporal_window is not None:
             cutoff = func.now() - temporal_window
             temporal_boost = case(
-                (Memory.created_at >= cutoff, 1.3),
+                (ing.c.created_at >= cutoff, 1.3),
                 else_=1.0,
             ).label("temporal_boost")
         else:
@@ -2513,8 +2715,8 @@ class PostgresService:
             from core_storage_api.config import settings as _storage_settings
 
             temporal_anchor = func.coalesce(
-                cast(Memory.ts_valid_start, Date),
-                cast(Memory.created_at, Date),
+                cast(ing.c.ts_valid_start, Date),
+                cast(ing.c.created_at, Date),
             )
             _start_dt = date_type.fromisoformat(date_range_start)
             _end_dt = date_type.fromisoformat(date_range_end)
@@ -2548,7 +2750,8 @@ class PostgresService:
         # different entity". Empty/stopword-only queries degrade ts_query to the
         # empty tsquery (matches nothing here), so the gate is inert for
         # vector-only / entity-only callers and conflicted stays demoted.
-        _exact_lexical_match = Memory.search_vector.op("@@")(ts_query) if query and query.strip() else false()
+        # The gate reads the ``fts_match`` ingredient column — the same
+        # expression the admission guard projected, evaluated once.
         # A63 — ``history_query``: the caller detected a past-state /
         # change / duration question ("what was…", "did I switch…",
         # "how long have I been…"). Such queries NEED the superseded
@@ -2561,23 +2764,23 @@ class PostgresService:
             status_penalty = literal_column("1.0").label("status_penalty")
         else:
             status_penalty = case(
-                (Memory.status == "outdated", 0.5),
-                (and_(Memory.status == "conflicted", ~_exact_lexical_match), 0.5),
+                (ing.c.status == "outdated", 0.5),
+                (and_(ing.c.status == "conflicted", ~ing.c.fts_match), 0.5),
                 else_=1.0,
             ).label("status_penalty")
 
         # Soft currency factor: memories whose ts_valid_end is in the past
         # relative to valid_at are down-weighted instead of excluded.
         # Pairs with the removal of the `ts_valid_end >= valid_at` WHERE
-        # clause below — one bad enrichment date no longer blanks a memory.
+        # clause above — one bad enrichment date no longer blanks a memory.
         if valid_at is not None:
             from core_storage_api.config import settings as _storage_settings_cf
 
             currency_factor = case(
                 (
                     and_(
-                        Memory.ts_valid_end.is_not(None),
-                        Memory.ts_valid_end < valid_at,
+                        ing.c.ts_valid_end.is_not(None),
+                        ing.c.ts_valid_end < valid_at,
                     ),
                     _storage_settings_cf.expired_currency_factor,
                 ),
@@ -2593,7 +2796,7 @@ class PostgresService:
             for mid, factor in memory_boost_factor.items():
                 boost_tiers.setdefault(factor, []).append(mid)
             whens = [
-                (Memory.id.in_(mids), factor) for factor, mids in sorted(boost_tiers.items(), reverse=True)
+                (ing.c.mem_id.in_(mids), factor) for factor, mids in sorted(boost_tiers.items(), reverse=True)
             ]
             entity_boost = case(*whens, else_=1.0).label("entity_boost")
         else:
@@ -2636,210 +2839,35 @@ class PostgresService:
                 * status_penalty
             ).label("score")
 
-        # -- Build scored CTE --
-        # CAURA-594: NULL-embedding rows are admitted only if they also
-        # match the FTS query — otherwise they'd rank on `Memory.weight *
-        # freshness * ...` alone and could fill top_k slots with rows
-        # that have no relationship to the query during a large backfill
-        # window. `search_vector @@ ts_query` is GIN-indexed, so the
-        # extra predicate is free for rows that already had to scan
-        # the tenant/fleet slice.
-        # Other paths (find_semantic_duplicate, find_similar_candidates,
-        # find_neighbors_by_embedding, compute_health_stats) keep their
-        # NULL guards — vector-pure operations where a NULL operand has
-        # no comparable semantics.
-        # `plainto_tsquery('english', '')` (and any whitespace-only or
-        # stop-word-only input it normalises down to empty) returns the
-        # empty `tsquery`, which `@@`-matches every non-NULL `tsvector`
-        # — that would silently re-admit every NULL-embedding row when
-        # callers pass `query=""` or `query="   "` (e.g. entity-only /
-        # vector-only search modes), bringing back the displacement-by-
-        # weight bug. Gate on the Python-side query string so the
-        # operator is only emitted when there's actual text to match.
-        _fts_guard = Memory.search_vector.op("@@")(ts_query) if query and query.strip() else false()
-        fts_match = _fts_guard.label("fts_match")
-        scored_stmt = (
-            select(
-                Memory.id.label("mem_id"),
-                score,
-                similarity,
-                vec_sim,
-                fts_match,
-                has_embedding,
-                status_penalty,
-                # CAURA-722 — the score's own ingredients, carried out of the
-                # CTE rather than discarded at its boundary.
-                #
-                # These are the five factors ``SearchDiagnostic.all_candidates``
-                # has always declared per row and always reported as ``None``:
-                # each was computed here, multiplied (or added, under the A50
-                # formula) into ``score``, and then left behind because the CTE
-                # select list did not name it. core-api reads all five by name
-                # in ``execute_scored_search`` and the diagnostic rounds each
-                # through ``_f()``, so three layers were built to receive values
-                # the query never sent. Nothing was wrong with ranking — only
-                # with explaining it, which is what made a null read as "this
-                # signal did not apply" and cost a benchmark the conclusion that
-                # entity retrieval contributed nothing.
-                #
-                # No new computation: every expression below already exists
-                # above because ``score`` needs it. ``reserved_stmt`` even
-                # ORDER BYs ``fts_score`` already.
-                #
-                # Always selected, not gated on a diagnostic flag: storage takes
-                # no such flag, and plumbing one through the route to save five
-                # floats per row — on a response already carrying each row's
-                # full content — costs more than it saves.
-                #
-                # Both union branches derive from this statement, so they stay
-                # column-compatible. Dedup behaviour is unchanged too: the
-                # factors are deterministic per ``mem_id``, so rows that
-                # collapsed before still collapse.
-                #
-                # ``fts_score`` is the one with a price, and it is paid
-                # deliberately. The four below are CASE or literal expressions
-                # over the row, so naming them costs nothing. ``fts_score`` is
-                # ``ts_rank_cd``, and SQLAlchemy inlines an expression at every
-                # site that names it, so one more reference takes the compiled
-                # statement from 9 renders to 10 and ``plainto_tsquery`` from 20
-                # to 21 — the ratchet ``test_fts_score_single_render`` guards,
-                # and whose constants move with this change.
-                #
-                # Only +1 rather than +2 because ``reserved_stmt`` already
-                # ORDER BYs ``fts_score``; once it is a real column that clause
-                # references the label instead of re-pasting the expression.
-                #
-                # The cost, from the measurement recorded on ``_saturate_rank``
-                # (halving 18 -> 9 renders bought 92.0ms -> 56.4ms at 11,505
-                # matching rows on a 31,446-memory corpus): about 4ms per
-                # render at that worst case, less on smaller matches, and
-                # diluted again end-to-end because the same query pays six
-                # pgvector distance computations per row. Against a ~1,300ms
-                # search p50 that is well under a percent, in exchange for the
-                # fifth factor ``SearchDiagnostic`` declares actually arriving.
-                #
-                # It also lands inside this CTE rather than after the
-                # entity-link fanout in the outer query, so it is evaluated per
-                # candidate row and not per joined row.
-                #
-                # The real fix is the inner-projection work ``_saturate_rank``
-                # describes, which takes renders to 1 and makes every factor
-                # free to project; that needs an optimisation barrier and its
-                # own plan-shape review. When it lands, the constant drops and
-                # this reference costs nothing.
-                fts_score,
-                freshness,
-                entity_boost,
-                recall_boost_expr,
-                temporal_boost,
-            )
-            # Multi-tenant read predicate: when ``readable_tenant_ids``
-            # is provided (cross-tenant agent key), reads widen across
-            # the full set; otherwise we stay single-tenant for the
-            # common case. Result rows still carry ``Memory.tenant_id``
-            # so the caller can attribute each row to its source tenant.
-            .where(
-                Memory.tenant_id.in_(readable_tenant_ids)
-                if readable_tenant_ids
-                else Memory.tenant_id == tenant_id
-            )
-            .where(Memory.deleted_at.is_(None))
-            .where(
-                or_(
-                    Memory.embedding.is_not(None),
-                    _fts_guard,
-                )
-            )
+        # -- Branch layer: candidate selection over the scored ingredients --
+        # The select list is the same column contract the outer query and
+        # ``SearchDiagnostic.all_candidates`` have consumed since CAURA-722:
+        # every factor ``score`` is built from is named here, and naming one is
+        # now free — each is a CASE/arithmetic over ingredient columns, with
+        # the heavy primitives already paid exactly once in the CTE below the
+        # fence. (CAURA-722 originally priced the ``fts_score`` projection at
+        # one extra ``ts_rank_cd`` render; the two-layer split retired that
+        # cost, and the ratchet constants in test_fts_score_single_render
+        # moved down with it.)
+        #
+        # Both union branches derive from this statement, so they stay
+        # column-compatible. Dedup behaviour is unchanged too: the factors are
+        # deterministic per ``mem_id``, so rows that collapsed before still
+        # collapse.
+        scored_stmt = select(
+            ing.c.mem_id,
+            score,
+            similarity,
+            ing.c.vec_sim,
+            ing.c.fts_match,
+            ing.c.has_embedding,
+            status_penalty,
+            ing.c.fts_score,
+            freshness,
+            entity_boost,
+            recall_boost_expr,
+            temporal_boost,
         )
-
-        if fleet_ids:
-            scored_stmt = scored_stmt.where(
-                _fleet_scope_clause(Memory, fleet_ids, strict=strict_fleet_scoping)
-            )
-
-        if caller_agent_id:
-            visibility_filter = or_(
-                Memory.visibility == "scope_org",
-                Memory.visibility == "scope_team",
-                and_(
-                    Memory.visibility == "scope_agent",
-                    Memory.agent_id == caller_agent_id,
-                ),
-            )
-            scored_stmt = scored_stmt.where(visibility_filter)
-        else:
-            scored_stmt = scored_stmt.where(Memory.visibility != "scope_agent")
-
-        if filter_agent_id:
-            scored_stmt = scored_stmt.where(Memory.agent_id == filter_agent_id)
-        if memory_type_filter:
-            scored_stmt = scored_stmt.where(Memory.memory_type == memory_type_filter)
-        if status_filter:
-            scored_stmt = scored_stmt.where(Memory.status == status_filter)
-        elif history_query:
-            # A63 — a history question ("what was…", "did I switch…",
-            # "how long have I been…") needs the superseded value: the
-            # older side of an update is EXACTLY what the caller asked
-            # for, so neither the exclusion below nor the status_penalty
-            # applies. Ranking is pure relevance; present-state queries
-            # keep both protections.
-            pass
-        else:
-            # Exclude superseded memories from default search results. The
-            # contradiction detector marks the older row ``outdated`` (RDF
-            # path) or ``conflicted`` (semantic path) and points the newer
-            # one at it via ``supersedes_id``. Surfacing both would dilute
-            # ranking with stale claims agents shouldn't act on. Callers
-            # that need to inspect superseded rows pass an explicit
-            # ``status_filter`` to override.
-            #
-            # Carve-out: a ``conflicted`` row that is an EXACT lexical match
-            # for the query is kept. ``conflicted`` (unlike ``outdated``) means
-            # "a competing claim exists", not "definitively retracted" — and the
-            # semantic contradiction path mismarks near-duplicate-but-distinct
-            # entities (e.g. ``Wayne #0000`` vs ``Wayne #0704``), so a blanket
-            # exclusion silently drops the very row the caller named. The
-            # exact-match gate scopes the carve-out to rows the caller clearly
-            # asked for; status_penalty above keeps a surfaced exact-match
-            # conflicted row un-demoted, and load_and_serialize still injects its
-            # supersedes successor so both sides are visible. ``outdated`` stays
-            # fully excluded.
-            scored_stmt = scored_stmt.where(
-                or_(
-                    Memory.status.notin_(("outdated", "conflicted")),
-                    and_(Memory.status == "conflicted", _exact_lexical_match),
-                )
-            )
-        if valid_at:
-            from datetime import date as _date_type
-
-            from sqlalchemy import Date as _Date
-            from sqlalchemy import cast as _cast
-            from sqlalchemy import literal as _literal
-
-            # Hard filter on the START side, compared at DAY granularity.
-            # Future-dated memories can't answer past questions — but strict
-            # timestamp comparison also excludes same-day memories written a
-            # few hours after the query was asked, which is too aggressive
-            # for workflows where the question + its evidence share a day.
-            # We cast both sides to DATE so same-day-later memories pass.
-            _valid_at_date = (
-                valid_at.date() if hasattr(valid_at, "date") else _date_type.fromisoformat(str(valid_at)[:10])
-            )
-            scored_stmt = scored_stmt.where(
-                or_(
-                    Memory.ts_valid_start.is_(None),
-                    _cast(Memory.ts_valid_start, _Date) <= _cast(_literal(_valid_at_date), _Date),
-                ),
-            )
-            # NOTE: the END side (`ts_valid_end >= valid_at`) is NO LONGER
-            # a hard filter.  A past ts_valid_end now triggers the soft
-            # ``currency_factor`` above (default 0.5x) — so an over-eager
-            # enrichment date can't silently hide a semantically strong
-            # memory from historical-question queries.
-
-        # NOTE: date_range_start/end no longer produces a hard WHERE filter;
-        # the multiplier ``date_range_boost`` above handles it softly.
 
         if _candidate_pool_size > 0:
             # A49: select the candidate POOL by semantic relevance (``similarity``)
@@ -2849,7 +2877,7 @@ class PostgresService:
             # PostFilterResults trims to the caller's top_k — so with A49 alone this
             # only *widens/relevance-selects the pool*, it does not reorder the final
             # result; the reorder is A50. Off (0) by default → unchanged behaviour.
-            main_stmt = scored_stmt.order_by(similarity.desc(), Memory.created_at.desc()).limit(
+            main_stmt = scored_stmt.order_by(similarity.desc(), ing.c.created_at.desc()).limit(
                 _candidate_pool_size
             )
         else:
@@ -2864,7 +2892,7 @@ class PostgresService:
             # result set. Ignoring a nested one is also the skew-safe direction:
             # an older core-api that still sends it gets the wider window it
             # always meant to ask for.
-            main_stmt = scored_stmt.order_by(score.desc(), Memory.created_at.desc()).limit(top_k)
+            main_stmt = scored_stmt.order_by(score.desc(), ing.c.created_at.desc()).limit(top_k)
 
         # Reserve candidate slots for full-text matches.
         #
@@ -2875,12 +2903,16 @@ class PostgresService:
         #
         # The dedicated branch is separately capped and the outer ORDER BY keeps
         # every row at its true score, so this changes candidate admission rather
-        # than the ranking formula.
+        # than the ranking formula. Its filter reads the ``fts_match`` /
+        # ``has_embedding`` ingredient columns — over the materialised CTE, not
+        # a second GIN probe of ``memories``.
         if _FTS_RESERVED_CANDIDATES > 0 and query and query.strip():
-            reserve_filter = _fts_guard if _fts_weight > 0.0 else and_(Memory.embedding.is_(None), _fts_guard)
+            reserve_filter = (
+                ing.c.fts_match if _fts_weight > 0.0 else and_(~ing.c.has_embedding, ing.c.fts_match)
+            )
             reserved_stmt = (
                 scored_stmt.where(reserve_filter)
-                .order_by(fts_score.desc(), Memory.created_at.desc())
+                .order_by(ing.c.fts_score.desc(), ing.c.created_at.desc())
                 .limit(_FTS_RESERVED_CANDIDATES)
             )
             # Each operand is wrapped in its own subquery so its ORDER BY/LIMIT is

--- a/core-storage-api/tests/test_fts_score_single_render.py
+++ b/core-storage-api/tests/test_fts_score_single_render.py
@@ -32,36 +32,37 @@ from core_storage_api.services.postgres_service import _saturate_rank
 # cost back, a fall means the inner-projection work landed. Either way,
 # re-measure and move the number deliberately rather than loosening the check.
 #
-# CAURA-722 moved these 9 -> 10 and 20 -> 21, deliberately and with the trade
-# measured. ``fts_score`` is now projected out of the scored CTE so
-# ``SearchDiagnostic.all_candidates`` can report it: it declares the factor per
-# row and had returned ``None`` for it on every row of every query, because the
-# CTE computed it, folded it into ``score`` and then did not name it in its
-# select list.
+# The inner-projection work ``_saturate_rank`` promised has landed: the heavy
+# primitives — ``ts_rank_cd`` and the pgvector cosine distance — are projected
+# exactly once into the fenced ``ingredients`` CTE, and every derived factor
+# (similarity, score, the CAURA-722 diagnostic columns) references them as
+# plain columns. That takes ``ts_rank_cd`` from 10 renders to 1 and the cosine
+# ``<=>`` from 6 to 1; CAURA-722's ``fts_score`` projection, priced at one
+# extra render when it shipped, now costs nothing — exactly the end state its
+# comment predicted ("at which point this constant drops").
 #
-# Why the rise is only +1 and not +2, with the statement appearing in two union
-# branches: ``reserved_stmt`` already ordered by ``fts_score``, and once the
-# factor is a real column that ORDER BY references the label instead of
-# re-pasting the expression.
-#
-# The price, scaled from the measurement on ``_saturate_rank`` (18 -> 9 renders
-# bought 92.0ms -> 56.4ms at 11,505 matching rows on a 31,446-memory corpus):
-# roughly 4ms per render at that worst case, less on smaller matches, and
-# smaller again end-to-end since the same query also pays six pgvector distance
-# computations per row. Against a search p50 near 1,300ms that is well under a
-# percent. The render lands inside the candidate CTE, not in the outer query
-# past the entity-link fanout, so it is per candidate row rather than per
-# joined row.
-#
-# This does not concede the ratchet. The inner-projection work
-# ``_saturate_rank`` describes still takes renders to 1 and would make every
-# factor free to project — at which point this constant drops and CAURA-722's
-# reference costs nothing. Guard both directions as before.
-_EXPECTED_TS_RANK_CD_RENDERS = 10
-# The main and reserved candidate branches each carry ``fts_match`` into the
-# candidate CTE. Projecting it there keeps the expression ahead of entity-link
-# fanout, where an outer render would evaluate it once per joined row.
-_EXPECTED_TSQUERY_RENDERS = 21
+# History of the constants: 18 -> 9 (``_saturate_rank`` algebra), 9 -> 10 and
+# 20 -> 21 (CAURA-722 diagnostic projection, deliberately), 10 -> 1 and
+# 21 -> 4 (the two-layer split). Measured effect of the split alone on a
+# 50k-row / 1024-dim rig: the scored candidate select dropped 427ms -> 90ms —
+# the six distance evaluations per row were the dominant per-row cost.
+_EXPECTED_TS_RANK_CD_RENDERS = 1
+# ``plainto_tsquery`` remains in exactly four places, all inside the
+# ingredients CTE: the CAURA-594 admission guard (WHERE), the conflicted
+# carve-out (WHERE), the ``ts_rank_cd`` call inside ``fts_score``, and the
+# ``fts_match`` projection. The WHERE-clause renders cannot fold into the
+# projected column — predicate evaluation happens before the targetlist — so 4
+# is the floor for this statement shape, not a concession.
+_EXPECTED_TSQUERY_RENDERS = 4
+# The pgvector cosine distance: the single most expensive expression in the
+# statement (a 1024-dim float loop per evaluation, ~6x the whole per-row cost
+# when it rendered 6 times). Must stay exactly 1 — inside ``vec_sim`` in the
+# ingredients CTE. If you need the distance (or a derived similarity) in a new
+# place, reference the ``vec_sim`` / ``similarity`` COLUMN, never
+# ``Memory.embedding.cosine_distance`` — and mind the ``AS MATERIALIZED``
+# fence on the CTE: without it a single-branch statement gets inlined and
+# every column reference re-expands to a fresh distance computation.
+_EXPECTED_COSINE_RENDERS = 1
 
 
 def _scaled_rank():
@@ -198,5 +199,87 @@ async def test_the_shipped_statement_holds_its_tsquery_render_count(
     got = _calls(sql, "plainto_tsquery")
     assert got == _EXPECTED_TSQUERY_RENDERS, (
         f"memory_scored_search renders plainto_tsquery {got} times, expected "
-        f"{_EXPECTED_TSQUERY_RENDERS} (27 before the single-render change)."
+        f"{_EXPECTED_TSQUERY_RENDERS} (21 before the two-layer split, 27 before "
+        f"the single-render change)."
     )
+
+
+async def test_the_shipped_statement_computes_the_cosine_distance_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The primary-path guarantee of the two-layer split.
+
+    pgvector's ``<=>`` over a 1024-dim column is the single most expensive
+    expression in the statement, and before the split the compiled SQL carried
+    it six times — once per site that named ``vec_sim`` or anything derived
+    from it. The two-layer build projects it once into the fenced
+    ``ingredients`` CTE; everything above references the column. Counted on
+    the operator, not a function name, because pgvector compiles
+    ``cosine_distance`` to the ``<=>`` operator.
+    """
+    sql = await _compiled_scored_search_sql(monkeypatch)
+    got = sql.count("<=>")
+    assert got == _EXPECTED_COSINE_RENDERS, (
+        f"memory_scored_search renders the cosine distance {got} times, expected "
+        f"{_EXPECTED_COSINE_RENDERS} (6 before the two-layer split). A rise means a "
+        f"new expression references Memory.embedding.cosine_distance directly, or "
+        f"the ingredients CTE lost its AS MATERIALIZED fence and single-branch "
+        f"statements are being inlined — reference the vec_sim/similarity column "
+        f"instead, and keep the fence."
+    )
+
+
+async def test_the_shipped_statement_keeps_the_inlining_fence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fence is what makes the single render HOLD, not just occur.
+
+    With the FTS-reserved branch present the ingredients CTE is referenced
+    twice and PostgreSQL materialises it regardless; but a blank-query call
+    (entity-only / vector-only search) has one branch, and a plain
+    single-reference CTE is inlined back into its consumer — re-expanding
+    every column reference into a fresh distance computation. ``AS
+    MATERIALIZED`` is the documented PostgreSQL 12+ modifier that forbids
+    that folding. The compiled-text count above cannot see server-side
+    inlining, so this pins the fence's presence on the single-branch
+    statement where it matters — and
+    tests/test_scored_search_materialized_plan.py pins the resulting PLAN
+    against a real database, catching any future PostgreSQL/SQLAlchemy
+    change that stops the modifier short of the planner.
+    """
+    captured: list = []
+
+    class _Stop(Exception):
+        pass
+
+    class _Session:
+        async def execute(self, stmt, *args, **kwargs):
+            captured.append(stmt)
+            raise _Stop
+
+    @contextlib.asynccontextmanager
+    async def _fake_session():
+        yield _Session()
+
+    monkeypatch.setattr(ps, "get_read_session", _fake_session)
+
+    search_params = {k: kn.value_type(kn.bounds[0]) for k, kn in SEARCH_KNOBS.items()}
+    search_params["fts_rank_scale"] = 6.0
+
+    with contextlib.suppress(_Stop):
+        # Blank query → no FTS guard, no reserved branch → single-reference CTE.
+        await ps.PostgresService().memory_scored_search(
+            tenant_id="t",
+            embedding=[0.1] * 1536,
+            query="",
+            search_params=search_params,
+            top_k=10,
+        )
+    assert captured, "no statement reached session.execute"
+    sql = str(captured[0].compile(dialect=postgresql.dialect()))
+    assert "ingredients AS MATERIALIZED" in sql, (
+        "the ingredients CTE lost its AS MATERIALIZED fence: a plain "
+        "single-reference CTE gets inlined by PostgreSQL and every vec_sim "
+        "column reference re-expands into a fresh cosine distance computation."
+    )
+    assert sql.count("<=>") == _EXPECTED_COSINE_RENDERS

--- a/tests/test_scored_search_materialized_plan.py
+++ b/tests/test_scored_search_materialized_plan.py
@@ -1,0 +1,151 @@
+"""The ingredients CTE must reach the PLANNER as a materialised node.
+
+``core-storage-api/tests/test_fts_score_single_render.py`` pins the compiled
+TEXT: ``AS MATERIALIZED`` present, one ``<=>`` render. Text cannot prove what
+the planner does with it: if a future PostgreSQL or SQLAlchemy change stopped
+the modifier short of the planner, the single-branch (blank-query) statement
+— a single-reference CTE, exactly the shape PostgreSQL 12+ inlines by
+default — would be folded into its consumer, and every ``vec_sim`` column
+reference would re-expand into a fresh 1024-dim cosine computation: a silent
+~6x hot-path regression no compiled-text assertion can see (427ms -> 90ms was
+the measured cost of exactly that expansion on a 50k-row corpus).
+
+So this asks the planner itself. ``EXPLAIN (FORMAT JSON, VERBOSE)`` of the
+statement the service actually issues must show the CTE as its own plan node
+(a ``CTE Scan`` over ``ingredients``), and the distance operator must appear
+exactly once in the whole plan — in the CTE's own target list, never
+re-expanded in a consumer node. An inlined CTE has no ``CTE Scan`` node at
+all, so either assertion alone would catch the fold; together they also catch
+a partial re-expansion.
+
+Needs a database, like the rest of the DB-backed tests in this tree (CI
+always has one; locally set TEST_DATABASE_URL). No rows are needed — the
+property under test is plan shape, not results.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+
+import pytest
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.expression import ClauseElement, Executable
+
+import core_storage_api.services.postgres_service as ps
+from common.constants import SEARCH_KNOBS, VECTOR_DIM
+
+
+class _ExplainJSON(Executable, ClauseElement):
+    """EXPLAIN wrapper that keeps the inner statement's bound parameters."""
+
+    inherit_cache = False
+
+    def __init__(self, stmt) -> None:
+        self.stmt = stmt
+
+
+@compiles(_ExplainJSON, "postgresql")
+def _compile_explain_json(element, compiler, **kw):
+    return "EXPLAIN (FORMAT JSON, VERBOSE) " + compiler.process(element.stmt, **kw)
+
+
+async def _captured_scored_search_stmt(monkeypatch: pytest.MonkeyPatch, query: str):
+    """The statement ``memory_scored_search`` would execute, uncompiled."""
+    captured: list = []
+
+    class _Stop(Exception):
+        pass
+
+    class _Session:
+        async def execute(self, stmt, *args, **kwargs):
+            captured.append(stmt)
+            raise _Stop
+
+    @contextlib.asynccontextmanager
+    async def _fake_session():
+        yield _Session()
+
+    monkeypatch.setattr(ps, "get_read_session", _fake_session)
+
+    search_params = {k: kn.value_type(kn.bounds[0]) for k, kn in SEARCH_KNOBS.items()}
+    search_params["fts_rank_scale"] = 6.0
+
+    with contextlib.suppress(_Stop):
+        await ps.PostgresService().memory_scored_search(
+            tenant_id="test-tenant-plan-shape",
+            embedding=[0.1] * VECTOR_DIM,
+            query=query,
+            search_params=search_params,
+            top_k=10,
+        )
+    assert captured, "no statement reached session.execute"
+    return captured[0]
+
+
+def _walk(node: dict):
+    yield node
+    for child in node.get("Plans", []):
+        yield from _walk(child)
+
+
+async def test_single_branch_statement_plans_the_cte_as_a_materialised_node(
+    db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Blank query → one CTE reference → the fence is all that stops inlining."""
+    stmt = await _captured_scored_search_stmt(monkeypatch, query="")
+
+    result = await db.execute(_ExplainJSON(stmt))
+    raw = result.scalar()
+    plan_doc = json.loads(raw) if isinstance(raw, str) else raw
+    root = plan_doc[0]["Plan"]
+
+    cte_scans = [
+        n
+        for n in _walk(root)
+        if n.get("Node Type") == "CTE Scan" and n.get("CTE Name") == "ingredients"
+    ]
+    assert cte_scans, (
+        "no CTE Scan over 'ingredients' in the plan — PostgreSQL inlined the "
+        "CTE despite AS MATERIALIZED (or the fence was dropped), so every "
+        "vec_sim reference re-expands into its own cosine distance computation:\n"
+        + json.dumps(root, indent=1)[:4000]
+    )
+
+    distance_renders = json.dumps(plan_doc).count("<=>")
+    assert distance_renders == 1, (
+        f"the cosine distance appears {distance_renders} times in the plan, "
+        f"expected exactly 1 (inside the materialised CTE's target list). More "
+        f"than one means a consumer node re-expanded an ingredient column:\n"
+        + json.dumps(root, indent=1)[:4000]
+    )
+
+
+async def test_reserved_branch_statement_also_plans_a_single_distance(
+    db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Text query → two CTE references → materialised regardless; pin it anyway.
+
+    This is the common production shape. It cannot regress by inlining (two
+    references), but a refactor that split the branches back onto separate
+    scans of ``memories`` would re-introduce a second distance evaluation —
+    the plan-wide count catches that.
+    """
+    stmt = await _captured_scored_search_stmt(
+        monkeypatch, query="connection pool sizing"
+    )
+
+    result = await db.execute(_ExplainJSON(stmt))
+    raw = result.scalar()
+    plan_doc = json.loads(raw) if isinstance(raw, str) else raw
+    root = plan_doc[0]["Plan"]
+
+    assert any(
+        n.get("Node Type") == "CTE Scan" and n.get("CTE Name") == "ingredients"
+        for n in _walk(root)
+    ), "no CTE Scan over 'ingredients' in the two-branch plan"
+
+    distance_renders = json.dumps(plan_doc).count("<=>")
+    assert distance_renders == 1, (
+        f"the cosine distance appears {distance_renders} times in the two-branch plan, expected 1"
+    )


### PR DESCRIPTION
## What

`memory_scored_search` paid the pgvector cosine distance **six times per candidate row** and `ts_rank_cd` ten times: SQLAlchemy inlines an expression at every site that names it, and `score`/`similarity`/`vec_sim` plus the CAURA-722 diagnostic columns each named the same CASE. This lands the inner-projection work `_saturate_rank`'s measurement note promised: heavy primitives (cosine distance, `ts_rank_cd`, the FTS guard, `has_embedding`) are projected **once** into a `WITH ingredients AS MATERIALIZED (...)` CTE; every derived factor (similarity, freshness, boosts, penalties, both score formulas) is CASE/arithmetic over those columns in the branch layer above.

## Measured

| Render counts (compiled statement) | before | after |
|---|---|---|
| cosine `<=>` (1024-dim, the dominant per-row cost) | 6 | **1** |
| `ts_rank_cd` | 10 | **1** |
| `plainto_tsquery` | 21 | **4** (two WHERE uses — predicates can't fold into a targetlist column — + `fts_score` + `fts_match`) |

On a 50k-row / 1024-dim rig, the candidate select dropped **427 ms → 90 ms** from this change alone. (Context: search p50 ~1,300 ms on a 31k corpus per the in-code measurement; the 188 s eToro scored-search datapoint scales with exactly this per-row cost.)

## Why `AS MATERIALIZED`

With the FTS-reserved branch present the CTE is referenced twice and PostgreSQL materialises it regardless. But a blank-query call (entity-only / vector-only search) leaves one branch — and a plain single-reference CTE is **inlined** back into its consumer, re-expanding every column reference into a fresh distance computation. `AS MATERIALIZED` is the documented PostgreSQL 12+ modifier that forbids exactly that folding (review moved this off an earlier `.offset(0)` draft that leaned on the incidental limitOffset-blocks-pull-up planner rule). SQLAlchemy 2.0 has no `materialized=` argument on `cte()`; `CTE.prefix_with("MATERIALIZED")` is the documented way to emit it. PG < 12 would reject the syntax, but the schema already floors on 12+ (pgvector, HNSW).

**Guarded at two levels:**
- Compiled text (`core-storage-api/tests/test_fts_score_single_render.py`): modifier present on the single-branch statement, cosine == 1, updated `ts_rank_cd`/`plainto_tsquery` ratchets with history.
- **The plan itself** (`tests/test_scored_search_materialized_plan.py`, new): `EXPLAIN (FORMAT JSON, VERBOSE)` of the statement the service actually issues must contain a `CTE Scan` over `ingredients` and **exactly one** distance operator in the whole plan — so a future PostgreSQL/SQLAlchemy change that stops the modifier short of the planner fails CI instead of surfacing as a silent ~6× hot-path latency regression. Runs against the real CI database; covers both the single-branch and two-branch statements.

## Semantics unchanged

- Row admission (CAURA-594 `embedding IS NOT NULL OR fts match`), all filters (fleet/visibility/agent/type/status carve-out/valid_at), both scoring formulas (legacy multiplicative + A50 additive), the CAURA-722 column contract, and union dedup are preserved — the select list of the scored CTE is byte-compatible.
- The reserved branch's filter now reads the `fts_match`/`has_embedding` **columns** over the materialised CTE instead of a second GIN probe — one scan feeds both union branches.
- `_exact_lexical_match` and `_fts_guard` were always the same expression; the status-penalty gate now reads the single projected column.

## Testing

- Ratchet suite: 11/11. New EXPLAIN plan-shape tests: 2/2 against a freshly migrated Postgres 16 + pgvector.
- Full suites against that fresh DB: **6,473 root + 373 core-storage-api tests pass**, including `test_recall_returns_memory_with_pending_embedding` and `test_fts_only_row_survives_a_saturated_candidate_window` (deferred-embedding + FTS-reservation end-to-end) and all A50/A49/CAURA-722 scoring tests.
- ruff + ruff format + mypy clean.

## Context

PR1 of the HNSW two-stage retrieval plan (`docs/plans/hnsw-two-stage-retrieval.md`, local): the primary search path can never use `ix_memories_embedding_hnsw` (ORDER BY is a blended score, not a distance), so it full-scans the tenant slice — this PR makes each scanned row ~6× cheaper with zero semantic change. PR2 (opt-in ANN candidate pool) builds on this layering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)