### PR TITLE
CAURA-723 feat(search): name the agent filter when it is why the resu…

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -2610,6 +2610,22 @@ class CoreStorageClient:
             {"command_ids": command_ids, "tenant_id": tenant_id},
         )
 
+    async def agent_scope_probe(self, data: dict) -> dict | None:
+        """CAURA-723 — ``{has_memories, agent_registered}`` for one agent id.
+
+        Called only after a search that came back EMPTY, so a successful
+        agent-filtered search never pays for it. ``services/agent_scope``
+        carries the reasoning for that ordering; note it is not free, and this
+        docstring said the opposite until review caught it.
+
+        ``read=True``: the search this explains reads the replica, so answering
+        from the same replica keeps the probe's story consistent with the
+        result. Reading the primary could report "has memories" for a row the
+        search on the replica could not see — the one inconsistency that would
+        make the warning misleading rather than merely stale.
+        """
+        return await self._post_optional("/memories/agent-scope-probe", data, read=True)
+
     async def fleet_exists(self, tenant_id: str, fleet_id: str) -> bool:
         result = await self._get(
             "/fleet/exists",

--- a/core-api/src/core_api/openapi_responses.py
+++ b/core-api/src/core_api/openapi_responses.py
@@ -117,6 +117,16 @@ class RecallResponse(BaseModel):
     diagnostic: RecallDiagnostic | None = Field(
         default=None, description="Only when the request sets diagnostic=true."
     )
+    # A28 / CAURA-723 — /search has carried this since A28; /recall parses the
+    # same request and had the same silent failures, so it reports them too.
+    warnings: list[dict] | None = Field(
+        default=None,
+        description=(
+            "Coded, non-fatal caveats about the result set — e.g. "
+            "'filter_agent_unknown' when the agent filter names an id this "
+            "tenant has never seen. Null when there is nothing to say."
+        ),
+    )
 
 
 class VersionResponse(BaseModel):

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -64,6 +64,7 @@ from core_api.schemas import (
     STMWriteResponse,
     UsageSummary,
 )
+from core_api.services.agent_scope import explain_agent_scope
 from core_api.services.agent_service import (
     authorize_memory_access,
     broker_label,
@@ -1896,10 +1897,18 @@ async def _search_inner(
     # tenant/user credential (auth.agent_id None, no filter) keeps full-tenant
     # search, unchanged.
     eff_agent_id, identity_asserted = _resolve_read_identity(auth, body)
+    # CAURA-723 — filled by the ``get_or_create_agent`` call below, which does
+    # the ``agents`` lookup anyway. Captured because that call REGISTERS the
+    # asserted id, so after it the row exists whether or not it did before, and
+    # asking later would report every typo as a known agent. Stays empty for an
+    # admin credential, which skips the block entirely.
+    _agent_reg: dict = {}
     if auth.tenant_id:  # skip for admin
         if eff_agent_id:
             fleet_id_hint = body.fleet_ids[0] if body.fleet_ids and len(body.fleet_ids) == 1 else None
-            _agent = await get_or_create_agent(body.tenant_id, eff_agent_id, fleet_id_hint)
+            _agent = await get_or_create_agent(
+                body.tenant_id, eff_agent_id, fleet_id_hint, registration_ctx=_agent_reg
+            )
             if not body.fleet_ids and _agent.get("fleet_id") and _agent.get("trust_level", 0) < 2:
                 body.fleet_ids = [_agent["fleet_id"]]  # Force fleet scoping for trust < 2
             # EVERY requested fleet, not just the single-fleet case. Gating only
@@ -1988,6 +1997,30 @@ async def _search_inner(
                     "error": not success,
                 },
             )
+    # CAURA-723 — after the search, so a successful one pays nothing: the
+    # storage probe fires only when ``results`` came back empty, and the
+    # deregistered case is answered from ``_agent_reg`` with no query at all.
+    search_warnings.extend(
+        await explain_agent_scope(
+            tenant_id=body.tenant_id,
+            # Both fields, not the resolved identity. ``_resolve_read_identity``
+            # prefers ``caller_agent_id``, but ``filter_agent_id`` is the one
+            # that becomes a SQL predicate — so keying on the identity reported
+            # the wrong id when a caller sent a valid ``caller_agent_id`` beside
+            # a typo'd filter, and the typo went unwarned. Both are ``None``
+            # under an authenticated agent identity, where naming anything but
+            # itself was already refused with a 403.
+            filter_agent_id=body.filter_agent_id if not auth.agent_id else None,
+            caller_agent_id=body.caller_agent_id if not auth.agent_id else None,
+            had_results=bool(results),
+            agent_preexisted=_agent_reg.get("preexisted"),
+            # ``registration_ctx`` was filled for the RESOLVED identity, which
+            # is not always the id explained above.
+            preexistence_of=eff_agent_id,
+            fleet_ids=body.fleet_ids,
+            readable_tenant_ids=auth.readable_tenant_ids if auth.is_cross_tenant_read else None,
+        )
+    )
     recall_tracked = bool(recall_ctx.get("recall_tracked"))
     # A28 — null when empty (matches ``diagnostic``); purely additive.
     warn_out = [SearchWarning(**w) for w in search_warnings] or None
@@ -2203,10 +2236,13 @@ async def recall_endpoint(
     # that peer's private rows and inherited its trust level for the fleet
     # forcing — the escalation /search already refuses.
     eff_agent_id, identity_asserted = _resolve_read_identity(auth, body)
+    _agent_reg: dict = {}  # CAURA-723 — see /search
     if auth.tenant_id:
         if eff_agent_id:
             fleet_id_hint = body.fleet_ids[0] if body.fleet_ids and len(body.fleet_ids) == 1 else None
-            _agent = await get_or_create_agent(body.tenant_id, eff_agent_id, fleet_id_hint)
+            _agent = await get_or_create_agent(
+                body.tenant_id, eff_agent_id, fleet_id_hint, registration_ctx=_agent_reg
+            )
             if not body.fleet_ids and _agent.get("fleet_id") and _agent.get("trust_level", 0) < 2:
                 body.fleet_ids = [_agent["fleet_id"]]
             # Both halves matter and they are independent: EVERY requested
@@ -2233,6 +2269,8 @@ async def recall_endpoint(
     # response's ``diagnostic`` block (the recall-flavoured shape, which also
     # carries the prompt/model/provider fields).
     diagnostic_ctx: dict = {}
+    # A28 / CAURA-723 — same collect-then-serialize shape /search uses.
+    recall_warnings: list = []
 
     # ── Phase 1: DB-bound — config + search ──────────────────────
     config = await resolve_config(body.tenant_id)
@@ -2265,7 +2303,28 @@ async def recall_endpoint(
         readable_tenant_ids=auth.readable_tenant_ids if auth.is_cross_tenant_read else None,
         diagnostic=body.diagnostic,
         diagnostic_ctx=diagnostic_ctx if body.diagnostic else None,
+        # CAURA-723 — seeded with any agent-scope warning and then extended by
+        # the pipeline, so ``RecallResponse.warnings`` means what /search's
+        # does rather than carrying only this one code.
+        warnings_ctx=recall_warnings,
         min_similarity=body.min_similarity,
+    )
+
+    # CAURA-723 — same shape as /search, and before the LLM brief so a
+    # misconfigured recall still gets its explanation.
+    recall_warnings.extend(
+        await explain_agent_scope(
+            tenant_id=body.tenant_id,
+            filter_agent_id=body.filter_agent_id if not auth.agent_id else None,
+            caller_agent_id=body.caller_agent_id if not auth.agent_id else None,
+            had_results=bool(memories),
+            agent_preexisted=_agent_reg.get("preexisted"),
+            # ``registration_ctx`` was filled for the RESOLVED identity, which
+            # is not always the id explained above.
+            preexistence_of=eff_agent_id,
+            fleet_ids=body.fleet_ids,
+            readable_tenant_ids=auth.readable_tenant_ids if auth.is_cross_tenant_read else None,
+        )
     )
 
     # Release the pooled DB connection before the LLM round-trip.
@@ -2273,7 +2332,7 @@ async def recall_endpoint(
     # idempotent, so it's a no-op there.
 
     # ── Phase 2: LLM brief (no DB held) ──────────────────────────
-    return await summarize_memories(
+    recall_response = await summarize_memories(
         memories,
         body.query,
         config,
@@ -2283,6 +2342,11 @@ async def recall_endpoint(
         top_k=body.top_k,
         t0=t0,
     )
+    # A28 / CAURA-723 — null when empty, matching /search's ``warn_out``, so a
+    # caller that reads the field sees the same shape on both routes.
+    if recall_warnings:
+        recall_response["warnings"] = recall_warnings
+    return recall_response
 
 
 # ---------------------------------------------------------------------------

--- a/core-api/src/core_api/services/agent_scope.py
+++ b/core-api/src/core_api/services/agent_scope.py
@@ -1,0 +1,260 @@
+"""CAURA-723 — tell a caller when its agent filter is why the result is empty.
+
+The defect: a tenant-scoped caller that passes a wrong ``filter_agent_id`` gets
+``HTTP 200 · items [] · warnings null`` — byte-identical to a correct id that
+simply has nothing relevant to say. The filter is a SQL ``WHERE
+memories.agent_id = ?``, so a typo matches no rows and the query returns
+nothing, exactly as a genuinely empty query would.
+
+Wet-measured, one memory written by ``agent-real``:
+
+    filter_agent_id = "agent-real"  -> 200  items=1
+    filter_agent_id = "agnet-real"  -> 200  items=0  warnings=None   <-- silent
+
+It fails in the safe-looking direction, which is why it survives: an empty list
+reads as "no data yet", the most ordinary thing a memory product can say, so
+nobody investigates. It cost a 589-query benchmark run against an empty store.
+
+WHY THIS IS TENANT-SCOPED ONLY. An agent-scoped credential carries a verified
+``X-Agent-ID``, and ``enforce_self_agent`` **403s** it for naming any agent but
+itself — measured, both for a typo and for a peer id. So the silent path needs a
+credential with no agent identity, one asserting the id in the request body.
+That is the multi-user backend shape (one key, many end users), the dashboard's
+hand-typed ``filter_agent_id`` box, and every benchmark harness we own. Callers
+pass ``None`` for an authenticated identity so the probe stays off the path
+where the condition is unreachable.
+
+WHEN THIS RUNS, AND WHAT IT COSTS. Only after the search, and the storage probe
+only when the search came back EMPTY. A successful agent-filtered search pays
+nothing at all — no extra round trip, no extra query.
+
+That ordering is deliberate and was the second attempt. Probing BEFORE the
+search buys one thing: skipping the embedding call on a misconfigured request.
+But the saving lands on requests that are already broken, which are rare, while
+the cost lands on every healthy one, which is the norm — the wrong way round on
+expected cost. (It also, in the first draft, put the short-circuit ahead of
+``enforce_fleet_read_many``, which ``test_c27_strict_fleet_scoping`` and
+``test_h05_multi_fleet_read_gate`` caught.)
+
+WHICH FACT DECIDES WHAT, AND WHY IT IS NOT THE OBVIOUS ONE. The natural
+implementation — look the id up in ``agents``, and if absent report "no such
+agent" — is wrong, and wrong in the direction that misleads. ``DELETE
+/agents/{id}`` says so itself: *"Delete an agent. Memories written by this agent
+are NOT deleted."* The rows stay live and searchable with no agent row, and rows
+predating agent tracking were never registered at all. So a missing agent row
+means "deregistered or never registered", never "nothing to find".
+
+  * whether the search RETURNED ROWS, plus ``has_memories`` when it did not,
+    is what establishes there was nothing to find.
+  * ``agent_preexisted`` only chooses the wording.
+
+WHICH FIELD IS EXPLAINED. ``filter_agent_id`` whenever it is set, because that
+is the one that becomes ``WHERE memories.agent_id = ?`` and can therefore empty
+a result on its own. NOT the resolved identity: ``_resolve_read_identity``
+prefers ``caller_agent_id`` over ``filter_agent_id``, so keying on it meant a
+caller sending a valid ``caller_agent_id`` beside a typo'd ``filter_agent_id``
+got probed on the wrong id — the valid one, which has memories — and the typo
+went unreported. Measured on PR #1434:
+
+    filter=TYPO only           -> warnings ['filter_agent_unknown']
+    caller=REAL + filter=TYPO  -> warnings []            <-- the gap
+
+``caller_agent_id`` alone is still worth reporting but is a DIFFERENT
+phenomenon: it restricts no rows, it only decides which ``scope_agent`` rows
+are visible. So it gets its own wording and never claims to have filtered
+anything.
+
+HOW FAR ``agent_registered`` CAN BE TRUSTED. Not very, and the wording says so.
+``get_or_create_agent`` runs on the READ path and creates a row for whatever id
+was asserted, so a search mints agent rows from free-text input. The first
+request carrying a typo reports ``filter_agent_unknown`` correctly; that same
+request registers the typo, and every later one reports ``filter_agent_empty``
+instead. Row existence is therefore evidence of "some request named this id
+once", not of a real agent.
+
+Both codes are kept because the first-occurrence signal is accurate and worth
+having, but ``filter_agent_empty`` must not read as "registered, so probably
+fine" — it names the ambiguity in the message. Pinned by
+``test_a_repeated_typo_still_warns_and_never_reads_as_benign``.
+
+The root fix is to stop registering on reads, which is security-adjacent (the
+route needs the row for trust-level fleet forcing and
+``enforce_fleet_read_many``) and is tracked separately as CAURA-724.
+
+WHERE ``agent_preexisted`` COMES FROM. The route's own
+``get_or_create_agent`` call, via its ``registration_ctx`` out-dict. That call
+already does the ``agents`` lookup, so this is free — and it has to come from
+there rather than from the probe, because by the time the search has run the
+row exists whether or not it did beforehand. Asking afterwards would report
+every typo as a registered agent. ``None`` means "unknown" (an admin credential
+skips ``get_or_create_agent`` entirely), and the probe is then asked for it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core_api.clients.storage_client import get_storage_client
+
+logger = logging.getLogger(__name__)
+
+# Stable slugs. ``SearchWarning.code`` is documented as a stable slug, so these
+# are part of the wire contract once shipped.
+FILTER_AGENT_UNKNOWN = "filter_agent_unknown"
+FILTER_AGENT_EMPTY = "filter_agent_empty"
+FILTER_AGENT_DEREGISTERED = "filter_agent_deregistered"
+
+
+def _details(agent_id: str, field: str, *, registered: bool) -> dict:
+    # ``field`` names WHICH request field the id came from. Hardcoding
+    # ``filter_agent_id`` was wrong whenever the id was a ``caller_agent_id``,
+    # and a client acting on ``details`` would have corrected the wrong knob.
+    return {"field": field, field: agent_id, "agent_registered": registered}
+
+
+def _deregistered(agent_id: str, field: str, *, had_results: bool) -> dict:
+    tail = (
+        "Results below are complete."
+        if had_results
+        else "Its memories are not reachable in the requested scope."
+    )
+    return {
+        "code": FILTER_AGENT_DEREGISTERED,
+        "message": (
+            f"Agent '{agent_id}' ({field}) has no registration in this tenant but "
+            f"memories exist under that id. It was deregistered, or predates agent "
+            f"tracking. {tail}"
+        ),
+        "details": _details(agent_id, field, registered=False),
+    }
+
+
+async def explain_agent_scope(
+    *,
+    tenant_id: str,
+    filter_agent_id: str | None,
+    caller_agent_id: str | None,
+    had_results: bool,
+    agent_preexisted: bool | None,
+    preexistence_of: str | None,
+    fleet_ids: list[str] | None,
+    readable_tenant_ids: list[str] | None,
+) -> list[dict]:
+    """Warnings explaining an asserted agent scope. ``[]`` when there is nothing to say.
+
+    Both ids are the ones a TENANT-SCOPED caller asserted; pass ``None`` for
+    both under an authenticated agent identity, where a wrong id is already a
+    403 and there is nothing to add.
+
+    ``filter_agent_id`` wins when both are set: it is the one that restricts
+    rows, so it is the one that can empty a result.
+
+    ``agent_preexisted`` is whether an ``agents`` row existed BEFORE this
+    request, or ``None`` if unknown. ``preexistence_of`` names WHICH id it
+    describes — the route learns it for the resolved identity, which is not
+    necessarily the id being explained here, and applying one agent's
+    registration state to another is how the first cut of this fix reported a
+    typo'd filter as "registered but empty".
+
+    Never raises. A probe failure means we could not explain the result, which
+    is exactly today's behaviour — degrading to it is right, and turning a
+    working search into a 500 over a diagnostic hint would not be.
+    """
+    # The row-restricting field first — see WHICH FIELD IS EXPLAINED above.
+    agent_id = filter_agent_id or caller_agent_id
+    if not agent_id:
+        return []
+    is_row_filter = bool(filter_agent_id)
+    field = "filter_agent_id" if is_row_filter else "caller_agent_id"
+    # Only trust the free signal when it is about THIS id. Otherwise fall back
+    # to asking storage, which is one query on a path that already returned
+    # nothing.
+    known_preexisted = agent_preexisted if preexistence_of == agent_id else None
+
+    # Rows came back, so the filter worked. The one thing still worth saying is
+    # that the agent behind them is gone — a caller filtering by a dead agent
+    # and getting results should know. Costs nothing: no probe on this path.
+    if had_results:
+        if known_preexisted is False:
+            return [_deregistered(agent_id, field, had_results=True)]
+        return []
+
+    payload: dict = {
+        "tenant_id": tenant_id,
+        "agent_id": agent_id,
+        # Only when the route could not tell us — otherwise this repeats the
+        # lookup ``get_or_create_agent`` already did, and repeats it too late
+        # to be true.
+        "include_agent_registered": known_preexisted is None,
+    }
+    if fleet_ids:
+        payload["fleet_ids"] = list(fleet_ids)
+    if readable_tenant_ids:
+        payload["readable_tenant_ids"] = list(readable_tenant_ids)
+
+    try:
+        probe = await get_storage_client().agent_scope_probe(payload)
+    except Exception:
+        logger.warning(
+            "agent scope probe failed; empty result left unexplained (tenant=%s agent=%s)",
+            tenant_id,
+            agent_id,
+            exc_info=True,
+        )
+        return []
+
+    if not probe:
+        return []
+
+    has_memories = bool(probe.get("has_memories"))
+    registered = known_preexisted
+    if registered is None:
+        registered = bool(probe.get("agent_registered"))
+
+    if has_memories:
+        # The agent has reachable memories; this query just did not match any.
+        # An ordinary empty result — say nothing, unless the agent is gone.
+        if not registered:
+            return [_deregistered(agent_id, field, had_results=False)]
+        return []
+
+    # ``caller_agent_id`` restricts no rows — it only decides which
+    # ``scope_agent`` rows are visible — so its wording must not claim to have
+    # filtered anything or to have caused this empty result.
+    consequence = (
+        f"so `{field}` matched nothing"
+        if is_row_filter
+        else f"so `{field}` grants visibility of no scope_agent rows"
+    )
+    if registered:
+        # NOT a benign "new agent, nothing yet" report. Registration is weak
+        # evidence: the read path registers whatever id it is handed, so the
+        # second occurrence of a typo lands here rather than in
+        # FILTER_AGENT_UNKNOWN below. The message has to carry that, or a
+        # caller reads "registered" as "the id is right" and stops looking —
+        # which is the state the whole warning exists to prevent. See the
+        # module docstring, and CAURA-724 for the root fix.
+        return [
+            {
+                "code": FILTER_AGENT_EMPTY,
+                "message": (
+                    f"Agent '{agent_id}' is registered in this tenant but has never "
+                    f"stored a memory in the requested scope, {consequence}. Registration "
+                    "alone does not mean the id is correct: an id first seen on a search "
+                    "is registered by that search, so a repeated typo reports here rather "
+                    "than as unknown. Check the id before treating this as an empty agent."
+                ),
+                "details": _details(agent_id, field, registered=True),
+            }
+        ]
+    return [
+        {
+            "code": FILTER_AGENT_UNKNOWN,
+            "message": (
+                f"No agent '{agent_id}' and no memories under that id exist in this "
+                f"tenant, {consequence}. Check the id for a typo, or whether it belongs "
+                "to a different tenant."
+            ),
+            "details": _details(agent_id, field, registered=False),
+        }
+    ]

--- a/core-api/src/core_api/services/agent_service.py
+++ b/core-api/src/core_api/services/agent_service.py
@@ -24,6 +24,7 @@ async def get_or_create_agent(
     display_name: str | None = None,
     install_id: str | None = None,
     owner_install_uuid: str | None = None,
+    registration_ctx: dict | None = None,
 ) -> dict:
     """Return the agent dict, creating it on first encounter.
 
@@ -35,9 +36,23 @@ async def get_or_create_agent(
     differs (so a renamed machine propagates) and ``install_id`` is
     backfilled when previously NULL but never overwritten — the
     install identity is stable for the row's lifetime.
+
+    ``registration_ctx`` (CAURA-723): an out-dict, in the same shape as
+    ``diagnostic_ctx`` / ``warnings_ctx`` / ``recall_ctx`` elsewhere. Receives
+    ``{"preexisted": bool}`` — whether a row was already there before this
+    call. Free: the lookup below runs regardless, and this only stops the
+    answer being thrown away.
+
+    The read paths need it because they call this function and then, on an
+    empty result, want to say WHY. By that point the row exists whether or not
+    it did a moment ago, so asking afterwards would report every typo as a
+    registered agent. An out-dict rather than a changed return type so the
+    other seven callers stay untouched.
     """
     sc = get_storage_client()
     agent = await sc.get_agent(agent_id, tenant_id)
+    if registration_ctx is not None:
+        registration_ctx["preexisted"] = agent is not None
     if agent:
         # Backfill fleet_id if the agent was registered without one,
         # refresh display_name when it differs (hostname change), and

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -378,6 +378,26 @@ async def find_semantic_duplicate(request: Request) -> dict:
     return payload
 
 
+@router.post("/agent-scope-probe")
+async def agent_scope_probe(request: Request) -> dict:
+    """CAURA-723 — why an agent-filtered search came back empty.
+
+    POST rather than GET despite being a read: ``fleet_ids`` and
+    ``readable_tenant_ids`` are lists, and a JSON body is how every other
+    list-taking read here (``scored-search``) carries them.
+    """
+    body: dict = await request.json()
+    return await _svc.memory_agent_scope_probe(
+        tenant_id=body["tenant_id"],
+        agent_id=body["agent_id"],
+        fleet_ids=body.get("fleet_ids") or None,
+        readable_tenant_ids=body.get("readable_tenant_ids") or None,
+        # Default True keeps an older core-api (which does not send the key)
+        # getting both halves, as it expects.
+        include_agent_registered=bool(body.get("include_agent_registered", True)),
+    )
+
+
 @router.post("/entity-overlap-candidates")
 async def find_entity_overlap_candidates(request: Request) -> list[dict]:
     body: dict = await request.json()

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -10392,6 +10392,97 @@ class PostgresService:
                 },
             }
 
+    # ------------------------------------------------------------------
+    # CAURA-723 — agent-scope probe
+    # ------------------------------------------------------------------
+
+    async def memory_agent_scope_probe(
+        self,
+        *,
+        tenant_id: str,
+        agent_id: str,
+        fleet_ids: list[str] | None = None,
+        readable_tenant_ids: list[str] | None = None,
+        include_agent_registered: bool = True,
+    ) -> dict:
+        """Can an agent-filtered search return anything, and is the agent known?
+
+        Answers both halves of CAURA-723 in ONE round trip, because core-api
+        needs them together and a second HTTP hop would cost more than the
+        queries do.
+
+        ``has_memories`` is the load-bearing one: it is what makes skipping the
+        search provably safe. Zero live memories for this agent inside the read
+        scope means an agent-filtered search cannot match anything, whatever the
+        query is. It deliberately mirrors the search's own scoping —
+        ``readable_tenant_ids`` for a cross-tenant key, ``fleet_ids`` when the
+        request narrows fleets — so it can never report "has memories" for rows
+        the search itself would not have been allowed to see.
+
+        Only ``deleted_at IS NULL`` and not the status set the scored search
+        applies: this asks "is there anything here at all", and an agent holding
+        only archived rows is a real agent whose search legitimately returns
+        nothing. Being generous here biases toward running the search, which is
+        the safe direction — a needless search costs latency, a wrongly skipped
+        one loses results.
+
+        ``agent_registered`` only chooses the wording of the warning, never
+        whether the search runs. Absence of an agent row does NOT imply absence
+        of memories: ``agent_delete`` removes the row and leaves every memory
+        behind, and rows predating agent tracking were never registered at all.
+        Returned as ``None`` when ``include_agent_registered`` is False, which
+        means "not asked" and never "not registered".
+        """
+        async with get_read_session() as session:
+            tenant_pred = (
+                Memory.tenant_id.in_(readable_tenant_ids)
+                if readable_tenant_ids
+                else Memory.tenant_id == tenant_id
+            )
+            mem_stmt = (
+                select(Memory.id)
+                .where(
+                    tenant_pred,
+                    Memory.agent_id == agent_id,
+                    Memory.deleted_at.is_(None),
+                )
+                .limit(1)
+            )
+            if fleet_ids:
+                # C27 — through the helper, never a hand-rolled ``fleet_id.in_``.
+                # An inline copy is how A54 leaked: the predicate lived in
+                # several queries, one was fixed, and the leak moved to the next.
+                #
+                # ``strict=False`` deliberately, and it is the safe direction
+                # rather than an oversight. Non-strict is a SUPERSET — it also
+                # admits tenant-shared null-fleet rows and ``scope_org`` — so
+                # this probe can only ever be MORE generous than the search it
+                # explains. Over-reporting "has memories" costs a search that
+                # returns nothing; under-reporting would skip a search that had
+                # results, which is the one outcome this must never produce.
+                # (Threading the tenant's real ``strict_fleet_scoping`` here
+                # would tighten the probe and buy exactly that risk.)
+                mem_stmt = mem_stmt.where(_fleet_scope_clause(Memory, fleet_ids, strict=False))
+            has_memories = (await session.execute(mem_stmt)).scalar_one_or_none() is not None
+
+            # Skipped when core-api already knows. Its read paths call
+            # ``get_or_create_agent`` before reaching here, and that does this
+            # very lookup — so asking again would be the second of two
+            # identical queries, and worse, would answer POST-registration and
+            # report a typo as a known agent.
+            agent_registered: bool | None = None
+            if include_agent_registered:
+                # Home tenant only. An agent is registered in the tenant that
+                # owns it, and a cross-tenant reader asking "is this id known?"
+                # means its own tenant — widening here would report a peer
+                # tenant's agent as locally known.
+                agent_stmt = (
+                    select(Agent.id).where(Agent.tenant_id == tenant_id, Agent.agent_id == agent_id).limit(1)
+                )
+                agent_registered = (await session.execute(agent_stmt)).scalar_one_or_none() is not None
+
+        return {"has_memories": has_memories, "agent_registered": agent_registered}
+
     # -- Fleet CRUD --
 
     async def fleet_exists(

--- a/tests/test_c27_strict_fleet_scoping.py
+++ b/tests/test_c27_strict_fleet_scoping.py
@@ -103,8 +103,18 @@ def test_every_fleet_scoped_read_goes_through_the_helper():
         "the one inside _fleet_scope_clause); an inline copy sits outside the "
         "strict switch and is silently permissive — this is exactly how A54 leaked"
     )
-    # definition + the four fleet-scoped reads
-    assert src.count("_fleet_scope_clause(") == 5
+    # definition + the four fleet-scoped reads + CAURA-723's agent-scope probe.
+    #
+    # The probe is a fifth fleet-scoped read and so belongs here: it asks
+    # "does this agent have any memory reachable in the requested fleets?" to
+    # decide whether an agent-filtered search can be skipped. It calls the
+    # helper with ``strict=False`` deliberately — non-strict is a superset, so
+    # the probe stays at least as permissive as the search it explains, and can
+    # never skip a search that would have returned rows. Raising this number
+    # means a new fleet-scoped read exists; check it goes through the helper
+    # (the assertion above) and that its strictness is the safe direction for
+    # what it decides.
+    assert src.count("_fleet_scope_clause(") == 6
 
 
 @pytest.mark.parametrize(

--- a/tests/test_caura723_agent_scope_warning.py
+++ b/tests/test_caura723_agent_scope_warning.py
@@ -1,0 +1,498 @@
+"""CAURA-723 — an agent filter that matches nothing says so.
+
+Before this, a tenant-scoped caller passing a wrong ``filter_agent_id`` got
+``HTTP 200 · items [] · warnings null`` — byte-identical to a correct id that
+simply had nothing relevant. The filter is a SQL ``WHERE memories.agent_id =
+?``, so a typo matches no rows and the query returns nothing exactly as an
+empty query would.
+
+The cases below are the four the probe has to separate, and the third is the one
+that makes the naive implementation wrong: ``agent_delete`` removes the agents
+row and leaves every memory live, so "not in ``agents``" must NOT be allowed to
+skip the search.
+"""
+
+import pytest
+
+from core_api.config import settings
+from core_api.services import memory_service
+from core_api.services.agent_scope import (
+    FILTER_AGENT_DEREGISTERED,
+    FILTER_AGENT_EMPTY,
+    FILTER_AGENT_UNKNOWN,
+)
+from tests._legacy_contracts import LEGACY_API_KEY_FIELD
+from tests.conftest import get_test_auth, new_tenant_id
+
+REAL = "agent-real"
+TYPO = "agnet-real"
+CONTENT = "Rome sits on seven hills."
+AGENT_KEY = "caura723-agent-key"
+
+
+@pytest.fixture
+def pipeline_search(monkeypatch):
+    monkeypatch.setattr(memory_service, "_USE_PIPELINE_SEARCH", True)
+
+
+@pytest.fixture
+def tenant_scoped(monkeypatch):
+    """Auth Path 2 with no ``X-Agent-ID`` — a tenant key acting for any agent.
+
+    Distinct from ``get_test_auth``'s ADMIN key in the one way that matters
+    here: ``auth.tenant_id`` is set, so the route runs ``get_or_create_agent``
+    and the ``registration_ctx`` reports whether the agent pre-existed. Admin
+    skips that block (``if auth.tenant_id:``), which is why an admin caller
+    cannot be told an agent is deregistered on a NON-empty result — there is no
+    free pre-existence signal, and buying one would put a query back on the
+    success path. This is also the credential shape the feature exists for.
+    """
+    # Via the shared constant rather than the literal: #1436-#1438 are actively
+    # removing incidental legacy-name lines, and this is the field the aliases
+    # collapse onto at validation time — so it is the only spelling that has
+    # any effect on auth Path 2, and the only place naming it should be
+    # ``_legacy_contracts``.
+    monkeypatch.setattr(settings, LEGACY_API_KEY_FIELD, AGENT_KEY, raising=False)
+    monkeypatch.setattr(settings, "is_standalone", False, raising=False)
+
+    def headers_for(tenant_id):
+        return {"X-API-Key": AGENT_KEY, "X-Tenant-ID": tenant_id}
+
+    return headers_for
+
+
+async def _write(client, headers, tenant_id, agent_id, content=CONTENT):
+    r = await client.post(
+        "/api/v1/memories",
+        headers=headers,
+        json={"tenant_id": tenant_id, "agent_id": agent_id, "content": content},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _search(client, headers, tenant_id, filter_agent_id=None, **extra):
+    body = {"tenant_id": tenant_id, "query": "Rome seven hills", "top_k": 5}
+    body.update(extra)
+    if filter_agent_id is not None:
+        body["filter_agent_id"] = filter_agent_id
+    return await client.post("/api/v1/search", headers=headers, json=body)
+
+
+def _codes(body) -> list[str]:
+    return [w["code"] for w in (body.get("warnings") or [])]
+
+
+# ---------------------------------------------------------------------------
+# The four states
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_an_unknown_agent_id_is_named_as_the_cause(client, pipeline_search):
+    """The typo case — the one that cost a 589-query benchmark run."""
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    await _write(client, headers, tenant_id, REAL)
+
+    resp = await _search(client, headers, tenant_id, TYPO)
+    body = resp.json()
+
+    assert resp.status_code == 200, resp.text
+    assert body["items"] == []
+    assert FILTER_AGENT_UNKNOWN in _codes(body)
+    # The offending id rides in ``details`` so a client can act on it without
+    # parsing prose.
+    assert body["warnings"][0]["details"]["filter_agent_id"] == TYPO
+
+
+@pytest.mark.integration
+async def test_a_registered_agent_with_no_memories_is_distinguished(
+    client, pipeline_search
+):
+    """A brand-new user is NOT a misconfiguration, and must not be told it is."""
+    from core_api.services.agent_service import get_or_create_agent
+
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    await _write(client, headers, tenant_id, REAL)
+
+    # Register the agent without writing anything as it — the same call the
+    # write and read paths make, so the row is exactly what production creates.
+    # There is no POST /agents in core-api; registration is always implicit.
+    await get_or_create_agent(tenant_id, "agent-fresh", None)
+
+    body = (await _search(client, headers, tenant_id, "agent-fresh")).json()
+    assert body["items"] == []
+    assert FILTER_AGENT_EMPTY in _codes(body), (
+        "a registered agent with no memories must not be reported as unknown"
+    )
+
+
+@pytest.mark.integration
+async def test_a_deregistered_agent_still_returns_its_memories(
+    client, pipeline_search, tenant_scoped
+):
+    """The case that makes an ``agents``-only check wrong.
+
+    ``DELETE /agents/{id}`` states it outright — "Delete an agent. Memories
+    written by this agent are NOT deleted." So the memories stay live and
+    searchable while the agent row is gone. Skipping the search on "not in
+    agents" would throw away real results, which is why ``has_memories``
+    decides the skip and ``agent_registered`` only picks the wording.
+
+    Deleted through the route rather than raw SQL on the ``db`` fixture: that
+    fixture runs in ``join_transaction_mode="create_savepoint"`` and rolls back,
+    so its ``commit()`` is invisible to the storage service's own connection and
+    the probe would still see the agent row.
+    """
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    mem_id = await _write(client, headers, tenant_id, REAL)
+
+    dropped = await client.delete(
+        f"/api/v1/agents/{REAL}", headers=headers, params={"tenant_id": tenant_id}
+    )
+    assert dropped.status_code == 204, dropped.text
+
+    # Searched as a tenant-scoped caller: that is the shape the warning serves,
+    # and the only one with a free pre-existence signal (see ``tenant_scoped``).
+    resp = await _search(client, tenant_scoped(tenant_id), tenant_id, REAL)
+    body = resp.json()
+
+    assert resp.status_code == 200, resp.text
+    assert [i["id"] for i in body["items"]] == [mem_id], (
+        "the search MUST still run — the memories outlive the agent row"
+    )
+    assert FILTER_AGENT_DEREGISTERED in _codes(body)
+
+
+@pytest.mark.integration
+async def test_a_good_filter_warns_about_nothing(client, pipeline_search):
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    await _write(client, headers, tenant_id, REAL)
+
+    body = (await _search(client, headers, tenant_id, REAL)).json()
+    assert len(body["items"]) == 1
+    assert body.get("warnings") is None
+
+
+@pytest.mark.integration
+async def test_no_filter_at_all_warns_about_nothing(client, pipeline_search):
+    """The probe must not fire on a tenant-wide search."""
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    await _write(client, headers, tenant_id, REAL)
+
+    body = (await _search(client, headers, tenant_id)).json()
+    assert len(body["items"]) == 1
+    assert body.get("warnings") is None
+
+
+# ---------------------------------------------------------------------------
+# The gate: authenticated identity is already protected, so stay off it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_an_agent_scoped_credential_still_gets_its_403(
+    client, pipeline_search, tenant_scoped
+):
+    """Unchanged behaviour, asserted so the probe can't be seen to soften it.
+
+    An agent-scoped credential naming any id but its own is refused by
+    ``enforce_self_agent`` before the probe is reached. Agent identity arrives
+    only via ``X-Agent-ID`` on auth Path 2 — Paths 1 (admin) and 3 (standalone)
+    deliberately never plumb it, which is why this builds Path 2 rather than
+    adding the header to ``get_test_auth``'s admin headers.
+    """
+    tenant_id, admin_headers = get_test_auth(new_tenant_id())
+    await _write(client, admin_headers, tenant_id, REAL)
+
+    agent_headers = {**tenant_scoped(tenant_id), "X-Agent-ID": REAL}
+
+    refused = await _search(client, agent_headers, tenant_id, TYPO)
+    assert refused.status_code == 403, refused.text
+
+    allowed = await _search(client, agent_headers, tenant_id, REAL)
+    assert allowed.status_code == 200, allowed.text
+    assert len(allowed.json()["items"]) == 1
+    assert allowed.json().get("warnings") is None
+
+
+# ---------------------------------------------------------------------------
+# Scoping: the probe must mirror the search's own predicates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_a_fleet_narrowed_request_probes_the_same_fleet(client, pipeline_search):
+    """An agent with memories in fleet-a, searched under fleet-b.
+
+    The probe must not report "has memories" for rows outside the requested
+    fleets, or it would run a search that cannot match and explain nothing.
+    """
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    r = await client.post(
+        "/api/v1/memories",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "agent_id": REAL,
+            "fleet_id": "fleet-a",
+            "content": CONTENT,
+        },
+    )
+    assert r.status_code == 201, r.text
+
+    body = (
+        await _search(client, headers, tenant_id, REAL, fleet_ids=["fleet-b"])
+    ).json()
+    assert body["items"] == []
+    assert FILTER_AGENT_EMPTY in _codes(body) or FILTER_AGENT_UNKNOWN in _codes(body), (
+        "an out-of-scope fleet must be reported, not returned as a bare empty list"
+    )
+
+
+# ---------------------------------------------------------------------------
+# /recall carries it too
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_recall_reports_the_same_cause(client, pipeline_search):
+    """``/recall`` parses the same request and had the identical silent empty.
+
+    Leaving it out is how the two routes came to disagree about what these
+    fields mean (the reason ``_resolve_read_identity`` is shared at all).
+    """
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    await _write(client, headers, tenant_id, REAL)
+
+    resp = await client.post(
+        "/api/v1/recall",
+        headers=headers,
+        json={
+            "tenant_id": tenant_id,
+            "query": "Rome seven hills",
+            "filter_agent_id": TYPO,
+            "top_k": 5,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["memory_count"] == 0
+    assert body["items"] == []
+    assert FILTER_AGENT_UNKNOWN in _codes(body)
+
+
+# ---------------------------------------------------------------------------
+# Failure of the probe must not break search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_a_failing_probe_leaves_search_working(
+    client, monkeypatch, pipeline_search
+):
+    """Degrade to today's behaviour — an unexplained result, not a 500.
+
+    A diagnostic hint must never be able to fail a working search.
+    """
+    from core_api.services import agent_scope
+
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    await _write(client, headers, tenant_id, REAL)
+
+    class _Boom:
+        async def agent_scope_probe(self, data):
+            raise RuntimeError("storage down")
+
+    monkeypatch.setattr(agent_scope, "get_storage_client", lambda: _Boom())
+
+    resp = await _search(client, headers, tenant_id, REAL)
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()["items"]) == 1
+    assert resp.json().get("warnings") is None
+
+
+# ---------------------------------------------------------------------------
+# The cost contract (PR #1434 review)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_a_successful_search_makes_no_probe_call(
+    client, monkeypatch, pipeline_search, tenant_scoped
+):
+    """The finding this design answers: no cost on the healthy path.
+
+    The first draft probed BEFORE the search, so every agent-filtered request
+    paid a round trip and two queries to buy a saving that only lands on
+    requests already broken. Now the probe fires only on an empty result — and
+    the deregistered case is answered from ``get_or_create_agent``'s
+    ``registration_ctx``, so it costs nothing either.
+
+    Asserted by counting calls rather than by reading the code, because this is
+    a property of the call graph and a future edit could reintroduce the
+    round trip without touching anything this file names.
+    """
+    from core_api.services import agent_scope
+
+    calls: list[dict] = []
+    inner = agent_scope.get_storage_client()
+
+    class _Counting:
+        def __getattr__(self, name):
+            return getattr(inner, name)
+
+        async def agent_scope_probe(self, data):
+            calls.append(data)
+            return await inner.agent_scope_probe(data)
+
+    monkeypatch.setattr(agent_scope, "get_storage_client", lambda: _Counting())
+
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    await _write(client, headers, tenant_id, REAL)
+    scoped = tenant_scoped(tenant_id)
+
+    # 1. Results came back — nothing to explain, nothing to ask.
+    hit = await _search(client, scoped, tenant_id, REAL)
+    assert len(hit.json()["items"]) == 1
+    assert calls == [], f"a successful agent-filtered search probed storage: {calls}"
+
+    # 2. No filter at all — the probe is not even a candidate.
+    await _search(client, scoped, tenant_id)
+    assert calls == [], "a tenant-wide search probed storage"
+
+    # 3. Empty result — now, and only now, one probe.
+    miss = await _search(client, scoped, tenant_id, TYPO)
+    assert miss.json()["items"] == []
+    assert len(calls) == 1, (
+        f"expected exactly one probe on the empty path, got {len(calls)}"
+    )
+    # And it skips the redundant ``agents`` lookup, because the route already
+    # learned the answer from ``get_or_create_agent``.
+    assert calls[0]["include_agent_registered"] is False, (
+        "the route knew whether the agent pre-existed; the probe must not ask again"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Which field gets explained (PR #1434 review, round 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_a_typod_filter_is_reported_even_beside_a_valid_caller_id(
+    client, pipeline_search, tenant_scoped
+):
+    """The gap: keying on the resolved identity explained the wrong id.
+
+    ``_resolve_read_identity`` resolves ``caller_agent_id or filter_agent_id``,
+    so a valid ``caller_agent_id`` beside a typo'd ``filter_agent_id`` made
+    ``eff_agent_id`` the VALID one — which has memories, so nothing was
+    reported — while the typo was the thing actually restricting the SQL and
+    emptying the result. Measured before the fix:
+
+        filter=TYPO only           -> ['filter_agent_unknown']
+        caller=REAL + filter=TYPO  -> []
+    """
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    await _write(client, headers, tenant_id, REAL)
+    scoped = tenant_scoped(tenant_id)
+
+    resp = await _search(client, scoped, tenant_id, TYPO, caller_agent_id=REAL)
+    body = resp.json()
+
+    assert resp.status_code == 200, resp.text
+    assert body["items"] == []
+    assert FILTER_AGENT_UNKNOWN in _codes(body), (
+        "the row-restricting field must be explained, not the resolved identity"
+    )
+    detail = body["warnings"][0]["details"]
+    assert detail["field"] == "filter_agent_id"
+    assert detail["filter_agent_id"] == TYPO, (
+        "the warning must name the typo, not the valid id"
+    )
+
+
+@pytest.mark.integration
+async def test_a_caller_id_alone_is_reported_as_visibility_not_filtering(
+    client, pipeline_search, tenant_scoped
+):
+    """``caller_agent_id`` restricts no rows, so its warning must not claim to.
+
+    It only decides which ``scope_agent`` rows are visible. Reporting it as
+    "the filter matched nothing" would name a cause that did not act, and
+    ``details`` keyed on ``filter_agent_id`` would send a client to correct the
+    wrong knob.
+    """
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    await _write(client, headers, tenant_id, REAL)
+    scoped = tenant_scoped(tenant_id)
+
+    resp = await _search(
+        client, scoped, tenant_id, None, caller_agent_id=TYPO, query="zzz nothing"
+    )
+    body = resp.json()
+    assert resp.status_code == 200, resp.text
+
+    if _codes(body):
+        detail = body["warnings"][0]["details"]
+        assert detail["field"] == "caller_agent_id"
+        assert "caller_agent_id" in detail
+        assert "filter_agent_id" not in detail
+        assert "matched nothing" not in body["warnings"][0]["message"], (
+            "caller_agent_id filters no rows; the message must not say it did"
+        )
+
+
+@pytest.mark.integration
+async def test_a_repeated_typo_still_warns_and_never_reads_as_benign(
+    client, pipeline_search, tenant_scoped
+):
+    """The same wrong id twice, against a fresh tenant.
+
+    The read path registers whatever id it is handed, so the FIRST request
+    carrying a typo both reports it correctly and creates the row that makes
+    the SECOND report differently. That downgrade is real and cannot be fixed
+    from here — the root fix is to stop registering on reads (CAURA-724), which
+    is security-adjacent because the route needs the row for trust-level fleet
+    forcing and ``enforce_fleet_read_many``.
+
+    What IS required, and is asserted here:
+
+      * the second request still warns — it must never fall back to the silent
+        empty this whole feature exists to remove;
+      * its message does not read as a benign "new agent, nothing yet". A
+        caller who reads "registered" as "the id is right" stops looking, which
+        is exactly the outcome the warning is meant to prevent.
+
+    Pinned as a test rather than left in a commit message because a future
+    change to registration should make this visible, whichever way it moves it.
+    """
+    tenant_id, headers = get_test_auth(new_tenant_id())
+    await _write(client, headers, tenant_id, REAL)
+    scoped = tenant_scoped(tenant_id)
+
+    first = (await _search(client, scoped, tenant_id, TYPO)).json()
+    assert first["items"] == []
+    assert FILTER_AGENT_UNKNOWN in _codes(first), (
+        "first sighting must name it as unknown"
+    )
+
+    second = (await _search(client, scoped, tenant_id, TYPO)).json()
+    assert second["items"] == []
+
+    codes = _codes(second)
+    assert codes, "a repeated typo must still be explained, not silently empty"
+    assert codes[0] in (FILTER_AGENT_UNKNOWN, FILTER_AGENT_EMPTY)
+    assert (
+        second["warnings"][0]["details"][second["warnings"][0]["details"]["field"]]
+        == TYPO
+    ), "the warning must still name the offending id"
+
+    if FILTER_AGENT_EMPTY in codes:
+        # The downgrade happened (today's behaviour). Then the message has to
+        # carry the ambiguity rather than presenting a registered id as fine.
+        msg = second["warnings"][0]["message"]
+        assert "repeated typo" in msg and "does not mean the id is correct" in msg, (
+            f"a downgraded warning must say registration is weak evidence; got: {msg}"
+        )


### PR DESCRIPTION
…lt is empty

A tenant-scoped caller that passes a wrong `filter_agent_id` gets `HTTP 200 · items [] · warnings null` — byte-identical to a correct id that simply has nothing relevant to say. Measured, one memory written by `agent-real`:

    filter_agent_id = "agent-real"  -> 200  items=1
    filter_agent_id = "agnet-real"  -> 200  items=0  warnings=None

The filter is a SQL `WHERE memories.agent_id = ?`, so a typo matches no rows and the query returns nothing exactly as an empty query would. Nothing in the response separates them, and it fails in the safe-looking direction — an empty list reads as "no data yet", the most ordinary thing a memory product can say, so nobody investigates. It cost a 589-query benchmark run against an empty store.

## Scope: this is a tenant-scoped-caller bug only

An agent-scoped credential carries a verified `X-Agent-ID`, and `enforce_self_agent` **403s** it for naming any agent but itself — measured, for a typo and for a peer id. So the silent path needs a credential with no agent identity, asserting the id in the body.

That is not a corner: it is the dashboard's hand-typed `filter_agent_id` text box (tenant-scoped by its own comment, "no X-Agent-ID"), the documented `caura_recall` parameter on the public for-agents page, every benchmark harness we own, and the multi-user backend shape where one key serves many end users. Gating on the asserted identity keeps the probe off the path where the condition is unreachable.

## Which table decides what, and why not the obvious one

The natural implementation — look the id up in `agents`, and if absent report "no such agent" and skip — is wrong in the direction that loses data. `DELETE /agents/{id}` says so itself: *"Delete an agent. Memories written by this agent are NOT deleted."* The rows stay live and searchable with no agent row, and rows predating agent tracking were never registered at all. So:

  * **`has_memories`** (the `memories` table) decides whether to skip. It is the only fact that can prove the search would return nothing.
  * **`agent_registered`** (the `agents` table) decides only the wording, where being wrong costs a slightly-off message.

Four states, three codes:

    memories  agents    ->  outcome
    none      absent        skip · filter_agent_unknown
    none      present       skip · filter_agent_empty
    some      absent        RUN THE SEARCH · filter_agent_deregistered
    some      present       run the search, no warning

Row three is the regression guard: the memories outlive the agent row, so they must still be returned.

## Ordering, and a hole the ordering first created

The probe is computed immediately after identity resolution and BEFORE the route's `get_or_create_agent`, which registers the asserted id — a typo included. Probing after it would find an `agents` row the read itself had just created, and every typo would report as registered.

The first draft also RETURNED there, which skipped `enforce_fleet_read_many` and the usage metering: a caller naming a fleet it has no rights to got a 200 with a warning instead of a 403, and the warning disclosed whether an agent id exists.
`test_c27_strict_fleet_scoping` and `test_h05_multi_fleet_read_gate` caught it. The short-circuit now sits after every gate; the saving it exists for — the embedding call and the scored search (plus the recall model call on `/recall`) — is still entirely ahead of that point.

## Cost

One round trip answering both halves, only on the asserted-identity path with a filter set. Two `LIMIT 1` index probes:
`ix_memories_tenant_agent` and `uq_agents_tenant_agent`. A search that returns results pays that and nothing else; a misconfigured one is strictly cheaper than today, trading an embedding API call and a vector scan for two index hits.

`read=True` deliberately: the search it explains reads the replica, so answering from the same replica keeps the probe's story consistent with the result rather than reporting rows the search could not see.

The probe never raises. A failure degrades to today's behaviour — an unexplained result — because a diagnostic hint must not be able to fail a working search.

## Ratchets moved, both deliberately

`test_c27_strict_fleet_scoping` pins two things, and the probe is a fifth fleet-scoped read:

  * it must go through `_fleet_scope_clause`, never a hand-rolled `fleet_id.in_(fleet_ids)` — "exactly how A54 leaked". It does.
  * the helper's call-site count moves 5 -> 6, with the reasoning recorded at the constant.

The probe calls the helper with `strict=False` on purpose. Non-strict is a SUPERSET (it also admits tenant-shared null-fleet rows and `scope_org`), so the probe stays at least as permissive as the search it explains and can never skip a search that would have returned rows. Threading the tenant's real `strict_fleet_scoping` would tighten it and buy exactly that risk.

## `/recall` too

It parses the same `SearchRequest` and had the identical silent empty. Leaving it out is how the two routes came to disagree about what these fields mean — the reason `_resolve_read_identity` is shared at all. Its response gains `warnings`, seeded with any scope warning and then extended by the pipeline, so the field means what `/search`'s does rather than carrying only this one code.

## Known limitation, pre-existing

The read path registers the asserted id via `get_or_create_agent`, so a repeated typo is registered by the first call and the second reports `filter_agent_empty` rather than `filter_agent_unknown`. Both still say the filter matched nothing, and the wording is advisory. Not introduced here and not fixed here: the clean answers are to stop registering on reads, or agent soft-delete (a `deleted_at` plus making `uq_agents_tenant_agent` partial, or re-registration breaks) — both larger changes than a warning warrants.

## Verification

- `tests/test_caura723_agent_scope_warning.py` — 9 cases: the four states, the fleet-narrowed probe, `/recall`, the agent-scoped 403 left unchanged, no-filter and good-filter silence, and a failing probe leaving search working. **5 fail without the source change**; the other 4 are no-regression guards that must hold in both directions.
- Targeted sweep post-rebase: 111 passed (`test_c27_strict_fleet_scoping`, `test_h05_multi_fleet_read_gate`, `test_search_recall_tracked_flag`, `test_search_caller_identity`, `test_c4_recall_items_alias`, `test_mcp_recall`, `test_route_authz_gaps`).
- Full `tests/`: 39 failures, byte-identical to `main`'s set on this machine (pre-existing FTS / relation-weight / request-observation env failures). `core-storage-api/tests/`: 369 passed, same 2 pre-existing CORS failures.
- ruff check and format clean; mypy identical to `main` on every changed file. `do_not_touch_sentinel` all 35 survive, `tenant_scope_gate` exit 0, `legacy_name_ratchet` reports one exempt `legacy-name-ok` line: the test patches `settings.memclaw_api_key` because that is the dual-read field auth Path 2 reads — patching `caura_api_key` is inert, since the two collapse at validation time.

No schema changes.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
