### PR TITLE
fix(search): budget and label successor injection (D16)

### DIFF
--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -909,6 +909,11 @@
             "title": "Id",
             "type": "string"
           },
+          "injected": {
+            "default": false,
+            "title": "Injected",
+            "type": "boolean"
+          },
           "is_inferred": {
             "default": false,
             "title": "Is Inferred",
@@ -1684,7 +1689,7 @@
           },
           "top_k": {
             "default": 5,
-            "description": "Maximum results to return (1-200, default 5).",
+            "description": "Maximum results the query returns (1-200, default 5). Not the response ceiling: each returned outdated/conflicted row also carries its newest correction, injected beyond this budget and marked injected: true (with score: null), so a response holds at most 2*top_k items.",
             "maximum": 200.0,
             "minimum": 1.0,
             "title": "Top K",

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -937,7 +937,9 @@ async def caura_recall(
         int,
         Field(
             description=f"Max results, default {DEFAULT_SEARCH_TOP_K}. "
-            f"Values above {MAX_SEARCH_TOP_K} are capped to {MAX_SEARCH_TOP_K}."
+            f"Values above {MAX_SEARCH_TOP_K} are capped to {MAX_SEARCH_TOP_K}. "
+            "Superseded hits add their newest correction beyond this cap, "
+            "marked injected:true."
         ),
     ] = DEFAULT_SEARCH_TOP_K,
     valid_at: Annotated[

--- a/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
+++ b/core-api/src/core_api/pipeline/steps/search/load_and_serialize.py
@@ -1,4 +1,10 @@
-"""LoadAndSerialize — serialize results to MemoryOut using pre-loaded entity links."""
+"""LoadAndSerialize — serialize results to MemoryOut using pre-loaded entity links.
+
+D16 — successor injection is budgeted and labelled: at most ONE injected
+successor per stale row (so a response holds at most 2*top_k items), and every
+injected row carries ``injected: true`` on the wire so a caller can tell it
+from a row the query actually recalled.
+"""
 
 from __future__ import annotations
 
@@ -78,6 +84,16 @@ def _warn(ctx: PipelineContext, *, reason: str, stale_result_count: int, enriche
             },
         }
     )
+
+
+def _successor_recency(successor: dict) -> tuple[str, str]:
+    """Sort key for picking THE successor of a stale row: newest first.
+
+    ``created_at`` arrives as an ISO-8601 UTC string over the storage wire, so
+    lexicographic order is chronological order; the id tie-break only keeps the
+    choice deterministic if two rows share a timestamp.
+    """
+    return (str(successor.get("created_at") or ""), str(successor.get("id") or ""))
 
 
 def _score_parts(row) -> ScoreParts | None:
@@ -160,25 +176,50 @@ class LoadAndSerialize:
                 # to an un-enriched result set is the right behaviour; doing it
                 # invisibly is not.
                 _warn(ctx, reason="storage_error", stale_result_count=stale_total, enriched=0)
+            # D16 — response budget: inject at most ONE successor per stale
+            # row, the newest. ``find_successors`` is a bare ``supersedes_id
+            # IN (...)`` with no per-predecessor cap, so several rows can claim
+            # to supersede the same predecessor — and before this cap ALL of
+            # them were appended (observed live: top_k=5 answered with 53
+            # items). A34 wants the newest value ranked above the stale claim;
+            # siblings beyond it add bloat, not safety, and stay reachable via
+            # an explicit ``status_filter``. Injection is therefore bounded by
+            # the stale-row count of the already-trimmed set, so a response
+            # holds at most 2*top_k items. Deliberately NOT re-trimmed to
+            # top_k afterwards: cutting the tail would evict a successor or
+            # its predecessor and reintroduce the stale-answer failure A34
+            # exists to prevent.
+            newest_by_predecessor: dict[str, dict] = {}
             for successor in successors:
