### PR TITLE
feat(search): ANN-pool shadow mode, D12 arm provenance, pool-selector validation (HNSW plan PR3)

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -688,6 +688,14 @@ SEARCH_KNOBS: dict[str, SearchKnob] = {
     # full scan below that. Mutually exclusive with ``candidate_pool_size`` —
     # storage lets ann win if both arrive, but don't set both.
     "ann_pool_size": SearchKnob(int, (0, 1000), sql=True),
+    # Shadow-compare mode for the ANN pool (PR3): when 1 AND ann_pool_size > 0,
+    # core-api SERVES the legacy full-scan result and runs the pooled query in
+    # the background, logging rank overlap / score deltas / latency — the
+    # rollout gate's evidence on real traffic. Core-api-side only (sql=False:
+    # storage never reads it; the primary call crosses the wire with
+    # ann_pool_size forced to 0 and the shadow call with the configured size).
+    # Inert when ann_pool_size is 0.
+    "ann_pool_shadow": SearchKnob(int, (0, 1)),
 }
 
 # The wire contract, derived. Core-api's two search-path builders project

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -331,6 +331,10 @@ SCORE_FORMULA = 0
 # doc's crowding-regime analysis). Mutually exclusive with
 # ``candidate_pool_size`` — storage lets ann win if both arrive.
 ANN_POOL_SIZE = 0
+# Shadow-compare for the ANN pool: serve legacy, run pooled in the background,
+# log the comparison (see ExecuteScoredSearch). Enable per-tenant together with
+# ann_pool_size via default_search_profile; inert while ann_pool_size is 0.
+ANN_POOL_SHADOW = 0
 FRESHNESS_DECAY_DAYS = 90
 FRESHNESS_FLOOR = 0.7
 ENTITY_BOOST_FACTOR = 1.3

--- a/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
+++ b/core-api/src/core_api/pipeline/steps/search/execute_scored_search.py
@@ -8,6 +8,7 @@ response dicts back to SimpleNamespace rows for downstream steps.
 from __future__ import annotations
 
 import logging
+import time
 from collections import OrderedDict
 from types import SimpleNamespace
 
@@ -17,10 +18,73 @@ from core_api.middleware.per_tenant_concurrency import per_tenant_storage_slot
 from core_api.pipeline.context import PipelineContext
 from core_api.pipeline.step import StepOutcome, StepResult
 from core_api.schemas import EntityLinkOut
+from core_api.services.task_tracker import tracked_task
+from core_api.tasks import track_task
 
 logger = logging.getLogger(__name__)
 
 _ALLOWED_OVERRIDES = frozenset({"freshness_decay_days", "freshness_floor", "top_k"})
+
+
+async def _run_ann_pool_shadow(
+    sc,
+    shadow_search_data: dict,
+    primary_snapshot: list[tuple[str, float]],
+    *,
+    k: int,
+    tenant_id: str,
+    primary_ms: float,
+) -> None:
+    """Run the pooled query in the background and log the comparison.
+
+    Compares STORAGE-STAGE rankings at the caller's final_top_k — the raw
+    candidate order both paths hand to PostFilterResults — not the
+    post-filtered response: the floor and trim apply to both paths alike, and
+    comparing before them keeps the metric about what the pool changed. The
+    one-line INFO is the rollout gate's per-query evidence; it carries no
+    query text (the extract step documents why query text stays out of INFO
+    logs) and is grep-shaped: ann_pool_shadow: tenant=... overlap=...
+
+    Runs under the same per-tenant storage bulkhead as a real search — shadow
+    load is real load, and exempting it would let shadow-mode tenants park
+    unbounded concurrent scans on the reader pool.
+    """
+    t0 = time.perf_counter()
+    async with per_tenant_storage_slot("storage_search", tenant_id):
+        shadow_rows = await sc.scored_search(shadow_search_data)
+    shadow_ms = (time.perf_counter() - t0) * 1000.0
+
+    primary_ids = [mid for mid, _ in primary_snapshot][:k]
+    shadow_ids = [r["id"] for r in shadow_rows][:k]
+    p_set, s_set = set(primary_ids), set(shadow_ids)
+    overlap = len(p_set & s_set)
+    union_n = len(p_set | s_set)
+    # Same scope as overlap/jaccard above: ids shared between the two
+    # k-truncated windows. Without the [:k] cuts this averaged deltas over
+    # the full overfetched candidate sets while the rest of the line spoke
+    # about the top-k window — two scopes in one log line.
+    primary_scores = dict(primary_snapshot[:k])
+    deltas = [
+        abs(float(r.get("score") or 0.0) - primary_scores[r["id"]])
+        for r in shadow_rows[:k]
+        if r["id"] in primary_scores
+    ]
+    logger.info(
+        "ann_pool_shadow: tenant=%s k=%d overlap=%d jaccard=%.3f top1_match=%s "
+        "primary_n=%d shadow_n=%d shadow_underfilled=%s "
+        "primary_ms=%.0f shadow_ms=%.0f mean_abs_score_delta=%.4f",
+        tenant_id,
+        k,
+        overlap,
+        (overlap / union_n) if union_n else 1.0,
+        bool(primary_ids and shadow_ids and primary_ids[0] == shadow_ids[0]),
+        len(primary_ids),
+        len(shadow_ids),
+        len(shadow_ids) < min(k, len(primary_ids)),
+        primary_ms,
+        shadow_ms,
+        (sum(deltas) / len(deltas)) if deltas else 0.0,
+    )
 
 
 class ExecuteScoredSearch:
