### PR TITLE
docs(openapi): declare recall_raw on RecallDiagnostic (oss-0902-l-16)

### DIFF
--- a/core-api/src/core_api/openapi_responses.py
+++ b/core-api/src/core_api/openapi_responses.py
@@ -87,6 +87,12 @@ class MemoryStatusPatchResponse(BaseModel):
 
 class RecallDiagnostic(BaseModel):
     recall_prompt: str | None
+    # WT-1 — ``summary`` carries only the extracted final answer; the raw
+    # completion stays inspectable here.
+    recall_raw: str | None = Field(
+        description="Unfiltered LLM completion (reasoning scaffold + answer marker) that summary "
+        "was extracted from; null when no LLM ran (no matches, or summarization disabled)."
+    )
     recall_model: str | None
     recall_provider: str | None
     all_candidates: list

--- a/tests/test_c33_openapi_completeness.py
+++ b/tests/test_c33_openapi_completeness.py
@@ -1,6 +1,6 @@
 """C33 — OpenAPI completeness guarantees.
 
-Three invariants:
+Four invariants:
 
 1. Every endpoint annotated via ``openapi_responses`` actually surfaces a
    non-empty success schema in the generated spec (the ``responses=``
@@ -11,6 +11,11 @@ Three invariants:
 3. The ``servers`` block is driven by ``public_api_url``: absent when the
    setting is empty (OSS default — spec byte-identical to pre-C33), present
    with the trailing-slash-normalized URL when set.
+4. Spec-only models cover what the handler actually serializes, where the
+   drift already happened once: every key ``/recall`` puts in ``diagnostic``
+   must be a declared ``RecallDiagnostic`` field (oss-0902-l-16 — WT-1 added
+   ``recall_raw`` to the handler and the model was never widened, so the
+   spec and generated clients understated the response).
 """
 
 import pytest
@@ -115,6 +120,88 @@ def test_empty_success_schema_ratchet():
         f"core_api/openapi_responses.py or raise the ceiling with justification. "
         f"Full list: {empty}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 — RecallDiagnostic covers the wire (oss-0902-l-16).