-                sid = successor.get("id")
-                if sid not in existing_ids:
-                    rows.append(
-                        SimpleNamespace(
-                            Memory=SimpleNamespace(**successor),
-                            score=None,
-                            similarity=None,
-                            vec_sim=None,
-                            fts_score=None,
-                            freshness=None,
-                            entity_boost=None,
-                            recall_boost=None,
-                            temporal_boost=None,
-                            status_penalty=None,
-                            entity_links=[],
-                        )
+                predecessor_id = str(successor.get("supersedes_id"))
+                incumbent = newest_by_predecessor.get(predecessor_id)
+                if incumbent is None or _successor_recency(successor) > _successor_recency(incumbent):
+                    newest_by_predecessor[predecessor_id] = successor
+            for successor in newest_by_predecessor.values():
+                sid = str(successor.get("id"))
+                if sid in existing_ids:
+                    # The correction was recalled on its own merit — the A34
+                    # reorder below pairs it with its predecessor; injecting a
+                    # sibling on top would spend budget on a duplicate claim.
+                    continue
+                rows.append(
+                    SimpleNamespace(
+                        Memory=SimpleNamespace(**successor),
+                        score=None,
+                        similarity=None,
+                        vec_sim=None,
+                        fts_score=None,
+                        freshness=None,
+                        entity_boost=None,
+                        recall_boost=None,
+                        temporal_boost=None,
+                        status_penalty=None,
+                        entity_links=[],
+                        # D16 — the wire label; serialized as ``injected: true``.
+                        injected=True,
                     )
-                    existing_ids.add(sid)
+                )
+                existing_ids.add(sid)
 
         # A34 — the retrieval contract for a genuine contradiction (ratified
         # 2026-08-25): whenever a result set contains both a superseded row
@@ -242,6 +283,9 @@ class LoadAndSerialize:
                 # successor-injected rows, which were never scored.
                 score=(round(float(row.score), 4) if row.score is not None else None),
                 score_parts=_score_parts(row),
+                # D16 — set only by the injection block above; a successor
+                # recalled organically stays unlabelled because it IS a result.
+                injected=bool(getattr(row, "injected", False)),
             )
             for row in rows
         ]

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -465,6 +465,16 @@ class MemoryOut(BaseModel):
     # successor-injected rows, which were never scored.
     score: float | None = None
     score_parts: ScoreParts | None = None
+    # D16 — true when the row was not matched by the query but injected as the
+    # newest successor of a returned outdated/conflicted row (hence its
+    # ``score``/``similarity`` are null — never scored). Injected rows arrive
+    # BEYOND the caller's ``top_k`` budget, at most one per stale row, ranked
+    # immediately above the row they supersede (A34). A successor the query
+    # recalled on its own merit is NOT marked — this flag says "you would not
+    # have gotten this row from ranking alone", not "this row supersedes
+    # something" (``supersedes_id`` already says that). Always false outside
+    # search responses.
+    injected: bool = False
     # RDF triple
     subject_entity_id: UUID | None = None
     predicate: str | None = None
@@ -859,7 +869,18 @@ class SearchRequest(BaseModel):
         default=DEFAULT_SEARCH_TOP_K,
         ge=1,
         le=MAX_SEARCH_TOP_K,
-        description=f"Maximum results to return (1-{MAX_SEARCH_TOP_K}, default {DEFAULT_SEARCH_TOP_K}).",
+        # D16 — top_k bounds what the query RECALLS, not the response length:
+        # successor injection is additive on purpose (suppressing a correction
+        # to honor a count would return stale claims as current), so the
+        # description states the real contract instead of promising a maximum
+        # the behavior never kept.
+        description=(
+            f"Maximum results the query returns (1-{MAX_SEARCH_TOP_K}, default "
+            f"{DEFAULT_SEARCH_TOP_K}). Not the response ceiling: each returned "
+            "outdated/conflicted row also carries its newest correction, "
+            "injected beyond this budget and marked injected: true (with "
+            "score: null), so a response holds at most 2*top_k items."
+        ),
     )
     # D12 — per-request cosine floor. Overrides the resolved profile/tenant
     # default for THIS call only (request beats profile beats tenant beats

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -772,6 +772,7 @@ def _memory_to_out(
     contradictions: list[ContradictionInfo] | None = None,
     score: float | None = None,
     score_parts: ScoreParts | None = None,
+    injected: bool = False,
 ) -> MemoryOut:
     # See ``_dict_to_memory_out`` for the falsy-``{}`` trap.
     if isinstance(memory, dict):
