### PR TITLE
feat(extraction): write back the predicate so the RDF path can fire (A65 groundwork)

### DIFF
--- a/core-api/src/core_api/clients/storage_client.py
+++ b/core-api/src/core_api/clients/storage_client.py
@@ -730,6 +730,26 @@ class CoreStorageClient:
         )
         return bool(result and result.get("updated"))
 
+    async def set_predicate_if_null(
+        self, memory_id: str, tenant_id: str, predicate: str, object_value: str
+    ) -> bool:
+        """A65 — conditional predicate/object write-back from the extraction worker.
+
+        Sibling of ``set_subject_entity_if_null``. Storage-side single UPDATE
+        guarded by ``predicate IS NULL`` (the write-time triple path's value
+        wins). Returns whether the row was actually updated; ``False`` is a
+        benign skip."""
+        result = await self._post(
+            f"/memories/{memory_id}/predicate",
+            {
+                "tenant_id": tenant_id,
+                "predicate": predicate,
+                "object_value": object_value,
+            },
+            read=False,
+        )
+        return bool((result or {}).get("updated"))
+
     async def update_memory_status(
         self,
         memory_id: str,

--- a/core-api/src/core_api/services/entity_extraction_worker.py
+++ b/core-api/src/core_api/services/entity_extraction_worker.py
@@ -3,9 +3,10 @@
 import asyncio
 import logging
 import re
-from typing import Any, Literal
+from typing import Any, Final, Literal
 from uuid import UUID
 
+from common.constants import SINGLE_VALUE_PREDICATES
 from common.embedding import get_embedding
 from common.entity_naming import canonical_match_key
 from core_api.clients.storage_client import get_storage_client
@@ -23,6 +24,50 @@ from core_api.services.entity_extraction import extract_entities_from_content
 from core_api.services.entity_service import upsert_relation
 
 logger = logging.getLogger(__name__)
+
+# A65 — map the extractor's free-form ``relation_type`` onto the canonical
+# predicate vocabulary, so two rows that state the same attribute in different
+# words compare equal on the deterministic RDF path.
+#
+# The extractor is asked for "a short verb phrase like works_on, uses,
+# belongs_to" and answers in whatever shape it likes: "Managed By", "reports-to",
+# "is located in". None of those equal ``managed_by`` / ``reports_to`` /
+# ``located_in`` as strings, so without normalisation the write-back below would
+# populate ``predicate`` with values that never match another row's.
+#
+# Deliberately conservative. It normalises SHAPE (case, spaces, hyphens, a
+# leading "is_"/"has_" where the bare form is canonical) and nothing else — no
+# synonym table, no stemming, no inference. A predicate that does not land in
+# ``SINGLE_VALUE_PREDICATES`` after that is returned as None and the row keeps a
+# NULL predicate, because a wrong predicate is worse than none: the RDF path
+# treats (subject, predicate) as authoritative and would compare two unrelated
+# attributes as if they were the same one.
+_PREDICATE_PREFIXES: Final[tuple[str, ...]] = ("is_", "has_", "was_", "the_")
+
+
+def _canonical_predicate(raw: str | None) -> str | None:
+    """The canonical single-value predicate for an extracted relation, or None."""
+    if not raw:
+        return None
+    norm = re.sub(r"[\s\-]+", "_", str(raw).strip().lower())
+    norm = re.sub(r"[^a-z0-9_]", "", norm).strip("_")
+    if not norm:
+        return None
+    # Strip FIRST, not last. The canonical set contains both spellings of
+    # several predicates — ``is_located_in`` AND ``located_in``,
+    # ``is_based_in`` AND ``based_in``, ``has_status`` AND ``status`` — so
+    # returning the raw form when it happens to be canonical would let two rows
+    # stating the SAME attribute land on two different canonical predicates and
+    # never match. That is precisely the failure this function exists to remove,
+    # so the bare form always wins and both spellings converge on it.
+    for prefix in _PREDICATE_PREFIXES:
+        if norm.startswith(prefix):
+            stripped = norm[len(prefix) :]
+            if stripped in SINGLE_VALUE_PREDICATES:
+                return stripped
+    if norm in SINGLE_VALUE_PREDICATES:
+        return norm
+    return None
 
 
 # CAURA graph-build fix (A): reject literal VALUES and attribute/field NAMES so they
@@ -792,6 +837,72 @@ async def process_entity_extraction(
                     ),
                 )
                 rel_count += 1
