### PR TITLE
feat(dedup): merge a same-claim near-duplicate instead of appending beside it (A71)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/detect_near_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/detect_near_duplicate.py
@@ -37,13 +37,63 @@ from __future__ import annotations
 import logging
 import time
 
-from common.constants import SEMANTIC_DEDUP_JUDGE_THRESHOLD
+from common.constants import SEMANTIC_DEDUP_JUDGE_THRESHOLD, SINGLE_VALUE_PREDICATES
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepOutcome, StepResult
 from core_api.services.dedup_identifier_filter import _content_is_identifier_bearing
 from core_api.services.memory_service import _find_semantic_duplicate
 
 logger = logging.getLogger(__name__)
+
+
+def _same_claim(new, candidate: dict) -> bool:
+    """True when the write restates a claim the candidate already carries.
+
+    A71. The near-duplicate band is full of two different things: a RESTATEMENT
+    of a fact whose value moved ("the deploy window is 04:00 UTC" over "…03:00
+    UTC"), and a COMPLEMENTARY fact that merely reads similarly. Only the first
+    should retire its predecessor; merging the second would delete information.
+
+    The test is deterministic and costs nothing. ``EmitMemoryTriple`` has
+    already run on this write and populated ``(subject_entity_id, predicate,
+    object_value)`` with no LLM call, and the candidate arrives from
+    ``_find_semantic_duplicate`` carrying the same columns — so both sides are
+    in hand before this function is called.
+
+    Deliberately NOT the LLM: the plan this implements describes asking "same
+    claim or complementary?" as part of the enrichment call, but enrichment
+    completes BEFORE the candidate is known (``ParallelEmbedEnrich`` precedes
+    this step), so that phrasing would mean a SECOND model call on the latency
+    path the fast mode exists to keep short. The triple answers the same
+    question from data already computed.
+
+    Three conditions, each narrowing toward "provably the same claim":
+
+    * both sides resolved a subject and predicate — an unresolved triple proves
+      nothing, and absence must never be read as a match;
+    * the predicate is in ``SINGLE_VALUE_PREDICATES`` — the set where a subject
+      can hold only ONE value, which is what makes a second value a replacement
+      rather than an addition. "works_on" can be true of five projects at once;
+      "status" cannot;
+    * the objects DIFFER — an identical object is a re-statement that adds
+      nothing, and superseding a row with its own content is churn. The existing
+      advisory metadata already records that case.
+    """
+    new_subject = getattr(new, "subject_entity_id", None)
+    new_predicate = getattr(new, "predicate", None)
+    new_object = getattr(new, "object_value", None)
+    if not new_subject or not new_predicate:
+        return False
+    if str(new_predicate) not in SINGLE_VALUE_PREDICATES:
+        return False
+    if str(new_subject) != str(candidate.get("subject_entity_id") or ""):
+        return False
+    if str(new_predicate) != str(candidate.get("predicate") or ""):
+        return False
+    cand_object = candidate.get("object_value")
+    if not new_object or not cand_object:
+        return False
+    return str(new_object).strip().casefold() != str(cand_object).strip().casefold()
 
 
 class DetectNearDuplicate:
