### PR TITLE
Remove retired resource references

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -293,9 +293,8 @@ class Settings(BaseSettings):
     # ``memory_service._get_or_cache_embedding`` (cache hits / in-flight
     # joiners take no slot), so one hot tenant's search storm can't
     # occupy the whole embedding service and starve other tenants
-    # (noisy-neighbor-search). The TEI backend is a fixed pool
-    # (``staging-memclaw-tei``: 2 instances x containerConcurrency 10 =  # legacy-name-floor: live, mid-cutover — staging-caura-tei twin already exists
-    # ~20 slots, no autoscale); with cap N on M core-api instances a
+    # (noisy-neighbor-search). Current TEI capacity assumptions live in
+    # ``common.embedding.constants``; with cap N on M core-api instances a
     # single tenant holds at most ``N * M`` of those, leaving headroom
     # for everyone else. Tighter than ``per_tenant_search_concurrency``
     # on purpose: a tenant may have many searches in flight but only a

--- a/core-worker/pyproject.toml
+++ b/core-worker/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "core-worker"
 version = "3.6.1"
-description = "Caura core async worker — subscribes to memclaw.memory.embed-requested and backfills embeddings" # legacy-name-floor: frozen topic name
+description = "Caura core async worker — consumes embedding requests and backfills embeddings"
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

- remove a retired staging TEI service name from the core API concurrency comment
- point capacity assumptions at `common.embedding.constants` instead of preserving a stale fixed-pool claim
- replace the core-worker package description's contracted topic name with behavior-oriented metadata

## Release-visible metadata

The `core-worker` description is wheel metadata. CI builds that wheel and release-please synchronizes its version through `release-please-config.json`, so the Summary field changes in a future release artifact. I found no workflow that publishes `core-worker` to PyPI or GHCR: the Docker publishing matrix currently contains only `core-api` and `core-storage-api`.

## Verification

- `uv run --frozen --project core-api --extra dev ruff check core-api/src/`
- `uv run --frozen --project core-api --extra dev ruff format --check core-api/src/`
- `uv build core-worker`
- verified the generated wheel METADATA Summary
- legacy-name ratchet against `origin/main` (2 exemptions removed; no new lines)
- simplification review completed and its stale-capacity finding was fixed