+
+        # ---- A65: predicate write-back ----
+        #
+        # A63 filled in ``subject_entity_id`` from the extractor and stopped
+        # there, so ``predicate`` and ``object_value`` stayed NULL on nearly
+        # every row — and the deterministic RDF contradiction path keys on
+        # (subject, predicate), so populating one of the three columns left it
+        # exactly as dormant as before. This is the same write-back for the
+        # other two.
+        #
+        # Only when EXACTLY ONE relation canonicalises, and it starts at the
+        # subject we just wrote back. The ambiguity rule is A63's, for A63's
+        # reason: downstream gates treat these columns as authoritative, so a
+        # wrong predicate is worse than none — it makes two unrelated attributes
+        # compare as the same one. Two canonical relations about one subject is
+        # exactly that risk, so it skips.
+        # Recomputed here rather than reused from the subject write-back above:
+        # that block is nested inside a conditional, so reaching into its locals
+        # would NameError on every path where it did not run. Same expression,
+        # same inputs, no cross-scope dependency.
+        subject_names = {name for name, _et, role in filtered if role == "subject" and name in name_to_id}
+        if len(subject_names) == 1:
+            subject_name = next(iter(subject_names))
+            canonical_rels = [
+                (p, rel.to_entity)
+                for rel in graph.relations
+                if rel.from_entity == subject_name and (p := _canonical_predicate(rel.relation_type))
+            ]
+            if len(canonical_rels) == 1:
+                pred, obj = canonical_rels[0]
+                try:
+                    updated = await sc.set_predicate_if_null(
+                        memory_id=str(memory_id),
+                        tenant_id=tenant_id,
+                        predicate=pred,
+                        object_value=str(obj),
+                    )
+                    logger.info(
+                        "predicate_writeback memory=%s predicate=%s outcome=%s",
+                        memory_id,
+                        pred,
+                        "set" if updated else "kept_existing",
+                    )
+                except Exception:
+                    # Non-fatal, exactly like the subject write-back: the row
+                    # simply keeps a NULL predicate, which is today's behaviour.
+                    logger.warning(
+                        "predicate_writeback failed for memory %s (non-fatal)",
+                        memory_id,
+                        exc_info=True,
+                    )
+            elif canonical_rels:
+                logger.info(
+                    "predicate_writeback memory=%s outcome=skipped_ambiguous n_predicates=%d",
+                    memory_id,
+                    len(canonical_rels),
+                )
+            else:
+                # The common case: the extractor named relations, none of which
+                # are single-valued attributes. Logged so "no canonical
+                # predicate" stays distinguishable from "never ran".
+                logger.info(
+                    "predicate_writeback memory=%s outcome=skipped_no_canonical n_relations=%d",
+                    memory_id,
+                    len(graph.relations),
+                )
 
         # Audit log
         await log_action(

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -617,6 +617,25 @@ async def set_subject_entity_if_null(memory_id: UUID, request: Request) -> dict:
     return {"updated": updated}
 
 
+@router.post("/{memory_id}/predicate")
+async def set_predicate_if_null(memory_id: UUID, request: Request) -> dict:
+    """A65 — conditional write-back of the extraction-derived predicate/object.
+
+    Sibling of ``/subject-entity`` (A63). Sets ``predicate`` and
+    ``object_value`` ONLY when ``predicate`` is currently NULL — the write-time
+    triple path's value always wins. Returns ``{"updated": bool}``; ``false``
+    covers absent / deleted / foreign-tenant / already-set rows alike.
+    """
+    body: dict = await request.json()
+    updated = await _svc.memory_set_predicate_if_null(
+        memory_id=memory_id,
+        tenant_id=body["tenant_id"],
+        predicate=body["predicate"],
+        object_value=body["object_value"],
+    )
+    return {"updated": updated}
+
+
 @router.get("/rdf-conflicts")
 async def find_rdf_conflicts(
     tenant_id: str,

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -1641,6 +1641,47 @@ class PostgresService:
             )
             return (result.rowcount or 0) > 0  # type: ignore[attr-defined]
 
+    async def memory_set_predicate_if_null(
+        self, memory_id: UUID, tenant_id: str, predicate: str, object_value: str
+    ) -> bool:
+        """A65 — write-back of the extraction-derived predicate and object.
+
+        The sibling of ``memory_set_subject_entity_if_null`` (A63), and it
+        exists for the reason that one's docstring already names: the
+        write-time triple path (``EmitMemoryTriple``, CAURA-123) only fires on
+        narrow phrase regexes, so ``predicate`` and ``object_value`` are NULL on
+        nearly every row. A63 filled in the subject and left those two behind —
+        which means the deterministic RDF contradiction path still cannot fire,
+        because it keys on (subject, predicate) and only one of the three
+        columns was ever populated.
+
+        Guarded by ``predicate IS NULL``, same as A63's guard and for the same
+        reason: when the regex path DID fire, its value came from a
+        deterministic match on the original text and is the higher-fidelity
+        source, so this async write-back must never clobber it. The guard also
+        makes concurrent deliveries race-safe without a read-modify-write.
+
+        Both columns are set together. A predicate without an object names an
+        attribute with no value, which the RDF comparison reads as a claim that
+        nothing can conflict with — worse than leaving the row untouched.
+
+        Returns ``True`` when the row was updated; ``False`` when it is absent,
+        soft-deleted, foreign-tenant, or already carries a predicate — all of
+        which callers treat as a benign skip.
+        """
+        async with get_session() as session:
+            result = await session.execute(
+                sql_update(Memory)
+                .where(
+                    Memory.id == memory_id,
+                    Memory.tenant_id == tenant_id,
+                    Memory.deleted_at.is_(None),
+                    Memory.predicate.is_(None),
+                )
+                .values(predicate=predicate, object_value=object_value)
+            )
+            return (result.rowcount or 0) > 0  # type: ignore[attr-defined]
+
     async def memory_update_status(
         self,
         memory_id: UUID,

--- a/tests/test_a65_predicate_writeback.py
+++ b/tests/test_a65_predicate_writeback.py
@@ -1,0 +1,157 @@
+"""reg-a65 groundwork — populate the predicate so the RDF path can fire at all.
+
+A63 wrote back ``subject_entity_id`` from the extractor and stopped there. Its
+own comment explains why the column was NULL to begin with: the write-time
+triple path fires only on narrow phrase regexes. But the deterministic RDF
+contradiction path keys on **(subject, predicate)**, so filling one of the three
+columns left it exactly as dormant as before — every row had a subject and no
+predicate.
+
+This is the same write-back for the other two columns, plus the canonicalisation
+that makes them comparable across wordings.
+
+SCOPE, stated plainly: this does NOT fix A65's two measured probe cases.
+"finished the Snowflake cutover for analytics" vs "the analytics warehouse is
+BigQuery" needs the INFERENCE that a cutover changes the warehouse — semantic
+work that no vocabulary mapping does. The other candidate fix (a tiered judge)
+targets those and is parked under the no-new-LLM-calls hold. What this does is
+remove the precondition that made the deterministic path unable to fire for
+anyone: predicate NULL everywhere.
+"""
+
+import inspect
+
+import pytest
+
+from core_api.services.entity_extraction_worker import _canonical_predicate as canon
+
+pytestmark = pytest.mark.unit
+
+
+# ── canonicalisation ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("is located in", "located in"),
+        ("is_based_in", "based_in"),
+        ("has_status", "status"),
+        ("is assigned to", "assigned-to"),
+        ("was_deployed_to", "deployed to"),
+        ("Managed By", "managed_by"),
+        ("reports-to", "REPORTS_TO"),
+    ],
+)
+def test_two_wordings_of_one_attribute_converge(a, b):
+    """The whole point. If these produced different predicates, two rows about
+    the same attribute would still never compare equal."""
+    assert canon(a) == canon(b) is not None
+
+
+def test_the_bare_form_wins_when_both_spellings_are_canonical():
+    """``SINGLE_VALUE_PREDICATES`` contains BOTH ``is_located_in`` and
+    ``located_in``. Returning whichever matched first would split one attribute
+    across two canonical names — reintroducing the bug at the layer meant to fix
+    it."""
+    assert canon("is_located_in") == "located_in"
+    assert canon("has_status") == "status"
+
+
+def test_a_multi_valued_relation_is_refused():
+    """``works_on`` can be true of five projects at once, so it is not a
+    single-value attribute and a second value is not a replacement."""
+    assert canon("works_on") is None
+    assert canon("uses") is None
+
+
+def test_an_unrecognised_relation_is_refused_rather_than_guessed():
+    """A wrong predicate is worse than none: the RDF path treats
+    (subject, predicate) as authoritative and would compare two unrelated
+    attributes as the same one."""
+    assert canon("total gibberish") is None
+    assert canon("") is None
+    assert canon(None) is None
+
+
+def test_it_does_not_invent_predicates_by_stripping():
+    """Prefix-stripping only returns a form that is ITSELF canonical, so it can
+    never manufacture a predicate the vocabulary does not contain."""
+    from common.constants import SINGLE_VALUE_PREDICATES
+
+    for probe in ("is_nonsense", "has_flurble", "was_widget"):
+        out = canon(probe)
+        assert out is None or out in SINGLE_VALUE_PREDICATES
+
+
+# ── the write-back ────────────────────────────────────────────────────────
+
+
+def _worker_src() -> str:
+    from core_api.services import entity_extraction_worker as w
+
+    return inspect.getsource(w)
+
+
+def test_it_writes_back_only_on_exactly_one_canonical_relation():
+    """A63's ambiguity rule, for A63's reason: two canonical relations about one
+    subject means we cannot tell which attribute the row asserts."""
+    src = _worker_src()
+    assert "if len(canonical_rels) == 1:" in src
+    assert "skipped_ambiguous" in src
+
+
+def test_the_relation_must_start_at_the_subject():
+    """A relation about some other entity in the same memory is not this row's
+    claim."""
+    src = _worker_src()
+    assert "rel.from_entity == subject_name" in src
+
+
+def test_it_does_not_reach_into_the_subject_writebacks_scope():
+    """``subject_ids`` is computed inside a conditional block; referencing it
+    from the outer level NameErrors on every path where that block did not run.
+    Recomputed from ``filtered`` instead."""
+    src = _worker_src()
+    tail = src[src.index("A65: predicate write-back") :]
+    assert "subject_names = {" in tail
+    assert "subject_ids" not in tail
+
+
+def test_both_columns_are_written_together():
+    """A predicate with no object names an attribute with no value, which the
+    RDF comparison reads as a claim nothing can conflict with."""
+    from core_api.clients.storage_client import CoreStorageClient
+
+    sig = inspect.signature(CoreStorageClient.set_predicate_if_null)
+    assert "predicate" in sig.parameters and "object_value" in sig.parameters
+
+
+def test_the_regex_paths_value_is_never_clobbered():
+    """Storage guards on ``predicate IS NULL`` — when the write-time triple path
+    fired, its value came from a deterministic match on the original text and
+    outranks this async write-back."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_set_predicate_if_null)
+    assert "Memory.predicate.is_(None)" in src
+    assert "Memory.tenant_id == tenant_id" in src
+    assert "Memory.deleted_at.is_(None)" in src
+
+
+def test_a_failure_is_non_fatal():
+    """Same contract as the subject write-back: the row keeps a NULL predicate,
+    which is today's behaviour for every row."""
+    src = _worker_src()
+    tail = src[src.index("A65: predicate write-back") :]
+    assert "non-fatal" in tail
+    assert "logger.warning" in tail
+
+
+def test_every_outcome_is_logged():
+    """set / kept_existing / ambiguous / no_canonical must be distinguishable —
+    otherwise "no predicate found" and "never ran" look identical, which is the
+    D3 ambiguity this codebase has already paid for twice."""
+    src = _worker_src()
+    for outcome in ("predicate_writeback", "skipped_ambiguous", "skipped_no_canonical"):
+        assert outcome in src


