### PR TITLE
flip and contract the audit topic family

### DIFF
--- a/common/events/topics.py
+++ b/common/events/topics.py
@@ -25,7 +25,20 @@ class Memory(enum.StrEnum):
 
 
 class Audit(enum.StrEnum):
-    EVENT_RECORDED = "memclaw.audit.event-recorded"
+    # CONTRACTED 2026-09-10, in the same change as its flip and NOT as a matter
+    # of taste. Flipping without contracting leaves ``publish_name`` returning
+    # the twin while ``subscribe_names(dual=False)`` -- the DEFAULT -- still
+    # returns the outgoing name, so ``unbound_publish_topics`` reports the
+    # family and every default-constructed ``PubSubEventBus`` raises FLEET-WIDE,
+    # not just in the service that moved. ``memory`` sat in that state for four
+    # days and ``org`` for hours; both were found by reading the module rather
+    # than by a failing test, which is why
+    # ``test_every_flipped_family_is_contracted_so_the_default_bus_is_legal``
+    # now exists and why these two steps ship together.
+    #
+    # This was the LAST declared topic carrying the outgoing prefix. This module
+    # now declares none.
+    EVENT_RECORDED = "caura.audit.event-recorded"
 
 
 class Pipeline(enum.StrEnum):
@@ -285,9 +298,35 @@ def family(topic: str) -> str:
 # against the live project — ``pubsub topics list`` matches no ``pipeline``
 # topic under either brand, in either environment.
 #
-# ``audit`` LAST, unconditionally — those rows are hash-chained, and a lost or
-# reordered audit event is the one failure here that replay cannot repair.
-FLIPPED_FAMILIES: frozenset[str] = frozenset({"lifecycle", "memory", "org"})
+# ``audit`` FLIPPED 2026-09-10 — last, as planned, but NOT for the reason this
+# comment used to give. It said these rows are hash-chained and that a lost or
+# reordered audit event is the one failure here replay cannot repair. That
+# conflated two unrelated paths. The hash-chained audit log is a SEPARATE
+# transport: an install batches locally-chained entries over HTTP and the
+# receiver verifies the links and refuses a discontinuity. It never travels
+# this topic. What rides here is an append-only notification whose consumer
+# tolerates duplicate delivery by design — no ordering requirement, and no
+# chain to break.
+#
+# The real hazard on this family is the opposite shape, and it is worth naming
+# because it is invisible: the audit publisher is fire-and-forget and swallows
+# every exception, deliberately, so that a bus outage cannot take down the
+# request path that produced the event. Flipping onto a name that did not exist
+# would therefore lose every audit event with NO error anywhere, into an
+# append-only store with no replay. What made this flip safe is evidence that
+# the twin exists and is attached, not chain ceremony: on 2026-09-10 both
+# environments carried ``<env>--caura.audit.event-recorded`` and its ``-dlq``
+# with an ACTIVE subscription each, the readiness gate read 17/17 with nothing
+# unbound, and the pre-flip week showed 20 production publishes on the legacy
+# name and zero on the twin.
+#
+# Nothing in THIS repo publishes or subscribes the audit topic — the member is
+# declared here and consumed downstream. Listing the family keeps the two
+# copies' flip state aligned, and means a publisher added here later inherits
+# the current name rather than the outgoing one.
+FLIPPED_FAMILIES: frozenset[str] = frozenset(
+    {"audit", "lifecycle", "memory", "org"}
+)
 
 
 def all_topics() -> tuple[str, ...]:

--- a/tests/test_events/test_topic_rename_cutover.py
+++ b/tests/test_events/test_topic_rename_cutover.py
@@ -130,13 +130,19 @@ def test_subscribe_names_defaults_to_the_current_name_only() -> None:
 
 
 def test_subscribe_names_dual_returns_both_without_duplicates() -> None:
-    # Exercised through ``audit``, which has NOT been renamed. ``subscribe_names``
-    # never consults ``FLIPPED_FAMILIES`` — it returns two names whenever
-    # ``renamed`` moves the name — so the only requirement is a member still on
-    # the outgoing prefix. It used to be ``memory``; that member is contracted
-    # now and yields one name, which is the case asserted just below.
-    both = topics_mod.subscribe_names(Topics.Audit.EVENT_RECORDED, dual=True)
-    assert both == (str(Topics.Audit.EVENT_RECORDED), "caura.audit.event-recorded")
+    # A SYNTHETIC name, because no declared member carries the outgoing prefix
+    # any more — audit was the last and contracted on 2026-09-10. This walked
+    # from ``memory`` to ``audit`` as each contracted; there is nowhere left for
+    # it to walk, so it stops chasing the estate and states the rule directly.
+    #
+    # Any first segment other than the new prefix exercises it. ``renamed``
+    # rewrites the first dot-segment rather than matching the outgoing brand by
+    # name — that is a deliberate property of the module, and relying on it here
+    # keeps the outgoing brand out of this file rather than minting a fresh
+    # occurrence of it for the ratchet to count.
+    outgoing = "outgoing.audit.event-recorded"
+    both = topics_mod.subscribe_names(outgoing, dual=True)
+    assert both == (outgoing, "caura.audit.event-recorded")
     # An already-renamed name must yield ONE entry, not the same string twice —
     # a duplicate would register the handler twice and double-dispatch it. Read
     # off a real contracted member rather than a hand-written string, so it stays
