### PR TITLE
feat(bulk): one contradiction pass per subject on a coherent batch (A73)

### DIFF
--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -2146,6 +2146,10 @@ async def create_memories_bulk(
             and tenant_config.enrichment_provider != "none"
         )
 
+        # A73 — subject -> the batch's most recent row for that subject, so one
+        # contradiction pass covers the whole run of writes about it.
+        bulk_subject_batching = getattr(tenant_config, "bulk_subject_batching", False)
+        deferred_by_subject: dict[str, tuple] = {}
         reembed_batch: list[tuple[UUID, str]] = []
         for orig_idx, mem_data, mem_id in resolved:
             if tenant_config.entity_extraction_enabled:
@@ -2221,7 +2225,25 @@ async def create_memories_bulk(
                 )
             if embeddings[orig_idx] is None:
                 reembed_batch.append((mem_id, items[orig_idx].content))
+            elif bulk_subject_batching and mem_data.get("subject_entity_id"):
+                # A73 — hold this row back. A coherent batch writes dozens of
+                # rows about one subject in seconds, and judging each against a
+                # store its own siblings are still landing in is what returns
+                # complementary facts as ``conflicted``. Keyed by subject and
+                # overwritten as the loop advances, so the LAST row for each
+                # subject is the one judged — by then every sibling is committed
+                # and is an ordinary candidate for it, so a real intra-batch
+                # contradiction is still caught, and so is one against the
+                # pre-existing store. What is dropped is the batch conflicting
+                # with itself N ways.
+                deferred_by_subject[str(mem_data["subject_entity_id"])] = (
+                    mem_id,
+                    items[orig_idx].content,
+                    embeddings[orig_idx],
+                )
             else:
