### PR TITLE
fix(memory): populate is_inferred so the invariant that reads it can fire (A62)

### DIFF
--- a/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
+++ b/core-api/src/core_api/pipeline/steps/write/write_memory_row.py
@@ -84,6 +84,18 @@ class WriteMemoryRow:
             "ts_valid_end": str(fields["ts_valid_end"]) if fields.get("ts_valid_end") else None,
             "status": fields["status"],
             "visibility": data.visibility or "scope_team",
+            # A62 — migration 036 added this column and nothing ever wrote it, so
+            # every row read ``False`` = "directly stated". That silently disabled
+            # the invariant at ``resolution.py``: ``if is_inferred and action in
+            # _DESTRUCTIVE`` exists so a memory the SYSTEM materialised cannot
+            # destructively overturn one a user actually stated — and with the
+            # column always False it has never once fired.
+            #
+            # Server-set only. It is absent from ``MemoryCreate`` (it lives on
+            # ``MemoryOut``), so a caller cannot claim to be inferred, nor claim
+            # not to be; the value comes from ``create_memory``'s internal
+            # keyword, which only platform writers pass.
+            "is_inferred": bool(ctx.data.get("is_inferred", False)),
         }
         storage_t0 = time.perf_counter()
         try:

--- a/core-api/src/core_api/services/crystallizer_service.py
+++ b/core-api/src/core_api/services/crystallizer_service.py
@@ -685,6 +685,12 @@ async def _run_crystallization(
                         status="confirmed",
                         metadata={"crystallized_from": [str(m.get("id")) for m in cluster_memories]},
                     ),
+                    # A62 — a crystallized fact is materialised by the system: an
+                    # LLM re-extraction that merges a cluster into a claim nobody
+                    # stated in those words. ``resolution.resolve`` uses this to
+                    # refuse letting it destructively overturn a fact a user did
+                    # state. Server-set; the flag is not on the wire.
+                    is_inferred=True,
                 )
                 new_ids.append(str(mem_out.id))
             except HTTPException as exc:

--- a/core-api/src/core_api/services/insights_service.py
+++ b/core-api/src/core_api/services/insights_service.py
@@ -1043,7 +1043,14 @@ async def _persist_findings(
 
     insight_ids: list[str | None] = []
     try:
-        response = await create_memories_bulk(bulk_data, bulk_attempt_id=bulk_attempt_id)
+        response = await create_memories_bulk(
+            bulk_data,
+            bulk_attempt_id=bulk_attempt_id,
+            # A62 — an insight is the system's own conclusion drawn ACROSS
+            # memories; nobody stated it. Marking the batch keeps it from
+            # destructively overturning a fact a user did state.
+            is_inferred=True,
+        )
     except Exception:
         logger.exception("Bulk persist of insight findings failed entirely")
         insight_ids = [None] * len(findings)

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -815,7 +815,17 @@ def _memory_to_out(
     )
 
 
-async def create_memory(data: MemoryCreate) -> MemoryOut:
+async def create_memory(data: MemoryCreate, *, is_inferred: bool = False) -> MemoryOut:
+    """Create one memory.
+
+    ``is_inferred`` is INTERNAL and keyword-only — deliberately not a field on
+    ``MemoryCreate``. It marks a row the system materialised by inference rather
+    than one a user stated, and ``resolution.resolve`` refuses to let such a row
+    destructively overturn an explicit one. Putting it on the wire would let a
+    caller pick which side of that invariant it sits on, which is the opposite of
+    a guard. Platform writers (the crystallizer, insights) pass True; every other
+    caller gets the default.
+    """
     if not data.agent_id:
         raise ValueError("agent_id must be resolved before calling create_memory")
     # Reserved-id guard (`main` fix): single chokepoint for REST + MCP + STM.
@@ -838,7 +848,7 @@ async def create_memory(data: MemoryCreate) -> MemoryOut:
     # needs its own call and its own route-level test.
     if data.metadata:
         data.metadata = sanitize_caller_metadata(data.metadata)
-    return await _run_write_pipeline(data)
+    return await _run_write_pipeline(data, is_inferred=is_inferred)
 
 
 def _memory_out_with_created_links(ctx, memory: dict) -> MemoryOut:
@@ -861,7 +871,7 @@ def _memory_out_with_created_links(ctx, memory: dict) -> MemoryOut:
     )
 
 
