### PR TITLE
test: remove incidental legacy-name fixtures

### DIFF
--- a/core-storage-api/tests/conftest.py
+++ b/core-storage-api/tests/conftest.py
@@ -27,10 +27,10 @@ os.environ.setdefault("TESTING", "1")
 # was real in CI and absent everywhere else.
 #
 # Create it once, alongside the database ``tests/`` uses:
-#     createdb memclaw_storage && psql -d memclaw_storage -c 'CREATE EXTENSION IF NOT EXISTS vector'  # legacy-name-floor: the database ci.yml already provisions; a pasteable command naming anything else is wrong
+#     createdb caura_storage && psql -d caura_storage -c 'CREATE EXTENSION IF NOT EXISTS vector'
 os.environ.setdefault(
     "DATABASE_URL",
-    "postgresql+asyncpg://memclaw:changeme@127.0.0.1:5432/memclaw_storage",  # legacy-name-ok: local test DB
+    "postgresql+asyncpg://caura:changeme@127.0.0.1:5432/caura_storage",
 )
 os.environ.setdefault("LOG_LEVEL", "WARNING")
 os.environ.setdefault("CORE_STORAGE_SHARED_SECRET", "test-storage-secret")

--- a/core-storage-api/tests/test_config.py
+++ b/core-storage-api/tests/test_config.py
@@ -145,7 +145,7 @@ def test_this_suite_does_not_share_the_root_suites_database() -> None:
     because a conftest is not importable as a module from another suite; it is
     the one value here that must be kept in step by hand.
     """
-    root_suite_database = "memclaw"  # legacy-name-ok: mirrors tests/conftest.py TEST_DB_URL
+    root_suite_database = "caura"  # mirrors tests/conftest.py TEST_DB_URL
 
     configured = urlsplit(settings.database_url.get_secret_value()).path.lstrip("/")
 

--- a/core-worker/tests/test_consumer.py
+++ b/core-worker/tests/test_consumer.py
@@ -14,7 +14,7 @@ import core_worker.consumer as consumer
 from common.events.base import Event
 from core_worker.config import Settings
 
-EMBED_REQUESTED_TOPIC = "memclaw.memory.embed-requested"  # legacy-name-ok: deployed Pub/Sub topic
+EMBED_REQUESTED_TOPIC = "caura.memory.embed-requested"
 
 # ── Helpers ──────────────────────────────────────────────────────────
 

--- a/core-worker/tests/test_consumer_enrich.py
+++ b/core-worker/tests/test_consumer_enrich.py
@@ -17,7 +17,7 @@ import core_worker.consumer as consumer
 from common.enrichment import EnrichmentResult
 from common.events.base import Event
 
-ENRICH_REQUESTED_TOPIC = "memclaw.memory.enrich-requested"  # legacy-name-ok: deployed Pub/Sub topic
+ENRICH_REQUESTED_TOPIC = "caura.memory.enrich-requested"
 
 
 def _make_event(payload: dict | None = None) -> Event:

--- a/tests/test_tool_rename_aliases.py
+++ b/tests/test_tool_rename_aliases.py
@@ -1,11 +1,11 @@
-"""Permanent-alias contract for the 2026-08-14 memclaw_* → caura_* rename.
+"""Permanent-alias contract for the 2026-08-14 tool rename.
 
 Three guarantees, each load-bearing forever:
 
 1. ``tools/list`` advertises ONLY ``caura_*`` names — the old names must
    never reappear in the listing (dual-listing doubles the client's
    tool-schema token budget, which is why the alias lives at dispatch).
-2. Every listed tool is callable under its legacy ``memclaw_*`` name —
+2. Every listed tool is callable under its pre-rename name —
    the ``_InstrumentedFastMCP.call_tool`` shim translates before
    dispatch, so saved prompts, keystone rules, and published tutorials
    written against the old names keep working.
@@ -72,7 +72,7 @@ async def test_listing_exposes_only_caura_names():
 
 @pytest.mark.asyncio
 async def test_every_tool_dispatches_under_its_legacy_name():
-    """memclaw_<suffix> must behave exactly like caura_<suffix>, for every
+    """Pre-rename and canonical spellings must behave identically for every
     registered tool — including tools that did not exist at rename time.
     """
     for name in await _listed_tool_names():


### PR DESCRIPTION
Tier: tests\n\nRepository: caura-ai/caura\n\nRatchet: 114 gated lines before, 111 after (-3). Measured with the canonical scripts/legacy_name_ratchet.py from caura origin/ratchet-stable.\n\nChanged only safe tests-tier occurrences of the retired name. Compatibility assertions for legacy tools, environment variables, routes, plugin paths, and persisted contracts remain intentionally.\n\nValidation: Canonical legacy-name ratchet; Ruff check and Ruff format check; 10 storage configuration tests; 36 worker tests; negative control confirmed the isolation test fails against the root suite database.\n\nNo deployment or merge is part of this PR.