### PR TITLE
feat(consumer): fan out atomic facts on the deferred path (A70 step 2b)

### DIFF
--- a/core-api/src/core_api/consumer.py
+++ b/core-api/src/core_api/consumer.py
@@ -30,6 +30,7 @@ import logging
 
 from pydantic import ValidationError
 
+from common.enrichment import AtomicFact
 from common.events.base import Event
 from common.events.factory import get_event_bus
 from common.events.memory_embedded import MemoryEmbedded
@@ -42,9 +43,98 @@ from core_api.services.governance_remediation import (
     GovernanceCascadeError,
     remediate_after_enrichment,
 )
+from core_api.services.memory_service import fan_out_atomic_facts
 from core_api.services.organization_settings import invalidate_cache, resolve_config
 
 logger = logging.getLogger(__name__)
+
+
+async def _fan_out_persisted_atomic_facts(sc, memory: dict, payload, outcome) -> None:
+    """Create the child memories for facts the async worker persisted (A70).
+
+    The synchronous path fans out inline. The worker cannot: its storage client
+    has no create-memory call, and giving it one would also mean a second copy
+    of ``fan_out_atomic_facts`` — a block whose every guarantee traces to an
+    incident (#808, CAURA-222, OSS #814, CAURA-602, the 2026-07-27 stranded
+    embeddings). So the worker stores the facts and this consumer creates the
+    rows, through the same function the synchronous path uses.
+
+    Never raises. A fan-out failure must not nack the event: contradiction
+    detection runs after this and is the handler's primary job, and a nack would
+    redeliver the whole handler to retry work that is already idempotent.
+    """
+    md = memory.get("metadata_") or {}
+    raw_facts = md.get("atomic_facts")
+    if not raw_facts:
+        return
+    try:
+        facts = [AtomicFact.model_validate(f) for f in raw_facts]
+    except (ValidationError, TypeError):
+        # Written by us one enrichment ago, so an unparseable shape means the
+        # schema moved under a row an older build wrote. Dropping is right: no
+        # retry re-parses it, and leaving the key set would re-attempt this on
+        # every redelivery forever.
+        logger.exception(
+            "memory-enriched: unparseable persisted atomic_facts; clearing",
+            extra={"memory_id": str(payload.memory_id), "tenant_id": payload.tenant_id},
+        )
+        facts = []
+
+    if facts:
+        # ``outcome.visibility`` FIRST — this is exactly why
+        # ``RemediationOutcome`` carries it. ``memory`` was read before the
+        # governance PATCH, so its ``visibility`` is the PRE-policy value, and a
+        # child inheriting that re-publishes precisely what ``keep_private`` just
+        # made private (#808).
+        parent_visibility = outcome.visibility or memory.get("visibility") or "scope_team"
+        try:
+            counts = await fan_out_atomic_facts(
+                sc,
+                atomic_facts=facts,
+                memory_id=payload.memory_id,
+                tenant_id=payload.tenant_id,
+                fleet_id=memory.get("fleet_id"),
+                agent_id=memory.get("agent_id") or "",
+                parent_metadata=md,
+                parent_visibility=parent_visibility,
+                parent_weight=memory.get("weight") or 0.5,
+                parent_ts_start=memory.get("ts_valid_start"),
+                tenant_config=await resolve_config(payload.tenant_id),
+            )
+        except Exception:
+            # Marker deliberately left in place: the facts are still stored, so a
+            # redelivery or a later re-enrichment can retry, and the fan-out's own
+            # live-hash dedup stops a retry duplicating whatever did land.
+            logger.exception(
+                "memory-enriched: atomic-fact fan-out failed; facts left in metadata for retry",
+                extra={"memory_id": str(payload.memory_id), "tenant_id": payload.tenant_id},
+            )
+            return
+        logger.info(
+            "memory-enriched: atomic-fact fan-out created=%d deduped=%d unembedded=%d",
+            counts["created"],
+            counts["deduped"],
+            counts["unembedded"],
+            extra={"memory_id": str(payload.memory_id), "tenant_id": payload.tenant_id},
+        )
+
+    # Mark consumed. The bus is at-least-once, so this is the CHEAP idempotency
+    # path, not the guarantee — that is the fan-out's own live-hash dedup, which
+    # already absorbs a redelivery arriving before this write lands. Merged via
+    # ``metadata_patch`` so sibling keys the worker set survive.
+    try:
+        await sc.update_memory(
+            str(payload.memory_id),
+            payload.tenant_id,
+            {"metadata_patch": {"atomic_facts": None}},
+        )
+    except Exception:
+        logger.warning(
+            "memory-enriched: could not clear the atomic_facts marker; a redelivery "
+            "will re-enter the fan-out and be absorbed by its dedup",
+            exc_info=True,
+            extra={"memory_id": str(payload.memory_id), "tenant_id": payload.tenant_id},
+        )
 
 
 async def handle_memory_enriched(event: Event) -> None:
