### PR TITLE
fix(contradiction): stop a paraphrased predicate hiding a real contradiction (A36)

### DIFF
--- a/common/constants.py
+++ b/common/constants.py
@@ -433,6 +433,130 @@ SINGLE_VALUE_PREDICATES: frozenset[str] = frozenset(
     }
 )
 
+# ── Predicate aliasing under paraphrase (A36) ──
+# ``SINGLE_VALUE_PREDICATES`` says WHICH attributes can hold only one value.
+# It does not say which of its own members are the SAME attribute — so
+# ``status`` and ``current_status`` are two keys, and a subject carrying one of
+# each is never compared. The RDF contradiction path keys on
+# ``(subject_entity_id, predicate)`` with an exact predicate match, so
+# "deploy target is staging" written as ``deployed_to`` and later contradicted
+# as ``deployed_on: production`` produces no conflict at all: both rows stay
+# live, both stay unpenalised, and a reader gets whichever ranks higher.
+#
+# Each key below is an alias; each value is the canonical member of its cluster
+# (itself always a member of ``SINGLE_VALUE_PREDICATES``). Consumers should go
+# through ``predicate_cluster()`` rather than reading this map directly.
+#
+# THE INCLUSION RULE, and why it is deliberately narrow. On the OBJECT side of
+# this query (A35) a wrong equivalence SUPPRESSES a real contradiction, so
+# normalising aggressively was safe. Here the failure runs the other way: a
+# wrong alias MANUFACTURES a contradiction between two facts that were never in
+# competition, and the loser takes a 0.5 ranking penalty. So a cluster is
+# admitted only when its members differ by a function word, an abbreviation, or
+# a form of the same word — never by a content word.
+#
+# What that rule REFUSES, and why each refusal is load-bearing:
+#
+#   * INVERSES. The set contains ``manager``/``manager_of``,
+#     ``head_of``/``headed_by``, ``ceo``/``ceo_of``,
+#     ``maintainer``/``maintainer_of``. These are not paraphrases — they point
+#     the other way. Aliasing "X's manager is Y" to "X is the manager of Y"
+#     would read an org chart as self-contradictory. Only the side that makes
+#     the value an attribute OF the subject joins a cluster.
+#   * ``title`` → ``job_title``. ``title`` is also a document's title, and the
+#     predicate carries no subject type to tell the two apart.
+#   * ``cost`` → ``price``. What a thing costs to make and what it sells for
+#     are two numbers that are SUPPOSED to differ.
+#   * ``latest_version`` / ``running_version`` → ``version``. Latest-released
+#     and currently-deployed differ on every system mid-rollout; that gap is
+#     the fact, not a conflict.
+#   * ``start_date`` / ``started_at`` and the ``end_date`` family. Planned vs
+#     actual. A slipped schedule would read as a contradiction.
+#   * ``resides_at`` / ``stationed_at`` / ``address`` / ``city`` / ``country``
+#     / ``region``. These differ from the location cluster in GRANULARITY, and
+#     "Boston" vs "12 Main St" is not a disagreement.
+#
+# Granularity note: this exposure is not new and is not created here —
+# ``located_in: Boston`` already conflicts with ``located_in: Massachusetts``
+# under a single predicate. The rule above keeps aliasing from WIDENING it.
+_PREDICATE_ALIAS_CLUSTERS: tuple[tuple[str, ...], ...] = (
+    # Identity & status. ``state``/``current_state`` sit in the set's own
+    # "Identity & status" section — geography is carried by ``region`` /
+    # ``country`` / ``city``, which stay out of every cluster.
+    ("status", "has_status", "current_status", "state", "current_state"),
+    ("phase", "current_phase"),
+    ("role", "has_role", "current_role"),
+    ("type", "has_type"),
+    # Where a thing is. One cluster on purpose: for a person "lives in" and
+    # "is located in" answer the same question, and the predicate does not
+    # know whether its subject is a person or a company.
+    (
+        "located_in",
+        "is_located_in",
+        "based_in",
+        "is_based_in",
+        "headquartered_in",
+        "hq_in",
+        "lives_in",
+        "resides_in",
+        "location",
+        "current_location",
+    ),
+    # Where a workload runs. Preposition-only differences.
+    ("deployed_to", "is_deployed_to", "deployed_at", "deployed_on"),
+    ("hosted_on", "is_hosted_on", "hosted_at"),
+    ("runs_on", "running_on"),
+    ("stored_in", "stored_at"),
+    ("registered_in", "registered_at"),
+    # Hierarchy — attribute-of-subject side only (see INVERSES above).
+    ("reports_to", "reporting_to", "supervisor", "supervised_by", "manager"),
+    ("led_by", "headed_by"),
+    ("assigned_to", "is_assigned_to", "assignee"),
+    ("maintained_by", "maintainer"),
+    # Metrics. ``price`` and ``cost`` are separate clusters, not one.
+    ("score", "has_score", "scored"),
+    ("rating", "has_rating", "rated"),
+    ("price", "has_price", "priced_at", "current_price"),
+    ("cost", "has_cost", "costs"),
+    ("rank", "has_rank", "ranked", "ranking"),
+    ("value", "has_value"),
+    ("version", "has_version", "current_version"),
+    ("due_date", "due_by", "due_on", "deadline", "has_deadline"),
+    # Contact & personal.
+    ("email", "has_email", "email_address"),
+    ("phone", "has_phone", "phone_number"),
+    ("birthdate", "date_of_birth"),
+    ("spouse", "married_to"),
+    ("employer", "employed_by"),
+)
+
+# alias → canonical. The first member of each tuple is the canonical form.
+PREDICATE_ALIASES: dict[str, str] = {
+    alias: cluster[0] for cluster in _PREDICATE_ALIAS_CLUSTERS for alias in cluster[1:]
+}
+
+# Any member → every member of its cluster, canonical included. This is the
+# lookup the query path wants: it turns one predicate into the set of spellings
+# a stored row might legitimately have used for the same attribute.
+_PREDICATE_CLUSTER_BY_MEMBER: dict[str, frozenset[str]] = {
+    member: frozenset(cluster)
+    for cluster in _PREDICATE_ALIAS_CLUSTERS
+    for member in cluster
+}
+
+
+def predicate_cluster(predicate: str) -> frozenset[str]:
+    """Every spelling that means the same attribute as ``predicate``.
+
+    Returns ``{predicate}`` (lowercased) for a predicate in no cluster, so a
+    caller can use the result unconditionally and an unaliased predicate keeps
+    exactly today's behaviour — a single-member IN is the same query as an
+    equality.
+    """
+    normalized = (predicate or "").strip().lower()
+    return _PREDICATE_CLUSTER_BY_MEMBER.get(normalized, frozenset({normalized}))
+
+
 # ── Lifecycle automation (CAURA-655) ──
 # Weight threshold for archive-stale: memories below this with zero
 # recalls are eligible for archival. Lives in common/ so the threshold

