### PR TITLE
contract the pipeline family

### DIFF
--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -29,8 +29,32 @@ class Audit(enum.StrEnum):
 
 
 class Pipeline(enum.StrEnum):
-    ENTITY_EXTRACT_REQUESTED = "memclaw.pipeline.entity-extract-requested"
-    ENTITY_EXTRACTED = "memclaw.pipeline.entity-extracted"
+    # CONTRACTED 2026-09-09, and the only family that could be contracted
+    # WITHOUT first being flipped -- because it is the only one with nothing to
+    # move. It declares no topic in either environment's Terraform, has never
+    # had one provisioned, and no code in either repo publishes or subscribes
+    # to these members; the two references that exist name the SYMBOL in design
+    # comments (CAURA-593/595, the planned entity-extraction worker fleet), not
+    # the string.
+    #
+    # That absence is exactly why ``pipeline`` must never enter
+    # FLIPPED_FAMILIES -- publishing into a topic that does not exist is silent
+    # loss that reports success -- and it is also why renaming the members here
+    # is safe in a way no other family's would be. Expand/flip/drain exists to
+    # keep messages from falling between two names. There are no messages.
+    #
+    # After this, ``renamed`` is the identity for both members, so
+    # ``publish_name`` and ``subscribe_names`` agree under dual=True and
+    # dual=False alike and ``unbound_publish_topics`` is unaffected. ``family``
+    # still reads ``pipeline`` -- the segment is unchanged -- so
+    # ``known_families()`` is the same set and the guard that validates
+    # FLIPPED_FAMILIES against it behaves identically.
+    #
+    # The members keep their names so the design comments that reference them
+    # stay correct. If that worker fleet is ever built, it inherits a family
+    # already carrying the current brand and needs no cutover of its own.
+    ENTITY_EXTRACT_REQUESTED = "caura.pipeline.entity-extract-requested"
+    ENTITY_EXTRACTED = "caura.pipeline.entity-extracted"
 
 
 class Org(enum.StrEnum):


### PR DESCRIPTION
Renames both `Pipeline` members onto the current brand.

This is the **only** family that can be contracted without first being flipped, because it is the only one with nothing to move:

- it declares no topic in either environment's Terraform, and none has ever been provisioned (`gcloud pubsub topics list | grep -c pipeline` → **0**);
- no code in either repo publishes or subscribes to these members.

The two references that exist name the **symbol**, in design comments for the planned entity-extraction worker fleet (`schedule_background_tasks.py:192`, `entity_extraction_worker.py:267`, both CAURA-593/595). They stay correct, and if that fleet is ever built it inherits a family already carrying the current brand and needs no cutover of its own.

### Why renaming here is safe when it would not be elsewhere

That same absence is why `pipeline` must never enter `FLIPPED_FAMILIES` — a flip would publish into a topic that does not exist, which is silent loss reported as success, and the module already says so. It is also why the *contract* step is safe on its own: expand → flip → drain exists to stop messages falling between two names, and there are no messages.

Verified by executing the module rather than reasoning about it:

```
family           pipeline        (unchanged — segment 1 is untouched)
renamed          identity
publish_name     caura.pipeline.entity-extracted
subscribe dual=False / dual=True   both one name, in agreement
unbound_publish_topics(False/True) both empty
known_families   {audit, lifecycle, memory, org, pipeline}  (unchanged)
```

So the guard that validates `FLIPPED_FAMILIES` against `known_families()` behaves identically, and the three tests that touch `Pipeline` still hold: `family()` is `"pipeline"`, `pipeline` stays out of `FLIPPED_FAMILIES`, and `known_families()` is the same set.

### What this leaves

`memclaw.audit.event-recorded` is now the **one** remaining legacy topic constant in the module — and it is the family that must be flipped last, because those rows are hash-chained.

### Not run locally

The DB-backed suite needs a live Postgres this machine does not have (`asyncpg.InvalidPasswordError` at the autouse fixture, before any test body). The topic-module logic above was verified by direct execution; CI runs the suite. `ruff check common/` and `ruff format --check` both clean.

The enterprise copy of this file is vendored and policy `manual`; it gets the same edit in the same cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)