### PR TITLE
fix(search): hold the per-tenant storage bulkhead on the entity-lookup fall-through (oss-0814-l-06)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -212,7 +212,7 @@ class ClassifyQuery:
                         valid_at=valid_at,
                         readable_tenant_ids=readable_tenant_ids,
                         strict_fleet_scoping=bool(ctx.data.get("strict_fleet_scoping")),
-                        slot_acquired_marker=ctx.data,
+                        pool_report=ctx.data,
                     )
 
                     # H-03: the short-circuit REPLACES scoring rather than
@@ -468,7 +468,7 @@ class ClassifyQuery:
         status_filter: str | None = None,
         valid_at: datetime | None = None,
         readable_tenant_ids: list[str] | None = None,
-        slot_acquired_marker: dict | None = None,
+        pool_report: dict | None = None,
         strict_fleet_scoping: bool = False,
     ) -> list[types.SimpleNamespace]:
         """Load memories linked to graph-expanded entities, scored by hop distance."""
@@ -540,11 +540,10 @@ class ClassifyQuery:
         # produce more rows than ``memory_boost`` has entries — so an under-sized
         # pool cannot pass that gate whatever the load returns. Loading anyway
         # spent a per-tenant storage permit and pulled full rows (embedding and
-        # tsvector included) for a result the caller discards, and worse, left
-        # ``_storage_slot_acquired`` set so the scored search that does run
-        # skipped the bulkhead. Reporting the pool size lets the caller say why
-        # it declined, since ``[]`` alone cannot distinguish "under-filled" from
-        # "no linked memories at all" (the ``not memory_boost`` return above).
+        # tsvector included) for a result the caller discards. Reporting the
+        # pool size lets the caller say why it declined, since ``[]`` alone
+        # cannot distinguish "under-filled" from "no linked memories at all"
+        # (the ``not memory_boost`` return above).
         #
         # One-directional on purpose. The converse is NOT decidable here: the
         # load applies visibility filters (caller_agent_id / status / valid_at)
@@ -552,8 +551,8 @@ class ClassifyQuery:
         # looks adequate can still return short. That is why the caller re-checks
         # after the load rather than trusting this count.
         if len(memory_boost) < top_k:
-            if slot_acquired_marker is not None:
-                slot_acquired_marker["_entity_pool_size"] = len(memory_boost)
+            if pool_report is not None:
+                pool_report["_entity_pool_size"] = len(memory_boost)
             return []
 
         # CAURA-687: load memories by ID via the dedicated short-circuit
@@ -592,27 +591,28 @@ class ClassifyQuery:
         # it would degrade to home-tenant reads with no error or log.
         if readable_tenant_ids and readable_tenant_ids != [tenant_id]:
             search_data["readable_tenant_ids"] = readable_tenant_ids
-        # Per-tenant storage bulkhead (CAURA-602 follow-up). C10: when
-        # this entity-lookup short-circuit acquires + releases the slot
-        # here, we mark the pipeline context so a downstream
-        # ``execute_scored_search`` running on the rare fall-through
-        # path (entity-lookup matched but produced no filtered rows)
-        # doesn't re-acquire and charge the tenant twice for one
-        # logical search. Same key as scored-search, intentional —
-        # the bucket counts request-level storage pressure, not
-        # call-level.
         # Record that the load ran, and against what size of pool. Without this
         # the caller cannot tell "no links at all" from "links existed, the load
         # ran, and visibility filtering dropped every row" — both arrive as an
         # empty list, and reporting the second as the first would send on-call
         # looking for a graph problem when the cause is a permission filter.
-        if slot_acquired_marker is not None:
-            slot_acquired_marker["_entity_pool_size"] = len(memory_boost)
-            slot_acquired_marker["_entity_pool_loaded"] = True
+        if pool_report is not None:
+            pool_report["_entity_pool_size"] = len(memory_boost)
+            pool_report["_entity_pool_loaded"] = True
+        # Per-tenant storage bulkhead (CAURA-602 follow-up), same key as
+        # scored-search on purpose: both are storage-reader roundtrips
+        # drawing on the same per-tenant pool budget. The slot is held only
+        # across this roundtrip and released on exit, so when this path
+        # falls through, ``ExecuteScoredSearch`` takes its own slot around
+        # its own roundtrip — the two are sequential and one logical search
+        # never holds two slots at once. (C10 used to set
+        # ``_storage_slot_acquired`` on ctx here so the downstream scored
+        # search skipped its slot as a "don't charge twice" dedup; the slot
+        # is an in-flight cap, not a charge, and the skip exempted the
+        # fall-through's scored_search roundtrip from the cap entirely —
+        # retired by audit oss-0814-l-06.)
         async with per_tenant_storage_slot("storage_search", tenant_id):
             memories = await sc.load_memories_by_ids(search_data)
-        if slot_acquired_marker is not None:
-            slot_acquired_marker["_storage_slot_acquired"] = True
 
         # Build result rows with boost scores.
         memories_by_id = {m["id"]: m for m in memories}

--- a/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
+++ b/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
@@ -164,17 +164,24 @@ class ExecuteScoredSearch:
         # code only. ``data["tenant_id"]`` is set upstream by
         # ``_search_memories_pipeline`` before this step runs.
         #