+#
+# ``openapi_responses`` models are spec-only (never ``response_model=``), so
+# nothing at runtime drops or flags an undeclared key; its module docstring
+# makes handler↔model sync a same-PR rule instead. These tests are that rule's
+# teeth for the one payload that already drifted: ``summarize_memories``
+# builds ``diagnostic`` at three sites (no-memories, recall-disabled, LLM
+# path) which are kept in lockstep by hand — every key each of them emits
+# must be a declared ``RecallDiagnostic`` field.
+# ---------------------------------------------------------------------------
+
+
+def test_recall_diagnostic_documents_recall_raw():
+    import typing
+
+    from core_api.openapi_responses import RecallDiagnostic
+
+    field = RecallDiagnostic.model_fields.get("recall_raw")
+    assert field is not None, (
+        "RecallDiagnostic must declare recall_raw — /recall has returned it in "
+        "diagnostic since WT-1 (recall_service.summarize_memories)"
+    )
+    # Nullable: the no-memories and recall-disabled branches emit null.
+    assert type(None) in typing.get_args(field.annotation), (
+        f"recall_raw must be nullable (str | None), got {field.annotation!r}"
+    )
+
+
+async def test_recall_diagnostic_covers_every_wire_key(monkeypatch):
+    """Keys serialized into ``diagnostic`` ⊆ declared ``RecallDiagnostic`` fields,
+    on all three builder branches."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    import core_api.services.recall_service as rs_mod
+    from core_api.openapi_responses import RecallDiagnostic
+
+    def _mem():
+        return SimpleNamespace(
+            content="The platform database is PostgreSQL 16.",
+            memory_type="fact",
+            title=None,
+            status="active",
+            ts_valid_start=None,
+            model_dump=lambda mode=None: {"content": "c", "memory_type": "fact"},
+        )
+
+    # No-memories branch (no LLM, no config reads).
+    empty = await rs_mod.summarize_memories([], "q", SimpleNamespace(), diagnostic=True)
+    # Recall-disabled branch.
+    disabled = await rs_mod.summarize_memories(
+        [_mem()],
+        "q",
+        SimpleNamespace(recall_enabled=False, recall_provider="p"),
+        diagnostic=True,
+    )
+    # LLM branch — the one that populates recall_raw with the completion.
+    monkeypatch.setattr(
+        rs_mod, "call_with_fallback", AsyncMock(return_value="**Answer:** 16")
+    )
+    llm = await rs_mod.summarize_memories(
+        [_mem()],
+        "q",
+        SimpleNamespace(recall_enabled=True, recall_provider="p", recall_model="m"),
+        diagnostic=True,
+    )
+
+    model_keys = set(RecallDiagnostic.model_fields)
+    for branch, resp in {
+        "no_memories": empty,
+        "recall_disabled": disabled,
+        "llm": llm,
+    }.items():
+        undocumented = set(resp["diagnostic"]) - model_keys
+        assert not undocumented, (
+            f"/recall ({branch} branch) serializes diagnostic keys missing from "
+            f"RecallDiagnostic: {sorted(undocumented)} — declare them in "
+            f"core_api/openapi_responses.py (spec-only; see its module docstring)"
+        )
 
 
 def test_servers_block_absent_by_default(monkeypatch):


### PR DESCRIPTION
## Problem

`RecallDiagnostic` — the spec-only OpenAPI model documenting `/recall`'s `diagnostic` payload — omits the `recall_raw` key the handler actually serializes, so the generated spec and any client/docs built from it understate the real response.

Validation evidence (origin/main @ 77e2d8c3):

- `core-api/src/core_api/services/recall_service.py:335` — `"recall_raw": completion` on the LLM path; `:182` and `:232` emit `"recall_raw": None` on the no-memories and recall-disabled branches. The key is present on **every** branch whenever the request sets `diagnostic=true`; runtime type is `str | None`.
- `core-api/src/core_api/routes/memories.py:2175` — `POST /recall` documents `_oar.RecallResponse` (which nests `RecallDiagnostic`) via spec-only `responses=`, and returns the service dict verbatim (`:2276`), so `recall_raw` lands on the wire.
- `core-api/src/core_api/openapi_responses.py:88-99` (pre-fix) — `RecallDiagnostic` declares `recall_prompt`/`recall_model`/`recall_provider`/… but not `recall_raw`.

How the drift happened: WT-1 (#986, Aug 25) added `recall_raw` to the handler; C33 (#990, Aug 26) created `RecallDiagnostic` one day later without it; CAURA-722 (#1357, Sep 8) widened the model again without backfilling. Nothing enforces these spec-only models at runtime — the `openapi_responses` module docstring makes handler↔model sync a same-PR rule instead.

## Fix

Direction check: the mismatch is the model lagging the handler, not the handler over-returning — WT-1's comments (`recall_service.py:74`, `:313-314`) and its dedicated test (`tests/test_wt1_recall_answer_extraction.py::test_diagnostic_carries_raw_completion`) document `diagnostic.recall_raw` as deliberate, load-bearing behavior (the reasoning scaffold stays inspectable while `summary` carries only the extracted answer). So the model is widened, not the response narrowed.

- Declare `recall_raw: str | None` on `RecallDiagnostic`, positioned in the handler's serialization order (right after `recall_prompt`), with a `Field(description=...)` in the file's style saying what it is and when it is null.
- No runtime behavior change (spec-only model). The broker contract baseline is unaffected — `/recall` is not a broker operation and `openapi.broker.json` never references `RecallDiagnostic`; `gen_broker_openapi.py --check` passes unchanged.

## Tests

Extended `tests/test_c33_openapi_completeness.py` (new invariant 4, giving the module-docstring sync rule teeth for the payload that already drifted):

- `test_recall_diagnostic_documents_recall_raw` — the model declares a nullable `recall_raw`.
- `test_recall_diagnostic_covers_every_wire_key` — the `diagnostic` keys emitted by all three `summarize_memories` builder branches (no-memories, recall-disabled, LLM) are a subset of declared `RecallDiagnostic` fields.

Failed-on-pre-fix proof: with only the model change stashed, both new tests fail — `test_recall_diagnostic_covers_every_wire_key` reports exactly `['recall_raw']` missing on each branch; unstashed, all pass.

## Gates run

- `pytest tests/test_c33_openapi_completeness.py tests/test_wt1_recall_answer_extraction.py` — 21 passed
- `pytest tests/test_broker_contract.py tests/test_mcp_manage_structured_returns.py` — 8 passed
- `python core-api/scripts/gen_broker_openapi.py --check` — baseline up to date (8 operations)
- `ruff check core-api/src/ tests/test_c33_openapi_completeness.py` — clean
- `ruff format --check` on both touched files — clean
- `cd core-api && mypy src/` — Success: no issues found in 204 source files

Audit tracker: oss-0902-l-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)