### PR DESCRIPTION
A63 wrote back `subject_entity_id` from the extractor and stopped there. Its own comment explains why that column was NULL to begin with — the write-time triple path fires only on narrow phrase regexes. But the deterministic RDF contradiction path keys on **(subject, predicate)**, so filling one of three columns left it exactly as dormant as before: every row got a subject and no predicate.

This is the same write-back for the other two columns, plus the canonicalisation that makes them comparable across wordings.

## Read this before assuming it closes A65

**It does not fix A65's two measured probe cases.** *"finished the Snowflake cutover for analytics"* vs *"the analytics warehouse is BigQuery"* requires **inferring** that a cutover changes the warehouse — semantic work no vocabulary mapping does. The other candidate fix (a tiered judge) targets those, and it's parked under the no-new-LLM-calls hold.

What this removes is the precondition that made the deterministic path unable to fire **for anyone**: `predicate` NULL on nearly every row.

## The canonicaliser

Normalises *shape* only — case, spaces, hyphens, and a leading `is_`/`has_`/`was_` where the bare form is canonical. No synonyms, no stemming, no inference. Anything that doesn't land in `SINGLE_VALUE_PREDICATES` returns `None` and the row keeps a NULL predicate, because **a wrong predicate is worse than none**: the RDF path treats (subject, predicate) as authoritative and would compare two unrelated attributes as the same one.

