### PR TITLE
fix(contradiction): let the deterministic check run where it was needed (A40)

### DIFF
--- a/core-api/src/core_api/services/contradiction_detector.py
+++ b/core-api/src/core_api/services/contradiction_detector.py
@@ -18,6 +18,7 @@ import logging
 import time
 import uuid as _uuid
 from datetime import datetime
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from core_api.cache import cache_delete_if, cache_set_nx
@@ -276,6 +277,238 @@ async def _acquire_detection_slot() -> tuple[asyncio.Semaphore, int]:
 # ---------------------------------------------------------------------------
 
 
+# ── A40 — the deterministic RDF pass, callable from both triggers ─────────
+#
+# Extracted verbatim from ``detect_contradictions_async`` so the SAME pass can
+# also run after entity extraction. It used to be reachable only at write time,
+# and that made it close to dead for the facts this product is actually about.
+#
+# The gate needs ``(subject_entity_id, predicate, object_value)``.
+# ``EmitMemoryTriple`` populates those during the write with no LLM call, but it
+# resolves a SUBJECT from only two sources: a caller-supplied ``entity_links``
+# row, or an identifier-shaped token. Proper nouns deliberately return None
+# ("Alice", "Atlas" — see ``_infer_subject_token``), deferring to the
+# entity-extraction worker's higher-precision output. Measured on this code:
+#
+#     "Maya lives in Boston"             predicate=lives_in          subject=None
+#     "Acme is headquartered in Berlin"  predicate=headquartered_in  subject=None
+#     "Priya reports to Dana"            predicate=reports_to        subject=None
+#     "TOKEN-XYZ has release date 2027"  predicate=release_date      subject=TOKEN-XYZ
+#
+# So for any human- or company-subject fact the row commits with a NULL subject,
+# this gate fails, and Path A falls straight through to the STOCHASTIC raw-text
+# semantic judge — the R7 miss. Extraction then fills the columns in moments and
+# fires Path C, which does entity-overlap plus another LLM judge and never
+# retries the deterministic check. The one non-stochastic verdict in the module
+# was structurally unreachable exactly where it was needed.
+#
+# Running it again post-extraction is also CHEAPER, not more expensive: Path A's
+# semantic judge is gated on ``if not contradictions``, so a deterministic
+# verdict SUPPRESSES an LLM call rather than adding one.
+#
+# Re-running is safe by construction. ``memory_find_rdf_conflicts`` selects only
+# ``active``/``confirmed``/``pending`` rows, so anything an earlier pass already
+# retired is out of scope, and the storage CAS (``WHERE supersedes_id IS NULL``)
+# is the backstop on the chain edge.
+class _RdfPassResult(NamedTuple):
+    contradictions: list[ContradictionInfo]
+    record_pairs: list[tuple[dict, str, float | None]]
+    supersedes_id: Any
+    ran: bool
+
+
+async def _rdf_conflict_pass(
+    sc,
+    new_memory: dict,
+    *,
+    memory_id,
+    tenant_id: str,
+    supersedes_id,
+) -> _RdfPassResult:
+    """Run the deterministic single-value-predicate contradiction check.
+
+    ``ran`` reports whether the triple gate passed, so a caller can tell "no
+    conflict" apart from "could not look" — the distinction that hid this bug.
+    """
+    subject_entity_id = new_memory.get("subject_entity_id")
+    predicate = new_memory.get("predicate")
+    object_value = new_memory.get("object_value")
+    contradictions: list[ContradictionInfo] = []
+    _record_pairs: list[tuple[dict, str, float | None]] = []
+    ran = bool(
+        subject_entity_id and predicate and object_value and predicate.lower() in SINGLE_VALUE_PREDICATES
+    )
+
+    # --- Path 1: RDF triple contradiction (single-value predicates only) ---
+    if subject_entity_id and predicate and object_value and predicate.lower() in SINGLE_VALUE_PREDICATES:
+        rdf_conflicts = await sc.find_rdf_conflicts(
+            tenant_id,
+            subject_entity_id,
+            predicate,
+            exclude_id=str(memory_id),
+            # CAURA-123 — scope by fleet so RDF detection respects the
+            # same isolation boundary as semantic detection. Without
+            # this the storage-api router previously forced
+            # ``fleet_id IS NULL`` and the path was unreachable for
+            # any fleeted write.
+            fleet_id=new_memory.get("fleet_id"),
+            # CAURA-123 — pass the new memory's own object_value so
+            # the storage layer's ``Memory.object_value != :ov`` filter
+            # excludes same-value rows. Otherwise two writes of the
+            # same fact trigger a false conflict on themselves.
+            object_value=object_value,
+            # A54 — scope by the writer's visibility tier, exactly as the
+            # semantic path does below. Without it the RDF path could select
+            # another agent's ``scope_agent`` row as a candidate and then mark
+            # it outdated/conflicted: a status write into a row this writer
+            # cannot read. ``agent_id`` pins the owner for the agent-private
+            # tier, where the visibility value alone says only "private to SOME
+            # agent" and so still matches a different agent's private rows.
+            visibility=new_memory.get("visibility", "scope_team"),
+            agent_id=new_memory.get("agent_id"),
+        )
+        # CAURA-125 — state-corruption guard. When ``rdf_conflicts``
+        # mixes older and newer candidates relative to ``new_memory``,
+        # an earlier flipped iteration already marked ``new_memory``
+        # outdated; a later canonical iteration must NOT then re-write
+        # ``new_memory`` back to its previous status ("active") while
+        # setting ``supersedes_id``.
+        new_memory_is_outdated = False
+        # Collapsed-write accumulator — folded in per audit P2 even
+        # though the RDF loop isn't gather-prefaced; same N+1 shape and
+        # keeps the file consistent with semantic / Path C. Keyed by
+        # ``memory_id`` so a mixed canonical/flipped run that touches
+        # ``new_memory`` twice collapses into one merged row (see
+        # ``_merge_status_update`` for the ordering rationale).
+        rdf_updates: dict[str, dict] = {}
+        for old in rdf_conflicts:
+            # CAURA-125 — decide attribution direction AFTER confirming
+            # the conflict, not before. ``_pick_older`` chooses which
+            # row carries ``outdated`` status; the other carries the
+            # supersedes_id edge pointing at the older row. This makes
+            # the verdict symmetric under candidate vs. new_memory swap
+            # while preserving the chain's newer→older direction.
+            older = _pick_older(old, new_memory)
+            older_is_new = str(older.get("id")) == str(memory_id)
+            newer = new_memory if not older_is_new else old
+            older_id = older.get("id")
+            newer_id = newer.get("id")
+
+            _merge_status_update(rdf_updates, {"memory_id": str(older_id), "status": "outdated"})
+            if newer is new_memory:
+                # Canonical case (candidate is older). Track via local
+                # ``supersedes_id`` so multiple conflict candidates in
+                # this run don't each issue a write; storage's CAS
+                # ``WHERE supersedes_id IS NULL`` would only honour the
+                # first anyway.
+                if not supersedes_id:
+                    supersedes_id = older_id
+                    # Separate the status-reversion guard from the
+                    # chain edge. When a prior flipped iteration has
+                    # already marked ``new_memory`` ``"outdated"``,
+                    # the canonical iteration must still wire
+                    # ``new_memory.supersedes_id`` to ``older_id`` —
+                    # otherwise the older canonical candidate is left
+                    # orphaned (outdated but unreachable via the
+                    # chain). Using ``"outdated"`` as the target
+                    # status here is idempotent with the flipped
+                    # iteration's earlier write.
+                    target_status = (
+                        "outdated" if new_memory_is_outdated else new_memory.get("status", "active")
+                    )
+                    _merge_status_update(
+                        rdf_updates,
+                        {
+                            "memory_id": str(memory_id),
+                            "status": target_status,
+                            "supersedes_id": str(older_id),
+                        },
+                    )
+            else:
+                # Flipped case (candidate is newer). The just-written
+                # memory is the older row and is now ``outdated``; the
+                # pre-existing candidate carries supersedes_id pointing
+                # back at new_memory.
+                new_memory_is_outdated = True
+                # Application-level guard against overwriting an
+                # existing supersedes_id on the candidate. Storage CAS
+                # (``WHERE supersedes_id IS NULL``) is the
+                # last-line-of-defence; this guard logs an explicit
+                # warning so the orphaning attempt is visible in logs
+                # rather than silently no-op'd at the DB.
+                if newer.get("supersedes_id"):
+                    logger.warning(
+                        "Flipped contradiction skipped supersedes_id overwrite "
+                        "for candidate %s (already supersedes %s)",
+                        newer_id,
+                        newer.get("supersedes_id"),
+                    )
+                else:
+                    _merge_status_update(
+                        rdf_updates,
+                        {
+                            "memory_id": str(newer_id),
+                            "status": newer.get("status", "active"),
+                            "supersedes_id": str(older_id),
+                        },
+                    )
+
+            # ``ContradictionInfo.old_memory_id`` is documented as the
+            # pre-existing candidate. Always populate from ``old``
+            # (the candidate row from storage), never from ``older``
+            # — those diverge in the flipped case.
+            direction = "canonical" if newer is new_memory else "flipped"
+            contradictions.append(
+                ContradictionInfo(
+                    old_memory_id=old.get("id"),
+                    # In canonical, the candidate is the row we just
+                    # marked outdated. In flipped, the candidate's
+                    # status is unchanged — surface its actual current
+                    # state rather than a misleading "outdated".
+                    old_status="outdated" if direction == "canonical" else old.get("status", "active"),
+                    reason="rdf_conflict",
+                    old_content_preview=old.get("content", "")[:200],
+                    direction=direction,
+                )
+            )
+            _record_pairs.append((old, "rdf", None))
+            logger.info(
+                "RDF contradiction: memory %s outdated by %s "
+                "(subject=%s predicate=%s old_value=%s new_value=%s direction=%s)",
+                older_id,
+                newer_id,
+                subject_entity_id,
+                predicate,
+                older.get("object_value"),
+                newer.get("object_value"),
+                direction,
+            )
+
+        if rdf_updates:
+            rdf_result = await sc.batch_update_status(
+                {"updates": list(rdf_updates.values())}, tenant_id=tenant_id
+            )
+            if rdf_result.get("skipped"):
+                # ``skipped`` carries rows the storage-side dropped — CAS
+                # gate fail (caller-supplied ``expected_supersedes_id``
+                # mismatch) or row already deleted. Pre-batch, the single-
+                # row PATCH route surfaced 404 as a hard error; the batch
+                # route returns the list instead so we don't abort the
+                # whole detection cycle. Log so the dropped writes are
+                # visible in tracing — the contradiction detector itself
+                # doesn't use ``expected_supersedes_id`` today, so a
+                # non-empty list usually means the target row was
+                # soft-deleted between detect-and-flush.
+                logger.warning(
+                    "batch_update_status (RDF path) skipped %d row(s) (trigger memory %s): %s",
+                    len(rdf_result["skipped"]),
+                    memory_id,
+                    rdf_result["skipped"],
+                )
+
+    return _RdfPassResult(contradictions, _record_pairs, supersedes_id, ran)
+
+
 async def detect_contradictions_async(
     memory_id: UUID,
     tenant_id: str,
@@ -476,179 +709,30 @@ async def _detect(
     _record_pairs: list[tuple[dict, str, float | None]] = []
 
     memory_id = new_memory.get("id")
-    subject_entity_id = new_memory.get("subject_entity_id")
-    predicate = new_memory.get("predicate")
-    object_value = new_memory.get("object_value")
+    # A40 — the triple is read inside ``_rdf_conflict_pass`` now, not here. It
+    # is deliberately NOT hoisted back out: the pass is also called after entity
+    # extraction, where the row it must read is a fresher one than this caller
+    # ever holds.
     tenant_id = new_memory.get("tenant_id")
     content = new_memory.get("content", "")
     supersedes_id = new_memory.get("supersedes_id")
 
     # --- Path 1: RDF triple contradiction (single-value predicates only) ---
-    if subject_entity_id and predicate and object_value and predicate.lower() in SINGLE_VALUE_PREDICATES:
-        rdf_conflicts = await sc.find_rdf_conflicts(
-            tenant_id,
-            subject_entity_id,
-            predicate,
-            exclude_id=str(memory_id),
-            # CAURA-123 — scope by fleet so RDF detection respects the
-            # same isolation boundary as semantic detection. Without
-            # this the storage-api router previously forced
-            # ``fleet_id IS NULL`` and the path was unreachable for
-            # any fleeted write.
-            fleet_id=new_memory.get("fleet_id"),
-            # CAURA-123 — pass the new memory's own object_value so
-            # the storage layer's ``Memory.object_value != :ov`` filter
-            # excludes same-value rows. Otherwise two writes of the
-            # same fact trigger a false conflict on themselves.
-            object_value=object_value,
-            # A54 — scope by the writer's visibility tier, exactly as the
-            # semantic path does below. Without it the RDF path could select
-            # another agent's ``scope_agent`` row as a candidate and then mark
-            # it outdated/conflicted: a status write into a row this writer
-            # cannot read. ``agent_id`` pins the owner for the agent-private
-            # tier, where the visibility value alone says only "private to SOME
-            # agent" and so still matches a different agent's private rows.
-            visibility=new_memory.get("visibility", "scope_team"),
-            agent_id=new_memory.get("agent_id"),
-        )
-        # CAURA-125 — state-corruption guard. When ``rdf_conflicts``
-        # mixes older and newer candidates relative to ``new_memory``,
-        # an earlier flipped iteration already marked ``new_memory``
-        # outdated; a later canonical iteration must NOT then re-write
-        # ``new_memory`` back to its previous status ("active") while
-        # setting ``supersedes_id``.
-        new_memory_is_outdated = False
-        # Collapsed-write accumulator — folded in per audit P2 even
-        # though the RDF loop isn't gather-prefaced; same N+1 shape and
-        # keeps the file consistent with semantic / Path C. Keyed by
-        # ``memory_id`` so a mixed canonical/flipped run that touches
-        # ``new_memory`` twice collapses into one merged row (see
-        # ``_merge_status_update`` for the ordering rationale).
-        rdf_updates: dict[str, dict] = {}
-        for old in rdf_conflicts:
-            # CAURA-125 — decide attribution direction AFTER confirming
-            # the conflict, not before. ``_pick_older`` chooses which
-            # row carries ``outdated`` status; the other carries the
-            # supersedes_id edge pointing at the older row. This makes
-            # the verdict symmetric under candidate vs. new_memory swap
-            # while preserving the chain's newer→older direction.
-            older = _pick_older(old, new_memory)
-            older_is_new = str(older.get("id")) == str(memory_id)
-            newer = new_memory if not older_is_new else old
-            older_id = older.get("id")
-            newer_id = newer.get("id")
-
-            _merge_status_update(rdf_updates, {"memory_id": str(older_id), "status": "outdated"})
-            if newer is new_memory:
-                # Canonical case (candidate is older). Track via local
-                # ``supersedes_id`` so multiple conflict candidates in
-                # this run don't each issue a write; storage's CAS
-                # ``WHERE supersedes_id IS NULL`` would only honour the
-                # first anyway.
-                if not supersedes_id:
-                    supersedes_id = older_id
-                    # Separate the status-reversion guard from the
-                    # chain edge. When a prior flipped iteration has
-                    # already marked ``new_memory`` ``"outdated"``,
-                    # the canonical iteration must still wire
-                    # ``new_memory.supersedes_id`` to ``older_id`` —
-                    # otherwise the older canonical candidate is left
-                    # orphaned (outdated but unreachable via the
-                    # chain). Using ``"outdated"`` as the target
-                    # status here is idempotent with the flipped
-                    # iteration's earlier write.
-                    target_status = (
-                        "outdated" if new_memory_is_outdated else new_memory.get("status", "active")
-                    )
-                    _merge_status_update(
-                        rdf_updates,
-                        {
-                            "memory_id": str(memory_id),
-                            "status": target_status,
-                            "supersedes_id": str(older_id),
-                        },
-                    )
-            else:
-                # Flipped case (candidate is newer). The just-written
-                # memory is the older row and is now ``outdated``; the
-                # pre-existing candidate carries supersedes_id pointing
-                # back at new_memory.
-                new_memory_is_outdated = True
-                # Application-level guard against overwriting an
-                # existing supersedes_id on the candidate. Storage CAS
-                # (``WHERE supersedes_id IS NULL``) is the
-                # last-line-of-defence; this guard logs an explicit
-                # warning so the orphaning attempt is visible in logs
-                # rather than silently no-op'd at the DB.
-                if newer.get("supersedes_id"):
-                    logger.warning(
-                        "Flipped contradiction skipped supersedes_id overwrite "
-                        "for candidate %s (already supersedes %s)",
-                        newer_id,
-                        newer.get("supersedes_id"),
-                    )
-                else:
-                    _merge_status_update(
-                        rdf_updates,
-                        {
-                            "memory_id": str(newer_id),
-                            "status": newer.get("status", "active"),
-                            "supersedes_id": str(older_id),
-                        },
-                    )
-
-            # ``ContradictionInfo.old_memory_id`` is documented as the
-            # pre-existing candidate. Always populate from ``old``
-            # (the candidate row from storage), never from ``older``
-            # — those diverge in the flipped case.
-            direction = "canonical" if newer is new_memory else "flipped"
-            contradictions.append(
-                ContradictionInfo(
-                    old_memory_id=old.get("id"),
-                    # In canonical, the candidate is the row we just
-                    # marked outdated. In flipped, the candidate's
-                    # status is unchanged — surface its actual current
-                    # state rather than a misleading "outdated".
-                    old_status="outdated" if direction == "canonical" else old.get("status", "active"),
-                    reason="rdf_conflict",
-                    old_content_preview=old.get("content", "")[:200],
-                    direction=direction,
-                )
-            )
-            _record_pairs.append((old, "rdf", None))
-            logger.info(
-                "RDF contradiction: memory %s outdated by %s "
-                "(subject=%s predicate=%s old_value=%s new_value=%s direction=%s)",
-                older_id,
-                newer_id,
-                subject_entity_id,
-                predicate,
-                older.get("object_value"),
-                newer.get("object_value"),
-                direction,
-            )
-
-        if rdf_updates:
-            rdf_result = await sc.batch_update_status(
-                {"updates": list(rdf_updates.values())}, tenant_id=tenant_id
-            )
-            if rdf_result.get("skipped"):
-                # ``skipped`` carries rows the storage-side dropped — CAS
-                # gate fail (caller-supplied ``expected_supersedes_id``
-                # mismatch) or row already deleted. Pre-batch, the single-
-                # row PATCH route surfaced 404 as a hard error; the batch
-                # route returns the list instead so we don't abort the
-                # whole detection cycle. Log so the dropped writes are
-                # visible in tracing — the contradiction detector itself
-                # doesn't use ``expected_supersedes_id`` today, so a
-                # non-empty list usually means the target row was
-                # soft-deleted between detect-and-flush.
-                logger.warning(
-                    "batch_update_status (RDF path) skipped %d row(s) (trigger memory %s): %s",
-                    len(rdf_result["skipped"]),
-                    memory_id,
-                    rdf_result["skipped"],
-                )
+    # A40 — the pass itself now lives in ``_rdf_conflict_pass`` so the SAME
+    # deterministic check can run again once entity extraction has populated
+    # the triple. At write time this gate fails for every proper-noun subject
+    # (``EmitMemoryTriple`` resolves only identifier-shaped ones), which is what
+    # sent those writes to the stochastic semantic judge below.
+    _rdf = await _rdf_conflict_pass(
+        sc,
+        new_memory,
+        memory_id=memory_id,
+        tenant_id=tenant_id,
+        supersedes_id=supersedes_id,
+    )
+    contradictions.extend(_rdf.contradictions)
+    _record_pairs.extend(_rdf.record_pairs)
+    supersedes_id = _rdf.supersedes_id
 
     # --- Path 2: Semantic contradiction (vector similarity + batch LLM check) ---
     if not contradictions:
@@ -2445,6 +2529,44 @@ async def detect_contradictions_by_entities_async(
             refreshed = await sc.get_memory(str(memory_id), tenant_id)
             if refreshed and refreshed.get("deleted_at") is None:
                 new_memory = refreshed
+
+        # A40 — run the DETERMINISTIC pass here, where the triple finally
+        # exists. This is the whole point of the fix: at write time
+        # ``EmitMemoryTriple`` resolves a subject only for identifier-shaped
+        # tokens, so every proper-noun fact ("Maya lives in Boston") committed
+        # with a NULL subject, Path A's RDF gate failed, and the verdict was
+        # handed to the stochastic raw-text judge. Entity extraction has now
+        # populated ``subject_entity_id`` / ``predicate`` / ``object_value``,
+        # and it is extraction completing that fired this very function — so
+        # this is the first moment the check CAN run for those rows.
+        #
+        # Cheaper, not dearer: a deterministic verdict short-circuits the
+        # entity-overlap LLM judge below, exactly as an RDF hit short-circuits
+        # Path A's semantic judge. Re-running is safe — the query selects only
+        # live rows, so anything Path A already retired is out of scope.
+        rdf = await _rdf_conflict_pass(
+            sc,
+            new_memory,
+            memory_id=memory_id,
+            tenant_id=tenant_id,
+            supersedes_id=new_memory.get("supersedes_id"),
+        )
+        if rdf.contradictions:
+            n_conflicts += len(rdf.contradictions)
+            if rdf.record_pairs and settings.contradiction_write_conflict_record:
+                from core_api.services.contradiction.resolver import (
+                    record_detected_conflicts,
+                )
+
+                await record_detected_conflicts(
+                    new_memory,
+                    rdf.record_pairs,
+                    tenant_id=tenant_id,
+                    fleet_id=new_memory.get("fleet_id"),
+                    tenant_config=tenant_config,
+                )
+            concluded = True
+            return
 
         candidates = await sc.find_entity_overlap_candidates(
             {

--- a/tests/test_a40_rdf_pass_after_extraction.py
+++ b/tests/test_a40_rdf_pass_after_extraction.py
@@ -1,0 +1,227 @@
+"""reg-a40 — the deterministic contradiction check could not run where it mattered.
+
+R7 filed this as "Path A semantic defer-and-retry vs base-judge stochasticity":
+when entity extraction has not completed, the check falls back to the raw-text
+LLM judge and silently misses or false-flags. The mechanism turns out to be
+sharper than a race.
+
+Path A's RDF gate needs ``(subject_entity_id, predicate, object_value)``.
+``EmitMemoryTriple`` fills those during the write with no LLM call — but it
+resolves a SUBJECT from only two sources: a caller-supplied ``entity_links``
+row, or an identifier-shaped token. Proper nouns deliberately return ``None``,
+deferring to the entity-extraction worker's higher-precision output. So for any
+ordinary human- or company-subject fact the row commits with a NULL subject, the
+gate fails, and the verdict goes to the stochastic judge.
+
+Extraction then populates the columns moments later and fires Path C — which did
+entity-overlap plus another LLM judge and never retried the deterministic check.
+The one non-stochastic verdict in the module was structurally unreachable
+exactly where it was needed.
+
+The pass is now shared and runs in both places. It is also CHEAPER: a
+deterministic verdict short-circuits an LLM judge rather than adding one.
+"""
+
+import inspect
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from core_api.services import contradiction_detector as cd
+
+pytestmark = pytest.mark.unit
+
+SUBJECT = "00000000-0000-0000-0000-0000000000aa"
+
+
+def _memory(**over) -> dict:
+    base = {
+        "id": str(uuid4()),
+        "tenant_id": "t1",
+        "fleet_id": "f1",
+        "content": "Maya lives in Boston",
+        "subject_entity_id": SUBJECT,
+        "predicate": "lives_in",
+        "object_value": "Boston",
+        "deleted_at": None,
+        "status": "active",
+        "visibility": "scope_team",
+        "supersedes_id": None,
+        "created_at": "2026-04-29T12:00:00+00:00",
+    }
+    base.update(over)
+    return base
+
+
+def _candidate(object_value: str, ts: str = "2026-04-29T10:00:00+00:00") -> dict:
+    return {
+        "id": str(uuid4()),
+        "content": f"Maya lives in {object_value}",
+        "status": "active",
+        "object_value": object_value,
+        "created_at": ts,
+    }
+
+
+# ── the premise: why the gate fails at write time ─────────────────────────
+
+
+@pytest.mark.parametrize(
+    "content,expected_subject",
+    [
+        ("Maya lives in Boston", None),
+        ("Acme is headquartered in Berlin", None),
+        ("Priya reports to Dana", None),
+        ("TOKEN-XYZ has release date 2027", "TOKEN-XYZ"),
+    ],
+)
+def test_write_time_subject_resolution_skips_proper_nouns(content, expected_subject):
+    """The root cause, pinned so it cannot change silently.
+
+    Three of these four match a single-value predicate and still resolve NO
+    subject, so ``EmitMemoryTriple`` skips and the row commits with a NULL
+    ``subject_entity_id``. That is what made the RDF gate unreachable for
+    human- and company-subject facts — which is most of them.
+    """
+    import re
+
+    from core_api.pipeline.steps.write.emit_memory_triple import (
+        _PHRASE_TO_PREDICATE,
+        _infer_subject_token,
+    )
+
+    norm = re.sub(r"\s+", " ", content)
+    matches = [(m, p) for pat, p in _PHRASE_TO_PREDICATE for m in pat.finditer(norm)]
+    assert matches, "fixture must match a predicate, or it proves nothing"
+    head = min(matches, key=lambda mp: mp[0].start())[0]
+    assert _infer_subject_token(norm, head) == expected_subject
+
+
+# ── "could not look" is not "found nothing" ───────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "missing",
+    ["subject_entity_id", "predicate", "object_value"],
+)
+async def test_pass_reports_it_could_not_run_when_the_triple_is_incomplete(missing):
+    """``ran`` exists precisely because this bug hid in the gap between "no
+    conflict" and "could not look". Without it, an unpopulated triple and a
+    clean bill of health are indistinguishable to every caller."""
+    sc = AsyncMock()
+    sc.find_rdf_conflicts = AsyncMock(return_value=[])
+    mem = _memory(**{missing: None})
+
+    result = await cd._rdf_conflict_pass(
+        sc, mem, memory_id=mem["id"], tenant_id="t1", supersedes_id=None
+    )
+
+    assert result.ran is False
+    assert result.contradictions == []
+    sc.find_rdf_conflicts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pass_runs_and_finds_nothing_when_the_triple_is_complete():
+    sc = AsyncMock()
+    sc.find_rdf_conflicts = AsyncMock(return_value=[])
+    mem = _memory()
+
+    result = await cd._rdf_conflict_pass(
+        sc, mem, memory_id=mem["id"], tenant_id="t1", supersedes_id=None
+    )
+
+    assert result.ran is True
+    assert result.contradictions == []
+    sc.find_rdf_conflicts.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_non_single_value_predicate_does_not_run_the_pass():
+    """``works_on`` can be true of five projects at once — a second value is an
+    addition, not a replacement."""
+    sc = AsyncMock()
+    sc.find_rdf_conflicts = AsyncMock(return_value=[])
+    mem = _memory(predicate="works_on")
+
+    result = await cd._rdf_conflict_pass(
+        sc, mem, memory_id=mem["id"], tenant_id="t1", supersedes_id=None
+    )
+
+    assert result.ran is False
+    sc.find_rdf_conflicts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pass_returns_the_conflict_and_the_chain_edge():
+    sc = AsyncMock()
+    cand = _candidate("Haifa")
+    sc.find_rdf_conflicts = AsyncMock(return_value=[cand])
+    sc.batch_update_status = AsyncMock(return_value={})
+    mem = _memory(object_value="Tel Aviv")
+
+    result = await cd._rdf_conflict_pass(
+        sc, mem, memory_id=mem["id"], tenant_id="t1", supersedes_id=None
+    )
+
+    assert result.ran is True
+    assert len(result.contradictions) == 1
+    assert result.contradictions[0].reason == "rdf_conflict"
+    # candidate is older, so it is the one retired and the chain points at it
+    assert str(result.supersedes_id) == cand["id"]
+    assert result.record_pairs and result.record_pairs[0][1] == "rdf"
+
+
+# ── both triggers reach the same pass ─────────────────────────────────────
+
+
+def test_write_time_path_delegates_to_the_shared_pass():
+    # ``detect_contradictions_async`` is the locking wrapper; ``_detect`` holds
+    # the path logic it guards.
+    src = inspect.getsource(cd._detect)
+    assert "_rdf_conflict_pass(" in src
+
+
+def test_the_write_time_pass_still_gates_the_semantic_judge():
+    """Path A's semantic judge has always been gated on ``if not
+    contradictions``. Extraction must not have dropped that, or the RDF path
+    would stop saving the LLM call it used to save."""
+    src = inspect.getsource(cd._detect)
+    assert "if not contradictions:" in src
+    assert src.index("_rdf_conflict_pass(") < src.index("if not contradictions:")
+
+
+def test_post_extraction_path_runs_the_pass_too():
+    """The fix. Path C is fired BY entity extraction completing, so it is the
+    first moment the triple exists for a proper-noun subject."""
+    src = inspect.getsource(cd.detect_contradictions_by_entities_async)
+    assert "_rdf_conflict_pass(" in src
+
+
+def test_the_pass_runs_before_the_entity_overlap_judge():
+    """Order is the cost argument. Running the deterministic check first lets a
+    hit short-circuit the LLM judge; running it after would spend the call
+    anyway and save nothing."""
+    src = inspect.getsource(cd.detect_contradictions_by_entities_async)
+    assert src.index("_rdf_conflict_pass(") < src.index(
+        "find_entity_overlap_candidates"
+    )
+
+
+def test_the_pass_reads_the_refreshed_row_not_the_one_fetched_before_retraction():
+    """A4 #13's retraction can clear ``supersedes_id`` and re-fetch. The pass
+    must sit after that re-fetch, or it would judge against a stale chain."""
+    src = inspect.getsource(cd.detect_contradictions_by_entities_async)
+    assert src.index("new_memory = refreshed") < src.index("_rdf_conflict_pass(")
+
+
+def test_a_deterministic_verdict_short_circuits_the_llm_judge():
+    """The no-new-LLM-calls property, asserted on the code rather than assumed:
+    Path C returns as soon as the pass produces contradictions, so a
+    deterministic verdict REPLACES a judge call instead of preceding one."""
+    src = inspect.getsource(cd.detect_contradictions_by_entities_async)
+    head = src[: src.index("find_entity_overlap_candidates")]
+    assert "if rdf.contradictions:" in head
+    assert "return" in head[head.index("if rdf.contradictions:") :]


### PR DESCRIPTION
R7 filed this as "Path A semantic defer-and-retry vs base-judge
stochasticity": when entity extraction hasn't completed, the check falls
back to the raw-text LLM judge and silently misses or false-flags. The
mechanism turns out to be sharper than a race — the deterministic path
was **structurally unreachable** for most facts, not merely late.

## What was happening

Path A's RDF gate needs `(subject_entity_id, predicate, object_value)`.
`EmitMemoryTriple` fills those during the write with no LLM call — but it
resolves a **subject** from only two sources: a caller-supplied
`entity_links` row, or an identifier-shaped token. Proper nouns
deliberately return `None`, deferring to the entity-extraction worker's
higher-precision output (`_infer_subject_token`, "skip-on-doubt").

Measured on this code:

```
"Maya lives in Boston"             predicate=lives_in          subject=None
"Acme is headquartered in Berlin"  predicate=headquartered_in  subject=None
"Priya reports to Dana"            predicate=reports_to        subject=None
"TOKEN-XYZ has release date 2027"  predicate=release_date      subject=TOKEN-XYZ
```

Three of four match a single-value predicate and still resolve no
subject. So for any ordinary human- or company-subject fact the row
commits with a NULL subject, the RDF gate fails, and the verdict goes to
the stochastic judge.

Extraction then populates the columns moments later and fires Path C —
which did entity-overlap plus **another** LLM judge and never retried the
deterministic check. The one non-stochastic verdict in the module could
not run in exactly the case it was written for.

## The change

The RDF pass is extracted verbatim into `_rdf_conflict_pass` and called
from both triggers. Path C runs it immediately after the A4 #13
retraction re-fetch — the first moment the triple exists for a
proper-noun subject, and the same event (extraction completing) that
fired Path C in the first place.

`ran` is returned alongside the verdict because this bug lived in the gap
between **"no conflict"** and **"could not look"**. Without it those two
are indistinguishable to every caller, which is how it stayed hidden.

## This reduces LLM calls, it does not add any

Path A's semantic judge is gated on `if not contradictions`; Path C now
returns as soon as the pass produces a verdict. So a deterministic result
**replaces** a judge call rather than preceding one. The pass itself is
pure SQL. Both properties are asserted on the code, not assumed.

Re-running is safe by construction: `memory_find_rdf_conflicts` selects
only `active`/`confirmed`/`pending` rows, so anything an earlier pass
retired is out of scope, and the storage CAS (`WHERE supersedes_id IS
NULL`) backstops the chain edge.

## Note

This is also what makes A35 (#1459) and A36 (#1462) worth having. Both
improved this query, and all three of the proper-noun predicates above —
`lives_in`, `headquartered_in`, `reports_to` — are in A36's alias
clusters. Until now that query largely didn't run for them.

Extraction is behaviour-preserving: the 316 existing contradiction tests
pass untouched. Full suite **31 failures, identical to main's 31** — none
new. `ruff` clean; `mypy` on core-api goes 164 -> **162**.