-        # C10: if ``classify_query`` already entered + released the same
-        # slot for ``load_memories_by_ids`` (entity-lookup short-circuit
-        # that fell through), it sets ``_storage_slot_acquired=True`` on
-        # ctx.data. Don't re-charge — one logical search counts once
-        # against the per-tenant storage_search bucket.
+        # Unconditional on purpose — this retires C10's
+        # ``_storage_slot_acquired`` skip (audit oss-0814-l-06). The slot
+        # is an IN-FLIGHT cap held only across the storage roundtrip, not
+        # a once-per-request charge: on the entity-lookup fall-through,
+        # ``classify_query`` released its slot when its
+        # ``load_memories_by_ids`` roundtrip returned, before this step
+        # ran, so acquiring here never double-holds — the two roundtrips
+        # are sequential and one logical search occupies at most one slot
+        # at any instant either way. What the C10 skip actually did was
+        # let THIS roundtrip run outside the cap entirely: a tenant whose
+        # queries matched entity tokens but fell through (pool loaded,
+        # then thinned below top_k by visibility filtering) could park
+        # unbounded concurrent scored_search calls on the storage-reader
+        # pool — exactly the noisy-neighbor hole the bulkhead exists to
+        # close.
         sc = get_storage_client()
-        if data.get("_storage_slot_acquired"):
+        async with per_tenant_storage_slot("storage_search", data["tenant_id"]):
             rows = await sc.scored_search(search_data)
-        else:
-            async with per_tenant_storage_slot("storage_search", data["tenant_id"]):
-                rows = await sc.scored_search(search_data)
 
         # Map response dicts to SimpleNamespace rows expected by downstream steps.
         grouped: OrderedDict[str, SimpleNamespace] = OrderedDict()

--- a/tests/test_audit_s6_c1_events.py
+++ b/tests/test_audit_s6_c1_events.py
@@ -47,8 +47,11 @@ def _search_ctx(tenant_id: str, readable: list[str] | None):
         "boosted_memory_ids": [],
         "memory_boost_factor": {},
         "readable_tenant_ids": readable,
-        # Skip the per-tenant slot context manager (already-acquired path).
-        "_storage_slot_acquired": True,
+        # No slot shortcut here: the C10 ``_storage_slot_acquired`` sentinel
+        # was retired (oss-0814-l-06 — it let the fall-through scored_search
+        # run outside the per-tenant cap), so the step always takes the real
+        # ``storage_search`` slot. Uncontended acquire on a fresh per-test
+        # (scope, tenant) key — instant, nothing to mock away.
     }
     return PipelineContext(data=data)
 

--- a/tests/test_c10_storage_slot_dedup.py
+++ b/tests/test_c10_storage_slot_dedup.py
@@ -1,23 +1,32 @@
-"""C10: per-tenant storage-slot deduplication across the search pipeline.
+"""Per-tenant storage_search slot coverage across the search pipeline paths.
 