@@ -139,6 +229,15 @@ async def handle_memory_enriched(event: Event) -> None:
             extra={"memory_id": str(payload.memory_id), "tenant_id": payload.tenant_id},
         )
         return
+
+    # A70 — create the children for facts the worker persisted. Placed here
+    # deliberately:
+    #   * AFTER remediation, so a dropped row spawns nothing and children inherit
+    #     the post-policy visibility (#808);
+    #   * BEFORE the embedding check, because a parent whose vector has not landed
+    #     still has valid facts and each child embeds itself. Gating on the
+    #     parent's embedding would strand the facts behind an unrelated race.
+    await _fan_out_persisted_atomic_facts(sc, memory, payload, outcome)
 
     embedding = memory.get("embedding")
     if not embedding:

--- a/tests/test_a70_fanout_wireup.py
+++ b/tests/test_a70_fanout_wireup.py
@@ -1,0 +1,111 @@
+"""reg-a70 step 2b — the deferred path finally creates its child memories.
+
+Step 1 (#1424) stopped the worker discarding ``atomic_facts``; step 2a (#1428)
+lifted the fan-out into ``fan_out_atomic_facts`` so it could be called from
+somewhere other than the synchronous write. This joins them: the enriched
+consumer reads the persisted facts and creates the children, closing the gap
+where a fast-mode write of multi-claim content produced fewer memories than the
+same content in strong mode.
+
+The placement is the load-bearing part and is what these tests mostly pin.
+"""
+
+import inspect
+
+import pytest
+
+from core_api import consumer as c
+
+pytestmark = pytest.mark.unit
+
+
+def test_the_consumer_fans_out():
+    assert callable(c._fan_out_persisted_atomic_facts)
+    assert (
+        "_fan_out_persisted_atomic_facts(sc, memory, payload, outcome)"
+        in inspect.getsource(c.handle_memory_enriched)
+    )
+
+
+def test_it_reuses_the_shared_fan_out_rather_than_reimplementing_it():
+    """A second copy of that block is the one outcome worth avoiding — every
+    guarantee in it was paid for by an incident."""
+    src = inspect.getsource(c._fan_out_persisted_atomic_facts)
+    assert "await fan_out_atomic_facts(" in src
+    assert "create_memory" not in src, "the consumer is writing rows itself again"
+
+
+def test_children_inherit_the_post_policy_visibility():
+    """#808. ``memory`` was read BEFORE the governance PATCH, so its visibility
+    is the pre-policy value; ``outcome.visibility`` is the only correct source,
+    and it must win."""
+    src = inspect.getsource(c._fan_out_persisted_atomic_facts)
+    assert 'outcome.visibility or memory.get("visibility")' in src
+
+
+def test_fan_out_runs_after_remediation_and_before_the_embedding_check():
+    """Order is the design. After remediation: a dropped row must spawn nothing,
+    and children need the post-policy visibility. Before the embedding check: a
+    parent whose vector has not landed still has valid facts, and each child
+    embeds itself — gating on the parent would strand them behind an unrelated
+    race."""
+    src = inspect.getsource(c.handle_memory_enriched)
+    drop = src.index("if outcome.dropped:")
+    fan = src.index("_fan_out_persisted_atomic_facts(")
+    embed = src.index('embedding = memory.get("embedding")')
+    assert drop < fan < embed
+
+
+def test_a_dropped_row_never_reaches_the_fan_out():
+    """The governance branch returns, so this is structural rather than a check
+    inside the fan-out."""
+    src = inspect.getsource(c.handle_memory_enriched)
+    drop_block = src[
+        src.index("if outcome.dropped:") : src.index("_fan_out_persisted_atomic_facts(")
+    ]
+    assert "return" in drop_block
+
+
+def test_no_facts_costs_nothing():
+    """Every enriched row enters here and most carry no facts."""
+    src = inspect.getsource(c._fan_out_persisted_atomic_facts)
+    head = src[: src.index("try:")]
+    assert "if not raw_facts:" in head and "return" in head
+
+
+def test_the_marker_is_cleared_by_merge_not_overwrite():
+    """``metadata_patch`` merges with JSONB ``||``; writing ``metadata_`` whole
+    would drop the summary/tags/pii keys the worker set in the same row."""
+    src = inspect.getsource(c._fan_out_persisted_atomic_facts)
+    assert '"metadata_patch": {"atomic_facts": None}' in src
+
+
+def test_a_failed_fan_out_keeps_the_facts_for_retry():
+    """The facts are the expensive part — they cost an LLM call. Clearing the
+    marker after a failure would discard them for good."""
+    src = inspect.getsource(c._fan_out_persisted_atomic_facts)
+    fail = src[src.index("atomic-fact fan-out failed") :]
+    assert "return" in fail[:400], "it falls through and clears the marker anyway"
+
+
+def test_it_never_raises_into_the_handler():
+    """A fan-out failure must not nack the event: contradiction detection runs
+    after it and is this handler's primary job."""
+    src = inspect.getsource(c._fan_out_persisted_atomic_facts)
+    assert src.count("except Exception:") >= 2
+
+
+def test_an_unparseable_payload_is_dropped_not_retried_forever():
+    """We wrote it, so a shape we cannot parse means the schema moved under an
+    older row. No redelivery re-parses it."""
+    src = inspect.getsource(c._fan_out_persisted_atomic_facts)
+    assert "except (ValidationError, TypeError):" in src
+    assert "facts = []" in src
+
+
+def test_counts_are_logged_so_the_deferred_path_is_observable():
+    """The synchronous path logs created/deduped/unembedded; without the same
+    three numbers here, nobody can tell whether the deferred path is working."""
+    src = inspect.getsource(c._fan_out_persisted_atomic_facts)
+    for k in ("created", "deduped", "unembedded"):
+        assert f'counts["{k}"]' in src