--- a/core-api/src/core_api/pipeline/steps/write/detect_near_duplicate.py
+++ b/core-api/src/core_api/pipeline/steps/write/detect_near_duplicate.py
@@ -88,6 +88,11 @@ def _same_claim(new, candidate: dict) -> bool:
         return False
     if str(new_subject) != str(candidate.get("subject_entity_id") or ""):
         return False
+    # A36 deliberately does NOT reach here. The contradiction path expands a
+    # predicate to its alias cluster so ``status`` meets ``current_status``; a
+    # match there only FLAGS a row. A match here RETIRES one, so widening this
+    # comparison is a separate decision with a worse downside, and it is not
+    # taken as a side effect of the contradiction fix. Exact match stands.
     if str(new_predicate) != str(candidate.get("predicate") or ""):
         return False
     cand_object = candidate.get("object_value")

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -64,6 +64,7 @@ from common.constants import (
     SEMANTIC_DEDUP_CANDIDATE_LIMIT,
     SEMANTIC_DEDUP_THRESHOLD,
     TYPE_DECAY_DAYS,
+    predicate_cluster,
 )
 from common.entity_naming import canonical_match_key, normalize_entity_name
 from common.events.lifecycle_purge_request import MEMORY_RETENTION_MAX_DAYS
@@ -3676,7 +3677,18 @@ class PostgresService:
                 Memory.deleted_at.is_(None),
                 Memory.status.in_(("active", "confirmed", "pending")),
                 Memory.subject_entity_id == subject_entity_id,