@@ -810,6 +811,7 @@ def _memory_to_out(
         last_recalled_at=_mem_attr(memory, "last_recalled_at"),
         supersedes_id=_mem_attr(memory, "supersedes_id"),
         superseded_by=contradictions if contradictions else None,
+        injected=injected,
     )
 
 

--- a/plugin/tools.json
+++ b/plugin/tools.json
@@ -740,7 +740,7 @@
       },
       {
         "default": 5,
-        "description": "Max results, default 5. Values above 200 are capped to 200.",
+        "description": "Max results, default 5. Values above 200 are capped to 200. Superseded hits add their newest correction beyond this cap, marked injected:true.",
         "name": "top_k",
         "required": false,
         "type": "int"

--- a/tests/fixtures/tools_list_baseline_v1.json
+++ b/tests/fixtures/tools_list_baseline_v1.json
@@ -839,7 +839,7 @@
         },
         "top_k": {
           "default": 5,
-          "description": "Max results, default 5. Values above 200 are capped to 200.",
+          "description": "Max results, default 5. Values above 200 are capped to 200. Superseded hits add their newest correction beyond this cap, marked injected:true.",
           "title": "Top K",
           "type": "integer"
         },

--- a/tests/test_d16_injection_budget_and_label.py
+++ b/tests/test_d16_injection_budget_and_label.py
@@ -142,7 +142,9 @@ async def test_response_holds_at_most_twice_top_k(monkeypatch):
     for sid in stale_ids:
         for hour in ("01", "02", "03"):
             successors.append(
-                _successor_dict(uuid.uuid4(), sid, created_at=f"2026-08-25T{hour}:00:00Z")
+                _successor_dict(
+                    uuid.uuid4(), sid, created_at=f"2026-08-25T{hour}:00:00Z"
+                )
             )
     ctx = await _run(rows, successors, monkeypatch)
     out = ctx.data["results"]