-async def _run_write_pipeline(data: MemoryCreate) -> MemoryOut:
+async def _run_write_pipeline(data: MemoryCreate, *, is_inferred: bool = False) -> MemoryOut:
     """Build the pipeline context and run the write pipeline this request needs.
 
     Kept separate from ``create_memory``, which stays a short prologue of
@@ -914,7 +924,7 @@ async def _run_write_pipeline(data: MemoryCreate) -> MemoryOut:
     if not data.persist or (
         len(data.content) > CHUNKING_THRESHOLD_CHARS and tenant_config.auto_chunk_enabled
     ):
-        ctx = PipelineContext(data={"input": data, "t0": time.perf_counter()})
+        ctx = PipelineContext(data={"input": data, "t0": time.perf_counter(), "is_inferred": is_inferred})
 
         # Phase 1: Enrichment (always runs)
         enrichment_pipeline = build_enrichment_pipeline()
@@ -965,6 +975,7 @@ async def _run_write_pipeline(data: MemoryCreate) -> MemoryOut:
             "input": data,
             "t0": time.perf_counter(),
             "resolved_write_mode": resolved_mode,
+            "is_inferred": is_inferred,
         },
         tenant_config=tenant_config,
     )
@@ -1381,6 +1392,7 @@ async def create_memories_bulk(
     *,
     bulk_attempt_id: str,
     memory_type_is_agent_set: bool | None = None,
+    is_inferred: bool = False,
 ) -> BulkMemoryResponse:
     """Create multiple memories with per-attempt idempotency (CAURA-602).
 
@@ -1938,6 +1950,12 @@ async def create_memories_bulk(
             "status": status,
             "visibility": data.visibility or "scope_team",
             "entity_links": entity_link_dicts,
+            # A62 — batch-level, because the only caller that passes True writes
+            # a batch that is entirely system-materialised (insights). Absent
+            # from ``BulkMemoryItem`` for the same reason it is absent from
+            # ``MemoryCreate``: a caller must not get to choose which side of the
+            # "inferred cannot overturn explicit" invariant its rows sit on.
+            "is_inferred": is_inferred,
         }
         pending.append((i, mem_data))
 

