### PR TITLE
fix(contradiction): stop reading a formatting difference as a contradiction (A35)

### DIFF
--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -33,6 +33,7 @@ from sqlalchemy import (
     distinct,
     false,
     func,
+    literal,
     literal_column,
     or_,
     select,
@@ -228,6 +229,30 @@ async def get_read_session() -> AsyncIterator[AsyncSession]:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _normalized_object_sql(column):
+    """SQL-side object normalisation for the RDF conflict compare (A35).
+
+    ``memory_find_rdf_conflicts`` selects a conflict with
+    ``Memory.object_value != object_value`` — raw string inequality. So
+    "7,500 rpm" and "7500 RPM" read as two DIFFERENT values for one
+    (subject, predicate) and the row is flagged as a contradiction it is not.
+    A false conflict is not free: the loser carries a 0.5 ranking penalty, so
+    a formatting difference quietly demotes a correct memory.
+
+    Normalises SHAPE only — case, whitespace, thousands separators — and
+    deliberately nothing semantic. "7500 rpm" and "7500 per minute" still
+    compare as different, because unit synonymy is open-ended and getting it
+    wrong in the other direction SUPPRESSES a real contradiction, which is the
+    worse failure. Same conservative line as A65's predicate canonicaliser.
+
+    Applied identically to the column and the bound parameter so the two can
+    never drift apart. It does cost the index on ``object_value``, which is
+    acceptable here: the query has already narrowed to one
+    (tenant, subject_entity_id, predicate) before this predicate is evaluated.
+    """
+    return func.lower(func.regexp_replace(column, r"[\s,]", "", "g"))
 
 
 def _fleet_scope_clause(
@@ -3652,7 +3677,11 @@ class PostgresService:
                 Memory.status.in_(("active", "confirmed", "pending")),
                 Memory.subject_entity_id == subject_entity_id,
                 func.lower(Memory.predicate) == predicate.lower(),
-                Memory.object_value != object_value,
+                # A35 — compare NORMALISED forms. Raw inequality made
+                # "7,500 rpm" and "7500 RPM" look like competing values for the
+                # same attribute and flagged a contradiction that was only a
+                # formatting difference.
+                _normalized_object_sql(Memory.object_value) != _normalized_object_sql(literal(object_value)),
                 Memory.id != memory_id,
             )
             if fleet_id:

--- a/tests/test_a35_object_normalization.py
+++ b/tests/test_a35_object_normalization.py
@@ -1,0 +1,124 @@
+"""reg-a35 — a formatting difference was being read as a contradiction.
+
+``memory_find_rdf_conflicts`` selected a conflict with raw string inequality::
+
+    Memory.object_value != object_value
+
+so "7,500 rpm" and "7500 RPM" read as two different values for one
+(subject, predicate) pair and the row was flagged as a contradiction it is not.
+That is not free: the losing row carries a 0.5 ranking penalty, so a comma
+quietly demoted a correct memory.
+
+Both sides are now normalised by the same expression. Shape only — case,
+whitespace, thousands separators — and deliberately nothing semantic:
+"7500 rpm" and "7500 per minute" still compare as different, because unit
+synonymy is open-ended and a wrong equivalence SUPPRESSES a real contradiction,
+which is the worse direction to fail in. Same line A65's predicate
+canonicaliser draws.
+"""
+
+import re
+
+import pytest
+from sqlalchemy import literal
+
+from common.models.memory import Memory
+from core_storage_api.services.postgres_service import _normalized_object_sql
+
+pytestmark = pytest.mark.unit
+
+
+def _mirror(v: str) -> str:
+    """Python mirror of the SQL expression, for readable pair assertions."""
+    return re.sub(r"[\s,]", "", v).lower()
+
+
+def _sql(v: str) -> str:
+    return str(
+        _normalized_object_sql(literal(v)).compile(
+            compile_kwargs={"literal_binds": True}
+        )
+    )
+
+
+# ── what now compares equal ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("7,500 rpm", "7500 RPM"),
+        ("7500rpm", "7500 rpm"),
+        ("Shipped", "shipped"),
+        ("BigQuery", "bigquery"),
+        ("  in progress ", "In Progress"),
+        ("1,000,000", "1000000"),
+    ],
+)
+def test_formatting_differences_no_longer_look_like_conflicts(a, b):
+    assert _mirror(a) == _mirror(b)
+
+
+# ── what deliberately still differs ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("7500 rpm", "7500 per minute"),  # unit synonymy — out of scope on purpose
+        ("shipped", "cancelled"),  # a real disagreement
+        ("bigquery", "snowflake"),  # the A65 probe case, still a conflict
+        ("100", "1000"),  # a comma strip must not equate magnitudes
+    ],
+)
+def test_real_differences_are_still_conflicts(a, b):
+    """The dangerous direction. Over-normalising SUPPRESSES a genuine
+    contradiction, which is worse than the false positive being fixed — a
+    suppressed conflict leaves two contradictory claims both live and current."""
+    assert _mirror(a) != _mirror(b)
+
+
+def test_comma_strip_cannot_merge_different_numbers():
+    """``1,000`` and ``1000`` are the same number; ``100`` and ``1000`` are not.
+    Stripping separators must not blur that."""
+    assert _mirror("1,000") == _mirror("1000")
+    assert _mirror("100") != _mirror("1000")
+
+
+# ── the SQL itself ────────────────────────────────────────────────────────
+
+
+def test_both_sides_use_the_same_expression():
+    """The property that matters. Normalising only the column, or only the
+    parameter, would compare a normalised value against a raw one and make the
+    mismatch worse rather than better."""
+    col = str(
+        _normalized_object_sql(Memory.object_value).compile(
+            compile_kwargs={"literal_binds": True}
+        )
+    )
+    param = _sql("7,500 RPM")
+    for fragment in ("lower(", "regexp_replace("):
+        assert fragment in col and fragment in param
+
+
+def test_the_query_applies_it_to_both_operands():
+    import inspect
+
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_find_rdf_conflicts)
+    assert src.count("_normalized_object_sql(") == 2
+    assert "Memory.object_value != object_value" not in src
+
+
+def test_predicate_matching_is_untouched():
+    """Predicate aliasing is A36's job. This change must not quietly widen the
+    predicate match as well — two attributes that merely format alike are still
+    two attributes."""
+    import inspect
+
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_find_rdf_conflicts)
+    assert "func.lower(Memory.predicate) == predicate.lower()" in src


