### PR TITLE
Add server.json for MCP Registry publishing

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.caura-ai/caura",
+  "title": "Caura",
+  "description": "Shared governed memory for AI agents - fleet memory that is governed, shared and self-improving.",
+  "websiteUrl": "https://caura.ai",
+  "repository": {
+    "url": "https://github.com/caura-ai/caura-memclaw",
+    "source": "github"
+  },
+  "version": "3.4.1",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://caura.ai/mcp",
+      "headers": [
+        {
+          "name": "X-API-Key",
+          "description": "Caura API key (mc_...) from caura.ai",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a top-level `server.json` so Caura can be published to the [official MCP Registry](https://registry.modelcontextprotocol.io).

The registry does **not** accept PRs for listings — publishing is done with the `mcp-publisher` CLI, which reads this file. This PR is the prerequisite; the actual publish is one command after merge.

### What's declared

- Name: `io.github.caura-ai/caura`
- Remote: `https://caura.ai/mcp` (`streamable-http`), with `X-API-Key` marked required + secret
- Version: `3.4.1` (matches `backend-v3.4.1`)

Remote-only, so no package ownership verification is needed — nothing has to change in the npm/PyPI/Docker publish workflows.

Validated against `server.schema.json` (`2025-12-11`) from `modelcontextprotocol/registry`.

### To publish after merge

```bash
mcp-publisher login github   # as a caura-ai org member, for the io.github.caura-ai/ namespace
mcp-publisher publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVvqznDdoMdjtS7jPaZ3Mv