--- a/tests/test_a62_is_inferred_populated.py
+++ b/tests/test_a62_is_inferred_populated.py
@@ -1,0 +1,152 @@
+"""reg-a62 — a guard that could never fire, because nothing wrote its input.
+
+Migration 036 (A55) added ``memories.is_inferred``. Nothing ever set it, so every
+row in every tenant read ``False`` = "directly stated". That silently disabled
+the invariant in ``resolution.resolve``::
+
+    if is_inferred and action in _DESTRUCTIVE:
+
+which exists so a memory the SYSTEM materialised cannot destructively overturn
+one a user actually stated. With the column permanently False, a crystallized
+merge or a generated insight could retire a fact a person wrote, and the branch
+guarding against it had never executed once.
+
+``confidence`` is deliberately NOT populated here. The column documents NULL as
+"unknown/legacy", and neither writer has an honest per-claim confidence to
+report — the crystallizer's ``weight`` is salience, not confidence in the claim.
+Writing a number nobody measured would be worse than NULL, because the resolver
+would then act on a fabricated signal rather than skip an absent one.
+"""
+
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ── it reaches the row ────────────────────────────────────────────────────
+
+
+def test_the_write_step_persists_the_column():
+    from core_api.pipeline.steps.write import write_memory_row as w
+
+    src = inspect.getsource(w)
+    assert '"is_inferred": bool(ctx.data.get("is_inferred", False))' in src
+
+
+def test_it_defaults_to_explicit():
+    """Absent means "a person stated this" — the safe reading, and what every
+    ordinary write is."""
+    from core_api.pipeline.steps.write import write_memory_row as w
+
+    assert 'ctx.data.get("is_inferred", False)' in inspect.getsource(w)
+
+
+def test_the_pipeline_runner_seeds_it():
+    from core_api.services import memory_service as ms
+
+    src = inspect.getsource(ms._run_write_pipeline)
+    assert src.count('"is_inferred": is_inferred') == 2, (
+        "both persisting pipeline contexts must carry it"
+    )
+
+
+def test_the_stm_path_is_not_seeded():
+    """STM writes through ``WriteSTMNote``, not ``WriteMemoryRow`` — there is no
+    row with this column to set, so seeding it there would be cargo cult."""
+    from core_api.services import memory_service as ms
+
+    src = inspect.getsource(ms._run_write_pipeline)
+    stm = src[
+        src.index("build_stm_write_pipeline()") - 600 : src.index(
+            "build_stm_write_pipeline()"
+        )
+    ]
+    assert '"is_inferred"' not in stm
+
+
+# ── it cannot be claimed by a caller ──────────────────────────────────────
+
+
+def test_it_is_keyword_only_and_internal_on_the_single_write():
+    from core_api.services.memory_service import create_memory
+
+    p = inspect.signature(create_memory).parameters["is_inferred"]
+    assert p.kind is inspect.Parameter.KEYWORD_ONLY
+    assert p.default is False
+
+
+def test_it_is_keyword_only_and_internal_on_the_bulk_write():
+    from core_api.services.memory_service import create_memories_bulk
+
+    p = inspect.signature(create_memories_bulk).parameters["is_inferred"]
+    assert p.kind is inspect.Parameter.KEYWORD_ONLY
+    assert p.default is False
+
+
+def test_it_is_absent_from_the_public_create_schemas():
+    """The whole point of the invariant is that the writer does not choose which
+    side of it they sit on. On the wire it would be an opt-out, not a guard."""
+    from core_api.schemas import MemoryCreate
+
+    assert "is_inferred" not in MemoryCreate.model_fields
+
+
+def test_it_stays_visible_on_read():
+    """Readers still need to know — the resolver reads it off the fetched row."""
+    from core_api.schemas import MemoryOut
+
+    assert "is_inferred" in MemoryOut.model_fields
+
+
+# ── the two writers that materialise memories ─────────────────────────────
+
+
+def test_the_crystallizer_marks_its_facts_inferred():
+    """A crystallized fact is an LLM re-extraction that merges a cluster into a
+    claim nobody stated in those words."""
+    from core_api.services import crystallizer_service as cs
+
+    src = inspect.getsource(cs)
+    i = src.index('agent_id="crystallizer"')
+    assert "is_inferred=True" in src[i : i + 900]
+
+
+def test_insights_mark_their_batch_inferred():
+    """An insight is the system's own conclusion drawn ACROSS memories."""
+    from core_api.services import insights_service as ins
+
+    src = inspect.getsource(ins)
+    assert "is_inferred=True" in src
+
+
+def test_the_atomic_fact_fanout_is_not_marked_inferred():
+    """Deliberate: a fan-out child is a claim EXTRACTED from content the user
+    wrote, not one the system inferred. Marking it would wrongly demote a
+    user-stated fact below every other user-stated fact."""
+    from core_api.services import memory_service as ms
+
+    src = inspect.getsource(ms.fan_out_atomic_facts)
+    assert "is_inferred" not in src
+
+
+# ── the invariant this restores ───────────────────────────────────────────
+
+
+def test_the_guard_it_feeds_still_exists():
+    """If this branch is ever removed, populating the column stops meaning
+    anything and this test should be the thing that notices."""
+    from core_api.services.contradiction import resolution
+
+    src = inspect.getsource(resolution.resolve)
+    assert "if is_inferred and action in _DESTRUCTIVE:" in src
+
+
+def test_confidence_is_left_null_on_purpose():
+    """Neither writer has an honest per-claim confidence; the column documents
+    NULL as unknown. A fabricated number would make the resolver act on a signal
+    nobody measured."""
+    from core_api.pipeline.steps.write import write_memory_row as w
+
+    assert '"confidence"' not in inspect.getsource(w)