### PR DESCRIPTION
`memory_find_rdf_conflicts` selected a conflict with raw string inequality:

```python
Memory.object_value != object_value
```

So `"7,500 rpm"` and `"7500 RPM"` read as **two different values** for one (subject, predicate) pair, and the row was flagged as a contradiction it isn't. That's not free — the losing row carries a **0.5 ranking penalty**, so a comma quietly demoted a correct memory.

Both operands are now normalised by the same expression:

```sql
lower(regexp_replace(memories.object_value, '[\s,]', '', 'g'))
  != lower(regexp_replace('7,500 RPM', '[\s,]', '', 'g'))
```

Applied **identically to column and parameter** — normalising one side and not the other would compare a normalised value against a raw one and make the mismatch worse.

## What it deliberately does *not* do

Shape only: case, whitespace, thousands separators. `"7500 rpm"` and `"7500 per minute"` still compare as different.

Unit synonymy is open-ended, and a wrong equivalence **suppresses** a real contradiction — the worse direction to fail in, because a suppressed conflict leaves two contradictory claims both live and both reading as current. That's the same line A65's predicate canonicaliser draws, and there are four tests pinning it (including that `100` and `1000` must not blur when separators are stripped).

**Predicate matching is untouched.** Aliasing (`"deadline"` vs `"completion date"`) is A36's job; two attributes that merely format alike are still two attributes. A test pins that this change didn't quietly widen it.

## Why in SQL rather than at write time

It covers rows **already stored**, and the displayed value stays the text the writer actually used.

It does cost the index on `object_value` — acceptable here, since the query has already narrowed to one (tenant, subject_entity_id, predicate) before this predicate is evaluated. Postgres-only by construction: core-storage-api has no SQLite path, and the query is mocked in the unit suite.

## Testing

14 new tests, split between pairs that must now compare equal and pairs that must **still** conflict — including `bigquery` vs `snowflake`, the A65 probe case, which must remain a genuine contradiction.

Full suite: **27 failures, identical to main's 27** — none new. `ruff` clean; `mypy` clean on core-storage-api.