### PR TITLE
fix(embedding): parse OPENAI_REQUEST_TIMEOUT_SECONDS defensively and re-read it at provider construction

### DIFF
--- a/common/embedding/constants.py
+++ b/common/embedding/constants.py
@@ -12,12 +12,22 @@ late. Examples:
 
     monkeypatch.setattr("common.embedding._service.EMBEDDING_RETRY_ATTEMPTS", 1)
     monkeypatch.setattr("common.embedding.providers.openai.OPENAI_REQUEST_TIMEOUT_SECONDS", 5.0)
+
+One deliberate exception: ``OPENAI_REQUEST_TIMEOUT_SECONDS`` is re-read
+from the environment when ``OpenAIEmbeddingProvider`` is constructed,
+with the module binding as the fallback — core-api's
+``bridge_credentials_to_environ()`` populates that env var during
+startup, after this module has already been imported. For that one knob
+``monkeypatch.setenv`` before provider construction works too; see
+``common/embedding/providers/openai.py``.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+
+from common.env_utils import clamp_keepalive, read_float_env, read_int_env
 
 # Default model identifiers per provider. Override via env (e.g. swap
 # ``OPENAI_EMBEDDING_MODEL=text-embedding-3-large`` for a higher-dim
@@ -38,8 +48,18 @@ OPENAI_EMBEDDING_MODEL: str = (
 # so a single tunable controls both the LLM and the embedding paths.
 # Without this, a hung api.openai.com response would ride the SDK's
 # default 600s timeout and silently eat the worker's whole ack budget.
-OPENAI_REQUEST_TIMEOUT_SECONDS: float = float(
-    os.environ.get("OPENAI_REQUEST_TIMEOUT_SECONDS", "25.0")
+#
+# ``read_float_env`` (fall back to the default with a stderr WARN naming
+# the variable), not bare ``float(...)``: a value like "25s" would
+# otherwise raise ``ValueError`` at import — crashing core-worker, which
+# has no pydantic-settings layer validating this var first, with a
+# traceback that names neither the env var nor the fix. Falling back is
+# the right failure mode for a timeout (the default is safe); raising is
+# reserved for misconfigs that guarantee 100% failed calls (see
+# ``_registry.get_embedding_provider``). Matches the LLM twin
+# (``common/llm/constants.py``) and every other numeric knob here.
+OPENAI_REQUEST_TIMEOUT_SECONDS: float = read_float_env(
+    "OPENAI_REQUEST_TIMEOUT_SECONDS", 25.0
 )
 
 # Retry budget for the high-level ``get_embedding`` call. Two attempts
@@ -65,12 +85,6 @@ EMBEDDING_RETRY_DELAY_S: float = float(os.environ.get("EMBEDDING_RETRY_DELAY_S",
 # concurrent writes x 10 enrichment calls = 160 concurrent LLM
 # requests per process, well over the keepalive budget). See
 # ``common/llm/constants.py`` for full rationale.
-from common.env_utils import (  # noqa: E402 — intentional late import, see module docstring
-    clamp_keepalive,
-    read_float_env,
-    read_int_env,
-)
-
 OPENAI_HTTPX_MAX_CONNECTIONS: int = read_int_env("OPENAI_HTTPX_MAX_CONNECTIONS", 200)
 OPENAI_HTTPX_MAX_KEEPALIVE_CONNECTIONS: int = clamp_keepalive(
     OPENAI_HTTPX_MAX_CONNECTIONS,

--- a/common/embedding/providers/openai.py
+++ b/common/embedding/providers/openai.py
@@ -20,6 +20,7 @@ from common.embedding.constants import (
     OPENAI_EMBEDDING_MODEL,
     OPENAI_REQUEST_TIMEOUT_SECONDS,
 )
+from common.env_utils import read_float_env
 
 # Opaque per-instance identity for ``dedup_scope``. A counter beats deriving
 # the scope from the backend config twice over: no credential ever enters the
@@ -120,6 +121,23 @@ class OpenAIEmbeddingProvider:
         # service layer already performs — and under the per-request
         # timeout that the bulk budgets are derived from. See
         # ``EMBEDDING_PROVIDER_MAX_RETRIES``.
+        #
+        # The request budget is re-read from the ENVIRONMENT here, at
+        # construction time, with the import-time constant as fallback:
+        # core-api's ``bridge_credentials_to_environ()`` copies the
+        # ``.env``-loaded ``settings.openai_request_timeout_seconds`` into
+        # ``os.environ`` during lifespan startup — AFTER this module was
+        # imported (``core_api.app`` pulls in ``common.embedding`` at
+        # module level via ``core_api.constants`` and the route modules) —
+        # so the frozen module constant would silently shadow a
+        # ``.env``-configured value. Same fix, same reason, as the
+        # construction-time read in ``common/llm/registry.py``. With the
+        # env var unset (and for the documented monkeypatch-the-module-
+        # binding test idiom) the constant still governs, so behaviour is
+        # unchanged for every existing configuration.
+        request_timeout: float = read_float_env(
+            "OPENAI_REQUEST_TIMEOUT_SECONDS", OPENAI_REQUEST_TIMEOUT_SECONDS
+        )
         client_kwargs: dict = {
             "api_key": api_key,
             "max_retries": EMBEDDING_PROVIDER_MAX_RETRIES,
@@ -127,14 +145,14 @@ class OpenAIEmbeddingProvider:
                 connect=EMBEDDING_HTTPX_CONNECT_TIMEOUT_SECONDS,
                 # read AND write keep the full request budget — the bare float
                 # this replaces set every phase to it.
-                read=OPENAI_REQUEST_TIMEOUT_SECONDS,
-                write=OPENAI_REQUEST_TIMEOUT_SECONDS,
+                read=request_timeout,
+                write=request_timeout,
                 # Pool tracks the request budget unless explicitly decoupled,
                 # preserving the previous behaviour for every configuration.
                 pool=(
                     EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS
                     if EMBEDDING_HTTPX_POOL_TIMEOUT_SECONDS is not None
-                    else OPENAI_REQUEST_TIMEOUT_SECONDS
+                    else request_timeout
                 ),
             ),
             "http_client": httpx.AsyncClient(

--- a/tests/test_embedding_timeout_env_parse.py
+++ b/tests/test_embedding_timeout_env_parse.py
@@ -1,0 +1,132 @@
+"""oss-0902-l-11 — ``OPENAI_REQUEST_TIMEOUT_SECONDS`` parsing and freshness.
+
+Two defects in ``common/embedding/constants.py``, both on the one env var
+the credential bridge also carries:
+
+1. The value was parsed with bare ``float(os.environ.get(...))`` at module
+   import. ``OPENAI_REQUEST_TIMEOUT_SECONDS=25s`` crashed the importing
+   process at import time with ``ValueError: could not convert string to
+   float: '25s'`` — a traceback naming neither the env var nor the fix,
+   before structured logging exists to report it. core-worker takes the
+   naked crash (no pydantic-settings layer validates the var first there);
+   every sibling knob in the module already used ``read_float_env``, whose
+   docstring names exactly this failure mode.
+
+2. The parse ran once at import and the provider froze the result — but
+   core-api's ``bridge_credentials_to_environ()`` (CAURA-595) writes the
+   ``.env``-loaded value into ``os.environ`` during lifespan startup,
+   after ``core_api.app``'s module-level imports have already pulled in
+   ``common.embedding.constants`` (via ``core_api.constants`` and the
+   route modules). A ``.env``-configured timeout therefore reached the
+   LLM client — whose registry re-reads the env at construction, with a
+   comment naming the bridge — but was silently ignored by the embedding
+   client, despite the constant's own comment promising "a single tunable
+   controls both the LLM and the embedding paths".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import common.embedding.constants as embedding_constants
+from common.embedding.providers.openai import OpenAIEmbeddingProvider
+
+pytestmark = pytest.mark.unit
+
+
+def _exec_constants_fresh() -> ModuleType:
+    """Execute ``common/embedding/constants.py`` as a NEW module object.
+
+    Import-time behaviour can only be exercised by running the module body
+    again. A fresh, unregistered module — not ``importlib.reload`` — leaves
+    the real module, and every ``from``-import snapshot other modules hold,
+    untouched.
+    """
+    path = Path(embedding_constants.__file__)
+    spec = importlib.util.spec_from_file_location("_fresh_embedding_constants", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestImportTimeParse:
+    """Sub-claim (a): a bad env value must not crash the import."""
+
+    @pytest.mark.parametrize("bad", ["25s", "", "twenty-five"])
+    def test_garbage_value_falls_back_and_names_the_var(self, bad, capsys):
+        """Pre-fix this raised ``ValueError`` out of the module body."""
+        with patch.dict(os.environ, {"OPENAI_REQUEST_TIMEOUT_SECONDS": bad}):
+            mod = _exec_constants_fresh()
+        assert mod.OPENAI_REQUEST_TIMEOUT_SECONDS == 25.0
+        # The operator-facing contract: the warning names the knob.
+        assert "OPENAI_REQUEST_TIMEOUT_SECONDS" in capsys.readouterr().err
+
+    def test_valid_value_is_parsed(self):
+        with patch.dict(os.environ, {"OPENAI_REQUEST_TIMEOUT_SECONDS": "7.5"}):
+            mod = _exec_constants_fresh()
+        assert mod.OPENAI_REQUEST_TIMEOUT_SECONDS == 7.5
+
+    def test_unset_uses_default(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_REQUEST_TIMEOUT_SECONDS", raising=False)
+        mod = _exec_constants_fresh()
+        assert mod.OPENAI_REQUEST_TIMEOUT_SECONDS == 25.0
+
+
+def _construct_with_mocked_sdk() -> MagicMock:
+    """Build a provider over a mocked ``openai.AsyncOpenAI``; return the ctor
+    mock so tests can assert against the ``timeout=`` kwarg it received."""
+    fake_client = MagicMock()
+    fake_client.embeddings.create = AsyncMock()
+    ctor = MagicMock(return_value=fake_client)
+    with patch("common.embedding.providers.openai.openai.AsyncOpenAI", ctor):
+        OpenAIEmbeddingProvider(api_key="sk-fake")
+    return ctor
+
+
+class TestConstructionTimeRead:
+    """Sub-claim (b): the client must honour the env var as it stands at
+    provider construction, not as it stood at module import."""
+
+    def test_env_set_after_import_reaches_the_client(self, monkeypatch):
+        """The credential-bridge scenario. ``bridge_credentials_to_environ()``
+        runs in core-api's lifespan startup — after import froze the module
+        constant — and the provider is constructed later still, lazily on
+        the first embed call. Setting the env var here, after import, is
+        exactly that ordering; pre-fix the client kept the frozen value."""
+        monkeypatch.setenv("OPENAI_REQUEST_TIMEOUT_SECONDS", "3.5")
+        timeout = _construct_with_mocked_sdk().call_args.kwargs["timeout"]
+        assert timeout.read == 3.5
+        assert timeout.write == 3.5
+        # Pool tracks the request budget when not explicitly decoupled.
+        assert timeout.pool == 3.5
+
+    def test_env_unset_falls_back_to_module_binding(self, monkeypatch):
+        """The documented test idiom — patch the module-level binding — must
+        keep working, and the all-defaults case must behave exactly as it
+        did before the construction-time read existed."""
+        monkeypatch.delenv("OPENAI_REQUEST_TIMEOUT_SECONDS", raising=False)
+        monkeypatch.setattr(
+            "common.embedding.providers.openai.OPENAI_REQUEST_TIMEOUT_SECONDS", 9.0
+        )
+        timeout = _construct_with_mocked_sdk().call_args.kwargs["timeout"]
+        assert timeout.read == 9.0
+
+    def test_garbage_env_at_construction_falls_back_with_warning(
+        self, monkeypatch, capsys
+    ):
+        """A bad value arriving via the bridge must not take the first embed
+        call down — same fallback-and-warn contract as at import."""
+        monkeypatch.setenv("OPENAI_REQUEST_TIMEOUT_SECONDS", "fast")
+        monkeypatch.setattr(
+            "common.embedding.providers.openai.OPENAI_REQUEST_TIMEOUT_SECONDS", 11.0
+        )
+        timeout = _construct_with_mocked_sdk().call_args.kwargs["timeout"]
+        assert timeout.read == 11.0
+        assert "OPENAI_REQUEST_TIMEOUT_SECONDS" in capsys.readouterr().err


### PR DESCRIPTION
## Problem

Audit finding oss-0902-l-11 (low), validated against `origin/main` (77e2d8c3). Both sub-claims **confirmed**:

**(a) Import-time crash on a bad value.** `common/embedding/constants.py:41-43` parsed the var with bare `float(os.environ.get("OPENAI_REQUEST_TIMEOUT_SECONDS", "25.0"))`. `OPENAI_REQUEST_TIMEOUT_SECONDS=25s` (or an empty string) raises `ValueError: could not convert string to float: '25s'` out of the module body at import — a stack trace naming neither the env var nor the fix, before structured logging is wired up. core-worker takes the naked crash (`core_worker/consumer.py:53` imports `common.embedding`; nothing in core-worker validates this var first). core-api happens to be shielded only because `Settings()` (`core_api/config.py:117`) validates the same var earlier in its import sequence. `common/env_utils.py`'s `read_float_env` docstring names exactly this failure mode as its reason to exist, and every sibling knob in the module — and the LLM twin, `common/llm/constants.py:194` — already uses it. This was the last bare parse of this var.

**(b) Frozen before the credential bridge runs.** The "credential bridge" is `core_api.config.bridge_credentials_to_environ` (CAURA-595, `core_api/config.py:744`): it copies the `.env`-loaded `settings.openai_request_timeout_seconds` into `os.environ["OPENAI_REQUEST_TIMEOUT_SECONDS"]` (`config.py:778`) during FastAPI lifespan startup (`core_api/app.py:286-288`). Import-order proof: `core_api/app.py:38` imports `core_api.constants`, whose line 30 imports `common.embedding.constants` — so the constant is evaluated at module import, strictly before the lifespan runs; `common/embedding/providers/openai.py:21` then snapshots it via `from`-import and used it in `__init__` (old lines 130-137). Provider construction is lazy (first embed call, after the bridge), but the value it used was the frozen one. The LLM path already fixed this exact race — `common/llm/registry.py:134-150` re-reads the env at construction with a comment naming the bridge — so a `.env`-configured timeout governed LLM calls but was silently ignored for embeddings, despite `constants.py`'s comment promising "a single tunable controls both the LLM and the embedding paths".

## Fix

- `common/embedding/constants.py`: parse with `read_float_env("OPENAI_REQUEST_TIMEOUT_SECONDS", 25.0)` — garbage falls back to the default with a stderr WARN naming the variable. Fallback rather than raise because the default is safe for a timeout; raising stays reserved for misconfigs that guarantee 100% failed calls (the `_registry.get_embedding_provider` precedent). The `common.env_utils` import moves to the top of the file so the parse can use it (its "intentional late import" comment pointed at a module docstring that says nothing about imports).
- `common/embedding/providers/openai.py`: `__init__` re-reads the env var at construction time (`read_float_env("OPENAI_REQUEST_TIMEOUT_SECONDS", OPENAI_REQUEST_TIMEOUT_SECONDS)`), mirroring `common/llm/registry.py`, and feeds it to the httpx read/write/pool budgets. With the var unset — including the documented monkeypatch-the-module-binding test idiom — the module constant still governs, so the all-defaults behaviour is unchanged.
- The constants module docstring now records this one knob as the deliberate exception to "setenv after import is too late".

Not touched (out of this finding's scope): the neighbouring bare parses `EMBEDDING_RETRY_ATTEMPTS` / `EMBEDDING_RETRY_DELAY_S` (`constants.py`, same defect class, no bridge interaction).

## Tests

`tests/test_embedding_timeout_env_parse.py` (unit, repo-root style: `pytestmark = pytest.mark.unit`, `patch.dict` env isolation; import-time behaviour exercised by executing the real module file as a fresh, unregistered module so no live snapshot is disturbed):

- garbage value (`"25s"`, `""`, `"twenty-five"`) → module body completes, value falls back to 25.0, stderr WARN names the knob
- valid value parsed; unset → default
- env set **after** import (the bridge ordering) → reaches the client's `httpx.Timeout` read/write/pool
- env unset → module-binding fallback (the documented monkeypatch idiom keeps working)
- garbage env at construction → falls back to the module binding with a WARN

**Failed-on-pre-fix proof:** with the two source files stashed (origin/main code) the suite fails 5 of 8 — the three garbage-at-import cases (ValueError out of the module body), the bridge-ordering test (client got the frozen 25.0 instead of 3.5), and the garbage-at-construction warning test. All 8 pass with the fix.

## Gates

- `pytest` over the new file + `test_c38_local_embedder_dim_guard`, `test_local_embedder_instance_cache`, `test_embedding_openai_compat`, `test_bulk_write_mode`, `test_backend_backpressure_is_capacity`, `test_provider_protocols`, `test_platform_providers`, `test_env_utils`, `test_credential_bridge`, `test_embedding_retry`, `test_embedding_registry_eviction`: **252 passed**
- `ruff check common/ tests/test_embedding_timeout_env_parse.py`: clean; `ruff format --check` on the three touched files: clean
- `mypy --config-file common/mypy.ini common/`: no issues in 101 files

Audit tracker: oss-0902-l-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)