### PR TITLE
perf(contradiction): admission-gate detection passes so stacked bursts queue instead of stampeding (A19)

### DIFF
--- a/core-api/src/core_api/config.py
+++ b/core-api/src/core_api/config.py
@@ -318,6 +318,29 @@ class Settings(BaseSettings):
     # enough that real exhaustion fails before the request hits the
     # worker.
     per_tenant_acquire_timeout_seconds: float = 0.05
+    # Process-wide cap on concurrently RUNNING contradiction-detection
+    # passes (A19). Every trigger — write, bulk fan-out, back-channel
+    # consumers, post-entity-extraction — schedules detection as an
+    # unbounded fire-and-forget task, so the caps above bound how fast
+    # writes are ADMITTED but nothing bounds how many detections then
+    # run at once: 8 concurrent 100-item bulks leave ~1,600 detection
+    # coroutines racing the moment they commit. Each pass holds up to
+    # ``_ENTITY_CTX_FANOUT_LIMIT`` (8) storage connections during its
+    # Path C context fetch and one LLM judge call for seconds, on the
+    # SAME storage pool (200 conns, 5s pool budget) and provider quota
+    # the foreground request path uses — a big enough burst turns into
+    # foreground PoolTimeouts and judge abstains (#821), i.e. dropped
+    # detections. Global rather than per-tenant because the resources
+    # being protected are process-global; detection is post-commit
+    # background work, so excess passes QUEUE (never shed) and drain in
+    # FIFO order. Sizing: 16 x 8 = 128 worst-instant storage conns
+    # (< 200 with headroom for foreground), 16 concurrent judge calls
+    # is below the enrichment path's accepted worst case (CAURA-627),
+    # and at a ~2s batch judge that sustains ~8 detections/s per
+    # process — comfortably above one saturated tenant's admitted
+    # write rate. Matches ``per_tenant_write_concurrency`` on purpose:
+    # one process keeps pace with one saturated tenant.
+    contradiction_detection_concurrency: int = 16
     # Idempotency-Key inbox TTL. 24h matches Stripe's default and is
     # longer than any realistic client retry budget. Cached responses
     # older than this are treated as absent and the request re-runs.