One subtlety worth the review: **the bare form deliberately wins over the raw one.** `SINGLE_VALUE_PREDICATES` contains *both* `is_located_in` and `located_in` — and `has_status` and `status`, and three more pairs. Returning whichever matched first would split one attribute across two canonical names, reintroducing the exact bug at the layer meant to fix it. Stripping first makes both spellings converge:

```
"is located in" -> located_in   |  "located in" -> located_in   MATCH
"has_status"    -> status       |  "status"     -> status       MATCH
"works_on"      -> None         (multi-valued: a second value adds, not replaces)
```

## Write-back rules

All inherited from A63, for A63's reasons: exactly one canonical relation starting at the subject; storage guarded by `predicate IS NULL` so the regex path's higher-fidelity value is never clobbered; non-fatal on failure; every outcome logged so "no canonical predicate" stays distinguishable from "never ran".

`subject_ids` from the subject write-back is **not** reused — it's computed inside a conditional, so reaching into its scope would `NameError` on every path where that block didn't run. Recomputed from `filtered` instead, and a test pins that.

## Testing

18 new tests, including seven wording pairs that must converge, that prefix-stripping can never invent a predicate outside the vocabulary, and the scope check above.

Full suite: **27 failures, identical to main's 27** — none new. `ruff` clean; `mypy` clean on core-storage-api, unchanged on core-api.