### PR DESCRIPTION
Closes the sync/async gap that A70 is about: **a fast-mode write of multi-claim content produced fewer memories than the same content written in strong mode.** The synchronous path fans the enricher's `atomic_facts` out into child memories; the deferred path had no way to.

- **Step 1** (#1424) stopped the worker discarding the facts.
- **Step 2a** (#1428) lifted the fan-out into `fan_out_atomic_facts` so something other than the write path could call it.
- **This PR** joins them — `handle_memory_enriched` reads the persisted facts and creates the children through the *same* function.

Not a second implementation. Every guarantee in that block traces to an incident (`#808`, `CAURA-222`, `OSS #814`, `CAURA-602`, the 2026-07-27 stranded embeddings), and the worker still has no create-memory call of its own.

## Placement is the design

```
remediation → [fan-out] → embedding check → contradiction detection
```

**After remediation.** A dropped row spawns nothing (that branch returns first), and children take `outcome.visibility` rather than the row's. `memory` was read *before* the governance PATCH, so its visibility is the pre-policy value — a child inheriting it would re-publish exactly what `keep_private` just made private (`#808`). This is the caller `RemediationOutcome.visibility` was added for; its docstring says so.

**Before the embedding check.** A parent whose vector hasn't landed still has valid facts, and each child embeds itself. Gating on the parent's embedding would strand them behind an unrelated race.

## Failure handling is asymmetric on purpose

| case | marker | why |
|---|---|---|
| fan-out fails | **kept** | the facts cost an LLM call and are still stored; a redelivery or re-enrichment retries, and the live-hash dedup stops a retry duplicating whatever landed |
| payload unparseable | **cleared** | we wrote it, so an unparseable shape means the schema moved under an older row — no redelivery will re-parse it |

The marker is cleared with `metadata_patch` (JSONB `||`) so the summary / tags / pii keys the worker set on the same row survive. That clear is the *cheap* idempotency path, not the guarantee — the guarantee is the dedup, which already absorbs a redelivery arriving before the write lands.

Nothing raises into the handler: contradiction detection runs after this and is the handler's primary job.

## Testing

11 new tests, most pinning the ordering (`drop < fan-out < embedding check`), that `outcome.visibility` wins, that a failed fan-out returns before clearing, and that the consumer calls the shared function rather than writing rows itself.

Full suite: **27 failures, identical to main's 27** — none new. `ruff` clean; `mypy` unchanged.

One anchor note for reviewers: `embedding = memory.get("embedding")` appears in **both** enriched and embedded handlers, so this is anchored on the governance drop-log unique to the enriched one.