-                func.lower(Memory.predicate) == predicate.lower(),
+                # A36 — match every spelling of the SAME attribute, not just
+                # the one this write happened to use. ``status`` and
+                # ``current_status`` are two members of
+                # ``SINGLE_VALUE_PREDICATES`` naming one attribute, and exact
+                # equality meant a subject holding one of each was never
+                # compared: no conflict raised, both rows live, both
+                # unpenalised. Expanded here rather than at write time so
+                # ALREADY-STORED rows are covered and the predicate a caller
+                # reads back is still the one its writer chose. A predicate in
+                # no cluster yields a single-member IN — the same query as the
+                # equality it replaces.
+                func.lower(Memory.predicate).in_(sorted(predicate_cluster(predicate))),
                 # A35 — compare NORMALISED forms. Raw inequality made
                 # "7,500 rpm" and "7500 RPM" look like competing values for the
                 # same attribute and flagged a contradiction that was only a

--- a/tests/test_a35_object_normalization.py
+++ b/tests/test_a35_object_normalization.py
@@ -112,13 +112,21 @@ def test_the_query_applies_it_to_both_operands():
     assert "Memory.object_value != object_value" not in src
 
 
-def test_predicate_matching_is_untouched():
-    """Predicate aliasing is A36's job. This change must not quietly widen the
-    predicate match as well — two attributes that merely format alike are still
-    two attributes."""
+def test_object_normalisation_did_not_widen_the_predicate_match():
+    """A35 normalises the OBJECT only. It must not blur the predicate as well —
+    two attributes that merely format alike are still two attributes.
+
+    Predicate aliasing arrived separately as A36, which replaced the equality
+    with a cluster IN. That is a reviewed, enumerated widening; what this test
+    still forbids is a normalising expression leaking onto the predicate the way
+    it was applied to the object.
+    """
     import inspect
 
     from core_storage_api.services.postgres_service import PostgresService
 
     src = inspect.getsource(PostgresService.memory_find_rdf_conflicts)
-    assert "func.lower(Memory.predicate) == predicate.lower()" in src
+    assert (
+        "func.lower(Memory.predicate).in_(sorted(predicate_cluster(predicate)))" in src
+    )
+    assert "_normalized_object_sql(Memory.predicate)" not in src