-When ``ClassifyQuery``'s entity-lookup short-circuit runs ``_collect_memories``
-it acquires ``per_tenant_storage_slot("storage_search", tenant_id)`` around
-the ``storage_client.load_memories_by_ids(...)`` round-trip. If the entity
-lookup falls through (matched entities, but their linked memories all got
-filtered out), the plan still routes through ``ExecuteScoredSearch`` which
-*also* used to acquire the same slot — charging the tenant's
-``storage_search`` bucket TWICE for one logical search.
+History, because this file used to pin the opposite contract. C10 (PR #264)
+made ``ClassifyQuery``'s entity-lookup load set
+``ctx.data["_storage_slot_acquired"] = True`` so that ``ExecuteScoredSearch``,
+on the entity-lookup fall-through, SKIPPED acquiring
+``per_tenant_storage_slot("storage_search", ...)`` — framed as "don't charge
+the tenant twice for one logical search". That framing treated the slot as a
+rate-limit charge. It is not: ``per_tenant_storage_slot`` is an in-flight cap
+held only across a single storage roundtrip, and classify's slot is released
+when its ``load_memories_by_ids`` roundtrip returns — before
+``ExecuteScoredSearch`` ever runs. The two roundtrips are sequential, so
+acquiring around each holds at most ONE slot at any instant; there was never a
+double-charge to dedup. What the skip actually did was exempt the
+fall-through's ``scored_search`` roundtrip from the cap entirely, letting a
+tenant whose queries matched entity tokens but fell through park unbounded
+concurrent scored_search calls on the storage-reader pool (audit
+oss-0814-l-06).
 
-C10's fix: when classify acquires + releases the slot, it sets
-``ctx.data["_storage_slot_acquired"] = True``. ``ExecuteScoredSearch`` reads
-that key and SKIPS the slot acquisition (but still runs ``scored_search``).
-Net effect: one logical search → one slot acquired against the bucket,
-regardless of path.
+The contract pinned now: EVERY storage roundtrip on the search path runs
+inside its own ``storage_search`` slot, whatever route classification took —
+and a logical search still never holds two slots at once, because the
+roundtrips are sequential, not because one of them is exempt.
 
-These tests pin that contract without exercising the real semaphore — the
-slot context manager is replaced by a recording CM on both modules'
-import-bindings, and each test asserts the (module, key, tenant_id) tuples
-that got recorded.
+These tests do not exercise the real semaphore — the slot context manager is
+replaced on both modules' import-bindings by a recorder that logs every
+acquisition AND tracks live holds, so tests can assert the slot was held
+WHILE the storage call ran (entering-then-releasing before the call would
+also satisfy a bare acquisition log).
 """
 
 from __future__ import annotations
@@ -62,51 +71,56 @@ _DEFAULT_SEARCH_PARAMS_FULL = {
 # ---------------------------------------------------------------------------
 
 
-def _make_recorder(acquisitions: list[tuple[str, str, str]], module_label: str):
-    """Return an async CM-factory that records (module, key, tenant_id) on
-    every ``__aenter__`` and yields immediately (no blocking)."""
+class _SlotRecorder:
+    """Stand-in for ``per_tenant_storage_slot`` on both step modules.
 
-    @asynccontextmanager
-    async def _ctx(key: str, tenant_id: str):
-        acquisitions.append((module_label, key, tenant_id))
-        yield
-
-    return _ctx
-
-
-def _patch_slots(acquisitions: list[tuple[str, str, str]]):
-    """Patch ``per_tenant_storage_slot`` on BOTH step modules' import-bindings.
-
-    Returns a tuple of (patcher_classify, patcher_execute). Caller is
-    responsible for starting/stopping both — typically via the ``with``
-    helper :func:`_recording_slots` below.
+    Beyond logging ``(module, key, tenant_id)`` per acquisition, it tracks
+    live holds: ``held`` is the number of slots currently inside their
+    ``async with``, ``max_held`` the high-water mark. A storage-client mock
+    can capture ``held`` at call time to prove the roundtrip ran INSIDE the
+    slot — the property oss-0814-l-06 found missing on the entity-lookup
+    fall-through — and ``max_held == 1`` proves the sequential roundtrips
+    never overlap holds (the double-charge C10 wrongly guarded against).
     """
-    classify_recorder = _make_recorder(acquisitions, "classify_query")
-    execute_recorder = _make_recorder(acquisitions, "execute_scored_search")
-    p1 = patch(
-        "core_api.pipeline.steps.search.classify_query.per_tenant_storage_slot",
-        classify_recorder,
-    )
-    p2 = patch(
-        "core_api.pipeline.steps.search.execute_scored_search.per_tenant_storage_slot",
-        execute_recorder,
-    )
-    return p1, p2
+
+    def __init__(self) -> None:
+        self.acquisitions: list[tuple[str, str, str]] = []
+        self.held = 0
+        self.max_held = 0
+
+    def bind(self, module_label: str):
+        @asynccontextmanager
+        async def _ctx(key: str, tenant_id: str):
+            self.acquisitions.append((module_label, key, tenant_id))
+            self.held += 1
+            self.max_held = max(self.max_held, self.held)
+            try:
+                yield
+            finally:
+                self.held -= 1
+
+        return _ctx
 
 
 class _recording_slots:
-    """Context manager that installs the recording slot CMs on both modules."""
+    """Install one shared ``_SlotRecorder`` on BOTH step modules'
+    import-bindings; yields the recorder."""
 
     def __init__(self):
-        self.acquisitions: list[tuple[str, str, str]] = []
-        self._p1 = None
-        self._p2 = None
+        self.recorder = _SlotRecorder()
+        self._p1 = patch(
+            "core_api.pipeline.steps.search.classify_query.per_tenant_storage_slot",
+            self.recorder.bind("classify_query"),
+        )
+        self._p2 = patch(
+            "core_api.pipeline.steps.search.execute_scored_search.per_tenant_storage_slot",
+            self.recorder.bind("execute_scored_search"),
+        )
 
-    def __enter__(self):
-        self._p1, self._p2 = _patch_slots(self.acquisitions)
+    def __enter__(self) -> _SlotRecorder:
         self._p1.start()
         self._p2.start()
-        return self.acquisitions
+        return self.recorder
 
     def __exit__(self, exc_type, exc, tb):
         self._p2.stop()
@@ -127,9 +141,8 @@ def _make_classify_ctx(
     ``top_k`` is a seam because H-03 made _collect_memories bail BEFORE the
     load when the linked-memory pool cannot fill it. ``_entity_match_sc``
     links exactly one memory, so tests here that need the load to actually
-    happen — every test about the storage-slot sentinel does — must ask for
-    one row. Otherwise no load runs, no slot is taken, and the sentinel these
-    tests exist to police is never set.
+    happen — every fall-through test does — must ask for one row. Otherwise
+    no load runs and the fall-through under test never spent a slot.
     """
     search_params = dict(_DEFAULT_SEARCH_PARAMS_FULL)
     if top_k is not None:
@@ -165,10 +178,15 @@ def _entity_match_sc(
     mid: str,
     memories: list[dict] | None,
     raise_on_load: Exception | None = None,
+    recorder: _SlotRecorder | None = None,
 ) -> AsyncMock:
     """Storage client mock that produces a hit through every entity-lookup
     gate: fts_search_entities → expand_graph → get_memory_ids_by_entity_ids
     → load_memories_by_ids.
+
+    When ``recorder`` is given, ``scored_search`` captures ``recorder.held``
+    at call time into ``sc.scored_search_held_at_call`` so tests can assert
+    the roundtrip ran inside the slot, not merely after an acquire/release.
     """
     sc = AsyncMock()
     sc.fts_search_entities = AsyncMock(return_value=[eid])
@@ -180,11 +198,11 @@ def _entity_match_sc(
         sc.load_memories_by_ids = AsyncMock(side_effect=raise_on_load)
     else:
         sc.load_memories_by_ids = AsyncMock(return_value=memories or [])
-    sc.scored_search = AsyncMock(return_value=[])
+    _wire_scored_search(sc, recorder)
     return sc
 
 
-def _bare_sc() -> AsyncMock:
+def _bare_sc(recorder: _SlotRecorder | None = None) -> AsyncMock:
     """Storage client mock for the non-entity-lookup path: fts_search_entities
     returns no matches, so classify never enters _collect_memories."""
     sc = AsyncMock()
@@ -192,8 +210,21 @@ def _bare_sc() -> AsyncMock:
     sc.expand_graph = AsyncMock(return_value={})
     sc.get_memory_ids_by_entity_ids = AsyncMock(return_value=[])
     sc.load_memories_by_ids = AsyncMock(return_value=[])
-    sc.scored_search = AsyncMock(return_value=[])
+    _wire_scored_search(sc, recorder)
     return sc
+
+
+def _wire_scored_search(sc: AsyncMock, recorder: _SlotRecorder | None) -> None:
+    sc.scored_search_held_at_call = []
+    if recorder is None:
+        sc.scored_search = AsyncMock(return_value=[])
+        return
+
+    async def _scored_search(_search_data: dict) -> list:
+        sc.scored_search_held_at_call.append(recorder.held)
+        return []
+
+    sc.scored_search = AsyncMock(side_effect=_scored_search)
 
 
 class _shared_storage_client:
@@ -225,85 +256,95 @@ class _shared_storage_client:
 
 
 # ---------------------------------------------------------------------------
-# Case 1 — entity-lookup SUCCESS → only classify acquires, execute skips
+# Case 1 — entity-lookup SUCCESS → classify acquires once; execute is
+# plan-skipped entirely (no slot, no storage call)
 # ---------------------------------------------------------------------------
 
 
 async def test_entity_lookup_success_classify_acquires_once_execute_skips():
     eid = str(uuid.uuid4())
     mid = str(uuid.uuid4())
-    sc = _entity_match_sc(
-        eid=eid,
-        mid=mid,
-        memories=[
-            {
-                "id": mid,
-                "tenant_id": "t1",
-                "content": "Alice test memory",
-                "memory_type": "fact",
-            }
-        ],
-    )
-    ctx = _make_classify_ctx("Alice", top_k=1)
+    with _recording_slots() as rec:
+        sc = _entity_match_sc(
+            eid=eid,
+            mid=mid,
+            memories=[
+                {
+                    "id": mid,
+                    "tenant_id": "t1",
+                    "content": "Alice test memory",
+                    "memory_type": "fact",
+                }
+            ],
+            recorder=rec,
+        )
+        ctx = _make_classify_ctx("Alice", top_k=1)
 
-    with _shared_storage_client(sc), _recording_slots() as acquisitions:
-        await ClassifyQuery().execute(ctx)
+        with _shared_storage_client(sc):
+            await ClassifyQuery().execute(ctx)
 
-        assert acquisitions == [("classify_query", "storage_search", "t1")]
-        plan: RetrievalPlan = ctx.data["retrieval_plan"]
-        assert plan.strategy == RetrievalStrategy.ENTITY_LOOKUP
-        assert plan.skip_scored_search is True
-        assert ctx.data.get("_storage_slot_acquired") is True
-        assert len(ctx.data.get("filtered_rows", [])) > 0
+            assert rec.acquisitions == [("classify_query", "storage_search", "t1")]
+            plan: RetrievalPlan = ctx.data["retrieval_plan"]
+            assert plan.strategy == RetrievalStrategy.ENTITY_LOOKUP
+            assert plan.skip_scored_search is True
+            assert len(ctx.data.get("filtered_rows", [])) > 0
 
-        # ExecuteScoredSearch must SKIP — no slot, no scored_search call.
-        _prime_for_execute(ctx)
-        result = await ExecuteScoredSearch().execute(ctx)
+            # ExecuteScoredSearch must SKIP — no slot, no scored_search call.
+            _prime_for_execute(ctx)
+            result = await ExecuteScoredSearch().execute(ctx)
 
-        assert isinstance(result, StepResult)
-        assert result.outcome == StepOutcome.SKIPPED
-        sc.scored_search.assert_not_awaited()
-        # Still exactly one acquisition recorded.
-        assert acquisitions == [("classify_query", "storage_search", "t1")]
+            assert isinstance(result, StepResult)
+            assert result.outcome == StepOutcome.SKIPPED
+            sc.scored_search.assert_not_awaited()
+            # Still exactly one acquisition recorded.
+            assert rec.acquisitions == [("classify_query", "storage_search", "t1")]
 
 
 # ---------------------------------------------------------------------------
-# Case 2 — entity-lookup FALL-THROUGH → classify acquires, execute does not
-# re-acquire but still calls scored_search
+# Case 2 — entity-lookup FALL-THROUGH → scored_search runs INSIDE its own
+# slot (oss-0814-l-06: this roundtrip used to run outside the cap)
 # ---------------------------------------------------------------------------
 
 
-async def test_entity_lookup_fallthrough_execute_skips_slot_but_calls_scored_search():
+async def test_entity_lookup_fallthrough_scored_search_runs_inside_the_slot():
     eid = str(uuid.uuid4())
     mid = str(uuid.uuid4())
-    # load_memories_by_ids returns []: _collect_memories runs the load, marks
-    # the sentinel, then returns [] → classify falls through past the
-    # ENTITY_LOOKUP plan-emission.
-    sc = _entity_match_sc(eid=eid, mid=mid, memories=[])
-    ctx = _make_classify_ctx("Alice", top_k=1)
+    with _recording_slots() as rec:
+        # load_memories_by_ids returns []: the pool looked adequate, the load
+        # ran (spending classify's slot), then visibility filtering dropped
+        # every row → classify falls through past the ENTITY_LOOKUP
+        # plan-emission. This is the exact path the audit flagged.
+        sc = _entity_match_sc(eid=eid, mid=mid, memories=[], recorder=rec)
+        ctx = _make_classify_ctx("Alice", top_k=1)
 
-    with _shared_storage_client(sc), _recording_slots() as acquisitions:
-        await ClassifyQuery().execute(ctx)
+        with _shared_storage_client(sc):
+            await ClassifyQuery().execute(ctx)
 
-        # Classify acquired once during the load.
-        assert acquisitions == [("classify_query", "storage_search", "t1")]
-        plan: RetrievalPlan = ctx.data["retrieval_plan"]
-        assert plan.strategy != RetrievalStrategy.ENTITY_LOOKUP
-        assert plan.skip_scored_search is False
-        # Sentinel is set even though no entity-lookup rows were emitted.
-        assert ctx.data.get("_storage_slot_acquired") is True
-        sc.load_memories_by_ids.assert_awaited_once()
+            # Classify acquired once, around the load, and released it.
+            assert rec.acquisitions == [("classify_query", "storage_search", "t1")]
+            assert rec.held == 0
+            plan: RetrievalPlan = ctx.data["retrieval_plan"]
+            assert plan.strategy != RetrievalStrategy.ENTITY_LOOKUP
+            assert plan.skip_scored_search is False
+            sc.load_memories_by_ids.assert_awaited_once()
 
-        # Now ExecuteScoredSearch must run scored_search WITHOUT re-acquiring.
-        _prime_for_execute(ctx)
-        sc.scored_search.reset_mock()
-        sc.scored_search.return_value = []
-        await ExecuteScoredSearch().execute(ctx)
+            _prime_for_execute(ctx)
+            await ExecuteScoredSearch().execute(ctx)
 
-        # Still exactly one acquisition — execute did NOT re-take the slot.
-        assert acquisitions == [("classify_query", "storage_search", "t1")]
-        # But scored_search WAS called (the storage call still happens).
-        sc.scored_search.assert_awaited_once()
+            # Execute took its own slot for its own roundtrip.
+            assert rec.acquisitions == [
+                ("classify_query", "storage_search", "t1"),
+                ("execute_scored_search", "storage_search", "t1"),
+            ]
+            # And the roundtrip ran INSIDE it — held == 1 at call time, not 0
+            # (which is what the retired C10 skip produced here).
+            sc.scored_search.assert_awaited_once()
+            assert sc.scored_search_held_at_call == [1]
+            # Sequential roundtrips never overlap holds: one logical search
+            # occupies at most one slot at any instant, so there was no
+            # double-charge for the skip to dedup in the first place.
+            assert rec.max_held == 1
+            assert rec.held == 0
 
 
 # ---------------------------------------------------------------------------
@@ -312,156 +353,103 @@ async def test_entity_lookup_fallthrough_execute_skips_slot_but_calls_scored_sea
 
 
 async def test_non_entity_lookup_path_execute_acquires_normally():
-    sc = _bare_sc()
-    # A query with no entity tokens — classify routes via SEMANTIC_SEARCH
-    # without ever running _collect_memories.
-    ctx = _make_classify_ctx("what do we know about pricing strategy next quarter")
+    with _recording_slots() as rec:
+        sc = _bare_sc(recorder=rec)
+        # A query with no entity tokens — classify routes via SEMANTIC_SEARCH
+        # without ever running _collect_memories.
+        ctx = _make_classify_ctx("what do we know about pricing strategy next quarter")
 
-    with _shared_storage_client(sc), _recording_slots() as acquisitions:
-        await ClassifyQuery().execute(ctx)
+        with _shared_storage_client(sc):
+            await ClassifyQuery().execute(ctx)
 
-        assert acquisitions == []
-        assert "_storage_slot_acquired" not in ctx.data
-        plan: RetrievalPlan = ctx.data["retrieval_plan"]
-        assert plan.skip_scored_search is False
-        sc.load_memories_by_ids.assert_not_awaited()
+            assert rec.acquisitions == []
+            plan: RetrievalPlan = ctx.data["retrieval_plan"]
+            assert plan.skip_scored_search is False
+            sc.load_memories_by_ids.assert_not_awaited()
 
+            _prime_for_execute(ctx)
+            await ExecuteScoredSearch().execute(ctx)
+
+            assert rec.acquisitions == [
+                ("execute_scored_search", "storage_search", "t1")
+            ]
+            sc.scored_search.assert_awaited_once()
+            assert sc.scored_search_held_at_call == [1]
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — a stale C10 sentinel must be inert: nothing on ctx may disable
+# the bulkhead
+# ---------------------------------------------------------------------------
+
+
+async def test_stale_sentinel_does_not_disable_the_bulkhead():
+    """Regression guard for reintroducing the skip. ``_storage_slot_acquired``
+    is written by nothing anymore, but a ctx replayed from an old caller (or a
+    hand-built test ctx — tests/test_audit_s6_c1_events.py used to do exactly
+    this to dodge the slot) could still carry it; execute must acquire
+    regardless."""
+    with _recording_slots() as rec:
+        ctx = _make_classify_ctx("Alice", top_k=1)
+        ctx.data["_storage_slot_acquired"] = True
         _prime_for_execute(ctx)
-        sc.scored_search.return_value = []
-        await ExecuteScoredSearch().execute(ctx)
+        sc = _bare_sc(recorder=rec)
 
-        # Execute acquired the slot because classify did not mark the sentinel.
-        assert acquisitions == [("execute_scored_search", "storage_search", "t1")]
-        sc.scored_search.assert_awaited_once()
+        with _shared_storage_client(sc):
+            await ExecuteScoredSearch().execute(ctx)
 
-
-# ---------------------------------------------------------------------------
-# Case 4 — sentinel suppresses ONLY the slot, NOT the storage call
-# ---------------------------------------------------------------------------
-
-
-async def test_sentinel_only_suppresses_slot_not_scored_search_call():
-    eid = str(uuid.uuid4())
-    mid = str(uuid.uuid4())
-    sc = _entity_match_sc(eid=eid, mid=mid, memories=[])
-    ctx = _make_classify_ctx("Alice", top_k=1)
-
-    with _shared_storage_client(sc), _recording_slots() as acquisitions:
-        await ClassifyQuery().execute(ctx)
-        assert ctx.data.get("_storage_slot_acquired") is True
-        assert len(acquisitions) == 1
-
-        _prime_for_execute(ctx)
-        # Sentinel set, but scored_search MUST still be called with the
-        # expected tenant_id baked into its search_data argument.
-        sc.scored_search.reset_mock()
-        sc.scored_search.return_value = []
-        await ExecuteScoredSearch().execute(ctx)
-
-        sc.scored_search.assert_awaited_once()
-        call_args = sc.scored_search.await_args
-        # scored_search's first positional arg is the search_data dict in
-        # current usage; also accept tenant_id passed as kwarg.
-        search_data = call_args.args[0] if call_args.args else call_args.kwargs
-        assert search_data.get("tenant_id") == "t1"
+        assert rec.acquisitions == [("execute_scored_search", "storage_search", "t1")]
+        assert sc.scored_search_held_at_call == [1]
 
 
 # ---------------------------------------------------------------------------
-# Case 5 — sentinel does NOT leak across requests
+# Case 5 — load_memories_by_ids failure: classify's slot is released by the
+# ``async with`` on the exception; the fall-through search still gets gated
 # ---------------------------------------------------------------------------
 
 
-async def test_sentinel_does_not_leak_across_requests():
-    # First request: entity-lookup fall-through → sentinel set, execute skips
-    # the slot.
-    eid = str(uuid.uuid4())
-    mid = str(uuid.uuid4())
-    sc_first = _entity_match_sc(eid=eid, mid=mid, memories=[])
-    ctx_a = _make_classify_ctx("Alice", top_k=1)
-
-    with _shared_storage_client(sc_first) as _sc, _recording_slots() as acquisitions:
-        await ClassifyQuery().execute(ctx_a)
-        _prime_for_execute(ctx_a)
-        sc_first.scored_search.return_value = []
-        await ExecuteScoredSearch().execute(ctx_a)
-
-        # First request: exactly 1 acquisition (classify only).
-        assert acquisitions == [("classify_query", "storage_search", "t1")]
-
-    # Second request: non-entity-lookup path. Fresh ctx → fresh
-    # ``_storage_slot_acquired`` state. Execute must acquire the slot.
-    sc_second = _bare_sc()
-    ctx_b = _make_classify_ctx("what do we know about pricing strategy next quarter")
-
-    with _shared_storage_client(sc_second), _recording_slots() as acquisitions_b:
-        await ClassifyQuery().execute(ctx_b)
-        assert "_storage_slot_acquired" not in ctx_b.data
-
-        _prime_for_execute(ctx_b)
-        sc_second.scored_search.return_value = []
-        await ExecuteScoredSearch().execute(ctx_b)
-
-        # The second request, in isolation, recorded one execute-side slot.
-        assert acquisitions_b == [("execute_scored_search", "storage_search", "t1")]
-
-
-# ---------------------------------------------------------------------------
-# Case 6 — load_memories_by_ids failure does NOT mark the sentinel
-# ---------------------------------------------------------------------------
-
-
-async def test_load_failure_does_not_mark_sentinel():
+async def test_load_failure_releases_slot_and_fallthrough_still_gated():
     eid = str(uuid.uuid4())
     mid = str(uuid.uuid4())
     boom = RuntimeError("storage exploded")
-    sc = _entity_match_sc(eid=eid, mid=mid, memories=None, raise_on_load=boom)
-    ctx = _make_classify_ctx("Alice", top_k=1)
+    with _recording_slots() as rec:
+        sc = _entity_match_sc(
+            eid=eid, mid=mid, memories=None, raise_on_load=boom, recorder=rec
+        )
+        ctx = _make_classify_ctx("Alice", top_k=1)
 
-    with _shared_storage_client(sc), _recording_slots() as acquisitions:
-        # Classify's outer try/except may catch the exception and fall through.
-        # If it doesn't, the test should still surface the failure cleanly.
-        try:
+        with _shared_storage_client(sc):
+            # Classify's outer try/except catches the load failure and falls
+            # through to the keyword/semantic cascade.
             await ClassifyQuery().execute(ctx)
-        except RuntimeError as exc:
-            assert exc is boom
 
-        # Sentinel must NOT be set — the implementation marks it only after
-        # a successful load.
-        assert ctx.data.get("_storage_slot_acquired") is not True
+            # Classify entered the slot (recorded on enter) even though the
+            # load inside raised; ``async with``'s __aexit__ released it.
+            assert rec.acquisitions == [("classify_query", "storage_search", "t1")]
+            assert rec.held == 0
 
-        # Classify entered the slot (the ``async with`` records on enter)
-        # even though the load inside raised. That's expected: the slot is
-        # released on exception by ``async with``'s __aexit__.
-        assert acquisitions == [("classify_query", "storage_search", "t1")]
+            plan: RetrievalPlan = ctx.data["retrieval_plan"]
+            assert plan.skip_scored_search is False
 
-        # If classify swallowed the exception and set a retrieval_plan, the
-        # downstream ExecuteScoredSearch must acquire the slot itself (since
-        # the sentinel was never set). If classify propagated the exception,
-        # ExecuteScoredSearch wouldn't run in the real pipeline — but we
-        # exercise it here to pin the sentinel-not-set behaviour.
-        if (
-            "retrieval_plan" in ctx.data
-            and not ctx.data["retrieval_plan"].skip_scored_search
-        ):
             _prime_for_execute(ctx)
-            sc.scored_search.reset_mock()
-            sc.scored_search.return_value = []
             await ExecuteScoredSearch().execute(ctx)
-            assert acquisitions == [
+            assert rec.acquisitions == [
                 ("classify_query", "storage_search", "t1"),
                 ("execute_scored_search", "storage_search", "t1"),
             ]
             sc.scored_search.assert_awaited_once()
+            assert sc.scored_search_held_at_call == [1]
 
 
 # ---------------------------------------------------------------------------
-# Case 7 — explicit skip path: when classify already emitted a
+# Case 6 — explicit skip path: when classify already emitted a
 # skip_scored_search plan (entity-lookup SUCCESS), ExecuteScoredSearch must
-# NOT touch scored_search or the slot regardless of the sentinel value.
+# NOT touch scored_search or the slot — the skip is the PLAN's, decided
+# before the slot block, never a sentinel's.
 # ---------------------------------------------------------------------------
 
 
-async def test_execute_skips_when_plan_says_skip_regardless_of_sentinel():
+async def test_execute_skips_when_plan_says_skip():
     ctx = PipelineContext(
         data={
             "tenant_id": "t1",
@@ -470,14 +458,14 @@ async def test_execute_skips_when_plan_says_skip_regardless_of_sentinel():
                 strategy=RetrievalStrategy.ENTITY_LOOKUP,
                 skip_scored_search=True,
             ),
-            # Sentinel set, just like a real entity-lookup SUCCESS path.
+            # A stale sentinel must be inert on this path too.
             "_storage_slot_acquired": True,
         },
     )
     _prime_for_execute(ctx)
 
-    with _recording_slots() as acquisitions:
+    with _recording_slots() as rec:
         result = await ExecuteScoredSearch().execute(ctx)
         assert isinstance(result, StepResult)
         assert result.outcome == StepOutcome.SKIPPED
-        assert acquisitions == []
+        assert rec.acquisitions == []

--- a/tests/test_entity_lookup_short_circuit.py
+++ b/tests/test_entity_lookup_short_circuit.py
@@ -695,10 +695,11 @@ async def test_under_filled_entity_pool_falls_through_to_scored_search():
     # And it must not pay for rows it throws away. Pool size is knowable from the
     # link query alone, so the content load — which pulls full rows including the
     # embedding, and holds one of only four per-tenant storage permits — is
-    # skipped. It also must not set _storage_slot_acquired, or the scored search
-    # that DOES run would slip past the bulkhead unmetered.
+    # skipped. (The C10 ``_storage_slot_acquired`` sentinel this decline also
+    # had to avoid setting is retired — oss-0814-l-06 — the scored search now
+    # always takes its own slot; the key must stay unwritten everywhere.)
     sc.load_memories_by_ids.assert_not_awaited()
-    assert ctx.data.get("_storage_slot_acquired") is not True
+    assert "_storage_slot_acquired" not in ctx.data
     # The marker the decline log reads is consumed, not left for the next step.
     assert "_entity_pool_size" not in ctx.data
 


### PR DESCRIPTION
## Problem

`per_tenant_storage_slot("storage_search", tenant_id)` is an **in-flight** cap — an `asyncio.Semaphore` held only across a single storage roundtrip (`core-api/src/core_api/middleware/per_tenant_concurrency.py:144-184`, cap default 4 via `per_tenant_storage_search_concurrency`). On the entity-lookup fall-through, `ExecuteScoredSearch` reached `sc.scored_search` **without holding it**:

- `classify_query.py` (entity-lookup) acquired **and released** the slot around `load_memories_by_ids`, then set `ctx.data["_storage_slot_acquired"] = True` *after* release.
- `execute_scored_search.py:172-177` (pre-fix) saw the sentinel and skipped acquisition: `if data.get("_storage_slot_acquired"): rows = await sc.scored_search(search_data)`.

At that moment the request held **zero** slots, so a tenant whose queries matched entity tokens but fell through (pool loaded, then thinned below `top_k` by visibility filtering — or every row dropped) could run unbounded concurrent `scored_search` roundtrips against the storage-reader pool, past its per-tenant budget. Exactly the noisy-neighbor hole the bulkhead exists to close.

The skip was C10's "don't charge twice for one logical search" dedup (#264) — a category error: the slot is an in-flight cap, not a rate-limit charge, and the two roundtrips are sequential, so acquiring around each holds at most one slot at any instant; there was never a double-charge to dedup. H-03 (#832) already called the skip a defect in passing ("left `_storage_slot_acquired` set so the scored search that does run skipped the bulkhead") and narrowed when the sentinel is set, but left the mechanism in place. Checked for in-flight work: #1425/#1426 (merged) cover the route-entry layer and settings authz, not this path.

## Fix

- `ExecuteScoredSearch` takes the slot **unconditionally**, matching the primary path and `memory_service._search_memories_legacy` (`memory_service.py:4801-4802`): held only across the `sc.scored_search` roundtrip, released on exit, unbounded acquire (queueing is the intended shape; the outer request budget caps wall time). No double-hold or deadlock is possible: classify's slot is provably released before this step runs (the `async with` wraps only the `load_memories_by_ids` call; the sentinel was set after exit).
- The now-purposeless `_storage_slot_acquired` sentinel is retired: the marker write is removed from `classify_query._collect_memories` and its `slot_acquired_marker` parameter is renamed to `pool_report` (it still carries the `_entity_pool_size` / `_entity_pool_loaded` decline diagnostics).

## Tests

`tests/test_c10_storage_slot_dedup.py` pinned the old skip contract; rewritten to pin the corrected one. The recorder now tracks **live holds**, so tests assert the roundtrip ran *inside* the slot (`held == 1` at `scored_search` call time), not merely that an acquire happened sometime — and that holds never overlap (`max_held == 1`, one logical search ≤ 1 slot at any instant).

- `test_entity_lookup_fallthrough_scored_search_runs_inside_the_slot` — the defect pin (audit path: pool loaded, all rows visibility-filtered).
- `test_stale_sentinel_does_not_disable_the_bulkhead` — a ctx still carrying the retired sentinel must not bypass the cap (reintroduction guard).
- Success path (plan-skip: no slot, no call), non-entity path, load-failure path (slot released by `__aexit__`, fall-through still gated) re-pinned.
- Verified failing on pre-fix code: with the src changes stashed, both new tests fail (`2 failed, 4 passed`); unstashed, all pass.
- `tests/test_audit_s6_c1_events.py` and `tests/test_entity_lookup_short_circuit.py` updated where they referenced the retired sentinel.

## Gates

- `pytest tests/ -m unit`: **3857 passed**, 3 failed — the 3 failures (`tests/test_a7_classifier_recall.py` entity-FTS tests) fail identically on clean `origin/main` in this environment (they need Postgres; no infra here), unrelated to this change.
- Affected files directly: `tests/test_c10_storage_slot_dedup.py tests/test_audit_s6_c1_events.py tests/test_entity_lookup_short_circuit.py tests/test_per_tenant_concurrency.py tests/pipeline/test_classify_query.py` → **67 passed**.
- `ruff check core-api/src/ tests/` — clean; `ruff format --check` on touched files — clean.
- `mypy src/` (core-api) — same 3 pre-existing missing-stub errors (`croniter`, `dateutil` in `common/`) as clean `origin/main`; no new errors.

Audit tracker: oss-0814-l-06

🤖 Generated with [Claude Code](https://claude.com/claude-code)