### PR TITLE
chore(scripts): make MCP E2E targets configurable

### DIFF
--- a/scripts/mcp_tool_smoke.py
+++ b/scripts/mcp_tool_smoke.py
@@ -15,6 +15,7 @@ Expects /tmp/e2e.env (written by the E2E register step) containing::
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 import time
@@ -22,11 +23,13 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+DEFAULT_ENV_FILE = Path("/tmp/e2e.env")
+DEFAULT_CORE_API = "http://localhost:8000"
 
-def load_env() -> dict[str, str]:
-    path = Path("/tmp/e2e.env")
+
+def load_env(path: Path) -> dict[str, str]:
     if not path.exists():
-        print("ERROR: /tmp/e2e.env missing — register a tenant + API key first.")
+        print(f"ERROR: {path} missing — register a tenant + API key first.")
         sys.exit(2)
     return dict(
         line.strip().split("=", 1)
@@ -35,13 +38,9 @@ def load_env() -> dict[str, str]:
     )
 
 
-ENV = load_env()
-TENANT = ENV["TENANT_ID"]
-KEY = ENV["KEY"]
 FLEET = "smoke-fleet"
 
 GATEWAY = "http://localhost"  # nginx
-CORE_API = "http://localhost:8000"  # direct core-api (MCP lives here)
 
 
 def http(method: str, url: str, body=None, headers=None):
@@ -165,6 +164,26 @@ def seed_fleet_and_memories() -> dict:
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_CORE_API,
+        help=f"Direct core-api URL (default: {DEFAULT_CORE_API})",
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=DEFAULT_ENV_FILE,
+        help=f"Credentials environment file (default: {DEFAULT_ENV_FILE})",
+    )
+    args = parser.parse_args()
+
+    global CORE_API, KEY, TENANT
+    CORE_API = args.url.rstrip("/")
+    env = load_env(args.env_file)
+    TENANT = env["TENANT_ID"]
+    KEY = env["KEY"]
+
     print(f"Tenant: {TENANT}")
     print(f"Fleet:  {FLEET}")
     print()

--- a/scripts/trust_matrix_e2e.py
+++ b/scripts/trust_matrix_e2e.py
@@ -18,17 +18,22 @@ Reads ``KEY`` and ``TENANT_ID`` from ``/tmp/e2e.env``::
     TENANT_ID=default
 """
 
+import argparse
 import json
 import urllib.error
 import urllib.request
 import uuid
+from pathlib import Path
+
+DEFAULT_ENV_FILE = Path("/tmp/e2e.env")
+DEFAULT_CORE_API = "http://localhost:8000"
 
 RUN = uuid.uuid4().hex[:8]  # nonce so re-runs don't hit write-dedup
 
 
-def load_env():
+def load_env(path: Path):
     env = {}
-    with open("/tmp/e2e.env") as f:
+    with path.open() as f:
         for line in f:
             k, _, v = line.strip().partition("=")
             if k:
@@ -36,12 +41,8 @@ def load_env():
     return env
 
 
-ENV = load_env()
-KEY = ENV["KEY"]
-TENANT = ENV.get("TENANT_ID", "default")
 OWN = "wt-fleet"  # the trust-1/2/3 agents' home fleet
 OTHER = "wt-other"  # a foreign fleet (cross-fleet target)
-CORE = "http://localhost:8000"  # direct core-api; X-API-Key resolves the tenant
 
 
 def http(method, url, body=None):
@@ -207,6 +208,25 @@ def run_read_liveness(ids):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_CORE_API,
+        help=f"Direct core-api URL (default: {DEFAULT_CORE_API})",
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=DEFAULT_ENV_FILE,
+        help=f"Credentials environment file (default: {DEFAULT_ENV_FILE})",
+    )
+    args = parser.parse_args()
+
+    CORE = args.url.rstrip("/")
+    ENV = load_env(args.env_file)
+    KEY = ENV["KEY"]
+    TENANT = ENV.get("TENANT_ID", "default")
+
     ids = provision()
     ok1 = run_grid(ids)
     ok2 = run_fleetless()


### PR DESCRIPTION
## Summary

Make the MCP smoke and trust-matrix scripts configurable without changing their default target or credential-file path.

## Related Issue

Closes #1408

## Type of Change

- [x] Other: developer tooling

## How Has This Been Tested?

- `python scripts/mcp_tool_smoke.py --help`
- `python scripts/trust_matrix_e2e.py --help`
- `PYTHONPYCACHEPREFIX=/private/tmp/caura-pycache python3 -m py_compile scripts/mcp_tool_smoke.py scripts/trust_matrix_e2e.py`
- `git diff --check`

The scripts require a live stack for their end-to-end flows. `ruff` is not installed in this local environment.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

Both flags retain the existing `http://localhost:8000` and `/tmp/e2e.env` defaults.