### PR TITLE
docs: remove safe legacy-name prose

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -52,9 +52,9 @@ cat > .env << 'EOF'
 ENVIRONMENT=development
 POSTGRES_HOST=127.0.0.1
 POSTGRES_PORT=5432
-POSTGRES_USER=memclaw
+POSTGRES_USER=caura
 POSTGRES_PASSWORD=changeme
-POSTGRES_DB=memclaw
+POSTGRES_DB=caura
 POSTGRES_REQUIRE_SSL=false
 IS_STANDALONE=true
 EMBEDDING_PROVIDER=fake
@@ -64,9 +64,9 @@ CORS_ORIGINS=http://localhost:8000,http://localhost:3000
 EOF
 
 # 5. Create the database (if it doesn't exist)
-psql -U postgres -c "CREATE USER memclaw WITH PASSWORD 'changeme';"
-psql -U postgres -c "CREATE DATABASE memclaw OWNER memclaw;"
-psql -U memclaw -d memclaw -c "CREATE EXTENSION IF NOT EXISTS vector;"
+psql -U postgres -c "CREATE USER caura WITH PASSWORD 'changeme';"
+psql -U postgres -c "CREATE DATABASE caura OWNER caura;"
+psql -U caura -d caura -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
 # 6. Run migrations
 alembic upgrade head

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -134,7 +134,7 @@ application tables.
 python scripts/benchmark_blend_locomo.py \
     --dataset locomo10.json \
     --embed-url http://localhost:8080 \
-    --pg-dsn postgresql://memclaw:changeme@localhost:5433/memclaw \
+    --pg-dsn postgresql://caura:changeme@localhost:5433/caura \
     --k 6
 ```
 


### PR DESCRIPTION
Tier: prose\n\nRepository: caura-ai/caura\n\nRatchet: 114 gated lines before, 108 after (-6). Measured with the canonical scripts/legacy_name_ratchet.py from caura origin/ratchet-stable.\n\nChanged only safe prose-tier occurrences of the retired name. Published compatibility guidance, permanent aliases, historical evidence, and functional examples remain.\n\nValidation: Canonical legacy-name ratchet; diff check.\n\nNo deployment or merge is part of this PR.