--- a/tests/test_crystallization_must_not_wedge.py
+++ b/tests/test_crystallization_must_not_wedge.py
@@ -169,7 +169,9 @@ async def test_a_duplicate_does_not_stop_the_facts_after_it() -> None:
     ]
     calls: list[str] = []
 
-    async def _create(payload):
+    # ``**_kw`` so a new server-only keyword on ``create_memory`` (e.g. A62's
+    # ``is_inferred``) does not fail this double on an unrelated signature change.
+    async def _create(payload, **_kw):
         calls.append(payload.content)
         if payload.content == "first":
             raise HTTPException(status_code=409, detail="Duplicate memory exists: abc")

--- a/tests/test_insights_service.py
+++ b/tests/test_insights_service.py
@@ -2045,7 +2045,9 @@ class TestInsightsWriteMode:
             seen: list = []
             real_bulk = ms_mod.create_memories_bulk
 
-            async def capturing_bulk(data, *, bulk_attempt_id):
+            # ``**_kw`` so a new server-only keyword on ``create_memories_bulk``
+            # (e.g. A62's ``is_inferred``) does not fail this double.
+            async def capturing_bulk(data, *, bulk_attempt_id, **_kw):
                 seen.extend(data.items)
                 return await real_bulk(data, bulk_attempt_id=bulk_attempt_id)
 


### PR DESCRIPTION
Migration 036 (A55) added `memories.is_inferred`. **Nothing ever wrote it**, so every row in every tenant read `False` = "directly stated". That silently disabled the guard in `resolution.resolve`:

```python
if is_inferred and action in _DESTRUCTIVE:
```

which exists so a memory the *system* materialised cannot destructively overturn one a user actually stated. With the column permanently False, a crystallized merge or a generated insight could retire a fact a person wrote — and the branch protecting against that **had never executed once**.

## Who is marked, and who isn't

| writer | inferred | why |
|---|---|---|
| crystallizer | ✅ | an LLM re-extraction merging a cluster into a claim nobody stated in those words |
| insights | ✅ | the system's own conclusion drawn *across* memories |
| atomic-fact fan-out | ❌ | a claim **extracted** from content the user wrote — marking it would demote a user-stated fact below every other user-stated fact |

That last row is the one worth arguing about, and I think it's clearly right: fan-out splits a user's sentence, it doesn't infer anything.

## Why it's off the wire

Server-set and keyword-only on `create_memory` / `create_memories_bulk`; absent from `MemoryCreate` and `BulkMemoryItem`. On the wire it would be an **opt-out, not a guard** — a writer must not get to choose which side of the invariant its rows sit on. It stays on `MemoryOut`, because the resolver reads it off the fetched row.

## `confidence` is left NULL, deliberately

The column documents NULL as "unknown/legacy", and neither writer has an honest per-claim confidence to report — the crystallizer's `weight` is *salience*, not confidence in the claim. A fabricated number would be worse than absence, because the resolver would then act on a signal nobody measured. A test pins that choice so it reads as intent rather than omission.

## Testing

13 new tests, including that the guard it feeds still exists (if that branch is ever deleted, populating the column stops meaning anything and this is what notices), and that STM is *not* seeded — STM writes through `WriteSTMNote`, so there's no row with this column.

Two existing doubles pinned the old signatures and failed on the new keyword; both now take `**_kw` so an unrelated server-side parameter can't break them again.

Full suite: **27 failures, identical to main's 27** — none new. `ruff` clean; `mypy` unchanged.