### PR TITLE
fix(search): fall back to hop-0 seeds when expand_graph fails for all fleets

### DIFF
--- a/core-api/src/core_api/pipeline/steps/search/classify_query.py
+++ b/core-api/src/core_api/pipeline/steps/search/classify_query.py
@@ -364,6 +364,10 @@ class ClassifyQuery:
     ) -> dict[UUID, tuple[int, float]]:
         """Expand *seed_ids* per fleet, or return them as hop-0 when expansion is off.
 
+        Expansion failure degrades the same way: ``_expand_per_fleet`` falls
+        back to the hop-0 seed set when every fleet's call fails, so callers
+        are guaranteed a non-empty dict for a non-empty seed set either way.
+
         The gate mirrors ``_entity_boost_via_storage`` exactly
         (``graph_expand and graph_max_hops > 0`` → expand, else hop-0 seeds
         with neutral weight), so ``search.graph_retrieval`` means the same
@@ -434,6 +438,30 @@ class ClassifyQuery:
                     or (hop == merged[eid][0] and weight > merged[eid][1])
                 ):
                     merged[eid] = (hop, weight)
+
+        # oss-0814-l-05: an empty merge for a non-empty seed set means NO call
+        # succeeded — a successful expand_graph response always contains the
+        # seeds themselves at hop 0 / weight 1.0 (entity_expand_graph seeds its
+        # result dict with them before traversing), and every per-fleet call is
+        # given the full seed list, so a single surviving fleet keeps them all
+        # (which is why partial failure needs no case of its own here).
+        # Returning ``{}`` discarded the already-resolved entity-FTS matches
+        # along with the expansion: ``_collect_memories`` had no entities to
+        # load links for (reported, misleadingly, as "entity matched but no
+        # linked memories"), and the ``_classified_entity_hops`` stash handed
+        # ParallelEmbedAndEntityBoost an empty dict — which its
+        # ``precomputed_hops is not None`` check treats as authoritative, so it
+        # did not re-derive FTS either and hop-boost contributed nothing.
+        # Degrade to the hop-0 seed set instead — the same shape as the
+        # ``graph_expand`` off gate in ``_hops_for_seeds`` — so the direct
+        # matches stay retrievable and only the (unavailable) graph
+        # neighbourhood is lost.
+        if seed_ids and not merged:
+            logger.warning(
+                "expand_graph failed for all fleets; degrading to %d hop-0 seed entities",
+                len(seed_ids),
+            )
+            return dict.fromkeys(seed_ids, (0, 1.0))
         return merged
 
     @staticmethod

--- a/tests/pipeline/test_classify_query.py
+++ b/tests/pipeline/test_classify_query.py
@@ -600,6 +600,119 @@ async def test_expand_per_fleet_partial_failure():
 
 
 # ---------------------------------------------------------------------------
+# Total expansion failure falls back to hop-0 seeds (oss-0814-l-05)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expand_per_fleet_total_failure_falls_back_to_hop0_seeds():
+    """When EVERY fleet's expand_graph call fails, the already-resolved seed
+    entities must survive as hop-0 / weight 1.0 instead of being dropped.
+
+    Pre-fix this returned ``{}``, which zeroed both consumers at once: the
+    ENTITY_LOOKUP pool had no entities to load links for, and the
+    ``_classified_entity_hops`` stash handed the boost step an empty dict its
+    ``precomputed_hops is not None`` check treats as authoritative — so entity
+    lookup AND hop-boost silently contributed nothing for the request.
+    """
+    eid_a = uuid.uuid4()
+    eid_b = uuid.uuid4()
+
+    sc = AsyncMock()
+    sc.expand_graph = AsyncMock(
+        side_effect=[
+            RuntimeError("storage 503"),
+            RuntimeError("storage 503"),
+        ]
+    )
+
+    result = await ClassifyQuery._expand_per_fleet(
+        sc=sc,
+        seed_ids=[eid_a, eid_b],
+        tenant_id="t1",
+        fleet_ids=["f1", "f2"],
+        max_hops=2,
+    )
+
+    assert result == {eid_a: (0, 1.0), eid_b: (0, 1.0)}
+    assert sc.expand_graph.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch("core_api.pipeline.steps.search.classify_query.get_storage_client")
+async def test_entity_lookup_survives_expand_graph_failure(mock_get_sc):
+    """Entity match + expand_graph down → ENTITY_LOOKUP still fires off the
+    hop-0 seeds (oss-0814-l-05).
+
+    Pre-fix the seeds were dropped with the failed expansion, so the linked
+    memory was unreachable and the query fell through to semantic search
+    after (misleadingly) logging "entity matched but no linked memories".
+    """
+    ctx = _make_ctx("Alice", top_k=1)
+
+    entity_id = uuid.uuid4()
+    memory_id = uuid.uuid4()
+    eid_str = str(entity_id)
+    mid_str = str(memory_id)
+
+    sc = _mock_sc()
+    sc.fts_search_entities = AsyncMock(return_value=[eid_str])
+    sc.expand_graph = AsyncMock(side_effect=RuntimeError("storage 503"))
+    sc.get_memory_ids_by_entity_ids = AsyncMock(
+        return_value=[{"memory_id": mid_str, "entity_id": eid_str, "role": "subject"}]
+    )
+    sc.load_memories_by_ids = AsyncMock(
+        return_value=[
+            {
+                "id": mid_str,
+                "tenant_id": "t1",
+                "content": "Alice test memory",
+                "memory_type": "fact",
+            }
+        ]
+    )
+    mock_get_sc.return_value = sc
+
+    step = ClassifyQuery()
+    await step.execute(ctx)
+
+    plan: RetrievalPlan = ctx.data["retrieval_plan"]
+    assert plan.strategy == RetrievalStrategy.ENTITY_LOOKUP
+    assert len(ctx.data["filtered_rows"]) == 1
+    # The links were looked up for the SEED, not for an empty expansion set.
+    sc.get_memory_ids_by_entity_ids.assert_awaited_once_with([eid_str], "t1")
+
+
+@pytest.mark.asyncio
+@patch("core_api.pipeline.steps.search.classify_query.get_storage_client")
+async def test_hop_boost_stash_survives_expand_graph_failure(mock_get_sc):
+    """Temporal decline + expand_graph down → ``_classified_entity_hops``
+    still carries the hop-0 seeds, NOT ``{}`` (oss-0814-l-05).
+
+    The boost step's ``precomputed_hops is not None`` check treats an empty
+    dict as an authoritative "no entities" answer and skips its own FTS, so a
+    ``{}`` stash turned an expansion outage into zero hop-boost for a query
+    whose entities were already resolved.
+    """
+    entity_id = uuid.uuid4()
+    eid_str = str(entity_id)
+
+    sc = _mock_sc()
+    sc.fts_search_entities = AsyncMock(return_value=[eid_str])
+    sc.expand_graph = AsyncMock(side_effect=RuntimeError("storage 503"))
+    mock_get_sc.return_value = sc
+
+    ctx = _make_ctx("Alice", temporal_window=timedelta(days=7), top_k=1)
+
+    step = ClassifyQuery()
+    await step.execute(ctx)
+
+    plan: RetrievalPlan = ctx.data["retrieval_plan"]
+    assert plan.strategy == RetrievalStrategy.TEMPORAL
+    assert ctx.data["_classified_entity_hops"] == {entity_id: (0, 1.0)}
+
+
+# ---------------------------------------------------------------------------
 # Entity cap tests (Fix G)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

When every per-fleet `expand_graph` call fails, `ClassifyQuery._expand_per_fleet` logs each failure and returns `{}` — discarding the seed entities the entity FTS had already resolved (`core-api/src/core_api/pipeline/steps/search/classify_query.py:419-437` pre-fix). With `fleet_ids=None` that is a single call, so one storage hiccup is "all fleets".

That empty dict silently zeroes both consumers for the request:

- **Entity lookup**: `_collect_memories` receives no entities, loads no links, and the ENTITY_LOOKUP short-circuit falls through — logged, misleadingly, as `"entity matched but no linked memories"` (`classify_query.py:297`).
- **Hop boost**: the `_classified_entity_hops` stash (`classify_query.py:180`, `:300`) hands `ParallelEmbedAndEntityBoost` an empty dict, and its `precomputed_hops is not None` check (`parallel_embed_entity_boost.py:58-60`) treats `{}` as authoritative — so it does not re-derive FTS either, and hop-boost contributes nothing.

A successful `expand_graph` response always contains the seeds at hop 0 / weight 1.0 (`core-storage-api/src/core_storage_api/services/postgres_service.py` — `entity_expand_graph` seeds its result dict before traversing), and every per-fleet call receives the full seed list, so an empty merge for a non-empty seed set can only mean **no call succeeded** — and any single surviving fleet keeps all seeds, so partial failure needs no case of its own.

## Fix

On an all-fleets-failed merge, `_expand_per_fleet` now logs a warning and degrades to the hop-0 seed set (`dict.fromkeys(seed_ids, (0, 1.0))`) — the exact shape the `graph_expand` off gate in `_hops_for_seeds` already returns, so matched entities stay retrievable and only the (unavailable) graph neighbourhood is lost. Success-path and partial-failure behaviour are unchanged.

## Tests

Three new tests in `tests/pipeline/test_classify_query.py`, next to the existing `test_expand_per_fleet_partial_failure`:

- `test_expand_per_fleet_total_failure_falls_back_to_hop0_seeds` — helper-level: all fleets fail → seeds returned at `(0, 1.0)`.
- `test_entity_lookup_survives_expand_graph_failure` — execute-level: expansion down, linked memory exists → ENTITY_LOOKUP still fires off the hop-0 seed (and the link lookup is made for the seed, not an empty set).
- `test_hop_boost_stash_survives_expand_graph_failure` — temporal-decline path: `_classified_entity_hops` carries `{seed: (0, 1.0)}`, not `{}`.

**Verified to fail on pre-fix code**: with the src change stashed, all three fail (helper returns `{}`; query falls through to SEMANTIC_SEARCH; stash is `{}`); with it restored, all three pass.

## Gates

- `pytest` (unit, `EMBEDDING_PROVIDER=fake`): 96 passed across `tests/pipeline/test_classify_query.py`, `test_entity_lookup_short_circuit.py`, `test_graph_expand_short_circuit.py`, `test_entity_retrieval_flag.py`, `test_skip_entity_boost_on_decline.py`, `test_c10_storage_slot_dedup.py`, `test_caura_000_graph_frontier_cap.py`, `test_entity_tokens.py`, `test_caura722_entity_diagnostic.py` (4 integration tests deselected — no local Postgres). `tests/pipeline/test_search_pipeline.py`: 19 passed, 2 pre-existing failures (`test_recall_returns_memory_with_pending_embedding[pipeline|legacy]`) that fail identically on clean `origin/main` (schema-fixture precondition: "search_vector must be populated"), unrelated to this change.
- `ruff check core-api/src/ tests/pipeline/` — clean.
- `ruff format --check` on both touched files — clean.
- `mypy src/` from `core-api/` (CI-equivalent env) — Success, no issues in 204 files.

Audit tracker: oss-0814-l-05

🤖 Generated with [Claude Code](https://claude.com/claude-code)