--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -207,6 +207,71 @@ def _merge_status_update(acc: dict[str, dict], row: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# A19 — process-wide admission gate for detection passes.
+# ---------------------------------------------------------------------------
+
+# Every trigger site schedules detection with ``track_task`` (a bare
+# ``asyncio.create_task``), so the per-tenant bulkheads bound how fast writes
+# are ADMITTED while nothing bounds how many detections then RUN at once: the
+# tasks outlive the requests that spawned them, and 8 concurrent 100-item
+# bulks leave ~1,600 detection coroutines racing the moment they commit. Each
+# pass holds up to ``_ENTITY_CTX_FANOUT_LIMIT`` (8) connections of the SAME
+# 200-connection / 5s-pool-budget storage pool the foreground request path
+# uses, plus one LLM judge call for seconds — a big enough burst surfaces as
+# foreground PoolTimeouts (the 2026-06-16 incident shape) and judge abstains
+# (#821), i.e. silently dropped detections. This gate turns that collapse
+# into bounded concurrency + FIFO queueing.
+#
+# Queue, never shed: detection is post-commit background work with no caller
+# waiting on it, and a shed pass is a contradiction nobody ever looks for.
+# Waiting coroutines cost ~KBs; the resources the cap protects (storage pool,
+# provider quota, event loop) are what actually collapse. ONE shared gate for
+# every entry point — mirroring ``interview_service.synthesis_sem`` — because
+# two independent Semaphore(N)s would allow 2N whenever Path A bursts overlap
+# Path C bursts, exactly the stampede the cap exists to prevent. Global
+# rather than per-tenant (unlike ``per_tenant_concurrency``) because the
+# protected resources are process-global; a hot tenant delaying another
+# tenant's BACKGROUND detection is acceptable in a way that pool exhaustion
+# for everyone is not.
+#
+# The semaphore is cached per running loop rather than created at import:
+# asyncio primitives bind to the first loop that awaits them, and the test
+# suite runs one loop per test — a module-level instance would poison every
+# later test with "bound to a different event loop" (same reason
+# ``_bounded_gather`` builds a fresh semaphore per call). Production has one
+# loop per process, so the cached instance is process-wide there.
+_DETECTION_GATE: tuple[asyncio.AbstractEventLoop, asyncio.Semaphore] | None = None
+
+
+def _detection_gate() -> asyncio.Semaphore:
+    global _DETECTION_GATE
+    loop = asyncio.get_running_loop()
+    if _DETECTION_GATE is None or _DETECTION_GATE[0] is not loop:
+        _DETECTION_GATE = (loop, asyncio.Semaphore(settings.contradiction_detection_concurrency))
+    return _DETECTION_GATE[1]
+
+
+async def _acquire_detection_slot() -> tuple[asyncio.Semaphore, int]:
+    """Take one detection slot, returning ``(gate, queued_ms)``.
+
+    ``queued_ms`` is surfaced in the ``path_a/c_completed`` lines so gate
+    pressure is quantifiable from production logs alone (detection-proper
+    time = ``elapsed_ms - queued_ms``); the pre-acquire DEBUG mirrors
+    ``per_tenant_storage_slot``'s saturation log. Split from the entry
+    points so both share one queue and one instrumentation story.
+    """
+    gate = _detection_gate()
+    if gate.locked():
+        logger.debug(
+            "contradiction-detection gate saturated; queuing",
+            extra={"cap": settings.contradiction_detection_concurrency},
+        )
+    t0 = time.monotonic()
+    await gate.acquire()
+    return gate, round((time.monotonic() - t0) * 1000)
+
+
+# ---------------------------------------------------------------------------
 # Public API: async post-commit entry point (P1-1)
 # ---------------------------------------------------------------------------
 
@@ -248,6 +313,15 @@ async def detect_contradictions_async(
     concluded = False
     lock_key = None
     lock_token = ""
+    # A19 — admission gate BEFORE any storage or Redis traffic, so a queued
+    # pass consumes nothing but a waiting coroutine. Acquired before the
+    # idempotency lock on purpose: the lock's 1h TTL must clock detection,
+    # not queue time, and a duplicate back-channel delivery that queued
+    # behind its twin still exits at the lock check in one Redis roundtrip.
+    # Acquire sits OUTSIDE the try so a cancellation mid-wait (shutdown's
+    # ``cancel_all_tasks``) cannot reach a ``release()`` for a slot that was
+    # never taken.
+    _gate, queued_ms = await _acquire_detection_slot()
     try:
         if new_memory is None:
             sc = get_storage_client()
@@ -316,6 +390,10 @@ async def detect_contradictions_async(
     except Exception:
         logger.exception("Async contradiction detection failed for memory %s", memory_id)
     finally:
+        # A19 — free the slot before the bookkeeping below: the Redis lock
+        # release and the completion log are not the contended work the gate
+        # protects, and a queued pass may as well start during them.
+        _gate.release()
         # H-06: keep the lock only for a run that reached a verdict. The lock
         # is taken BEFORE detection, so without this one transient LLM or
         # storage failure suppressed every later trigger for this memory for a
@@ -326,11 +404,12 @@ async def detect_contradictions_async(
             await _release_lock(lock_key, lock_token)
         elapsed_ms = round((time.monotonic() - t_start) * 1000)
         logger.info(
-            "path_a_completed for memory %s n_conflicts=%d skipped=%s elapsed_ms=%d tenant_id=%s",
+            "path_a_completed for memory %s n_conflicts=%d skipped=%s elapsed_ms=%d queued_ms=%d tenant_id=%s",
             memory_id,
             n_conflicts,
             str(skipped).lower(),
             elapsed_ms,
+            queued_ms,
             tenant_id,
         )
 
@@ -2317,6 +2396,13 @@ async def detect_contradictions_by_entities_async(
     concluded = False
     lock_key = None
     lock_token = ""
+    # A19 — same admission gate as Path A, and deliberately the SAME gate:
+    # Path C is the heavier occupant (its context fetch holds up to
+    # ``_ENTITY_CTX_FANOUT_LIMIT`` storage connections at once), so giving it
+    # a second Semaphore(N) would double the very stampede budget the cap
+    # exists to bound. See ``_acquire_detection_slot`` for ordering + the
+    # outside-the-try rationale.
+    _gate, queued_ms = await _acquire_detection_slot()
     try:
         # The row is fetched BEFORE the lock is taken, unlike Path A. The lock
         # key carries a fingerprint of the content this run will examine (H-06)
@@ -2849,6 +2935,8 @@ async def detect_contradictions_by_entities_async(
     except Exception:
         logger.exception("Entity-based contradiction detection failed for %s", memory_id)
     finally:
+        # A19 — free the slot before the bookkeeping; see Path A's block.
+        _gate.release()
         # H-06 — see the matching block in ``detect_contradictions_async``.
         # ``concluded`` is set at each legitimate exit rather than once early,
         # so a throw ANYWHERE in the judging loop still releases: a failure
@@ -2859,13 +2947,14 @@ async def detect_contradictions_by_entities_async(
         elapsed_ms = round((time.monotonic() - t_start) * 1000)
         logger.info(
             "path_c_completed for memory %s n_candidates=%d n_conflicts=%d "
-            "n_retractions=%d skipped=%s elapsed_ms=%d tenant_id=%s",
+            "n_retractions=%d skipped=%s elapsed_ms=%d queued_ms=%d tenant_id=%s",
             memory_id,
             n_candidates,
             n_conflicts,
             n_retractions,
             str(skipped).lower(),
             elapsed_ms,
+            queued_ms,
             tenant_id,
         )
 

--- a/tests/test_a19_detection_admission_gate.py
+++ b/tests/test_a19_detection_admission_gate.py
@@ -1,0 +1,264 @@
+"""A19 — contradiction detection is admission-gated, process-wide.
+
+Every trigger site schedules detection with ``track_task`` (a bare
+``asyncio.create_task``), so the per-tenant bulkheads bound how fast writes are
+ADMITTED while nothing bounded how many detections then RAN at once: the tasks
+outlive the requests that spawned them, and a stack of bulk writes leaves
+hundreds of detection coroutines racing the moment they commit — all sharing
+the foreground storage pool (200 conns, 5s pool budget) and the LLM provider.
+
+The fix is one shared admission gate (``_acquire_detection_slot``) across BOTH
+detector entry points, capped by ``settings.contradiction_detection_concurrency``.
+Excess passes queue FIFO — never shed — because detection is post-commit
+background work and a shed pass is a contradiction nobody ever looks for.
+
+The concurrency-tracking shape mirrors ``test_contradiction_fanout_bounded``;
+the lock/storage mocking mirrors ``test_h06_contradiction_lock``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from core_api.services import contradiction_detector as detector
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class _FakeLocks:
+    """In-memory SETNX/compare-and-delete — every id below is unique, so the
+    idempotency lock never dedupes; the gate alone shapes concurrency."""
+
+    def __init__(self) -> None:
+        self.keys: dict[str, str] = {}
+
+    async def set_nx(self, key: str, value: str, ttl: int) -> bool:
+        if key in self.keys:
+            return False
+        self.keys[key] = value
+        return True
+
+    async def delete_if(self, key: str, expected: str) -> bool:
+        if self.keys.get(key) == expected:
+            del self.keys[key]
+            return True
+        return False
+
+
+def _memory(mid) -> dict:
+    return {
+        "id": str(mid),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "agent_id": "a1",
+        "content": f"fact {mid}",
+        "status": "active",
+        "visibility": "scope_team",
+        "supersedes_id": None,
+        "deleted_at": None,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _fresh_gate(monkeypatch):
+    """Each test gets its own gate instance at its own cap.
+
+    The gate is cached per running loop; tests run one loop each, but resetting
+    the cache makes the cap monkeypatch take effect regardless of what an
+    earlier test on a reused loop did.
+    """
+    monkeypatch.setattr(detector, "_DETECTION_GATE", None)
+    yield
+
+
+def _locks_patches(fake: _FakeLocks):
+    return (
+        patch("core_api.services.contradiction_detector.cache_set_nx", new=fake.set_nx),
+        patch(
+            "core_api.services.contradiction_detector.cache_delete_if",
+            new=fake.delete_if,
+        ),
+    )
+
+
+async def _resolve_config(tenant_id):
+    return None
+
+
+async def test_path_a_burst_never_exceeds_the_cap(monkeypatch):
+    """The A19 collapse mechanism, pinned: 40 simultaneously-scheduled Path A
+    passes must run at most ``contradiction_detection_concurrency`` at a time.
+
+    Pre-fix every pass ran immediately (peak == 40)."""
+    monkeypatch.setattr(detector.settings, "contradiction_detection_concurrency", 4)
+
+    active = 0
+    peak = 0
+
+    async def fake_detect(new_memory, embedding, tenant_config=None):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        try:
+            await asyncio.sleep(0.005)
+            return []
+        finally:
+            active -= 1
+
+    fake = _FakeLocks()
+    a, d = _locks_patches(fake)
+    with (
+        a,
+        d,
+        patch("core_api.services.contradiction_detector._detect", new=fake_detect),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=_resolve_config,
+        ),
+    ):
+        mids = [uuid4() for _ in range(40)]
+        await asyncio.gather(
+            *(
+                detector.detect_contradictions_async(
+                    mid, "t1", "f1", f"fact {mid}", [0.1] * 8, new_memory=_memory(mid)
+                )
+                for mid in mids
+            )
+        )
+
+    assert peak <= 4, f"admission gate exceeded: peak={peak}"
+    assert peak > 1, "sanity: passes did run concurrently up to the cap"
+
+
+async def test_path_a_and_path_c_share_one_gate(monkeypatch):
+    """Path C must draw from the SAME gate as Path A — two independent
+    Semaphore(N)s would allow 2N whenever the write burst's Path A passes
+    overlap the entity-extraction burst's Path C passes, which is exactly the
+    stampede the cap exists to bound (Path C is the heavier occupant: its
+    context fetch holds up to 8 storage connections)."""
+    monkeypatch.setattr(detector.settings, "contradiction_detection_concurrency", 3)
+
+    active = 0
+    peak = 0
+
+    async def _occupy():
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        try:
+            await asyncio.sleep(0.005)
+        finally:
+            active -= 1
+
+    async def fake_detect(new_memory, embedding, tenant_config=None):
+        await _occupy()
+        return []
+
+    async def fake_overlap_candidates(payload):
+        # Runs while a Path C pass holds its slot; empty -> concluded early.
+        await _occupy()
+        return []
+
+    sc = AsyncMock()
+    sc.find_entity_overlap_candidates = fake_overlap_candidates
+    sc.get_memory = AsyncMock(side_effect=lambda mid, tid: _memory(mid))
+
+    fake = _FakeLocks()
+    a, d = _locks_patches(fake)
+    with (
+        a,
+        d,
+        patch("core_api.services.contradiction_detector._detect", new=fake_detect),
+        patch(
+            "core_api.services.contradiction_detector.get_storage_client",
+            return_value=sc,
+        ),
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=_resolve_config,
+        ),
+    ):
+        runs = []
+        for _ in range(10):
+            mid_a, mid_c = uuid4(), uuid4()
+            runs.append(
+                detector.detect_contradictions_async(
+                    mid_a,
+                    "t1",
+                    "f1",
+                    f"fact {mid_a}",
+                    [0.1] * 8,
+                    new_memory=_memory(mid_a),
+                )
+            )
+            runs.append(
+                detector.detect_contradictions_by_entities_async(mid_c, "t1", "f1")
+            )
+        await asyncio.gather(*runs)
+
+    assert peak <= 3, f"the two paths must share one gate: peak={peak}"
+    assert peak > 1, "sanity: passes did run concurrently up to the cap"
+
+
+async def test_a_failing_pass_releases_its_slot(monkeypatch):
+    """A pass that throws must free its slot — a leaked slot is a silent,
+    permanent shrink of detection throughput (and at cap failures, a
+    deadlock). The entry's own except swallows the error; the gate release
+    lives in the finally, so the failure path is the one worth pinning."""
+    monkeypatch.setattr(detector.settings, "contradiction_detection_concurrency", 2)
+
+    async def exploding_detect(new_memory, embedding, tenant_config=None):
+        raise RuntimeError("boom")
+
+    ran_after_failures = False
+
+    async def fine_detect(new_memory, embedding, tenant_config=None):
+        nonlocal ran_after_failures
+        ran_after_failures = True
+        return []
+
+    fake = _FakeLocks()
+    a, d = _locks_patches(fake)
+    with (
+        a,
+        d,
+        patch(
+            "core_api.services.organization_settings.resolve_config",
+            new=_resolve_config,
+        ),
+    ):
+        with patch(
+            "core_api.services.contradiction_detector._detect", new=exploding_detect
+        ):
+            mids = [uuid4() for _ in range(6)]
+            # Would hang here (not raise) if failing passes leaked slots.
+            await asyncio.wait_for(
+                asyncio.gather(
+                    *(
+                        detector.detect_contradictions_async(
+                            mid,
+                            "t1",
+                            "f1",
+                            f"fact {mid}",
+                            [0.1] * 8,
+                            new_memory=_memory(mid),
+                        )
+                        for mid in mids
+                    )
+                ),
+                timeout=5.0,
+            )
+        with patch("core_api.services.contradiction_detector._detect", new=fine_detect):
+            mid = uuid4()
+            await asyncio.wait_for(
+                detector.detect_contradictions_async(
+                    mid, "t1", "f1", f"fact {mid}", [0.1] * 8, new_memory=_memory(mid)
+                ),
+                timeout=5.0,
+            )
+
+    assert ran_after_failures, "slots leaked by failing passes starved later detection"


### PR DESCRIPTION
## The throughput mechanism, as the code stands today (post-A73)

Contradiction detection never runs on the request path — every trigger schedules it as a fire-and-forget background task via `track_task`, which is a **bare `asyncio.create_task` with no pool, no queue depth, no semaphore** (`core-api/src/core_api/tasks.py`):

- single writes: `pipeline/steps/write/schedule_background_tasks.py` (both fast and strong mode) — one Path A pass per write, plus entity extraction which then fires one Path C pass per row (`entity_extraction_worker.py:931`);
- bulk writes: `memory_service.py` — one Path A pass **per created row** (up to `BULK_MAX_ITEMS=100` per request);
- back-channel consumers (`consumer.py`, ENRICHED/EMBEDDED) — sequential per subscription, so not the stampede source.

The per-tenant bulkheads (`per_tenant_slot("write")`, 429 + `Retry-After: 1`) bound how fast writes are **admitted**, but the detection tasks **outlive the requests that spawned them**, so nothing bounds how many run at once. 8 concurrent 100-item bulks leave ~1,600 detection coroutines racing the moment they commit. Each pass holds:

- up to 8 connections (`_ENTITY_CTX_FANOUT_LIMIT`) of the **same 200-connection / 5s-pool-budget storage httpx pool the foreground request path uses** (`storage_client._make_pool`), during Path C's context fan-out;
- one LLM judge call for seconds (25s request budget, abstain-on-failure per #821).

So a stacked burst degrades foreground search/write storage calls toward their 5s PoolTimeout (the 2026-06-16 incident shape) and pushes judge calls toward the 25s budget, where they **abstain — silently dropped detections**, not just slow ones. That is the "throughput collapses under stacked load" of the register row: unbounded admission with no backpressure loop.

### Re-measure first: what A73 (#1455) actually changed

A73 batches the **bulk** path's Path A passes to one per subject — but it is **opt-in (`write.bulk_subject_batching`, default OFF)**, applies only to rows carrying a write-time `subject_entity_id`, and entity extraction still fires **one Path C pass per row** even when it is on. It fixed the false-conflict noise of a coherent batch judging itself, and shrinks Path A volume on opted-in coherent batches, but the unbounded dispatch — the actual collapse mechanism — remains on every path. **Verdict: still real, narrowed at the margin by A73.**

## Measurement (code-level + local simulation; no production access)

1. A harness driving the **real** `detect_contradictions_async` (locks live, storage/LLM mocked) measured dispatch concurrency: bursts of 200 / 800 / 1,600 scheduled passes ran at **peak concurrency 200 / 800 / 1,600** — peak == burst, i.e. unbounded.
2. A resource model at the code's own constants (storage pool 200@5s, LLM SDK pool 200@25s, 2s batch judge, Path C 5×8 fan-out, 50ms storage roundtrips, foreground probe doing one storage call per 50ms):

| scenario | peak runs | foreground storage-call wait (max) | detections lost |
|---|---|---|---|
| 1,600-run burst, unbounded (today) | 1,600 | **~2.0s** (40× the call's own cost; ~2–3× this burst crosses the 5s budget → user-visible PoolTimeouts) | 0 at this scale; abstains begin as judge waits cross 25s, and real provider RPM limits arrive far earlier |
| 1,600-run burst, gated at 16 | 16 | **~52–54ms, flat** | 0 (backlog drains FIFO at ~7 passes/s) |

3. Post-fix, the same real-entry harness measures **peak 16** with zero failures — the entry self-gates.

## Plan — the options the register row names, and the choice

- **"Widen the pool"** — there is no detection pool to widen; that is the finding. The per-run fan-out limit (8) and the storage pool (200) are already sized sanely; raising them only moves the cliff. What was missing is the pool's *existence* at the run level.
- **"SLO + Retry-After"** — the write surface already returns 429 + `Retry-After: 1` at the per-tenant cap; that stays the admission backpressure. Detection itself is post-commit and eventually-consistent, so its contract under load should be *bounded concurrency + FIFO queueing*, made observable.

**Chosen: add the missing pool as an admission gate, plus the observability to hold it to an SLO.** One process-wide semaphore across BOTH detector entry points (every trigger routes through them — pinned by `test_contradiction_trigger_coverage`), capped by a new `settings.contradiction_detection_concurrency` (default **16**: 16×8 = 128 worst-instant storage connections < 200 with foreground headroom; judge concurrency below the enrichment path's accepted worst case per CAURA-627; ~8 detections/s sustained at a 2s judge, above one saturated tenant's admitted write rate; deliberately equal to `per_tenant_write_concurrency`). Excess passes **queue, never shed** — a shed pass is a contradiction nobody ever looks for. Mirrors `interview_service.synthesis_sem` (one shared gate for every entry point) and the `per_tenant_storage_slot` queueing idiom; gate acquired **before** the idempotency lock so the lock's 1h TTL clocks detection, not queue time. The `path_a/c_completed` lines now carry `queued_ms`, so gate pressure — and any future formal SLO on detection lag — is measurable from production logs alone.

**Deliberately untouched:** the per-candidate entity-link N+1 *inside* each Path C pass (`_fetch_entity_context` per candidate, `get_entity` per link) is **oss-0902-m-05** and stays in that row's lane. It inflates each run's cost; this PR bounds how many runs contend. The two fixes compose.

## Tests & gates

- `tests/test_a19_detection_admission_gate.py` — burst never exceeds the cap; Path A and Path C share ONE gate; a failing pass releases its slot. **Verified to fail pre-fix**: with the gate unwired from the entries, the burst test measures peak=40/40 and the shared-gate test peak=20/20 (and with the whole fix stashed the suite is red — the gate and its setting don't exist).
- 472 existing contradiction/consumer/bulk/concurrency tests pass (`-k "contradiction or consumer_enriched or a73 or h06 or a4_14 or embed_off_hot_path or enrich_off_hot_path or config"` + `-k "per_tenant or concurren or fanout or track or background"`); DB-needing tests (e.g. `test_a7_classifier_recall.py`) not run — environment has no Postgres.
- `ruff check` / `ruff format --check` clean on touched files; `mypy src/` shows only the 6 pre-existing stub/mcp-version errors, byte-identical to origin/main.

Audit tracker: reg-a19 (A19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