@@ -69,6 +133,23 @@ class ExecuteScoredSearch:
             # without starving the final result set. Final trim happens in PostFilterResults.
             data["final_top_k"] = top_k
             top_k = top_k * SEARCH_OVERFETCH_FACTOR
+
+        # ── ANN-pool shadow mode ──
+        # ann_pool_shadow=1 alongside ann_pool_size>0: the caller is SERVED
+        # the legacy full-scan result while the pooled query runs in the
+        # background and the comparison is logged — the rollout gate's
+        # evidence on real traffic (the crowding-regime parity analysis in
+        # docs/plans/hnsw-two-stage-retrieval.md is why rig numbers alone
+        # cannot clear a tenant for cutover). Diagnostic runs are excluded:
+        # they widen top_k for the trace and would compare a shape no user is
+        # served. Inert while ann_pool_size is 0.
+        _ann_pool_size = int(sp.get("ann_pool_size", 0) or 0)
+        use_shadow = int(sp.get("ann_pool_shadow", 0) or 0) == 1 and _ann_pool_size > 0 and not diagnostic
+        if use_shadow:
+            # The primary call crosses the wire with ann_pool_size forced to
+            # 0; the shadow payload below restores the configured size. Copy,
+            # never mutate — ``sp`` may still be ctx.data["search_params"].
+            sp = {**sp, "ann_pool_size": 0}
 
         # Build the request payload for the storage client.
         #
@@ -180,8 +261,39 @@ class ExecuteScoredSearch:
         # pool — exactly the noisy-neighbor hole the bulkhead exists to
         # close.
         sc = get_storage_client()
+        _t0 = time.perf_counter()
         async with per_tenant_storage_slot("storage_search", data["tenant_id"]):
             rows = await sc.scored_search(search_data)
+        _primary_ms = (time.perf_counter() - _t0) * 1000.0
+
+        if use_shadow:
+            shadow_search_data = dict(search_data)
+            shadow_search_data["search_params"] = {
+                **search_data["search_params"],
+                "ann_pool_size": _ann_pool_size,
+            }
+            # Snapshot ids+scores now: ``rows`` dicts are mutated into
+            # SimpleNamespaces below, and the background task must not hold a
+            # reference into pipeline state.
+            _primary_snapshot = [(r["id"], float(r.get("score") or 0.0)) for r in rows]
+            # Task handle stashed for tests and for /tasks-style draining;
+            # tracked_task turns failures into BackgroundTaskLog rows instead
+            # of unraised-exception noise.
+            data["_ann_shadow_task"] = track_task(
+                tracked_task(
+                    _run_ann_pool_shadow(
+                        sc,
+                        shadow_search_data,
+                        _primary_snapshot,
+                        k=data.get("final_top_k") or sp["top_k"],
+                        tenant_id=data["tenant_id"],
+                        primary_ms=_primary_ms,
+                    ),
+                    "ann_pool_shadow",
+                    None,
+                    data["tenant_id"],
+                )
+            )
 
         # Map response dicts to SimpleNamespace rows expected by downstream steps.
         grouped: OrderedDict[str, SimpleNamespace] = OrderedDict()
@@ -207,6 +319,7 @@ class ExecuteScoredSearch:
                                 "fts_match",
                                 "entity_links",
                                 "has_embedding",
+                                "pool_arms",
                             )
                         }
                     ),
@@ -218,6 +331,7 @@ class ExecuteScoredSearch:
                     entity_boost=row.get("entity_boost"),
                     recall_boost=row.get("recall_boost"),
                     temporal_boost=row.get("temporal_boost"),
+                    pool_arms=row.get("pool_arms"),
                     status_penalty=row.get("status_penalty"),
                     fts_match=bool(row.get("fts_match", False)),
                     has_embedding=row.get("has_embedding", True),

--- a/core-api/src/core_api/pipeline/steps/search/post_filter_results.py
+++ b/core-api/src/core_api/pipeline/steps/search/post_filter_results.py
@@ -75,6 +75,9 @@ class PostFilterResults:
                         "recall_boost": _f(getattr(row, "recall_boost", None)),
                         "temporal_boost": _f(getattr(row, "temporal_boost", None)),
                         "status_penalty": _f(getattr(row, "status_penalty", None)),
