### PR TITLE
docs: refresh rebrand sunset status

### DIFF
--- a/docs/plans/rebrand-sunset-plan.md
+++ b/docs/plans/rebrand-sunset-plan.md
@@ -1,6 +1,6 @@
 # Rebrand sunset plan — the in-repo reference
 
-**Status:** active · **Last verified against the repos:** 2026-08-24
+**Status:** active · **Last verified against the repos and live project:** 2026-09-09
 **Enforcement:** `scripts/legacy_name_ratchet.py` and `scripts/do_not_touch_sentinel.py`, both required checks
 
 The product was renamed to Caura. This file is the in-repo answer to "is this old-brand
@@ -60,12 +60,14 @@ migrated, each by a sequence that is deliberate rather than optional:
 
 - **Pub/Sub** — expand → migrate → contract. Topics cannot be renamed, so the new
   family is created alongside, publishers move one family at a time, subscriptions
-  drain to zero, and only then are the old topics deleted. Never dual-publish.
+  drain to zero, and only then are the old topics deleted. Never dual-publish. See
+  [Current state and what remains](#current-state-and-what-remains).
 - **The database** — a new role is created `IN ROLE` the old one so grants and
   ownership are inherited, DSNs flip one service revision at a time, and the rename
   itself is a single short window. The old role is kept.
-- **Cloud Run** — the services are being decoupled from build-time configuration
-  first, so that a rename is a deploy rather than a rebuild.
+- **Cloud Run** — the services are decoupled from build-time configuration so that a
+  rename is a deploy rather than a rebuild. The current deployment state is recorded
+  [below](#service-prefix-status).
 - **The broker's default cloud host** — the compile-time default in the daemon and
   the release mirror derived from it move together, and only once the gateway serves
   the new host. The mirror is the auto-updater's only source for a broker that never
@@ -74,6 +76,64 @@ migrated, each by a sequence that is deliberate rather than optional:
   daemon as the repository's only `TODO(rebrand cutover)`.
 
 If you are about to change one of these, the sequence matters more than the change.
+
+---
+
+## Current state and what remains
+
+This is an operative plan, so it records a dated decision surface rather than carrying
+an expired inventory forward as though it were live. Re-measure before acting after the
+verification date at the top changes.
+
+### Pub/Sub programme status
+
+| family | publisher flip | enum contraction | current state |
+| --- | --- | --- | --- |
+| `fleet` | 2026-08-25 | 2026-08-31 | complete; no legacy-prefixed topic remains |
+| `security` | 2026-08-26 | 2026-08-31 | complete; no legacy-prefixed topic or durable subscription remains |
+| `lifecycle` | 2026-08-28 | 2026-09-01 | complete; the former 36-subscription inventory no longer exists |
+| `memory` | 2026-09-01 | 2026-09-05 | complete; no legacy-prefixed topic or durable subscription remains |
+| `org` | 2026-09-08 | 2026-09-08 | complete; three production topics and two durable subscriptions await the authorized manual Terraform apply |
+| `audit` | pending | pending | **last, unconditionally**; live legacy-prefixed work and DLQ resources remain in both environments |
+| `pipeline` | not applicable | 2026-09-09 | never provisioned; its enum moved directly to current names rather than performing a fictitious flip |
+
+Read-only inventory on 2026-09-09 returned current-prefixed topics and subscriptions as
+the positive control. The legacy-prefixed remainder is finite: seven topics (four
+`audit`, three production `org`) and six durable subscriptions (four `audit`, two
+production `org`). No legacy-prefixed Pub/Sub resource remains for `fleet`, `security`,
+`lifecycle`, or `memory`.
+
+Contraction and resource retirement are deliberately separate. A completed contraction
+stops consumers binding the legacy name; it does not authorize deletion. Directly
+gathered evidence has already classified the retained production `org` resources ready
+and Terraform declares them for deletion; the authorized manual apply remains. `audit`
+still requires its own last-family flip and contraction before any retirement plan can
+exist.
+
+The previous 31 August per-subscription measurement remains in repository history as
+evidence of the pre-contraction state. Its 36 named lifecycle subscriptions have since
+been removed, so that snapshot is history rather than an operative runbook.
+
+### Service-prefix status
+
+The enterprise deployment-control variables have selected the current service prefix in
+staging since 2026-09-02 and in production since 2026-09-08. The `caura-ops` and
+`caura-test-automation` consumer variables selected the staging prefix on the same date
+and the production prefix on 2026-09-09. The live service inventory contains the current
+stack in both environments and no legacy staging services. Fourteen legacy production
+services remain as a separately governed retirement surface; their presence does not
+make the prefix flip incomplete.
+
+For the two estate tracks remeasured here, the remaining work is explicit:
+
+1. Flip and contract `audit` last, with its hash-chain ordering guarantees intact.
+2. Apply the already-evidenced production `org` retirement through the authorized
+   manual Terraform gate.
+3. Retire the retained production service stack through its own runbook and gates.
+4. Remove flip scaffolding only after no legacy topic or subscription remains.
+
+The database and broker-host tracks retain their own sequences above. Their day-to-day
+state remains in the maintainers' handover and was not remeasured for this snapshot.
 
 ---
 
@@ -102,23 +162,18 @@ python3 scripts/do_not_touch_sentinel.py --list
 
 ### Expensive to move is not floor
 
-Environment Terraform is the standing counter-example. About 300 old-brand lines sit in
-the two deployment environment files, every review of this programme so far has called
-them floor, and **none of them is**. Neither file carries a floor marker today, and that
-is correct rather than an oversight.
+Environment Terraform is the standing counter-example. Old-brand lines in the two
+deployment environment files may name live or deliberately retained resources, but
+that does not make them floor. Neither file carries a floor marker today, and that is
+correct rather than an oversight.
 
-Of the staging file's 115 lines, **107 are Pub/Sub family names** — and those families
-are not in the same state as each other:
+The [current status](#pubsub-programme-status) separates the final family still to move
+from retirement work after a completed move. Both kinds of Terraform entry remain
+reachable by this programme.
 
-| the line names a family that | lines | why it is not floor |
-| --- | ---: | --- |
-| has **already** flipped | 65 | the rename reached it; the name is behind the work, not beyond it |
-| has **not yet** flipped | 42 | live infrastructure, renamed when its family flips |
-
-A line whose family flipped last week is the opposite of permanent: it is outstanding
-work. Marking it stops it being counted and starts it being **trusted**, which is much
-the more expensive of the two mistakes — a floor marker is a claim that nobody will ever
-need to look again.
+Marking such a line stops it being counted and starts it being **trusted**, which is
+the more expensive mistake: a floor marker claims that nobody will ever need to look
+again.
 
 So the test is not what a rename would cost. **It is whether a rename will ever happen.**
 Infrastructure is deferred because recreating a live resource is expensive; *deferred*
@@ -242,152 +297,10 @@ shared as configuration and contract tests instead. Each probe now composes
 `<environment service prefix>-core-api` from its repository's established input shape:
 enterprise workflows provide `SP` or `PP`, while the test-automation probe accepts
 `STAGING_SERVICE_PREFIX` and `PROD_SERVICE_PREFIX` and currently falls back when its
-nightly caller omits them. Those fallbacks preserve the current names until the later
-variable flip. Reconsider code extraction only if a larger piece of behaviour, rather
-than another small contract, starts changing in lockstep.
-
-### Lifecycle drain finding: no subscription is removable
-
-Verified 2026-08-31 against `caura/main` at `51c33d9f` and
-`caura-enterprise/dev` at `7301fee3`. The Terraform declaration from the earlier
-investigation still holds at the latter revision, and live `describe` calls found all
-72 lifecycle subscriptions active and attached to the expected topic: 18 legacy and
-18 current subscriptions in each environment, split nine work and nine DLQ.
-
-The source-side family premise needed correction before measuring. The publish path's
-`FLIPPED_FAMILIES` values establish this status:
-
-| Family | `caura/main` | `caura-enterprise/dev` | Source-side status |
-| --- | --- | --- | --- |
-| lifecycle | current | current | Flipped in both repositories; drain scope below |
-| memory | legacy | legacy | Not flipped |
-| org | legacy | legacy | Not flipped |
-| audit | legacy | legacy | Not flipped |
-| security | not declared | current | Enterprise-only; flipped 2026-08-26, outside this drain scope |
-| fleet | not declared | current | Enterprise-only; flipped 2026-08-25, outside this drain scope |
-
-So lifecycle is the only **shared** family that has flipped, but not the only family.
-No drain query below was widened to security or fleet. Source status is also not runtime
-evidence: production still published to legacy lifecycle topics inside the measured
-window.
-
-#### Window, instruments and notation
-
-The bounded window is **2026-08-29 00:30:00Z through 2026-08-31 00:30:00Z**
-(48 hours). It crosses two 02:00 lifecycle sweeps and two 04:00 embed-backfill runs,
-so it is longer than one complete daily cycle. It was deliberately not shortened after
-the first non-zero legacy reading.
-
-- `gcloud pubsub subscriptions describe` supplied configuration only: existence,
-  `ACTIVE` state, topic attachment and DLQ policy. It supplied no traffic or backlog
-  number.
-- Direct Cloud Monitoring `projects.timeSeries.list` GETs supplied every number below.
-  Topic publishes are the count of `topic/message_sizes`; pull activity is
-  `subscription/pull_request_count`; backlog is
-  `subscription/num_undelivered_messages`; age is
-  `subscription/oldest_unacked_message_age`.
-- `subscription/open_streaming_pulls` returned **no time series** for any of the 72
-  subscriptions, current twins included. That is recorded as `no-series`, never as
-  zero. These consumers issue unary Pull RPCs, and their non-zero Pull counts are the
-  direct attachment witness.
-- No subscription pull was issued, so no message was acknowledged. Cloud Logging was
-  not used for a drain number: the publish path has no success log keyed by topic, so
-  log absence would be another unvalidated zero.
-
-`L/C` means legacy/current twin from the same query and window. `Y` means the condition
-was established and its zero has a non-zero current control. `N` means a legacy non-zero
-directly disproved the condition. `?` means the legacy side read zero but the twin also
-read zero or no series, so the instrument did not validate that negative. For backlog,
-`n=end/max` and `age=end/max` report the end-of-window gauge and window maximum; ages are
-seconds. On a work row C4 reads its paired DLQ; on a DLQ row C4 explicitly reads itself.
-
-The high-signal results are not marginal:
-
-- Every legacy work subscription was still attached: 20,726–20,999 Pull requests per
-  staging core-worker subscription, 178,366–182,435 per staging core-api subscription,
-  and comparable non-zero counts in production. Each current twin was independently
-  non-zero under the same query.
-- Production legacy topics received the 2026-08-29 scheduled cycle: 131 messages on
-  each of six scheduled topics, three purge messages, and 131 embed-backfill messages;
-  one on-demand message followed at 05:42Z. The current twins then carried the
-  2026-08-30 cycle (134 messages on each scheduled topic and four purge messages).
-- Four staging legacy DLQs ended the window with **833 undelivered messages**:
-  crystallize 308, crystallize-on-demand 1, entity-link 295 and insights 229. Their
-  oldest messages were 441,070–593,304 seconds old at the window end.
-
-#### Staging
-
-| Legacy subscription | C1 nothing publishes | C2 nothing attached | C3 backlog zero | C4 DLQ empty | Verdict |
-| --- | --- | --- | --- | --- | --- |
-| `core-worker--staging--memclaw.lifecycle.archive-expired-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | Y — msgs L/C=0/176 | N — Pull L/C=20,726/20,659; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-worker--staging--memclaw.lifecycle.archive-expired-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-worker--staging--memclaw.lifecycle.archive-stale-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | Y — msgs L/C=0/164 | N — Pull L/C=20,916/20,687; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-worker--staging--memclaw.lifecycle.archive-stale-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-worker--staging--memclaw.lifecycle.purge-soft-deleted-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | Y — msgs L/C=0/12 | N — Pull L/C=20,805/20,791; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-worker--staging--memclaw.lifecycle.purge-soft-deleted-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-worker--staging--memclaw.lifecycle.embed-backfill-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | Y — msgs L/C=0/164 | N — Pull L/C=20,999/20,576; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-worker--staging--memclaw.lifecycle.embed-backfill-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-api--staging--memclaw.lifecycle.crystallize-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | Y — msgs L/C=0/173 | N — Pull L/C=181,188/181,750; stream L/C=no-series/no-series | Y — L n=0/0 age=0/0s; C n=0/8 age=0/104s | N — paired L n=308/543 age=593253/604910s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--staging--memclaw.lifecycle.crystallize-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | N — L n=308/543 age=593253/604910s; C n=0/0 age=0/0s | N — self L n=308/543 age=593253/604910s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--staging--memclaw.lifecycle.crystallize-on-demand-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | N — Pull L/C=182,435/180,577; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | N — paired L n=1/1 age=441070/441070s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--staging--memclaw.lifecycle.crystallize-on-demand-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | N — L n=1/1 age=441070/441070s; C n=0/0 age=0/0s | N — self L n=1/1 age=441070/441070s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--staging--memclaw.lifecycle.entity-link-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | Y — msgs L/C=0/164 | N — Pull L/C=178,366/181,019; stream L/C=no-series/no-series | Y — L n=0/0 age=0/0s; C n=0/5 age=0/137s | N — paired L n=295/593 age=593304/604909s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--staging--memclaw.lifecycle.entity-link-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | N — L n=295/593 age=593304/604909s; C n=0/0 age=0/0s | N — self L n=295/593 age=593304/604909s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--staging--memclaw.lifecycle.insights-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | Y — msgs L/C=0/164 | N — Pull L/C=180,495/181,682; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | N — paired L n=229/426 age=593269/604874s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--staging--memclaw.lifecycle.insights-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | N — L n=229/426 age=593269/604874s; C n=0/0 age=0/0s | N — self L n=229/426 age=593269/604874s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--staging--memclaw.lifecycle.forge-distill-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | N — Pull L/C=182,035/180,864; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--staging--memclaw.lifecycle.forge-distill-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-
-Verdicts: **13 not drained**, **5 could not establish**, **0 drained and removable**.
-
-#### Production
-
-| Legacy subscription | C1 nothing publishes | C2 nothing attached | C3 backlog zero | C4 DLQ empty | Verdict |
-| --- | --- | --- | --- | --- | --- |
-| `core-worker--prod--memclaw.lifecycle.archive-expired-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | N — msgs L/C=131/134 | N — Pull L/C=21,930/22,057; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-worker--prod--memclaw.lifecycle.archive-expired-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-worker--prod--memclaw.lifecycle.archive-stale-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | N — msgs L/C=131/134 | N — Pull L/C=21,610/21,868; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-worker--prod--memclaw.lifecycle.archive-stale-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-worker--prod--memclaw.lifecycle.purge-soft-deleted-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | N — msgs L/C=3/4 | N — Pull L/C=21,765/21,810; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-worker--prod--memclaw.lifecycle.purge-soft-deleted-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-worker--prod--memclaw.lifecycle.embed-backfill-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | N — msgs L/C=131/134 | N — Pull L/C=22,057/21,715; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-worker--prod--memclaw.lifecycle.embed-backfill-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-api--prod--memclaw.lifecycle.crystallize-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | N — msgs L/C=131/134 | N — Pull L/C=181,935/182,423; stream L/C=no-series/no-series | Y — L n=0/0 age=0/0s; C n=0/45 age=0/102s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--prod--memclaw.lifecycle.crystallize-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-api--prod--memclaw.lifecycle.crystallize-on-demand-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | N — msgs L/C=1/0 | N — Pull L/C=182,264/181,902; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--prod--memclaw.lifecycle.crystallize-on-demand-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-api--prod--memclaw.lifecycle.entity-link-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | N — msgs L/C=131/134 | N — Pull L/C=182,264/183,369; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--prod--memclaw.lifecycle.entity-link-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-api--prod--memclaw.lifecycle.insights-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | N — msgs L/C=131/134 | N — Pull L/C=182,177/180,032; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--prod--memclaw.lifecycle.insights-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-| `core-api--prod--memclaw.lifecycle.forge-distill-requested` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | N — Pull L/C=183,548/180,584; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — paired L n=0/0 age=0/0s; C n=0/0 age=0/0s | **not drained** |
-| `core-api--prod--memclaw.lifecycle.forge-distill-requested-dlq` <!-- legacy-name-ok: live subscription id required for per-queue drain evidence --> | ? — msgs L/C=0/0 | ? — Pull L/C=0/0; stream L/C=no-series/no-series | ? — L n=0/0 age=0/0s; C n=0/0 age=0/0s | ? — self L n=0/0 age=0/0s; C n=0/0 age=0/0s | **could not establish** |
-
-Verdicts: **9 not drained**, **9 could not establish**, **0 drained and removable**.
-
-#### Removal order refused
-
-There is no evidence-backed removal order. Recommending one would turn active Pull
-traffic, in-window production publishes and an 833-message staging DLQ backlog into a
-deletion plan.
-
-Evidence could exist after all of these happen, in order, but each change is outside
-this read-only finding:
-
-1. Find and stop the production path that still published legacy messages, then start a
-   new window after its last observed publish. A deploy or publisher change is a write.
-2. Contract the dual subscription binding and deploy it everywhere, then prove legacy
-   Pull requests stop. That is also a write; an empty backlog while these Pull counts
-   continue is not idle.
-3. Inspect and decide the disposition of the 833 staging DLQ messages without
-   acknowledging them. Replay, export, acknowledgement or purge changes data and needs
-   a separate authorized runbook.
-4. Run the same Monitoring queries for at least 48 hours, spanning the 02:00 and 04:00
-   cycles. Where a current twin remains zero or `no-series`, produce an explicit safe
-   positive control or keep the legacy condition as `could not establish`.
-
-Until then the successful outcome of this package is: **the drain evidence does not
-exist yet; remove none of these subscriptions.**
+nightly caller omits them. The fallbacks are now compatibility safeguards, not the
+rollout state recorded in [Service-prefix status](#service-prefix-status). Reconsider
+code extraction only if a larger piece of behaviour, rather than another small
+contract, starts changing in lockstep.
 
 Neither gate looks at **values**. A setting correctly renamed to `CAURA_*` that still
 *holds* an old-brand value scores as fully migrated forever. Renaming is not migrating.
@@ -396,39 +309,6 @@ To exempt a line the ratchet would otherwise fail, annotate it in that file's ow
 comment syntax with `legacy-name-ok:` followed by the reason. Exemptions are reported
 on every run, so a PR that adds them is visible as such to a reviewer. Use them for
 contract, not for convenience.
-
-### The step after the flip has no owner by default
-
-The drain finding above answers *can we delete yet* — no. It does not answer *what is
-the next action*, and the two get conflated. The order is fixed:
-
-    flip publishers -> contract the enum members -> let the pool drain -> only then delete
-
-**A flipped family sits at step 2 until somebody contracts its enum members.** Nothing
-schedules that, nothing measures it, and no count falls while it waits — so a family can
-be described as flipped for weeks and be no closer to having its topics deleted. The
-enterprise-only families have been through step 2; at the time of writing the largest
-shared one has not.
-
-**Do not read "already flipped" as "retires automatically."** Terraform lines naming an
-already-flipped family are *overdue*, not permanent. They retire when someone performs
-step 2 and step 4 — not on their own.
-
-### `pipeline` must not be flipped
-
-`pipeline` is declared in `common/events/topics.py` and has **zero live topics in either
-environment**. Rule 1 is why that matters more than it looks: a publish to a topic that
-does not exist is silent loss, not an error. **Flipping `pipeline` would move no traffic
-and report success** — the exact failure shape this plan exists to prevent.
-
-The remaining shared families are not interchangeable, and their order is not arbitrary:
-
-| family | status |
-| --- | --- |
-| `memory` | ready — 16 of 16 twin durable subscriptions, no ephemerals |
-| `org` | shared, and its staging ephemeral pool was under investigation as a suspected subscription leak |
-| `audit` | **last, unconditionally** — the rows are hash-chained, and a lost or reordered audit event is the one failure here that replay cannot repair |
-| `pipeline` | **never, while it has no live topics** |
 
 ### A mention gets reworded, a contract gets the marker
 
@@ -482,9 +362,10 @@ what is left.
 
 ## Where the detail lives
 
-This file holds the rules, which are stable. The phase-by-phase board — what has
-landed, what is in flight, and which of it is running in parallel — is maintained
-outside the repo and changes daily; ask the maintainers for the current handover
-document rather than trusting a copy committed here.
+This file holds stable rules and the dated, remeasured snapshot at the top. Refresh that
+snapshot whenever one of its listed states advances. The phase-by-phase board — what is
+running in parallel and who owns it — is maintained outside the repo and changes daily;
+ask the maintainers for the current handover document rather than trusting a copy
+committed here.
 
 Keep this file short. It earns its place by being correct, not by being complete.


### PR DESCRIPTION
## Document decision

`docs/plans/rebrand-sunset-plan.md` is an **operative procedure**, not a completed
historical record. Readers use it to decide what remains, so its embedded 31 August
per-subscription inventory could not stay presented as live state after those resources
were contracted and removed.

This change replaces that expired 36-row inventory with a remeasured 9 September status
snapshot. The old measurement remains in Git history and is described here as
pre-contraction evidence rather than current instruction.

## What changed

- records all five live families that have completed publisher flip and enum contraction
- leaves `audit` explicit as the only live family still to flip and contract
- distinguishes contraction from later resource retirement
- records the finite live Pub/Sub remainder: seven legacy-prefixed topics and six durable
  subscriptions, all in `audit` or retained production `org`
- records that production `org` retirement evidence is already READY and awaits the
  authorized manual Terraform apply
- records the completed service-prefix selection in enterprise and consumer repositories,
  while keeping the 14 retained production services visible as retirement work
- removes the 36 false marker claims together with the vanished subscription literals;
  no marker was removed from a surviving old-brand occurrence

## Evidence

- inspected current `common/events/topics.py` history in OSS and enterprise for the five
  flip/contraction dates and the non-provisioned `pipeline` contraction
- read-only `gcloud pubsub topics list` and `subscriptions list`, with current-prefixed
  resources as positive controls
- read-only `gcloud run services list`: current stacks in both environments, no legacy
  staging services, 14 retained legacy production services
- paginated GitHub repository-variable reads for enterprise, caura-ops, and
  caura-test-automation
- enterprise commit `f14692b5`: production `org` evidence READY and declared for deletion
  on the next authorized manual apply

## Verification

- `python3 scripts/legacy_name_ratchet.py --base origin/main` — 36 exempt lines removed,
  no new lines
- `python3 scripts/do_not_touch_sentinel.py` — all 35 protected strings survive
- targeted ratchet, sentinel, and census tests — 280 passed, 1 skipped
- `git diff --check`