@@ -209,7 +211,9 @@ async def test_newer_correction_is_injected_above_an_older_organic_one(monkeypat
     NEWER correction exists: the newest is injected (marked), the organic row
     keeps its earned place and stays unmarked."""
     stale, organic_id, newest = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
-    organic = _mem_ns(organic_id, status="active", content="older correction", score=0.9)
+    organic = _mem_ns(
+        organic_id, status="active", content="older correction", score=0.9
+    )
     organic.Memory.supersedes_id = stale
     organic.Memory.created_at = "2026-08-25T01:00:00Z"
     ctx = await _run(

--- a/tests/test_d16_injection_budget_and_label.py
+++ b/tests/test_d16_injection_budget_and_label.py
@@ -1,0 +1,242 @@
+"""D16 — successor injection is budgeted and labelled.
+
+Before this row, injection was additive with no bound and no marker: every
+outdated/conflicted row in the already-trimmed result set pulled in EVERY row
+that superseded it (``supersedes_id IN (...)`` has no per-predecessor cap), so
+a top_k=5 call answered with 10 items — 53 on a conflict-heavy store — and
+nothing on the wire said which rows the query had actually recalled.
+
+The contract now:
+  * at most ONE injected successor per stale row — the newest — so a response
+    holds at most 2*top_k items;
+  * every injected row is marked ``injected: true`` (beside its ``score:
+    null``); a successor recalled on its own merit stays unmarked;
+  * the response is deliberately NOT re-trimmed to top_k — evicting a
+    successor or its predecessor at the boundary would reintroduce the
+    stale-answer failure A34 exists to prevent;
+  * ``top_k``'s own description states all of this instead of promising a
+    maximum the behavior never kept.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search import load_and_serialize as las
+from core_api.schemas import MemoryOut, SearchRequest
+
+pytestmark = pytest.mark.unit
+
+
+def _mem_ns(mid, status="active", content="c", **score):
+    return SimpleNamespace(
+        Memory=SimpleNamespace(
+            id=mid,
+            tenant_id="t",
+            fleet_id=None,
+            agent_id="a1",
+            agent_display_name=None,
+            memory_type="fact",
+            title="row",
+            content=content,
+            weight=0.5,
+            source_uri=None,
+            run_id=None,
+            metadata_=None,
+            created_at="2026-08-25T00:00:00Z",
+            expires_at=None,
+            subject_entity_id=None,
+            predicate=None,
+            object_value=None,
+            ts_valid_start=None,
+            ts_valid_end=None,
+            status=status,
+            visibility="scope_fleet",
+            recall_count=0,
+            last_recalled_at=None,
+            supersedes_id=None,
+        ),
+        score=score.get("score", 1.0),
+        similarity=None,
+        vec_sim=score.get("vec_sim", 0.9),
+        fts_score=None,
+        freshness=None,
+        entity_boost=None,
+        recall_boost=None,
+        temporal_boost=None,
+        status_penalty=None,
+        has_embedding=True,
+        entity_links=[],
+    )
+
+
+def _successor_dict(sid, supersedes, created_at="2026-08-25T01:00:00Z"):
+    return {
+        "id": str(sid),
+        "tenant_id": "t",
+        "fleet_id": None,
+        "agent_id": "a1",
+        "memory_type": "fact",
+        "title": "successor",
+        "content": "the corrected fact",
+        "weight": 0.5,
+        "source_uri": None,
+        "run_id": None,
+        "metadata_": None,
+        "created_at": created_at,
+        "expires_at": None,
+        "subject_entity_id": None,
+        "predicate": None,
+        "object_value": None,
+        "ts_valid_start": None,
+        "ts_valid_end": None,
+        "status": "active",
+        "visibility": "scope_fleet",
+        "recall_count": 0,
+        "last_recalled_at": None,
+        "supersedes_id": str(supersedes),
+    }
+
+
+async def _run(rows, successors, monkeypatch) -> PipelineContext:
+    sc = MagicMock()
+    sc.find_successors = AsyncMock(return_value=successors)
+    monkeypatch.setattr(las, "get_storage_client", lambda: sc)
+    ctx = PipelineContext(data={"filtered_rows": rows, "tenant_id": "t"})
+    await las.LoadAndSerialize().execute(ctx)
+    return ctx
+
+
+# ── budget ────────────────────────────────────────────────────────────────
+
+
+async def test_one_injected_successor_per_stale_row_newest_wins(monkeypatch):
+    """Three rows supersede the same stale row; only the newest is injected,
+    regardless of the order storage returned them in."""
+    stale = uuid.uuid4()
+    old, older, newest = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    ctx = await _run(
+        [_mem_ns(stale, status="conflicted", score=1.0)],
+        [
+            _successor_dict(old, stale, created_at="2026-08-25T02:00:00Z"),
+            _successor_dict(newest, stale, created_at="2026-08-25T03:00:00Z"),
+            _successor_dict(older, stale, created_at="2026-08-25T01:00:00Z"),
+        ],
+        monkeypatch,
+    )
+    out = ctx.data["results"]
+    assert [str(m.id) for m in out] == [str(newest), str(stale)]
+
+
+async def test_response_holds_at_most_twice_top_k(monkeypatch):
+    """The register's live shape: every trimmed row stale, heavy successor
+    fan-out. top_k=5 used to answer with up to 53 items; the budget bounds it
+    at 10 while keeping the A34 pairing for every stale row."""
+    top_k = 5
+    stale_ids = [uuid.uuid4() for _ in range(top_k)]
+    rows = [_mem_ns(sid, status="outdated", score=1.0) for sid in stale_ids]
+    successors = []
+    for sid in stale_ids:
+        for hour in ("01", "02", "03"):
+            successors.append(
+                _successor_dict(uuid.uuid4(), sid, created_at=f"2026-08-25T{hour}:00:00Z")
+            )
+    ctx = await _run(rows, successors, monkeypatch)
+    out = ctx.data["results"]
+    assert len(out) == 2 * top_k
+    # A34 pairing survives the budget: each stale row sits directly under the
+    # one successor injected for it.
+    for i, m in enumerate(out):
+        if m.status == "outdated":
+            assert str(out[i - 1].supersedes_id) == str(m.id)
+            assert out[i - 1].injected is True
+
+
+async def test_successful_injection_stays_out_of_warnings(monkeypatch):
+    """A28's ``warnings`` mean the enrichment is INCOMPLETE. The budget marks
+    rows instead of warning about them — a normal injection must not start
+    emitting warnings, or the incomplete signal stops meaning anything."""
+    stale = uuid.uuid4()
+    ctx = await _run(
+        [_mem_ns(stale, status="conflicted")],
+        [_successor_dict(uuid.uuid4(), stale)],
+        monkeypatch,
+    )
+    assert ctx.data.get("warnings") is None
+
+
+# ── label ─────────────────────────────────────────────────────────────────
+
+
+async def test_injected_row_is_marked_and_recalled_rows_are_not(monkeypatch):
+    stale, other = uuid.uuid4(), uuid.uuid4()
+    succ = uuid.uuid4()
+    ctx = await _run(
+        [_mem_ns(stale, status="conflicted", score=1.0), _mem_ns(other, score=0.5)],
+        [_successor_dict(succ, stale)],
+        monkeypatch,
+    )
+    by_id = {str(m.id): m for m in ctx.data["results"]}
+    assert by_id[str(succ)].injected is True
+    # the register's shape: injected: true beside score: null
+    assert by_id[str(succ)].score is None
+    assert by_id[str(stale)].injected is False
+    assert by_id[str(other)].injected is False
+
+
+async def test_organic_successor_is_not_marked_injected(monkeypatch):
+    """A successor the query recalled on its own merit is a result, not an
+    injection — and it satisfies the budget, so no sibling is injected for
+    its predecessor either."""
+    stale, succ = uuid.uuid4(), uuid.uuid4()
+    organic = _mem_ns(succ, status="active", content="corrected", score=2.0)
+    organic.Memory.supersedes_id = stale
+    ctx = await _run(
+        [organic, _mem_ns(stale, status="conflicted", score=1.0)],
+        [_successor_dict(succ, stale)],
+        monkeypatch,
+    )
+    out = ctx.data["results"]
+    assert [str(m.id) for m in out] == [str(succ), str(stale)]
+    assert out[0].injected is False and out[0].score == 2.0
+
+
+async def test_newer_correction_is_injected_above_an_older_organic_one(monkeypatch):
+    """An organic successor does not exhaust the predecessor's budget when a
+    NEWER correction exists: the newest is injected (marked), the organic row
+    keeps its earned place and stays unmarked."""
+    stale, organic_id, newest = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    organic = _mem_ns(organic_id, status="active", content="older correction", score=0.9)
+    organic.Memory.supersedes_id = stale
+    organic.Memory.created_at = "2026-08-25T01:00:00Z"
+    ctx = await _run(
+        [organic, _mem_ns(stale, status="conflicted", score=1.0)],
+        [
+            _successor_dict(organic_id, stale, created_at="2026-08-25T01:00:00Z"),
+            _successor_dict(newest, stale, created_at="2026-08-25T02:00:00Z"),
+        ],
+        monkeypatch,
+    )
+    out = ctx.data["results"]
+    assert [str(m.id) for m in out] == [str(organic_id), str(newest), str(stale)]
+    assert [m.injected for m in out] == [False, True, False]
+
+
+# ── wire contract ─────────────────────────────────────────────────────────
+
+
+def test_injected_defaults_false_everywhere_else():
+    """Create/get/list build MemoryOut without the flag; the default must keep
+    them truthful rather than requiring every call site to say ``False``."""
+    assert MemoryOut.model_fields["injected"].default is False
+
+
+def test_top_k_description_states_the_injection_contract():
+    """D16's third clause: the tool surface documents that top_k bounds the
+    recall, not the response, and names the marker a caller should look for."""
+    desc = SearchRequest.model_fields["top_k"].description or ""
+    assert "injected" in desc
+    assert "2*top_k" in desc

--- a/tests/test_mcp_token_budget.py
+++ b/tests/test_mcp_token_budget.py
@@ -90,6 +90,12 @@ FIXTURES = Path(__file__).parent / "fixtures"
 # at 5269 that headroom is 81 and the guard is looser than it was designed to
 # be. Lowering it banks the saving instead of spending it on slack, and the
 # next addition still only has to state its reason, as that entry asked.
+#
+# 2026-09-09 (D16): 5287 cl100k (+18) after ``caura_recall.top_k`` disclosed
+# that superseded hits pull their newest correction in BEYOND the cap, marked
+# ``injected:true``. The old text promised a maximum ("Max results") that
+# successor injection has violated since A34 — a caller reading it could not
+# explain a 10-item answer to a top_k=5 call. Ceiling NOT raised; 33 remain.
 CEILING_TOKENS = 5320
 
 

--- a/tests/test_search_default_profile.py
+++ b/tests/test_search_default_profile.py
@@ -340,6 +340,11 @@ def test_top_k_cap_has_one_source_of_truth():
     assert recall_top_k_desc == (
         f"Max results, default {core_constants.DEFAULT_SEARCH_TOP_K}. "
         f"Values above {common_constants.MAX_SEARCH_TOP_K} are capped to "
-        f"{common_constants.MAX_SEARCH_TOP_K}."
+        f"{common_constants.MAX_SEARCH_TOP_K}. "
+        # D16 — the cap sentence stays constant-fed; the injection sentence is
+        # part of the pinned surface so a rewrite that drops the disclosure
+        # fails here, not in a user report.
+        "Superseded hits add their newest correction beyond this cap, "
+        "marked injected:true."
     )
     assert common_constants.MAX_SEARCH_TOP_K == 200


### PR DESCRIPTION
## Summary

Closes register row **D16** (caura_shared_tasks/v4-task-checklist; absorbs audit finding oss-0814-l-07 as a duplicate).

Successor injection was additive with no bound and no marker: every outdated/conflicted row in the already-trimmed result set pulled in **every** row superseding it (`supersedes_id IN (...)` has no per-predecessor cap), so a `top_k=5` call answered with 10 items — 53 on a conflict-heavy store — and nothing on the wire said which rows the query actually recalled. Both the REST schema ("Maximum results to return") and the MCP tool surface ("Max results") promised a ceiling the behavior never kept.

## Changes

* **Budget** (`load_and_serialize.py`): inject at most **one successor per stale row — the newest** (`created_at`, deterministic id tie-break), so a response holds at most **2×top_k** items. Deliberately **not** re-trimmed to `top_k`: cutting the tail would evict a successor or its predecessor at the boundary and reintroduce the stale-answer failure the A34 contract exists to prevent. If the newest correction was already recalled organically, nothing is injected for that predecessor.
* **Label** (`schemas.py`, `memory_service.py`): new `injected: bool = False` on `MemoryOut`, set only by the injection block — beside the row's existing `score: null`. A successor recalled on its own merit stays unmarked, because it *is* a result. Flows to REST and MCP unchanged (`model_dump` is full-fidelity).
* **Contract docs**: `SearchRequest.top_k` and the MCP `caura_recall.top_k` descriptions now state the real contract (recall bound, not response ceiling; marker to look for; ≤ 2×top_k). `plugin/tools.json` + tool-surface baselines regenerated via their documented scripts: **5287 cl100k (+18), under the 5320 ceiling** — ledger entry added, ceiling not raised.

## Relationship to A28 / A34

Extends **A28** (closed), which made lookup-bound truncation visible but deliberately did not budget the response. Successful injection still emits **no warning** — `warnings` keep meaning "enrichment incomplete". The **A34** pairing (successor immediately above its stale predecessor) is preserved under the budget; the new suite asserts it for every stale row.

## Tests

* New: `tests/test_d16_injection_budget_and_label.py` — 8 tests: newest-wins budget, 2×top_k bound with A34 pairing intact, wire labels, organic-successor cases (no sibling spend; newer correction still injected above an older organic one), no-warning-on-success, `top_k` description pin.
* Updated: `test_search_default_profile.py::test_top_k_cap_has_one_source_of_truth` — the verbatim MCP-description pin now includes the disclosure sentence (single-source-of-truth intent unchanged).
* D16 + A34 + A28 + token-budget + export-sync + description-baseline suites: **59 passed**. Full root suite: only the 32 pre-existing infra-dependent failures, byte-identical with the change stashed (verified both ways).

🤖 Generated with [Claude Code](https://claude.com/claude-code)