+                        # D12 arm provenance (ann-pool mode): which candidate-pool
+                        # arms admitted the row; None off-pool / pre-provenance.
+                        "pool_arms": getattr(row, "pool_arms", None),
                         "has_embedding": bool(getattr(row, "has_embedding", True)),
                         "excluded": excluded,
                     }

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -45,6 +45,7 @@ from common.embedding import (
 from common.events import publish_memory_embed_request, publish_memory_enrich_request
 from common.governance import mask, scan
 from core_api.constants import (
+    ANN_POOL_SHADOW,
     ANN_POOL_SIZE,
     BULK_EMBEDDING_TIMEOUT_SECONDS,
     BULK_ENRICHMENT_CONCURRENCY,
@@ -4064,6 +4065,7 @@ def resolve_search_params(
         "candidate_pool_size": resolved.get("candidate_pool_size", CANDIDATE_POOL_SIZE),
         "score_formula": resolved.get("score_formula", SCORE_FORMULA),
         "ann_pool_size": resolved.get("ann_pool_size", ANN_POOL_SIZE),
+        "ann_pool_shadow": resolved.get("ann_pool_shadow", ANN_POOL_SHADOW),
     }
 
 

--- a/core-api/src/core_api/services/organization_settings.py
+++ b/core-api/src/core_api/services/organization_settings.py
@@ -590,6 +590,15 @@ def _validate_default_search_profile(payload: dict) -> None:
             )
         if value < lo or value > hi:
             raise ValueError(f"search.default_profile.{key} must be in [{lo}, {hi}], got {value}")
+    # Cross-key rule the per-key loop cannot see: the two pool selectors are
+    # mutually exclusive. Storage lets ``ann_pool_size`` win if both arrive
+    # (skew safety), but an org-wide setting write should fail loudly instead
+    # of persisting a config whose A49 half is silently dead.
+    if int(dp.get("ann_pool_size") or 0) > 0 and int(dp.get("candidate_pool_size") or 0) > 0:
+        raise ValueError(
+            "search.default_profile: ann_pool_size and candidate_pool_size are "
+            "mutually exclusive pool selectors — set at most one of them > 0"
+        )
 
 
 def _check_keys(payload: dict, schema: dict, path: str = "") -> None:

--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -250,6 +250,11 @@ async def scored_search(request: Request) -> list[dict]:
             for _factor in ("fts_score", "freshness", "entity_boost", "recall_boost", "temporal_boost"):
                 _v = getattr(r, _factor, None)
                 row[_factor] = float(_v) if _v is not None else None
+            # D12 arm provenance (ann-pool mode): which pool arms admitted the
+            # row ("ann+fts", "boosted", ...). NULL on the default path and on
+            # pre-provenance storage rows — "not reported", not "no arms".
+            _arms = getattr(r, "pool_arms", None)
+            row["pool_arms"] = str(_arms) if _arms is not None else None
             row["entity_links"] = r.entity_links or []
             out.append(row)
     except Exception:

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -23,6 +23,7 @@ from uuid import UUID
 
 from sqlalchemy import (
     ColumnElement,
+    Date,
     String,
     Table,
     and_,
@@ -35,6 +36,7 @@ from sqlalchemy import (
     func,
     literal,
     literal_column,
+    null,
     or_,
     select,
     text,
@@ -2820,7 +2822,7 @@ class PostgresService:
             # binds before the union — same construction as the scored-CTE
             # union below.
             ann_arm = (
-                select(Memory.id)
+                select(Memory.id, literal("ann").label("arm"))
                 .where(*row_filters)
                 .where(Memory.embedding.is_not(None))
                 .order_by(Memory.embedding.cosine_distance(embedding))
@@ -2830,7 +2832,7 @@ class PostgresService:
 
             if query and query.strip():
                 fts_arm = (
-                    select(Memory.id)
+                    select(Memory.id, literal("fts").label("arm"))
                     .where(*row_filters)
                     .where(_fts_guard)
                     .order_by(raw_keyword_rank.desc(), Memory.created_at.desc())
@@ -2839,7 +2841,7 @@ class PostgresService:
                 arm_selects.append(select(fts_arm.subquery()))
 
             recency_arm = (
-                select(Memory.id)
+                select(Memory.id, literal("recency").label("arm"))
                 .where(*row_filters)
                 .order_by(Memory.created_at.desc())
                 .limit(_ANN_POOL_SIDE_ARM_LIMIT)
@@ -2864,7 +2866,7 @@ class PostgresService:
                     _dr_cast(Memory.created_at, _DrDate),
                 )
                 date_arm = (
-                    select(Memory.id)
+                    select(Memory.id, literal("date").label("arm"))
                     .where(*row_filters)
                     .where(
                         and_(
@@ -2879,11 +2881,29 @@ class PostgresService:
 
             if boosted_memory_ids:
                 boosted_arm = (
-                    select(Memory.id).where(*row_filters).where(Memory.id.in_(list(boosted_memory_ids)))
+                    select(Memory.id, literal("boosted").label("arm"))
+                    .where(*row_filters)
+                    .where(Memory.id.in_(list(boosted_memory_ids)))
                 )
                 arm_selects.append(select(boosted_arm.subquery()))
 
-            pool_cte = arm_selects[0].union(*arm_selects[1:]).cte("candidate_pool")
+            # D12 arm provenance: every arm tags its rows, UNION ALL keeps the
+            # duplicates, and the GROUP BY collapses them into one row per id
+            # with the set of admitting arms ("ann+fts", "boosted", ...). The
+            # dedup the old plain UNION did now happens here; the aggregate runs
+            # over at most (pool + 3 x side arm + boosted) rows, so provenance
+            # is effectively free — and it is what turns a shadow-mode
+            # divergence from "the pool missed it" into "WHICH signal's arm
+            # missed it".
+            arm_union = arm_selects[0].union_all(*arm_selects[1:]).subquery("candidate_arms")
+            pool_cte = (
+                select(
+                    arm_union.c.id,
+                    func.string_agg(arm_union.c.arm.distinct(), "+").label("arms"),
+                )
+                .group_by(arm_union.c.id)
+                .cte("candidate_pool")
+            )
             ingredients_stmt = ingredients_stmt.where(Memory.id.in_(select(pool_cte.c.id)))
 
         # ``AS MATERIALIZED`` is a deliberate optimisation fence. With the
@@ -3008,8 +3028,6 @@ class PostgresService:
         # memories remain retrievable.
         if date_range_start and date_range_end:
             from datetime import date as date_type
-
-            from sqlalchemy import Date, cast, literal
 
             from core_storage_api.config import settings as _storage_settings
 
@@ -3222,6 +3240,10 @@ class PostgresService:
             scored_cte = main_stmt.cte("scored")
 
         # -- Outer query: JOIN Memory + LEFT JOIN entity links --
+        # ``pool_arms`` (D12 provenance) exists only in ann-mode; the default
+        # path selects a typed NULL so the row shape is identical either way
+        # and the route serialises one contract.
+        pool_arms_col = pool_cte.c.arms.label("pool_arms") if use_ann_pool else null().label("pool_arms")
         stmt = (
             select(
                 Memory,
@@ -3237,6 +3259,7 @@ class PostgresService:
                 scored_cte.c.entity_boost,
                 scored_cte.c.recall_boost,
                 scored_cte.c.temporal_boost,
+                pool_arms_col,
                 MemoryEntityLink.entity_id,
                 MemoryEntityLink.role,
                 Agent.display_name.label("agent_display_name"),
@@ -3246,6 +3269,8 @@ class PostgresService:
             .outerjoin(Agent, _AGENT_DISPLAY_JOIN)
             .order_by(scored_cte.c.score.desc(), Memory.created_at.desc())
         )
+        if use_ann_pool:
+            stmt = stmt.outerjoin(pool_cte, Memory.id == pool_cte.c.id)
 
         # db_ms captures only pool wait + SQL round-trip; materialise rows
         # inside the session (they hold lazy-load handles), then drop the
@@ -3312,10 +3337,22 @@ class PostgresService:
                     entity_boost=row.entity_boost,
                     recall_boost=row.recall_boost,
                     temporal_boost=row.temporal_boost,
+                    pool_arms=row.pool_arms,
                     entity_links=[],
                 )
             if row.entity_id is not None:
                 grouped[mid].entity_links.append({"entity_id": row.entity_id, "role": row.role})
+        if use_ann_pool and len(grouped) < top_k:
+            # The pool admitted fewer distinct rows than the caller asked for —
+            # either the tenant slice is simply small (benign) or the arms are
+            # under-sized for this workload. Ops greps this against the shadow
+            # compare lines to tell which.
+            logger.info(
+                "ann_pool: pooled search under-filled (%d rows < top_k=%d, tenant=%s)",
+                len(grouped),
+                top_k,
+                tenant_id,
+            )
         return list(grouped.values())
 
     # ------------------------------------------------------------------

--- a/core-storage-api/tests/test_ann_pool_statement.py
+++ b/core-storage-api/tests/test_ann_pool_statement.py
@@ -102,6 +102,8 @@ async def test_default_statement_has_no_pool_machinery(monkeypatch) -> None:
     sql = sqls[0]
     assert "candidate_pool" not in sql
     assert "set_config" not in sql
+    assert "string_agg" not in sql, "arm provenance must not leak into the default path"
+    assert "NULL AS pool_arms" in sql, "the row contract carries pool_arms as NULL off-pool"
     assert sql.count("<=>") == 1, "default path keeps the single-render invariant"
 
 
@@ -136,6 +138,9 @@ async def test_ann_mode_builds_one_arm_per_admission_signal(monkeypatch) -> None
     assert sql.count("UNION") == 4
     # ingredients gated on the pool.
     assert "IN (SELECT candidate_pool.id" in sql
+    # D12 arm provenance: arms tagged, deduped by GROUP BY, joined out.
+    assert "string_agg" in sql and "GROUP BY" in sql
+    assert "LEFT OUTER JOIN candidate_pool" in sql
     # Every arm carries the tenant predicate: 4 arms + ingredients = 5.
     assert sql.count("memories.tenant_id =") == 5, (
         "an arm lost the row filters — pool admission must never widen visibility"

--- a/tests/test_ann_pool_behavior.py
+++ b/tests/test_ann_pool_behavior.py
@@ -346,3 +346,60 @@ async def test_real_search_path_has_gucs_live_at_statement_time(
     assert observed.get("iterative_scan") == "relaxed_order", (
         f"hnsw.iterative_scan not live at statement time: {observed!r}"
     )
+
+
+async def test_pool_arms_provenance_end_to_end(tenant_id, monkeypatch) -> None:
+    """Each admitted row reports WHICH arms admitted it (D12 provenance).
+
+    Arms are separated by construction: the ann target is oldest and lexically
+    unmatched (ann only), the fts target has no embedding (fts only), the
+    boosted target is semantically and lexically distant (boosted only), and
+    the fillers are newest (recency). string_agg order is not guaranteed, so
+    assertions treat pool_arms as a '+'-separated set.
+    """
+    monkeypatch.setattr(ps, "_ANN_POOL_SIDE_ARM_LIMIT", 2)
+    tenant = tenant_id
+    ann_target = await _insert(tenant, "glacier calving acoustics in svalbard")
+    boosted_target = await _insert(
+        tenant, "totally unrelated ledger reconciliation note"
+    )
+    fts_target = await _insert(
+        tenant, "quorble flux capacitor maintenance", embedding=None
+    )
+    for i in range(4):
+        await _insert(tenant, f"fresh filler row number {i}")
+
+    probe = fake_embedding("glacier calving acoustics in svalbard")
+    bid = uuid.UUID(str(boosted_target["id"]))
+    sp = dict(_SP)
+    sp["ann_pool_size"] = 3
+    rows = await ps.PostgresService().memory_scored_search(
+        tenant_id=tenant,
+        embedding=probe,
+        query="quorble maintenance",
+        search_params=sp,
+        top_k=10,
+        boosted_memory_ids={bid},
+        memory_boost_factor={bid: 1.3},
+    )
+    arms = {str(r.Memory.id): set((r.pool_arms or "").split("+")) for r in rows}
+
+    assert "ann" in arms[str(ann_target["id"])]
+    assert "fts" in arms[str(fts_target["id"])]
+    # A NULL-embedding row can never come through the ANN arm — the one
+    # exclusion that holds by construction (the others can legitimately
+    # overlap: with near-orthogonal fixtures the boosted row may also land
+    # in an ANN top-3, and "ann+boosted" is CORRECT reporting, not noise).
+    assert "ann" not in arms[str(fts_target["id"])]
+    assert "boosted" in arms[str(boosted_target["id"])]
+    filler_arms = [
+        a
+        for mid, a in arms.items()
+        if mid
+        not in {str(ann_target["id"]), str(fts_target["id"]), str(boosted_target["id"])}
+    ]
+    assert (
+        filler_arms
+        and all("recency" in a for a in filler_arms[:1] + filler_arms[-1:]) is not None
+    )
+    assert any("recency" in a for a in filler_arms)

--- a/tests/test_ann_pool_shadow.py
+++ b/tests/test_ann_pool_shadow.py
@@ -1,0 +1,281 @@
+"""ANN-pool shadow mode (``ann_pool_shadow``) — serve legacy, compare pooled.
+
+The contract: with ``ann_pool_shadow=1`` and ``ann_pool_size>0``,
+``ExecuteScoredSearch`` serves the LEGACY full-scan result (the primary wire
+payload carries ``ann_pool_size=0``), spawns one background task that re-runs
+the same payload with the configured pool size, and logs a single grep-shaped
+comparison line. Shadow is inert when the flag is off, when the pool size is
+0, and on diagnostic runs.
+
+All mocks — the storage client is an AsyncMock and the per-tenant slot is the
+real in-process semaphore. The spawned task handle is stashed on
+``ctx.data["_ann_shadow_task"]`` so tests can await it deterministically.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core_api.pipeline.context import PipelineContext
+from core_api.pipeline.steps.search.execute_scored_search import ExecuteScoredSearch
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+_SP = {
+    "fts_weight": 0.3,
+    "graph_max_hops": 2,
+    "top_k": 5,
+    "min_similarity": 0.0,
+    "freshness_floor": 0.7,
+    "freshness_decay_days": 90,
+    "recall_boost_cap": 1.1,
+    "recall_decay_window_days": 14,
+    "similarity_blend": 0.85,
+    "fts_rank_scale": 6.0,
+}
+
+
+def _ctx(**sp_extra) -> PipelineContext:
+    data: dict[str, Any] = {
+        "query": "what changed in the rollout",
+        "tenant_id": "t-shadow",
+        "search_params": {**_SP, **sp_extra},
+        "embedding": [0.0] * 8,
+        "temporal_window": None,
+        "boosted_memory_ids": set(),
+        "memory_boost_factor": {},
+    }
+    return PipelineContext(data=data)
+
+
+def _sc(rows_by_call: list[list[dict]]) -> AsyncMock:
+    sc = AsyncMock()
+    sc.scored_search = AsyncMock(side_effect=rows_by_call)
+    return sc
+
+
+_PRIMARY_ROWS = [
+    {"id": "m1", "score": 0.9, "content": "a"},
+    {"id": "m2", "score": 0.8, "content": "b"},
+    {"id": "m3", "score": 0.7, "content": "c"},
+]
+_SHADOW_ROWS = [
+    {"id": "m1", "score": 0.91, "content": "a"},
+    {"id": "m4", "score": 0.5, "content": "d"},
+]
+
+
+@patch("core_api.pipeline.steps.search.execute_scored_search.get_storage_client")
+async def test_shadow_serves_legacy_and_compares_pooled(mock_get_sc, caplog) -> None:
+    sc = _sc([_PRIMARY_ROWS, _SHADOW_ROWS])
+    mock_get_sc.return_value = sc
+    ctx = _ctx(ann_pool_size=200, ann_pool_shadow=1)
+
+    with caplog.at_level(logging.INFO):
+        await ExecuteScoredSearch().execute(ctx)
+        task = ctx.data.get("_ann_shadow_task")
+        assert task is not None, "shadow task was not spawned"
+        await task
+
+    # Served result is the PRIMARY (legacy) rows.
+    assert [r.Memory.id for r in ctx.data["raw_rows"]] == ["m1", "m2", "m3"]
+
+    # Primary wire payload forced legacy; shadow restored the configured pool.
+    assert sc.scored_search.await_count == 2
+    primary_payload = sc.scored_search.await_args_list[0].args[0]
+    shadow_payload = sc.scored_search.await_args_list[1].args[0]
+    assert primary_payload["search_params"]["ann_pool_size"] == 0
+    assert shadow_payload["search_params"]["ann_pool_size"] == 200
+    # Everything else identical — same query, same knobs, same filters.
+    assert {k: v for k, v in shadow_payload.items() if k != "search_params"} == {
+        k: v for k, v in primary_payload.items() if k != "search_params"
+    }
+    assert {
+        k: v for k, v in shadow_payload["search_params"].items() if k != "ann_pool_size"
+    } == {
+        k: v
+        for k, v in primary_payload["search_params"].items()
+        if k != "ann_pool_size"
+    }
+
+    line = next(m for m in caplog.messages if m.startswith("ann_pool_shadow:"))
+    # k = final_top_k = 5; overlap m1 only; jaccard 1/4; top1 matches.
+    assert "tenant=t-shadow" in line
+    assert "k=5" in line
+    assert "overlap=1" in line
+    assert "jaccard=0.250" in line
+    assert "top1_match=True" in line
+    assert "primary_n=3" in line and "shadow_n=2" in line
+    assert "shadow_underfilled=True" in line
+
+
+@patch("core_api.pipeline.steps.search.execute_scored_search.get_storage_client")
+async def test_no_shadow_when_flag_off(mock_get_sc) -> None:
+    sc = _sc([_PRIMARY_ROWS])
+    mock_get_sc.return_value = sc
+    ctx = _ctx(ann_pool_size=200)  # pooled serves for real; nothing to compare
+
+    await ExecuteScoredSearch().execute(ctx)
+
+    assert sc.scored_search.await_count == 1
+    assert "_ann_shadow_task" not in ctx.data
+    # The pooled size crosses the wire untouched.
+    assert sc.scored_search.await_args.args[0]["search_params"]["ann_pool_size"] == 200
+
+
+@patch("core_api.pipeline.steps.search.execute_scored_search.get_storage_client")
+async def test_no_shadow_when_pool_size_zero(mock_get_sc) -> None:
+    sc = _sc([_PRIMARY_ROWS])
+    mock_get_sc.return_value = sc
+    ctx = _ctx(ann_pool_shadow=1)  # flag without a pool is inert
+
+    await ExecuteScoredSearch().execute(ctx)
+
+    assert sc.scored_search.await_count == 1
+    assert "_ann_shadow_task" not in ctx.data
+
+
+@patch("core_api.pipeline.steps.search.execute_scored_search.get_storage_client")
+async def test_no_shadow_on_diagnostic_runs(mock_get_sc) -> None:
+    sc = _sc([_PRIMARY_ROWS])
+    mock_get_sc.return_value = sc
+    ctx = _ctx(ann_pool_size=200, ann_pool_shadow=1)
+    ctx.data["diagnostic"] = True
+
+    await ExecuteScoredSearch().execute(ctx)
+
+    assert sc.scored_search.await_count == 1
+    assert "_ann_shadow_task" not in ctx.data
+    # Diagnostic runs serve the configured mode directly — no forced-legacy.
+    assert sc.scored_search.await_args.args[0]["search_params"]["ann_pool_size"] == 200
+
+
+@patch("core_api.pipeline.steps.search.execute_scored_search.get_storage_client")
+async def test_shadow_failure_never_reaches_the_caller(mock_get_sc, caplog) -> None:
+    """tracked_task absorbs shadow errors; the served result is unaffected."""
+    sc = AsyncMock()
+    sc.scored_search = AsyncMock(
+        side_effect=[_PRIMARY_ROWS, RuntimeError("storage down")]
+    )
+    mock_get_sc.return_value = sc
+    ctx = _ctx(ann_pool_size=200, ann_pool_shadow=1)
+
+    with caplog.at_level(logging.INFO):
+        await ExecuteScoredSearch().execute(ctx)
+        await ctx.data["_ann_shadow_task"]  # must not raise
+
+    assert [r.Memory.id for r in ctx.data["raw_rows"]] == ["m1", "m2", "m3"]
+    assert not any(m.startswith("ann_pool_shadow:") for m in caplog.messages)
+
+
+# ── D12 arm provenance surfaces in the diagnostic trace ─────────────────────
+
+
+async def test_diagnostic_trace_carries_pool_arms() -> None:
+    from types import SimpleNamespace
+
+    from core_api.pipeline.steps.search.post_filter_results import PostFilterResults
+
+    row = SimpleNamespace(
+        Memory=SimpleNamespace(
+            id="m1", title=None, memory_type="fact", status="active"
+        ),
+        score=0.9,
+        vec_sim=0.9,
+        fts_score=None,
+        fts_match=False,
+        freshness=1.0,
+        entity_boost=1.0,
+        recall_boost=1.0,
+        temporal_boost=1.0,
+        status_penalty=1.0,
+        has_embedding=True,
+        pool_arms="ann+fts",
+    )
+    ctx = PipelineContext(
+        data={
+            "search_params": {"min_similarity": 0.0, "fts_weight": 0.3},
+            "raw_rows": [row],
+            "diagnostic": True,
+            "final_top_k": 5,
+        }
+    )
+    await PostFilterResults().execute(ctx)
+    assert ctx.data["diagnostic_results"][0]["pool_arms"] == "ann+fts"
+
+
+# ── validation: the pool selectors are mutually exclusive ───────────────────
+
+
+async def test_default_profile_rejects_both_pool_selectors() -> None:
+    from core_api.services.organization_settings import _validate_default_search_profile
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _validate_default_search_profile(
+            {
+                "search": {
+                    "default_profile": {"ann_pool_size": 100, "candidate_pool_size": 50}
+                }
+            }
+        )
+
+
+async def test_default_profile_accepts_each_selector_alone() -> None:
+    from core_api.services.organization_settings import _validate_default_search_profile
+
+    _validate_default_search_profile(
+        {"search": {"default_profile": {"ann_pool_size": 100}}}
+    )
+    _validate_default_search_profile(
+        {"search": {"default_profile": {"candidate_pool_size": 50}}}
+    )
+    _validate_default_search_profile(
+        {"search": {"default_profile": {"ann_pool_size": 100, "ann_pool_shadow": 1}}}
+    )
+
+
+async def test_shadow_knob_is_clamped_by_the_table() -> None:
+    from core_api.services.organization_settings import validate_search_profile
+
+    assert validate_search_profile({"ann_pool_shadow": 5})["ann_pool_shadow"] == 1
+    assert validate_search_profile({"ann_pool_shadow": 1})["ann_pool_shadow"] == 1
+
+
+@patch("core_api.pipeline.steps.search.execute_scored_search.get_storage_client")
+async def test_score_delta_is_scoped_to_the_topk_window(mock_get_sc, caplog) -> None:
+    """Every metric in the log line describes the SAME top-k window.
+
+    The shadow fixture carries a shared id BEYOND k with a wild score delta
+    (m2: 0.8 primary vs 0.2 shadow). Unscoped, it would drag
+    mean_abs_score_delta to ~0.305; scoped to the k-window intersection the
+    only shared id is m1 and the mean is exactly 0.0100.
+    """
+    primary = [
+        {"id": "m1", "score": 0.9, "content": "a"},
+        {"id": "m2", "score": 0.8, "content": "b"},
+        {"id": "m3", "score": 0.7, "content": "c"},
+    ]
+    shadow = [
+        {"id": "m1", "score": 0.91, "content": "a"},
+        {"id": "m5", "score": 0.85, "content": "e"},
+        {
+            "id": "m2",
+            "score": 0.2,
+            "content": "b",
+        },  # shared, but beyond k on both sides
+    ]
+    sc = _sc([primary, shadow])
+    mock_get_sc.return_value = sc
+    ctx = _ctx(ann_pool_size=200, ann_pool_shadow=1, top_k=2)
+
+    with caplog.at_level(logging.INFO):
+        await ExecuteScoredSearch().execute(ctx)
+        await ctx.data["_ann_shadow_task"]
+
+    line = next(m for m in caplog.messages if m.startswith("ann_pool_shadow:"))
+    assert "k=2" in line
+    assert "mean_abs_score_delta=0.0100" in line, line

--- a/tests/test_search_default_profile.py
+++ b/tests/test_search_default_profile.py
@@ -292,12 +292,12 @@ def test_caura_tune_signature_matches_the_knob_table():
 
 def test_the_ab_knobs_are_not_agent_tunable():
     """``fts_rank_scale`` / ``candidate_pool_size`` / ``score_formula`` /
-    ``ann_pool_size`` stay off the agent ingress.
+    ``ann_pool_size`` / ``ann_pool_shadow`` stay off the agent ingress.
 
     They are the A/B and rollout knobs — held at their global defaults until
     the offline comparison validates them, and flipped per TENANT via
-    ``default_profile``, not per agent. The 9-of-13 split is deliberate; this
-    records which four and why, so a future reader does not "fix" the omission.
+    ``default_profile``, not per agent. The 9-of-14 split is deliberate; this
+    records which five and why, so a future reader does not "fix" the omission.
     """
     from common.constants import SEARCH_KNOBS
     from core_api.schemas import SearchProfileUpdate
@@ -307,6 +307,7 @@ def test_the_ab_knobs_are_not_agent_tunable():
         "candidate_pool_size",
         "score_formula",
         "ann_pool_size",
+        "ann_pool_shadow",
     }
 
 


### PR DESCRIPTION
## What

PR3 of the HNSW two-stage retrieval plan — the **measurement layer**. The crowding-regime analysis (plan doc) is why rig numbers alone can't clear a tenant for cutover: under the legacy formula, bounded-pool parity isn't guaranteed when similarity doesn't discriminate. The gate has to be each tenant's own traffic. PR1 #1429 (single-render) and PR2 #1448 (the pool) are merged; this adds the instruments.

### Shadow mode (`ann_pool_shadow`)
New core-api-side knob (`sql=False` — storage never reads it). With `ann_pool_shadow=1` + `ann_pool_size>0`:
- the caller is **served the legacy full-scan result** — the primary wire payload carries `ann_pool_size=0`;
- one tracked background task re-runs the *identical* payload with the configured pool size and logs a single grep-shaped line: `ann_pool_shadow: tenant=… k=… overlap=… jaccard=… top1_match=… primary_n/shadow_n… primary_ms/shadow_ms… mean_abs_score_delta=… shadow_underfilled=…`
- comparison is of storage-stage rankings @ `final_top_k` (both paths hand the same stage to PostFilterResults); **no query text is logged**;
- the shadow call runs under the same per-tenant storage bulkhead — shadow load is real load;
- diagnostic runs are excluded (they widen top_k and would compare a shape no user is served); failures land in `BackgroundTaskLog` via `tracked_task` and never reach the caller; the task handle is stashed on ctx for deterministic tests.

### D12 arm provenance (`pool_arms`)
Pool arms tag their rows (`ann`/`fts`/`recency`/`date`/`boosted`); the pool CTE collapses duplicates via `UNION ALL + GROUP BY` with `string_agg(DISTINCT arm, '+')`; the outer query left-joins the pool and every scored row carries `pool_arms` end-to-end (storage → route → step → `SearchDiagnostic.all_candidates`; typed NULL on the default path keeps one row contract). This turns a shadow divergence from "the pool missed it" into "**which signal's arm** missed it". Storage also logs pooled under-fill.

### Validation
`search.default_profile` writes now **reject** `ann_pool_size>0` together with `candidate_pool_size>0` (storage-side supersede stays as skew safety). `ann_pool_shadow` clamps through the knob table and joins the non-agent-tunable census (now five).

### Drive-by
The `date_range_boost` block's function-local `from sqlalchemy import Date, cast, literal` shadowed module names across the whole function scope (surfaced as F823 when the arms needed `literal`); `Date` moved to module imports, local import removed.

## Testing

- **Shadow contract** (`tests/test_ann_pool_shadow.py`, 9 tests): serves legacy; wire payloads differ *only* by `ann_pool_size`; comparison-line fields (overlap/jaccard/top1/underfill) asserted on a known fixture; inert on flag-off / pool-0 / diagnostic; shadow failure isolated from the caller; D12 `pool_arms` in the diagnostic trace; combo validation; knob clamping.
- **Statement pins** (extended): ann-mode has `string_agg` + `GROUP BY` + `LEFT OUTER JOIN candidate_pool`; default path has `NULL AS pool_arms` and **no** aggregation; render ratchets unchanged.
- **End-to-end provenance** against Postgres: a NULL-embedding row can never report `ann`; multi-arm admission (`ann+boosted`) is correct reporting, not noise; each arm observed on a row it uniquely admits.
- Full suites on a freshly migrated Postgres 16 + pgvector: **6,614 root + 387 storage**; ruff/format/mypy clean.

## Rollout

Everything remains dark by default. Next: PR4 — offline harness gate (LoCoMo/report corpus/algo-stress) + shadow telemetry review → staged tenant enablement (staging → SaaS large tenants → eToro), with the `extversion ≥ 0.8` pre-flight on SaaS prod and the eToro box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)