+                # No resolved subject (or batching off): nothing to group by, so
+                # this keeps the per-row behaviour rather than guessing at a key.
                 track_task(
                     tracked_task(
                         run_contradiction_detection(
@@ -2237,6 +2259,32 @@ async def create_memories_bulk(
                         data.tenant_id,
                     )
                 )
+        # One pass per subject, after every row in the batch is committed —
+        # which is what makes the last row's candidate set complete.
+        for _subject, (_mid, _content, _emb) in deferred_by_subject.items():
+            track_task(
+                tracked_task(
+                    run_contradiction_detection(
+                        _mid,
+                        data.tenant_id,
+                        data.fleet_id,
+                        trigger=Trigger.BULK,
+                        content=_content,
+                        embedding=_emb,
+                    ),
+                    "contradiction_detection",
+                    _mid,
+                    data.tenant_id,
+                )
+            )
+        if deferred_by_subject:
+            logger.info(
+                "bulk_subject_batching: %d subject(s) judged for %d created row(s) tenant_id=%s",
+                len(deferred_by_subject),
+                len(resolved),
+                data.tenant_id,
+            )
+
         if reembed_batch:
             # memory_id is None: no single UUID is authoritative for a
             # batch. _reembed_memories_bulk logs per-item failures with

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -208,6 +208,25 @@ DEFAULT_SETTINGS: dict = {
         # instead of falling through to the LLM. ``None`` resolves to
         # the global default (true).
         "triple_emission_enabled": None,
+        # A73 — one contradiction pass per SUBJECT on a bulk write, instead of
+        # one per row. A coherent batch (seeding a biography, importing a
+        # document) writes dozens of rows about the same subject in seconds, and
+        # each row is currently judged against a store its own siblings are still
+        # landing in. Complementary facts come back ``conflicted`` — ~40% of a
+        # 55-fact biography in one observed store, before the first conversation
+        # — and a conflicted row carries a 0.5 ranking penalty, so the store
+        # starts every retrieval handicapped.
+        #
+        # With this on, the batch's LAST row per subject is judged and the rest
+        # are not. That still catches both kinds of real conflict: an earlier
+        # sibling is already committed and so is a candidate for the last row's
+        # pass, and the pre-existing store is too. What it removes is the
+        # N-way churn of a batch conflicting with itself.
+        #
+        # Default OFF like every switch that changes what a write produces. It
+        # also REDUCES LLM calls (N rows -> one per subject), so it is not
+        # blocked by the no-new-LLM-calls hold.
+        "bulk_subject_batching": None,
         # CAURA-130 (L3.8) — Path C retraction kill-switch. When true
         # (the default), Path C's ``_attempt_entity_retraction`` runs
         # the entity-aware judge and may revert a Path A verdict. When
@@ -608,6 +627,7 @@ _LEAF_TYPES: dict[str, type | tuple[type, ...]] = {
     "entity_blocklist": list,
     "memclaw.auto_upgrade_enabled": bool,  # legacy-name-floor: floor
     "write.triple_emission_enabled": bool,
+    "write.bulk_subject_batching": bool,
     "write.retraction_enabled": bool,
     # Skill Factory SF-006 — type validators for the skills_factory namespace.
     "skills_factory.enabled": bool,
@@ -1060,6 +1080,17 @@ class ResolvedConfig:
         if val in ("fast", "strong"):
             return val
         return "fast"  # default to fast when unset
+
+    @property
+    def bulk_subject_batching(self) -> bool:
+        """One contradiction pass per subject on a bulk write (default OFF).
+
+        Off by default because it changes which rows get judged. Turning it on
+        both fixes the false-conflict storm on coherent batches AND reduces LLM
+        calls, so it is a tenant's choice rather than a cost trade.
+        """
+        val = self._ts.get("write", {}).get("bulk_subject_batching")
+        return val if val is not None else False
 
     @property
     def triple_emission_enabled(self) -> bool:

--- a/tests/test_a73_bulk_subject_batching.py
+++ b/tests/test_a73_bulk_subject_batching.py
@@ -1,0 +1,130 @@
+"""reg-a73 — a coherent bulk ingest flagged its own facts as contradictions.
+
+Seeding a biography, or importing a document, writes dozens of rows about one
+subject within seconds. The bulk path fired ``run_contradiction_detection`` once
+per created row, so each row was judged against a store its own siblings were
+still landing in — and complementary facts came back ``conflicted``. In one
+observed store ~40% of a 55-fact biography was flagged before the first
+conversation, and a conflicted row carries a 0.5 ranking penalty, so the store
+began every retrieval handicapped.
+
+``write.bulk_subject_batching`` judges the batch's LAST row per subject instead
+of every row. That is not "detect less": by the time the last row is judged
+every sibling is committed and is an ordinary candidate for it, so a genuine
+intra-batch contradiction is still found — and so is one against the
+pre-existing store. What disappears is the batch conflicting with itself N ways.
+
+It also turns N detections into one per subject, so it REDUCES LLM calls rather
+than adding any.
+"""
+
+import inspect
+
+import pytest
+
+from core_api.services import memory_service as ms
+
+pytestmark = pytest.mark.unit
+
+
+def _bulk_src() -> str:
+    return inspect.getsource(ms.create_memories_bulk)
+
+
+# ── the flag ──────────────────────────────────────────────────────────────
+
+
+def test_the_flag_defaults_off():
+    from core_api.services.organization_settings import ResolvedConfig
+
+    assert ResolvedConfig(tenant_settings={}).bulk_subject_batching is False
+
+
+def test_the_flag_is_readable_when_set():
+    from core_api.services.organization_settings import ResolvedConfig
+
+    cfg = ResolvedConfig(tenant_settings={"write": {"bulk_subject_batching": True}})
+    assert cfg.bulk_subject_batching is True
+
+
+def test_the_flag_is_a_declared_writable_key():
+    from core_api.services.organization_settings import _LEAF_TYPES
+
+    assert _LEAF_TYPES["write.bulk_subject_batching"] is bool
+
+
+def test_the_bulk_path_reads_the_flag():
+    assert 'getattr(tenant_config, "bulk_subject_batching", False)' in _bulk_src()
+
+
+# ── what gets deferred, and what does not ─────────────────────────────────
+
+
+def test_a_row_with_a_subject_is_held_back_when_batching_is_on():
+    src = _bulk_src()
+    assert 'elif bulk_subject_batching and mem_data.get("subject_entity_id"):' in src
+
+
+def test_the_last_row_per_subject_wins():
+    """A plain dict assignment keyed by subject — each row overwrites the
+    previous one, so the survivor is the batch's most recent claim about that
+    subject, which is the row whose candidate set is complete."""
+    src = _bulk_src()
+    assert 'deferred_by_subject[str(mem_data["subject_entity_id"])] = (' in src
+
+
+def test_a_subjectless_row_keeps_per_row_detection():
+    """There is nothing to group by, and inventing a key would merge unrelated
+    rows into one pass."""
+    src = _bulk_src()
+    branch = src[src.index("elif bulk_subject_batching") :]
+    else_i = branch.index("else:")
+    assert "run_contradiction_detection(" in branch[else_i : else_i + 900]
+
+
+def test_batching_off_leaves_the_old_behaviour_exactly():
+    """The flag is dark by default; with it off every row must still take the
+    per-row branch."""
+    src = _bulk_src()
+    # The guard is a conjunction, so a False flag falls through to ``else``
+    # regardless of whether the row resolved a subject.
+    assert "elif bulk_subject_batching and" in src
+
+
+def test_an_unembedded_row_still_goes_to_reembed_first():
+    """Ordering: the embedding check precedes the batching branch, so batching
+    cannot swallow a row that has no vector to judge with."""
+    src = _bulk_src()
+    assert src.index("if embeddings[orig_idx] is None:") < src.index(
+        "elif bulk_subject_batching"
+    )
+
+
+# ── when the deferred passes run ──────────────────────────────────────────
+
+
+def test_the_deferred_passes_run_after_the_loop():
+    """Before the loop ends, the later siblings are not committed yet — judging
+    then would reproduce the very race this fixes."""
+    src = _bulk_src()
+    assign = src.index('deferred_by_subject[str(mem_data["subject_entity_id"])]')
+    schedule = src.index(
+        "for _subject, (_mid, _content, _emb) in deferred_by_subject.items():"
+    )
+    assert assign < schedule
+
+
+def test_the_deferred_pass_uses_the_same_bulk_trigger():
+    """Nothing downstream should be able to tell a batched pass from a per-row
+    one; only the number of passes changes."""
+    src = _bulk_src()
+    tail = src[src.index("for _subject, (_mid, _content, _emb)") :]
+    assert "trigger=Trigger.BULK" in tail[:700]
+
+
+def test_the_reduction_is_logged():
+    """Subjects-vs-rows is the number that says whether the flag is doing
+    anything, and it is also the LLM-call saving."""
+    src = _bulk_src()
+    assert "bulk_subject_batching:" in src
+    assert "len(deferred_by_subject)" in src and "len(resolved)" in src


### PR DESCRIPTION
Seeding a biography, or importing a document, writes dozens of rows about one subject within seconds. The bulk path fired `run_contradiction_detection` **once per created row**, so every row was judged against a store its own siblings were still landing in — and complementary facts came back `conflicted`.

In one observed store **~40% of a 55-fact biography was flagged before the first conversation**. A conflicted row carries a 0.5 ranking penalty, so the store began every retrieval already handicapped.

`write.bulk_subject_batching` judges the batch's **last row per subject** instead of every row.

## This is not "detect less"

By the time that row is judged, every sibling is committed and is an ordinary candidate for it. So a genuine intra-batch contradiction is still found — and so is one against the pre-existing store. What disappears is the batch conflicting with **itself**, N ways, which is the only part that was ever noise.

Three details carry the correctness:

- the accumulator is **keyed by subject and overwritten** as the loop advances, so the survivor is the most recent claim — the one whose candidate set is complete;
- the passes are scheduled **after** the loop, because before it ends the later siblings aren't committed, and judging then reproduces the very race this fixes;
- a row with **no resolved subject** keeps per-row detection. There's nothing to group it by, and inventing a key would fold unrelated rows into one pass.

The embedding check still comes first, so batching can't swallow a row that has no vector to judge with.

## Flag

`write.bulk_subject_batching`, per-tenant, **default off** — like every switch that changes what a write produces. It turns N detections into one per subject, so it **reduces** LLM calls and isn't blocked by the no-new-LLM-calls hold.

## Testing

12 new tests, covering the flag default, that a subjectless row keeps the old path, that the deferred passes run *after* the loop, and that the embedding check still precedes the batching branch.

Full suite: **27 failures, identical to main's 27** — none new. `ruff` clean; `mypy` unchanged.

⚠️ **Reproducing locally:** a venv predating #1134's `mcp>=2.1.1` bump fails collection on 38 modules with `cannot import name 'CacheHint'`. That's environment drift, not this branch — `uv pip install "mcp>=2.1.1,<3"` fixes it.