### PR TITLE
chore: remove stale legacy-name comments

### DIFF
--- a/clients/python/src/caura_client/__init__.py
+++ b/clients/python/src/caura_client/__init__.py
@@ -4,7 +4,7 @@ fleets.
 
 from __future__ import annotations
 
-# The MemClaw/MemClawError/MemClawAPIError class-level aliases from the  # legacy-name-ok: records the retirement of the class-alias surface
+# The pre-rename class-level aliases from the
 # 2026-08 rename were retired 2026-09, the same treatment already given to
 # the separate legacy import package and the two legacy package-forwarder
 # distributions that once depended on this one -- no transition is owed to

--- a/core-storage-api/src/core_storage_api/config.py
+++ b/core-storage-api/src/core_storage_api/config.py
@@ -12,8 +12,8 @@ from common.storage_auth import read_shared_secret_file
 
 # The "local-dev compatibility default" this preserved is retired: the whole
 # ephemeral local/CI Postgres role+db population (ci.yml, both docker-compose
-# files, .env.example, env.dev, this default) was renamed memclaw -> caura  # legacy-name-floor: historical note on a completed rename
-# together in one sweep, so nothing outside this repo depends on "memclaw"  # legacy-name-floor: historical note on a completed rename
+# files, .env.example, env.dev, this default) was renamed to the Caura spelling
+# together in one sweep, so nothing outside this repo depends on the old value
 # here any more. Not a legacy-name-ok alias — just the current default.
 LOCAL_DATABASE_URL = "postgresql+asyncpg://caura:changeme@localhost:5432/caura"
 

--- a/core-worker/Dockerfile
+++ b/core-worker/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Core Worker service
-# Async-embed event consumer — subscribes to memclaw.memory.embed-requested
+# Async-embed event consumer — subscribes to caura.memory.embed-requested
 # and PATCHes the resulting embedding back to core-storage-api.
 
 # Optional Datadog serverless-init source (CAURA-0000 observability POC).

--- a/scripts/benchmark_blend_locomo.py
+++ b/scripts/benchmark_blend_locomo.py
@@ -75,8 +75,8 @@ from _locomo_bench import (
 from core_api.constants import FTS_RANK_SCALE, FTS_WEIGHT
 
 # The "existing local benchmark database defaults" this preserved are retired:
-# the ephemeral local/CI Postgres role+db population was renamed memclaw ->  # legacy-name-floor: historical note on a completed rename
-# caura together in one sweep (see core_storage_api.config.LOCAL_DATABASE_URL).
+# the ephemeral local/CI Postgres role+db population was renamed to the Caura
+# spelling in one sweep (see core_storage_api.config.LOCAL_DATABASE_URL).
 # Not a legacy-name-ok alias — just the current default.
 DEFAULT_PG_DSN = "postgresql://caura:changeme@localhost:5433/caura"
 


### PR DESCRIPTION
Tier: comments\n\nRepository: caura-ai/caura\n\nRatchet: 114 gated lines before, 113 after (-1). Measured with the canonical scripts/legacy_name_ratchet.py from caura origin/ratchet-stable.\n\nChanged only safe comments-tier occurrences of the retired name. Functional identifiers, permanent compatibility aliases, historical evidence, and justified ratchet markers remain.\n\nValidation: Canonical legacy-name ratchet; Ruff check on the changed Python sources; diff check.\n\nNo deployment or merge is part of this PR.