@@ -114,6 +164,37 @@ class DetectNearDuplicate:
         metadata["near_duplicate_similarity"] = round(similarity, 4)
         logger.info(
             "near_duplicate_of=%s similarity=%.4f tenant_id=%s",
+            candidate_id,
+            similarity,
+            data.tenant_id,
+        )
+
+        # A71 — decide here, act after the write. This step runs BEFORE
+        # ``WriteMemoryRow``, so the new row has no id yet and cannot be linked
+        # to anything; ``ScheduleBackgroundTasks`` performs the supersession once
+        # it does. Splitting the decision from the effect also means a merge can
+        # be reasoned about (and tested) without writing rows.
+        if not getattr(tenant_config, "merge_near_duplicates", False):
+            return None
+        # Never retire a row that is already retired, and never take a chain a
+        # contradiction verdict is holding: ``outdated`` / ``conflicted`` rows
+        # have an owner, and stacking a second supersession on one is how a
+        # lineage forks.
+        if (sem_dup_dict or {}).get("status") not in ("active", "confirmed"):
+            metadata["near_dup_merge_skipped"] = "candidate_not_live"
+            return None
+        if not _same_claim(data, sem_dup_dict or {}):
+            # The common outcome, and the one that protects information: a
+            # near-duplicate that is a COMPLEMENTARY fact keeps its own row.
+            metadata["near_dup_merge_skipped"] = "not_same_claim"
+            return None
+
+        ctx.data["merge_supersedes_id"] = str(candidate_id)
+        metadata["near_duplicate_merged"] = True
+        logger.info(
+            "near_duplicate_merge subject=%s predicate=%s candidate=%s similarity=%.4f tenant_id=%s",
+            getattr(data, "subject_entity_id", None),
+            getattr(data, "predicate", None),
             candidate_id,
             similarity,
             data.tenant_id,

--- a/core-api/src/core_api/pipeline/steps/write/schedule_background_tasks.py
+++ b/core-api/src/core_api/pipeline/steps/write/schedule_background_tasks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+from core_api.clients.storage_client import get_storage_client
 from core_api.config import settings
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepResult
@@ -12,6 +13,58 @@ from core_api.services.task_tracker import tracked_task
 from core_api.tasks import track_task
 
 logger = logging.getLogger(__name__)
+
+
+async def _merge_near_duplicate(new_id: str, candidate_id: str, tenant_id: str) -> None:
+    """Retire the near-duplicate this write supersedes (A71).
+
+    Two writes, and the ORDER is the safety property:
+
+      1. point the NEW row at the candidate (``supersedes_id``), leaving both
+         live for an instant;
+      2. mark the CANDIDATE ``outdated``.
+
+    Done the other way round, a failure between them leaves a row retired with
+    nothing standing in its place — the claim disappears from recall with no
+    successor to find. In this order the same failure leaves both rows live and
+    linked, which is exactly what an in-flight contradiction chain looks like
+    and which the existing lineage already tolerates.
+
+    ``update_memory_status`` guards the link with a CAS against NULL, so if a
+    contradiction verdict claimed this row between the write and here, that
+    verdict wins and this becomes a no-op rather than a second opinion.
+
+    Never raises: the memory is already committed and the caller returned 201.
+    A merge that fails leaves an ordinary near-duplicate pair — the state every
+    tenant without this flag is in — so degrading is strictly better than
+    failing a write that succeeded.
+    """
+    sc = get_storage_client()
+    try:
+        await sc.update_memory_status(new_id, "active", supersedes_id=candidate_id, tenant_id=tenant_id)
+    except Exception:
+        logger.warning(
+            "near-duplicate merge: could not link %s -> %s; leaving both rows live",
+            new_id,
+            candidate_id,
+            exc_info=True,
+        )
+        return
+    try:
+        await sc.update_memory_status(candidate_id, "outdated", tenant_id=tenant_id)
+    except Exception:
+        # The link landed, so the pair is discoverable and a later contradiction
+        # pass can finish the job. Logged at WARNING rather than swallowed
+        # because until then the superseded row still ranks as current.
+        logger.warning(
+            "near-duplicate merge: linked %s -> %s but could not retire the "
+            "candidate; it still reads as current",
+            new_id,
+            candidate_id,
+            exc_info=True,
+        )
+        return
+    logger.info("near_duplicate_merged new=%s superseded=%s tenant_id=%s", new_id, candidate_id, tenant_id)
 
 
 class ScheduleBackgroundTasks:
@@ -27,6 +80,13 @@ class ScheduleBackgroundTasks:
         enrichment = ctx.data.get("enrichment")
         resolved_write_mode = ctx.data.get("resolved_write_mode")
         memory_id = memory["id"] if isinstance(memory, dict) else memory.id
+
+        # A71 — perform the merge ``DetectNearDuplicate`` decided on. It runs
+        # before the row exists, so it can only record the intent; this is the
+        # first point at which there is an id to link.
+        merge_target = ctx.data.get("merge_supersedes_id")
+        if merge_target:
+            await _merge_near_duplicate(str(memory_id), str(merge_target), data.tenant_id)
 
         # Fast mode fan-out. The fast branch returns BEFORE the strong-mode
         # entity-extraction + Path A blocks below, so historically each had

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -147,6 +147,19 @@ DEFAULT_SETTINGS: dict = {
     },
     "dedup": {
         "semantic_dedup_enabled": None,
+        # A71 — act on the near-duplicate band instead of only reporting it.
+        # ``DetectNearDuplicate`` already finds the nearest stored row on every
+        # fast write and stashes ``near_duplicate_of`` as advice nothing acts on,
+        # so a restated fact accumulates a sibling and both stay live. With this
+        # on, a hit that is provably the SAME CLAIM (same subject, same
+        # single-valued predicate, different object) supersedes its predecessor
+        # instead of appending beside it.
+        #
+        # Default OFF, like every switch that changes what a write PRODUCES
+        # rather than what it reports. Turning it on retires rows, and while the
+        # supersession is reversible through the existing lineage, a tenant
+        # should choose that rather than inherit it from a deploy.
+        "merge_near_duplicates": None,
     },
     "lifecycle": {
         "lifecycle_automation_enabled": None,
@@ -615,6 +628,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "search.entity_retrieval": bool,
     "crystallizer.auto_crystallize": bool,
     "dedup.semantic_dedup_enabled": bool,
+    "dedup.merge_near_duplicates": bool,
     "lifecycle.lifecycle_automation_enabled": bool,
     "lifecycle.memory_retention_days": int,
     "entity_linking.auto_entity_linking_enabled": bool,
@@ -996,6 +1010,18 @@ class ResolvedConfig:
     def semantic_dedup_enabled(self) -> bool:
         val = self._ts.get("dedup", {}).get("semantic_dedup_enabled")
         return val if val is not None else True
+
+    @property
+    def merge_near_duplicates(self) -> bool:
+        """Supersede a same-claim near-duplicate instead of appending (default OFF).
+
+        Gated OFF because it changes what a write produces, not what it reports:
+        an enabled tenant sees its older row move to ``outdated``. Reversible via
+        the same lineage a contradiction supersession uses, but still a tenant's
+        choice rather than something inherited from a deploy.
+        """
+        val = self._ts.get("dedup", {}).get("merge_near_duplicates")
+        return val if val is not None else False
 
     # Lifecycle
     @property

--- a/tests/test_a71_merge_near_duplicates.py
+++ b/tests/test_a71_merge_near_duplicates.py
@@ -1,0 +1,195 @@
+"""reg-a71 — act on the near-duplicate band instead of only reporting it.
+
+``DetectNearDuplicate`` already finds the nearest stored row on every fast write
+(one ANN round-trip, no LLM) and stashes ``near_duplicate_of`` as advice nothing
+acts on. So a restated fact accumulates a sibling and BOTH stay live, and recall
+sees two rows where one claim exists — the composite-crowding pathology from the
+2026-09-08 replay, arriving one duplicate at a time.
+
+With ``dedup.merge_near_duplicates`` on, a hit that is provably the same claim
+supersedes its predecessor instead of appending beside it.
+
+The judgement is deterministic and free. The plan this implements describes
+asking the enrichment LLM "same claim or complementary?", but enrichment
+completes BEFORE the candidate is known (``ParallelEmbedEnrich`` precedes this
+step), so that phrasing means a SECOND model call on the latency path fast mode
+exists to keep short. ``EmitMemoryTriple`` has already populated
+``(subject_entity_id, predicate, object_value)`` with no LLM, and the candidate
+arrives carrying the same columns — the triple answers the same question from
+data already in hand.
+"""
+
+import inspect
+
+import pytest
+
+from core_api.pipeline.steps.write.detect_near_duplicate import _same_claim
+
+pytestmark = pytest.mark.unit
+
+
+class _New:
+    def __init__(self, subject=None, predicate=None, obj=None):
+        self.subject_entity_id = subject
+        self.predicate = predicate
+        self.object_value = obj
+
+
+def _cand(subject=None, predicate=None, obj=None, status="active"):
+    return {
+        "subject_entity_id": subject,
+        "predicate": predicate,
+        "object_value": obj,
+        "status": status,
+    }
+
+
+# ── what counts as the same claim ─────────────────────────────────────────
+
+
+def test_same_subject_and_single_valued_predicate_with_a_new_value_is_a_merge():
+    """The case the whole task exists for: a fact whose value moved."""
+    assert _same_claim(
+        _New("s1", "status", "shipped"), _cand("s1", "status", "in progress")
+    )
+
+
+def test_an_identical_value_is_not_merged():
+    """A re-statement adds nothing, and superseding a row with its own content
+    is churn. The advisory metadata already records that case."""
+    assert not _same_claim(
+        _New("s1", "status", "shipped"), _cand("s1", "status", "shipped")
+    )
+
+
+def test_case_and_whitespace_do_not_make_a_new_value():
+    assert not _same_claim(
+        _New("s1", "status", " Shipped "), _cand("s1", "status", "shipped")
+    )
+
+
+def test_a_different_subject_is_never_the_same_claim():
+    """Two subjects can hold the same predicate and value without either
+    replacing the other."""
+    assert not _same_claim(
+        _New("s1", "status", "shipped"), _cand("s2", "status", "blocked")
+    )
+
+
+def test_a_multi_valued_predicate_is_never_merged():
+    """The heart of the safety argument. ``works_on`` can be true of five
+    projects at once, so a second value ADDS information; only a predicate where
+    a subject holds exactly one value makes a new value a replacement."""
+    assert not _same_claim(
+        _New("s1", "works_on", "project-b"), _cand("s1", "works_on", "project-a")
+    )
+
+
+@pytest.mark.parametrize(
+    "new,cand",
+    [
+        (_New(None, "status", "x"), _cand("s1", "status", "y")),
+        (_New("s1", None, "x"), _cand("s1", "status", "y")),
+        (_New("s1", "status", "x"), _cand(None, "status", "y")),
+        (_New("s1", "status", "x"), _cand("s1", None, "y")),
+        (_New("s1", "status", None), _cand("s1", "status", "y")),
+        (_New("s1", "status", "x"), _cand("s1", "status", None)),
+    ],
+)
+def test_an_unresolved_triple_proves_nothing(new, cand):
+    """Absence must never read as a match — an unresolved triple is the common
+    case, and treating it as agreement would merge unrelated rows wholesale."""
+    assert not _same_claim(new, cand)
+
+
+# ── the gate ──────────────────────────────────────────────────────────────
+
+
+def test_the_flag_defaults_off():
+    """It changes what a write PRODUCES, not what it reports: an enabled tenant
+    sees its older row move to ``outdated``."""
+    from core_api.services.organization_settings import ResolvedConfig
+
+    assert ResolvedConfig(tenant_settings={}).merge_near_duplicates is False
+
+
+def test_the_flag_is_a_declared_writable_key():
+    from core_api.services.organization_settings import _LEAF_TYPES
+
+    assert _LEAF_TYPES["dedup.merge_near_duplicates"] is bool
+
+
+def test_the_detector_checks_the_flag_before_deciding():
+    from core_api.pipeline.steps.write import detect_near_duplicate as d
+
+    src = inspect.getsource(d.DetectNearDuplicate.execute)
+    assert 'getattr(tenant_config, "merge_near_duplicates", False)' in src
+
+
+def test_a_dead_candidate_is_never_superseded():
+    """An ``outdated`` or ``conflicted`` row already has an owner; stacking a
+    second supersession on one is how a lineage forks."""
+    from core_api.pipeline.steps.write import detect_near_duplicate as d
+
+    src = inspect.getsource(d.DetectNearDuplicate.execute)
+    assert '("active", "confirmed")' in src
+    assert "candidate_not_live" in src
+
+
+def test_a_declined_merge_says_why():
+    """``not_same_claim`` is the common outcome and the one that protects
+    information — it needs to be visible, not silent."""
+    from core_api.pipeline.steps.write import detect_near_duplicate as d
+
+    src = inspect.getsource(d.DetectNearDuplicate.execute)
+    assert "not_same_claim" in src
+
+
+# ── decide here, act after the write ──────────────────────────────────────
+
+
+def test_the_detector_only_records_the_intent():
+    """It runs BEFORE ``WriteMemoryRow``, so the new row has no id and cannot be
+    linked to anything yet."""
+    from core_api.pipeline.steps.write import detect_near_duplicate as d
+
+    src = inspect.getsource(d.DetectNearDuplicate.execute)
+    assert 'ctx.data["merge_supersedes_id"]' in src
+    assert "update_memory_status" not in src, "the detector is writing rows itself"
+
+
+def test_the_post_write_step_performs_it():
+    from core_api.pipeline.steps.write import schedule_background_tasks as sb
+
+    assert callable(sb._merge_near_duplicate)
+    assert "_merge_near_duplicate(" in inspect.getsource(
+        sb.ScheduleBackgroundTasks.execute
+    )
+
+
+def test_the_link_is_written_before_the_candidate_is_retired():
+    """The safety property. Retiring first means a failure between the two
+    leaves a row ``outdated`` with nothing standing in its place — the claim
+    vanishes from recall. This order leaves both live and linked instead."""
+    src = inspect.getsource(
+        __import__(
+            "core_api.pipeline.steps.write.schedule_background_tasks", fromlist=["x"]
+        )._merge_near_duplicate
+    )
+    link = src.index("supersedes_id=candidate_id")
+    retire = src.index('"outdated"')
+    assert link < retire
+
+
+def test_a_merge_failure_never_fails_the_write():
+    """The row is already committed and the caller already has its 201."""
+    src = inspect.getsource(
+        __import__(
+            "core_api.pipeline.steps.write.schedule_background_tasks", fromlist=["x"]
+        )._merge_near_duplicate
+    )
+    assert src.count("except Exception:") == 2
+    # Statement-level check: the docstring says "Never raises", so a substring
+    # search for "raise" matches the promise rather than a violation of it.
+    code = [ln.strip() for ln in src.splitlines() if not ln.lstrip().startswith("#")]
+    assert not any(ln == "raise" or ln.startswith("raise ") for ln in code)


### PR DESCRIPTION
P0 half two, and the second of the two Critical rows. `DetectNearDuplicate` already finds the nearest stored row on **every fast write** — one ANN round-trip, no LLM — and stashes `near_duplicate_of` as advice nothing acts on. So a restated fact accumulates a sibling and **both stay live**: recall sees two rows where one claim exists. That's the composite-crowding pathology from the 2026-09-08 replay, arriving one duplicate at a time.

With `dedup.merge_near_duplicates` on, a hit that is provably the same claim supersedes its predecessor instead of appending.

## One deliberate departure from the plan

The plan says the enrichment call also answers *"same claim or complementary?"*. **It can't.** Enrichment completes *before* the candidate is known — `ParallelEmbedEnrich` precedes this step — so that phrasing means a **second** model call, on the latency path fast mode exists to keep short, and it wouldn't clear the no-new-LLM-calls hold.

`EmitMemoryTriple` has already populated `(subject_entity_id, predicate, object_value)` with no LLM, and the candidate arrives from `_find_semantic_duplicate` carrying the same columns. The triple answers the same question from data already in hand — so the merge check stays **free**, exactly as the plan claims it should be.

## What counts as the same claim

All three, each narrowing toward provable:

| condition | why |
|---|---|
| both sides resolved a subject **and** predicate | an unresolved triple proves nothing; absence must never read as a match |
| predicate ∈ `SINGLE_VALUE_PREDICATES` | the set where a subject holds exactly **one** value — what makes a second value a *replacement*. `works_on` can be true of five projects at once; `status` cannot |
| the objects **differ** | an identical object is a re-statement that adds nothing, and superseding a row with its own content is churn |

A candidate that isn't `active`/`confirmed` is left alone: an outdated or conflicted row already has an owner, and stacking a second supersession is how a lineage forks.

## Decision and effect are split

The detector runs **before** `WriteMemoryRow`, so the new row has no id and can't be linked to anything — it records the intent, and `ScheduleBackgroundTasks` performs the merge once an id exists.

The two writes are ordered **link, then retire**. Done the other way, a failure between them leaves a row `outdated` with nothing in its place and the claim vanishes from recall; this order leaves both live and linked — which is what an in-flight contradiction chain already looks like. The link is CAS-guarded against NULL, so a contradiction verdict that claimed the row first wins and this becomes a no-op.

A merge failure never fails the write: the row is committed and the caller already has its 201.

## Flag

`dedup.merge_near_duplicates`, per-tenant, **default off** — like every switch that changes what a write *produces* rather than what it reports. Reversible through the same lineage a contradiction supersession uses.

## Testing

20 new tests, including that a multi-valued predicate is never merged (the heart of the safety argument), that an unresolved triple proves nothing across six shapes, that the link precedes the retire, and that a merge failure can't raise into the write.

Full suite: **27 failures, identical to main's 27** — none new. `ruff` clean; `mypy` unchanged.