@@ -155,7 +161,7 @@ def test_subscribe_names_dual_returns_both_without_duplicates() -> None:
 # has to be stated in exactly two places — the module, and this literal — and the
 # equality in ``test_exactly_the_flipped_families_are_flipped`` is what turns the
 # second one into a deliberate stop rather than a chore.
-FLIPPED = frozenset({"lifecycle", "memory", "org"})
+FLIPPED = frozenset({"audit", "lifecycle", "memory", "org"})
 
 # A synthetic flipped-but-NOT-contracted topic, for the tests that need the
 # silent-failure state to exist. Every real family here is now either unflipped
@@ -210,9 +216,18 @@ def test_exactly_the_flipped_families_are_flipped() -> None:
     also holds ``fleet`` and ``security``, which are declared only there; naming
     either here would raise at import in every OSS service.
 
-    ``audit`` is called out because it must be flipped LAST — those rows are
-    hash-chained, and a lost or reordered audit event is the one failure in this
-    programme that cannot be undone.
+    ``audit`` flipped 2026-09-10, last, which closes the cutover. It was held to
+    the end on a premise that did not survive checking: that these rows are
+    hash-chained and a lost or reordered audit event could not be repaired. The
+    hash-chained audit log is a SEPARATE transport and never touches this topic;
+    what rides here is an append-only notification whose consumer tolerates
+    duplicates and requires no ordering. The hazard is the opposite shape — the
+    audit publisher swallows every exception by design, so a flip onto a name
+    that did not exist would have lost every event in silence. The evidence that
+    made it safe was existence and attachment, not chain ceremony: both
+    environments carrying the twin and its ``-dlq`` with an ACTIVE subscription
+    each, the readiness gate at 17/17 with nothing unbound, and a pre-flip week
+    of 20 production publishes on the legacy name and zero on the twin.
 
     ``pipeline`` is called out for the opposite reason: it is declared in both
     repos but has no live topic in either environment, so flipping it would
@@ -235,7 +250,6 @@ def test_exactly_the_flipped_families_are_flipped() -> None:
     which ``dual=False`` was illegal fleet-wide.
     """
     assert topics_mod.FLIPPED_FAMILIES == FLIPPED
-    assert "audit" not in topics_mod.FLIPPED_FAMILIES
     assert "pipeline" not in topics_mod.FLIPPED_FAMILIES
 
 
@@ -362,13 +376,16 @@ def test_pubsub_subscribe_binds_both_names_when_enabled() -> None:
     b = PubSubEventBus(
         project_id="proj", subscription_prefix="core-api", dual_subscribe=True
     )
-    # ``audit`` is still on the outgoing prefix, so it has a twin to bind.
-    # ``memory`` is contracted and would bind exactly one name, which would make
-    # this assertion pass without testing the expansion at all.
-    b.subscribe(Topics.Audit.EVENT_RECORDED, handler)
+    # A SYNTHETIC name on the outgoing prefix. Every declared member is
+    # contracted now — audit was the last, on 2026-09-10 — and a contracted
+    # member binds exactly one name, which would make this assertion pass
+    # without testing the expansion at all. ``renamed`` rewrites whatever the
+    # first dot-segment is, so any non-``caura`` prefix exercises the twin.
+    outgoing = "outgoing.audit.event-recorded"
+    b.subscribe(outgoing, handler)
     assert sorted(b._handlers) == [
         "caura.audit.event-recorded",
-        str(Topics.Audit.EVENT_RECORDED),
+        outgoing,
     ]
     # One handler per name, not two on one name.
     assert all(len(hs) == 1 for hs in b._handlers.values())
@@ -412,12 +429,14 @@ def test_inprocess_binds_both_names_with_no_flag() -> None:
     flipped, instead of silently delivering to nobody.
     """
     b = InProcessEventBus()
-    # ``audit`` for the same reason as the Pub/Sub case above: a contracted
-    # member binds one name and would make this pass vacuously.
-    b.subscribe(Topics.Audit.EVENT_RECORDED, handler)
+    # A synthetic outgoing name for the same reason as the Pub/Sub case above:
+    # every declared member is contracted now, and a contracted member binds one
+    # name, which would make this pass vacuously.
+    outgoing = "outgoing.audit.event-recorded"
+    b.subscribe(outgoing, handler)
     assert sorted(b._handlers) == [
         "caura.audit.event-recorded",
-        str(Topics.Audit.EVENT_RECORDED),
+        outgoing,
     ]
 
 