--- a/tests/test_a36_predicate_aliasing.py
+++ b/tests/test_a36_predicate_aliasing.py
@@ -1,0 +1,224 @@
+"""reg-a36 — a paraphrased predicate hid a real contradiction.
+
+``SINGLE_VALUE_PREDICATES`` declares WHICH attributes hold only one value at a
+time. It never said which of its own members name the SAME attribute, and
+``memory_find_rdf_conflicts`` matched predicates with exact equality::
+
+    func.lower(Memory.predicate) == predicate.lower()
+
+So a subject whose deploy target was recorded once as ``deployed_to: staging``
+and later as ``deployed_on: production`` was never compared: no conflict
+raised, both rows left live and unpenalised, and a reader got whichever ranked
+higher. The predicate is now expanded to its alias cluster.
+
+The failure direction is the OPPOSITE of A35's, and that governs the whole
+design. On the object side a wrong equivalence SUPPRESSES a real contradiction,
+so normalising broadly was safe. Here a wrong alias MANUFACTURES a contradiction
+between two facts that were never competing, and the loser takes a 0.5 ranking
+penalty. Hence a narrow, enumerated map instead of a general rule — and hence
+the refusals below, which are as much the fix as the clusters are.
+"""
+
+import inspect
+
+import pytest
+
+from common.constants import (
+    _PREDICATE_ALIAS_CLUSTERS,
+    PREDICATE_ALIASES,
+    SINGLE_VALUE_PREDICATES,
+    predicate_cluster,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ── the map's own invariants ──────────────────────────────────────────────
+
+
+def test_every_clustered_predicate_is_a_single_value_predicate():
+    """A cluster member outside ``SINGLE_VALUE_PREDICATES`` is unreachable: the
+    detector gates on membership before it ever calls the query, so the alias
+    would sit in the map looking effective and never fire."""
+    stray = sorted(
+        m
+        for cluster in _PREDICATE_ALIAS_CLUSTERS
+        for m in cluster
+        if m not in SINGLE_VALUE_PREDICATES
+    )
+    assert stray == []
+
+
+def test_no_predicate_belongs_to_two_clusters():
+    """Two clusters sharing a member would make the attribute's identity depend
+    on which spelling the writer happened to use."""
+    seen: dict[str, tuple[str, ...]] = {}
+    collisions = []
+    for cluster in _PREDICATE_ALIAS_CLUSTERS:
+        for m in cluster:
+            if m in seen:
+                collisions.append((m, seen[m], cluster))
+            seen[m] = cluster
+    assert collisions == []
+
+
+def test_no_alias_chains():
+    """Every canonical must be a terminal. If a canonical were itself an alias,
+    resolving once would land on a form that resolves again, and two callers
+    doing different numbers of passes would disagree."""
+    canonicals = set(PREDICATE_ALIASES.values())
+    assert [a for a in PREDICATE_ALIASES if a in canonicals] == []
+
+
+def test_canonical_is_the_first_member_and_is_itself_in_its_cluster():
+    for cluster in _PREDICATE_ALIAS_CLUSTERS:
+        canonical = cluster[0]
+        assert canonical in predicate_cluster(canonical)
+        for alias in cluster[1:]:
+            assert PREDICATE_ALIASES[alias] == canonical
+
+
+# ── what now compares ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("status", "current_status"),
+        ("state", "status"),
+        ("deployed_to", "deployed_on"),
+        ("hosted_on", "hosted_at"),
+        ("runs_on", "running_on"),
+        ("located_in", "based_in"),
+        ("headquartered_in", "hq_in"),
+        ("lives_in", "resides_in"),
+        ("reports_to", "supervisor"),
+        ("assigned_to", "assignee"),
+        ("email", "email_address"),
+        ("phone", "phone_number"),
+        ("spouse", "married_to"),
+        ("employer", "employed_by"),
+        ("birthdate", "date_of_birth"),
+        ("due_date", "deadline"),
+        ("version", "current_version"),
+    ],
+)
+def test_paraphrases_of_one_attribute_now_meet(a, b):
+    assert predicate_cluster(a) == predicate_cluster(b)
+
+
+# ── what deliberately still does NOT compare ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "a,b,why",
+    [
+        ("manager", "manager_of", "inverse: X's manager vs X manages Y"),
+        ("head_of", "headed_by", "inverse"),
+        ("ceo", "ceo_of", "inverse"),
+        ("maintainer", "maintainer_of", "inverse"),
+        ("title", "job_title", "a title is also a document's title"),
+        ("cost", "price", "what it costs to make vs what it sells for"),
+        ("version", "latest_version", "latest-released vs currently-deployed"),
+        ("version", "running_version", "latest-released vs currently-deployed"),
+        ("start_date", "started_at", "planned vs actual"),
+        ("end_date", "ended_at", "planned vs actual"),
+        ("located_in", "city", "granularity, not disagreement"),
+        ("located_in", "country", "granularity, not disagreement"),
+        ("located_in", "region", "granularity, not disagreement"),
+        ("resides_in", "resides_at", "a city is not a street address"),
+        ("located_in", "address", "granularity, not disagreement"),
+        ("status", "role", "two different attributes"),
+        ("score", "rating", "two different metrics"),
+    ],
+)
+def test_refusals_stay_refused(a, b, why):
+    """The load-bearing half of A36.
+
+    Each pair here would, if aliased, invent a contradiction out of two facts
+    that were never in competition — and the losing row would take a 0.5
+    ranking penalty for it. The inverse pairs are the sharpest case: aliasing
+    "X's manager is Y" to "X is the manager of Y" would read an ordinary org
+    chart as self-contradictory.
+    """
+    assert predicate_cluster(a) != predicate_cluster(b), why
+
+
+def test_inverse_predicates_are_in_no_cluster_at_all():
+    """Belt and braces on the whole ``*_of`` family, so a future cluster cannot
+    pull one in without this failing."""
+    clustered = {m for cluster in _PREDICATE_ALIAS_CLUSTERS for m in cluster}
+    inverses = {p for p in SINGLE_VALUE_PREDICATES if p.endswith("_of")}
+    assert inverses, "guard would be vacuous if the set had no *_of predicates"
+    assert sorted(inverses & clustered) == []
+
+
+# ── the resolver's contract ───────────────────────────────────────────────
+
+
+def test_unclustered_predicate_passes_through_unchanged():
+    """An unaliased predicate must keep exactly today's behaviour: a
+    single-member IN is the same query as the equality it replaced."""
+    assert predicate_cluster("works_on") == frozenset({"works_on"})
+    assert predicate_cluster("depends_on_completion_of") == frozenset(
+        {"depends_on_completion_of"}
+    )
+
+
+@pytest.mark.parametrize("raw", ["Status", "  status ", "STATUS", "status"])
+def test_lookup_is_case_and_whitespace_insensitive(raw):
+    assert predicate_cluster(raw) == predicate_cluster("status")
+
+
+@pytest.mark.parametrize("raw", ["", "   ", None])
+def test_empty_predicate_does_not_explode(raw):
+    """The detector gates on a truthy predicate, but the resolver is public and
+    must not raise if something else reaches it."""
+    assert predicate_cluster(raw) == frozenset({""})
+
+
+# ── the query actually uses it ────────────────────────────────────────────
+
+
+def test_the_query_expands_the_cluster():
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_find_rdf_conflicts)
+    assert "predicate_cluster(predicate)" in src
+    # the equality this replaced must be gone, or aliases would never widen
+    # anything — the IN would sit beside a filter that already excluded them
+    assert "func.lower(Memory.predicate) == predicate.lower()" not in src
+
+
+def test_expansion_is_ordered_so_the_sql_is_stable():
+    """``frozenset`` iteration order is not stable across processes. An IN list
+    built straight from the set would produce a different SQL string per worker
+    and defeat statement caching."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_find_rdf_conflicts)
+    assert "sorted(predicate_cluster(predicate))" in src
+
+
+def test_object_side_normalisation_still_applies():
+    """A35 and A36 touch adjacent lines of one WHERE clause. Neither may quietly
+    drop the other."""
+    from core_storage_api.services.postgres_service import PostgresService
+
+    src = inspect.getsource(PostgresService.memory_find_rdf_conflicts)
+    assert src.count("_normalized_object_sql(") == 2
+
+
+def test_the_destructive_merge_path_was_left_alone():
+    """A71's ``_same_claim`` compares predicates with the same exact equality —
+    but a match there RETIRES a row, where a match in the contradiction path
+    only flags one. Widening a destructive comparison is a separate decision
+    with a separate risk profile, and it is deliberately not taken here.
+
+    This test pins that choice so a later reader sees an intentional asymmetry
+    rather than a missed call site.
+    """
+    from core_api.pipeline.steps.write.detect_near_duplicate import _same_claim
+
+    src = inspect.getsource(_same_claim)
+    assert "predicate_cluster" not in src


### PR DESCRIPTION
`SINGLE_VALUE_PREDICATES` declares **which** attributes can hold only one
value at a time. It never said which of its own 274 members name the
**same** attribute — and `memory_find_rdf_conflicts` matched predicates
with exact equality:

```python
func.lower(Memory.predicate) == predicate.lower()
```

So a subject whose deploy target was recorded once as `deployed_to:
staging` and later contradicted as `deployed_on: production` was never
compared. No conflict raised, both rows left live and unpenalised, and a
reader gets whichever happens to rank higher. Same for
`status`/`current_status`, `email`/`email_address`,
`reports_to`/`supervisor`.

The predicate is now expanded to its alias cluster: 27 clusters, 59
aliases, enumerated in `common/constants.py`.

## The failure direction is the opposite of A35's

That governs the whole design. On the **object** side (A35, #1459) a
wrong equivalence *suppresses* a real contradiction, so normalising
broadly was the safe move. Here a wrong alias *manufactures* a
contradiction between two facts that were never in competition — and the
losing row takes a 0.5 ranking penalty for it.

So this is a narrow enumerated map, not a general rule. A cluster is
admitted only when its members differ by a function word, an
abbreviation, or a form of the same word — never by a content word. The
refusals are as much the fix as the clusters, and each is pinned by a
test:

- **inverses** — `manager`/`manager_of`, `head_of`/`headed_by`,
  `ceo`/`ceo_of`, `maintainer`/`maintainer_of`. These point the other
  way; aliasing them would read an ordinary org chart as
  self-contradictory. Only the side that makes the value an attribute
  *of* the subject joins a cluster.
- `title` → `job_title` — a title is also a document's title, and the
  predicate carries no subject type to tell them apart.
- `cost` → `price` — what a thing costs to make and what it sells for
  are two numbers that are *supposed* to differ.
- `latest_version` / `running_version` → `version` — latest-released and
  currently-deployed differ on every system mid-rollout; that gap is the
  fact, not a conflict.
- `start_date`/`started_at`, and the `end_date` family — planned vs
  actual. A slipped schedule would read as a contradiction.
- `resides_at`, `stationed_at`, `address`, `city`, `country`, `region` —
  these differ from the location cluster in **granularity**, and
  "Boston" vs "12 Main St" is not a disagreement.

## Two deliberate scope choices

**Expanded at query time, not write time.** Already-stored rows are
covered, and the predicate a caller reads back is still the one its
writer chose. Same reasoning as A35's SQL-side normalisation. A
predicate in no cluster yields a single-member `IN` — the same query as
the equality it replaces.

**A71's `_same_claim` was left alone.** It compares predicates with the
same exact equality, but a match *there* retires a row where a match in
the contradiction path only flags one. Widening a destructive comparison
is a separate decision with a worse downside, and it is not taken as a
side effect of this one. The asymmetry is commented at the call site and
pinned by a test so it reads as intentional rather than missed.

## Notes

`test_predicate_matching_is_untouched` in the A35 suite was a tripwire
left for exactly this change; it is rewritten to assert the new shape and
still forbid a normalising expression leaking onto the predicate.

Granularity exposure is not new and is not created here — `located_in:
Boston` already conflicts with `located_in: Massachusetts` under a single
predicate. The inclusion rule keeps aliasing from widening it.

Full suite: **31 failures, identical to main's 31** — none new (the 4
`test_ann_pool_behavior` failures are local-only; that file's HNSW index
is created by raw SQL in migrations, which a model-built test DB never
runs). `ruff` clean; `mypy` adds zero errors on either service.