@@ -592,8 +611,9 @@ def test_unbound_publish_topics_names_a_flipped_family_when_dual_is_off(
         assert topics_mod.publish_name(topic) not in topics_mod.subscribe_names(
             topic, dual=False
         )
-    # A family that has NOT flipped is not swept up in the report — audit above
-    # all, since it is the one that must flip last.
+    # A family that has NOT flipped is not swept up in the report. ``audit`` is
+    # the illustration because it was the last family to flip; the set is
+    # patched above, so this holds regardless of the module's real value.
     assert not any(topics_mod.family(t) == "audit" for t in unbound)
 
 

--- a/tests/test_events/test_topics.py
+++ b/tests/test_events/test_topics.py
@@ -3,18 +3,18 @@
 from __future__ import annotations
 
 from common.events import Topics
-from tests._legacy_contracts import frozen_topic
 
 
-# memory is contracted, so its wire name is now the caura one and these
-# assertions carry the new literal. ``frozen_topic`` stays for ``audit``, which
-# has not flipped: the helper pins the LEGACY namespace independently of the
-# enum, and using it for a contracted family would assert the wrong thing.
+# Every family is contracted now — audit was the last, on 2026-09-10 — so both
+# assertions carry the current literal. This used ``frozen_topic`` for audit
+# while it was the one member still on the legacy namespace; that helper pins
+# the LEGACY prefix independently of the enum, and pointing it at a contracted
+# family would assert the wrong thing.
 # Literals here rather than the enum on both sides, so the test still fails if
 # the value moves — comparing the enum to itself would pass through any rename.
 def test_members_compare_equal_to_their_string_value() -> None:
     assert Topics.Memory.ENRICHED == "caura.memory.enriched"
-    assert frozen_topic("audit.event-recorded") == Topics.Audit.EVENT_RECORDED
+    assert Topics.Audit.EVENT_RECORDED == "caura.audit.event-recorded"
 
 
 def test_members_format_as_their_string_value() -> None:


### PR DESCRIPTION
Last of the seven families. This module now declares no topic carrying the outgoing prefix.

## Flip and contract ship together

This started as flip-only — add `"audit"` to `FLIPPED_FAMILIES`. `test_every_flipped_family_is_contracted_so_the_default_bus_is_legal` failed on it, correctly.

Flipping alone leaves `publish_name` returning the twin while `subscribe_names(dual=False)` — the **default** — still returns the outgoing name. `unbound_publish_topics` then reports the family and every default-constructed `PubSubEventBus` raises **fleet-wide**, not just in the service that moved. Per that test's own docstring, `memory` sat in that state for four days and `org` for hours, and *"No test failed either time; the breakage was found by reading the module."* The test exists because of those two incidents, and it did its job here.

## The stated reason audit was last was wrong

The comment said these rows are hash-chained and that a lost or reordered audit event is the one failure replay cannot repair. That conflates two unrelated paths, and it is corrected in this diff rather than left to mislead the next reader:

- **The hash chain** is the broker audit log — an install batches locally-chained entries over HTTP to a receiver that verifies `prev_hash`/`entry_hash` and refuses a discontinuity. It never travels this topic.
- **This topic** carries an append-only notification whose consumer tolerates duplicate delivery by design. No ordering requirement, no chain to break.

## The real hazard, and the evidence against it

The opposite shape, and invisible: the audit publisher is fire-and-forget and swallows every exception, deliberately, so a bus outage cannot take down the request path that produced the event. A flip onto a name that did not exist would therefore lose every audit event with **no error anywhere**, into an append-only store with no replay.

What makes this safe is existence and attachment, measured 2026-09-10:

| Check | Result |
|---|---|
| Twin topics | both environments, each with a `-dlq` |
| Subscriptions | ACTIVE and attached on all four |
| Readiness gate | 17/17, nothing unbound |
| Pre-flip week | 20 production publishes on the legacy name, **0** on the twin |
| Control (`memory`, `security`) | six- and four-figure reads → instrument confirmed live |

The control matters: expired credentials fail silently here and return empty.

## Tests

Three tests used `audit` as their example of a member still on the outgoing prefix — it was the last one. They now use a synthetic name. `renamed()` rewrites whatever the first dot-segment is rather than matching the outgoing brand, so they keep exercising the expansion **without minting a fresh occurrence of the old brand**, which is the property its docstring says the derivation exists to provide.

Ratchet: `1 removed, -1 net`. Ruff clean. `tests/test_events/` is 18 failed / 130 passed identically on this branch and on a clean `main` control worktree — all 18 are `ModuleNotFoundError: No module named 'google'` in this environment. The wider suite hits 38 collection errors on **both** branch and control, so it is unverified locally and CI is the real check.

## Sequencing

This is the OSS half. The caura-enterprise mirror follows **after this merges**, re-recording the vendored drift baseline in the same commit — doing it before the OSS merge is what broke #1637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)