### PR TITLE
fix(api): give every auth refusal a code that names the reason (C32)

### DIFF
--- a/core-api/src/core_api/errors.py
+++ b/core-api/src/core_api/errors.py
@@ -102,6 +102,29 @@ AUTH_TENANT_NOT_READABLE = "TENANT_NOT_READABLE"
 AUTH_CROSS_TENANT_REQUIRED = "CROSS_TENANT_READ_REQUIRED"
 AUTH_ORG_SUSPENDED = "ORGANIZATION_SUSPENDED"
 
+# C32 — the reasons the remaining 33 refusal sites actually give. Added rather
+# than folded into the codes above because each one leaves the caller a
+# DIFFERENT next move, which is the whole test for whether a code earns its
+# place: "register this agent" and "raise this agent's trust_level" are both
+# FORBIDDEN and are not the same instruction.
+AUTH_AGENT_NOT_REGISTERED = "AGENT_NOT_REGISTERED"
+AUTH_AGENT_TRUST_TOO_LOW = "AGENT_TRUST_TOO_LOW"
+AUTH_TARGET_AGENT_RESTRICTED = "TARGET_AGENT_RESTRICTED"
+AUTH_FLEET_SCOPE_FORBIDDEN = "FLEET_SCOPE_FORBIDDEN"
+AUTH_FEATURE_DISABLED = "FEATURE_DISABLED"
+
+# Three codes whose VALUES are inherited, not chosen. ``skills_inbox`` and
+# ``stm`` already shipped a machine-readable token welded to the front of the
+# prose — ``"TENANT_MISMATCH — this credential is not scoped…"`` — with a
+# comment at the site stating that clients branch on the prefix and not on the
+# message. That is a live contract, so moving it into ``error.code`` must keep
+# the string byte-for-byte; a "tidier" spelling here would be a silent breaking
+# change for every caller already parsing it. ``TENANT_MISMATCH`` needed no new
+# constant — ``AUTH_TENANT_MISMATCH`` above already carries that exact value.
+AUTH_UNAUTHENTICATED = "UNAUTHENTICATED"
+AUTH_SKILLS_FACTORY_DISABLED = "SKILLS_FACTORY_DISABLED"
+AUTH_SKILLS_INBOX_FORBIDDEN = "SKILLS_INBOX_FORBIDDEN"
+
 
 def coded_detail(code: str, message: str, **details: object) -> dict:
     """An ``HTTPException`` detail that keeps its own error code.

--- a/core-api/src/core_api/routes/conflicts.py
+++ b/core-api/src/core_api/routes/conflicts.py
@@ -23,6 +23,10 @@ from core_api import openapi_responses as _oar
 from core_api.agent_ids import DEFAULT_AGENT_ID
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
+from core_api.errors import (
+    AUTH_AGENT_NOT_REGISTERED,
+    coded_detail,
+)
 from core_api.schemas import ConflictListResponse, ConflictOut, ConflictResolveRequest
 from core_api.services.audit_service import log_action
 from core_api.services.trust_service import require_trust as _require_trust
@@ -108,10 +112,11 @@ async def resolve_conflict(
     if not_found or terr:
         raise HTTPException(
             status_code=403,
-            detail=(
+            detail=coded_detail(
+                AUTH_AGENT_NOT_REGISTERED,
                 f"Agent '{reviewer}' cannot review conflicts. Reviewing records ground "
                 "truth about detector accuracy, so it requires a registered agent at "
-                "trust >= 2 — call with X-Agent-ID or an agent-scoped credential."
+                "trust >= 2 — call with X-Agent-ID or an agent-scoped credential.",
             ),
         )
     payload = {

--- a/core-api/src/core_api/routes/interview.py
+++ b/core-api/src/core_api/routes/interview.py
@@ -31,6 +31,10 @@ from pydantic import BaseModel, Field
 from core_api.auth import AuthContext, get_auth_context
 from core_api.config import settings as app_settings
 from core_api.constants import INTERVIEW_EVENT_MAX_CHARS, INTERVIEW_MAX_EVENTS_PER_SUBMIT
+from core_api.errors import (
+    AUTH_FEATURE_DISABLED,
+    coded_detail,
+)
 from core_api.schemas import STRICT_WRITE_BODY
 from core_api.services.interview_service import (
     InterviewJobPermanentlyFailedError,
@@ -163,7 +167,10 @@ async def submit_interview(
     if not interviewer_cfg.get("enabled"):
         # Defense in depth: the scheduler shouldn't have queued a command
         # for a disabled tenant; refuse rather than silently ingest.
-        raise HTTPException(status_code=403, detail="interviewer is not enabled for this tenant")
+        raise HTTPException(
+            status_code=403,
+            detail=coded_detail(AUTH_FEATURE_DISABLED, "interviewer is not enabled for this tenant"),
+        )
 
     if app_settings.interview_async_submit:
         # Persist-and-accept (#665). The 60-90s inline synthesis outlived

--- a/core-api/src/core_api/routes/keystones.py
+++ b/core-api/src/core_api/routes/keystones.py
@@ -56,6 +56,11 @@ from core_api import openapi_responses as _oar
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import KeystoneUpsertPayload, get_storage_client
 from core_api.config import settings as app_settings
+from core_api.errors import (
+    AUTH_AGENT_NOT_REGISTERED,
+    AUTH_AGENT_TRUST_TOO_LOW,
+    coded_detail,
+)
 from core_api.schemas import STRICT_WRITE_BODY
 from core_api.services.audit_service import log_action
 from core_api.services.trust_service import parse_trust_error
@@ -143,15 +148,19 @@ async def _enforce_author_trust(
     if not_found:
         raise HTTPException(
             status_code=403,
-            detail=(
+            detail=coded_detail(
+                AUTH_AGENT_NOT_REGISTERED,
                 f"Agent '{agent_id}' has no registered agent row, so its keystone-author "
                 "trust can't be verified. Register it (write one memory as that agent, then "
                 "promote its trust), or call with X-Agent-ID / an agent-scoped credential for "
-                "an agent at trust ≥ 2."
+                "an agent at trust ≥ 2.",
             ),
         )
     if terr:
-        raise HTTPException(status_code=403, detail=parse_trust_error(terr) + hint)
+        raise HTTPException(
+            status_code=403,
+            detail=coded_detail(AUTH_AGENT_TRUST_TOO_LOW, parse_trust_error(terr) + hint),
+        )
 
 
 def _resolve_caller_identity(auth: AuthContext, x_agent_id: str | None) -> tuple[str, bool]:
@@ -479,15 +488,19 @@ async def delete_keystone(
         if not_found:
             raise HTTPException(
                 status_code=403,
-                detail=(
+                detail=coded_detail(
+                    AUTH_AGENT_NOT_REGISTERED,
                     f"Agent '{caller_agent_id}' has no registered agent row, so its "
                     "keystone-author trust can't be verified. Register it (write one memory "
                     "as that agent, then promote its trust), or call with X-Agent-ID / an "
-                    "agent-scoped credential for an agent at trust ≥ 2."
+                    "agent-scoped credential for an agent at trust ≥ 2.",
                 ),
             )
         if terr:
-            raise HTTPException(status_code=403, detail=parse_trust_error(terr))
+            raise HTTPException(
+                status_code=403,
+                detail=coded_detail(AUTH_AGENT_TRUST_TOO_LOW, parse_trust_error(terr)),
+            )
 
     sc = get_storage_client()
     # Look up the rule before computing the scope-derived floor — the
@@ -510,7 +523,10 @@ async def delete_keystone(
         if trust < min_level:
             raise HTTPException(
                 status_code=403,
-                detail=(f"Agent '{caller_agent_id}' (trust_level={trust}) < required {min_level}."),
+                detail=coded_detail(
+                    AUTH_AGENT_TRUST_TOO_LOW,
+                    f"Agent '{caller_agent_id}' (trust_level={trust}) < required {min_level}.",
+                ),
             )
 
     # TOCTOU narrowing: re-fetch the stored row immediately before the

--- a/core-api/src/core_api/routes/memories.py
+++ b/core-api/src/core_api/routes/memories.py
@@ -34,7 +34,12 @@ from core_api.constants import (
     MAX_LIST_LIMIT,
     MEMORY_STATUSES_PATTERN,
 )
-from core_api.errors import coded_detail
+from core_api.errors import (
+    AUTH_AGENT_TRUST_TOO_LOW,
+    AUTH_FLEET_SCOPE_FORBIDDEN,
+    AUTH_TARGET_AGENT_RESTRICTED,
+    coded_detail,
+)
 from core_api.middleware.idempotency import (
     IDEMPOTENCY_HEADER,
     IdempotencyGuard,
@@ -257,7 +262,10 @@ async def _resolve_scoped_read(
         # unregistered agent_id is cosmetic here because nothing is persisted.
         _, _, terr = await require_trust(tenant_id, caller_agent_id, min_level=min_level)
         if terr:
-            raise HTTPException(status_code=403, detail=parse_trust_error(terr))
+            raise HTTPException(
+                status_code=403,
+                detail=coded_detail(AUTH_AGENT_TRUST_TOO_LOW, parse_trust_error(terr)),
+            )
     return author_filter, fleet_id
 
 
@@ -1146,7 +1154,10 @@ async def _write_memory_inner(
     if agent.get("trust_level", 0) == 0:
         raise HTTPException(
             status_code=403,
-            detail=f"Agent '{body.agent_id}' is not approved. Contact tenant admin to set trust_level >= 1.",
+            detail=coded_detail(
+                AUTH_AGENT_TRUST_TOO_LOW,
+                f"Agent '{body.agent_id}' is not approved. Contact tenant admin to set trust_level >= 1.",
+            ),
         )
     # Resolve fleet_id from agent's home fleet if not provided
     if not body.fleet_id and agent.get("fleet_id"):
@@ -1634,8 +1645,9 @@ async def delete_memory(
             if not allowed:
                 raise HTTPException(
                     status_code=403,
-                    detail=(
-                        f"Agent '{caller_agent_id}' cannot delete memory in fleet '{target.get('fleet_id')}'."
+                    detail=coded_detail(
+                        AUTH_FLEET_SCOPE_FORBIDDEN,
+                        f"Agent '{caller_agent_id}' cannot delete memory in fleet '{target.get('fleet_id')}'.",
                     ),
                 )
     # ``soft_delete_memory`` already routes the fetch + delete through the
@@ -1705,7 +1717,10 @@ async def update_memory_status(
         if not allowed:
             raise HTTPException(
                 status_code=403,
-                detail=f"Agent '{auth.agent_id}' cannot modify memory in fleet '{memory.get('fleet_id')}'.",
+                detail=coded_detail(
+                    AUTH_FLEET_SCOPE_FORBIDDEN,
+                    f"Agent '{auth.agent_id}' cannot modify memory in fleet '{memory.get('fleet_id')}'.",
+                ),
             )
     old_status = memory.get("status")
     await sc.update_memory_status(str(memory_id), status, tenant_id=tenant_id)
@@ -2324,7 +2339,9 @@ async def redistribute_memories(
     if caller is None or caller.get("trust_level", 0) < 3:
         raise HTTPException(
             status_code=403,
-            detail=f"Agent '{agent_id}' requires trust_level >= 3 for redistribute.",
+            detail=coded_detail(
+                AUTH_AGENT_TRUST_TOO_LOW, f"Agent '{agent_id}' requires trust_level >= 3 for redistribute."
+            ),
         )
 
     # Verify target agent exists and is not restricted
@@ -2337,8 +2354,11 @@ async def redistribute_memories(
     if target.get("trust_level", 0) < 1:
         raise HTTPException(
             status_code=403,
-            detail=f"Target agent '{body.target_agent_id}' is restricted (trust_level=0). "
-            "Cannot assign memories to a restricted agent.",
+            detail=coded_detail(
+                AUTH_TARGET_AGENT_RESTRICTED,
+                f"Target agent '{body.target_agent_id}' is restricted (trust_level=0). "
+                "Cannot assign memories to a restricted agent.",
+            ),
         )
 
     # Usage quota

--- a/core-api/src/core_api/routes/reports.py
+++ b/core-api/src/core_api/routes/reports.py
@@ -37,6 +37,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
+from core_api.errors import (
+    AUTH_CROSS_TENANT_REQUIRED,
+    coded_detail,
+)
 from core_api.services.agent_digest import run_agent_digest
 from core_api.services.audit_service import log_action
 from core_api.services.caller_identity import resolve_caller_and_gate
@@ -238,7 +242,9 @@ async def get_report(
     if org_mode and not (auth.is_admin or auth.is_cross_tenant_read):
         raise HTTPException(
             status_code=403,
-            detail="scope='org' requires a cross-tenant read credential.",
+            detail=coded_detail(
+                AUTH_CROSS_TENANT_REQUIRED, "scope='org' requires a cross-tenant read credential."
+            ),
         )
     # The internal admin credential (the enterprise org-report proxy) may pass an
     # explicit tenant set — the proxy has already org-admin-gated the caller and

--- a/core-api/src/core_api/routes/skills_inbox.py
+++ b/core-api/src/core_api/routes/skills_inbox.py
@@ -37,6 +37,13 @@ from pydantic import BaseModel, Field
 
 from core_api.auth import AuthContext, get_auth_context
 from core_api.clients.storage_client import get_storage_client
+from core_api.errors import (
+    AUTH_SKILLS_FACTORY_DISABLED,
+    AUTH_SKILLS_INBOX_FORBIDDEN,
+    AUTH_TENANT_MISMATCH,
+    AUTH_UNAUTHENTICATED,
+    coded_detail,
+)
 from core_api.schemas import STRICT_WRITE_BODY
 from core_api.services.audit_service import log_action
 from core_api.services.forge.poison import write_rejected_fingerprint
@@ -78,7 +85,10 @@ async def _require_skills_factory_enabled(tenant_id: str) -> dict:
     if not enabled:
         raise HTTPException(
             status_code=403,
-            detail="SKILLS_FACTORY_DISABLED — set org_settings.skills_factory.enabled=true to use the inbox",
+            detail=coded_detail(
+                AUTH_SKILLS_FACTORY_DISABLED,
+                "SKILLS_FACTORY_DISABLED — set org_settings.skills_factory.enabled=true to use the inbox",
+            ),
         )
     return await get_settings_for_display(tenant_id)
 
@@ -114,7 +124,10 @@ def _require_tenant(auth: AuthContext, explicit_tenant_id: str | None = None) ->
             # on the ``TENANT_MISMATCH`` prefix, not on the prose.
             raise HTTPException(
                 status_code=403,
-                detail="TENANT_MISMATCH — this credential is not scoped to the requested tenant.",
+                detail=coded_detail(
+                    AUTH_TENANT_MISMATCH,
+                    "TENANT_MISMATCH — this credential is not scoped to the requested tenant.",
+                ),
             )
         return auth.tenant_id
     if getattr(auth, "is_admin", False):
@@ -126,7 +139,7 @@ def _require_tenant(auth: AuthContext, explicit_tenant_id: str | None = None) ->
         )
     raise HTTPException(
         status_code=401,
-        detail="UNAUTHENTICATED — auth context has no tenant_id",
+        detail=coded_detail(AUTH_UNAUTHENTICATED, "UNAUTHENTICATED — auth context has no tenant_id"),
     )
 
 
@@ -176,7 +189,9 @@ def _require_inbox_admin(auth: AuthContext) -> None:
     if not is_admin:
         raise HTTPException(
             status_code=403,
-            detail="SKILLS_INBOX_FORBIDDEN — inbox actions require admin privileges",
+            detail=coded_detail(
+                AUTH_SKILLS_INBOX_FORBIDDEN, "SKILLS_INBOX_FORBIDDEN — inbox actions require admin privileges"
+            ),
         )
 
 

--- a/core-api/src/core_api/routes/stm.py
+++ b/core-api/src/core_api/routes/stm.py
@@ -10,6 +10,12 @@ from pydantic import BaseModel
 from common.enrichment.constants import SERVER_RESERVED_MEMORY_TYPES
 from core_api.auth import AuthContext, get_auth_context
 from core_api.config import settings
+from core_api.errors import (
+    AUTH_AGENT_TRUST_TOO_LOW,
+    AUTH_TENANT_MISMATCH,
+    AUTH_UNAUTHENTICATED,
+    coded_detail,
+)
 from core_api.middleware.per_tenant_concurrency import per_tenant_slot
 from core_api.middleware.rate_limit import write_limit
 from core_api.schemas import STRICT_WRITE_BODY
@@ -161,7 +167,10 @@ def _require_tenant(auth: AuthContext, explicit_tenant_id: str | None = None) ->
             # ``TENANT_MISMATCH`` prefix, not on the prose.
             raise HTTPException(
                 status_code=403,
-                detail="TENANT_MISMATCH — this credential is not scoped to the requested tenant.",
+                detail=coded_detail(
+                    AUTH_TENANT_MISMATCH,
+                    "TENANT_MISMATCH — this credential is not scoped to the requested tenant.",
+                ),
             )
         return auth.tenant_id
     if getattr(auth, "is_admin", False):
@@ -173,7 +182,7 @@ def _require_tenant(auth: AuthContext, explicit_tenant_id: str | None = None) ->
         )
     raise HTTPException(
         status_code=401,
-        detail="UNAUTHENTICATED — auth context has no tenant_id",
+        detail=coded_detail(AUTH_UNAUTHENTICATED, "UNAUTHENTICATED — auth context has no tenant_id"),
     )
 
 
@@ -348,7 +357,10 @@ async def promote_stm(
     if agent.get("trust_level", 0) == 0:
         raise HTTPException(
             status_code=403,
-            detail=f"Agent '{body.agent_id}' is not approved. Contact tenant admin to set trust_level >= 1.",
+            detail=coded_detail(
+                AUTH_AGENT_TRUST_TOO_LOW,
+                f"Agent '{body.agent_id}' is not approved. Contact tenant admin to set trust_level >= 1.",
+            ),
         )
     # Resolve fleet from the agent's home fleet, as the write path does, so the
     # fleet-write policy below is evaluated against the fleet the memory will

--- a/core-api/src/core_api/routes/testing.py
+++ b/core-api/src/core_api/routes/testing.py
@@ -12,6 +12,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from core_api.auth import AuthContext, get_auth_context
+from core_api.errors import (
+    AUTH_FEATURE_DISABLED,
+    AUTH_TENANT_MISMATCH,
+    coded_detail,
+)
 from core_api.schemas import STRICT_WRITE_BODY
 
 logger = logging.getLogger(__name__)
@@ -54,7 +59,9 @@ class TimeWarpResponse(BaseModel):
 def _require_testing_mode() -> None:
     """Fail fast if TESTING env var is not set."""
     if os.getenv("TESTING") != "1":
-        raise HTTPException(status_code=403, detail="Testing endpoints require TESTING=1")
+        raise HTTPException(
+            status_code=403, detail=coded_detail(AUTH_FEATURE_DISABLED, "Testing endpoints require TESTING=1")
+        )
 
 
 # ── Endpoint ──
@@ -123,7 +130,7 @@ async def _handle_set_field(body: TimeWarpRequest, auth: AuthContext) -> TimeWar
             # Admin credentials carry no tenant. The old comparison rejected
             # them here too — ``memories.tenant_id`` is NOT NULL, so it could
             # never equal None — and there is no tenant to scope the fetch to.
-            raise HTTPException(status_code=403, detail="Tenant mismatch")
+            raise HTTPException(status_code=403, detail=coded_detail(AUTH_TENANT_MISMATCH, "Tenant mismatch"))
         row = await sc.get_memory(body.id, auth.tenant_id)
         if not row:
             raise HTTPException(status_code=404, detail="Memory not found")

--- a/core-api/src/core_api/services/agent_service.py
+++ b/core-api/src/core_api/services/agent_service.py
@@ -10,6 +10,12 @@ from fastapi import HTTPException
 from core_api.agent_ids import AgentIdentity
 from core_api.clients.storage_client import get_storage_client
 from core_api.constants import DEFAULT_TRUST_LEVEL
+from core_api.errors import (
+    AUTH_AGENT_NOT_REGISTERED,
+    AUTH_AGENT_TRUST_TOO_LOW,
+    AUTH_FLEET_SCOPE_FORBIDDEN,
+    coded_detail,
+)
 from core_api.services.audit_service import log_action
 
 logger = logging.getLogger(__name__)
@@ -275,7 +281,10 @@ async def enforce_fleet_write(
     if trust < 3:
         raise HTTPException(
             status_code=403,
-            detail=f"fleet-scope policy: fleet '{fleet_id}' is not writable by principals of fleet '{agent.get('fleet_id') or 'none'}'.",
+            detail=coded_detail(
+                AUTH_FLEET_SCOPE_FORBIDDEN,
+                f"fleet-scope policy: fleet '{fleet_id}' is not writable by principals of fleet '{agent.get('fleet_id') or 'none'}'.",
+            ),
         )
     return agent
 
@@ -330,7 +339,10 @@ async def enforce_fleet_read_many(
         if trust < 2:
             raise HTTPException(
                 status_code=403,
-                detail=f"fleet-scope policy: fleet '{fleet_id}' is not readable by principals of fleet '{own_fleet or 'none'}'.",
+                detail=coded_detail(
+                    AUTH_FLEET_SCOPE_FORBIDDEN,
+                    f"fleet-scope policy: fleet '{fleet_id}' is not readable by principals of fleet '{own_fleet or 'none'}'.",
+                ),
             )
 
 
@@ -554,14 +566,19 @@ async def enforce_delete(
     if not agent:
         raise HTTPException(
             status_code=403,
-            detail=f"Agent '{agent_id}' is not registered and cannot delete memories.",
+            detail=coded_detail(
+                AUTH_AGENT_NOT_REGISTERED, f"Agent '{agent_id}' is not registered and cannot delete memories."
+            ),
         )
 
     trust = agent.get("trust_level", 0)
     if trust < 3:
         raise HTTPException(
             status_code=403,
-            detail=f"access policy: principals of fleet '{agent.get('fleet_id') or 'none'}' are not permitted to delete memories.",
+            detail=coded_detail(
+                AUTH_AGENT_TRUST_TOO_LOW,
+                f"access policy: principals of fleet '{agent.get('fleet_id') or 'none'}' are not permitted to delete memories.",
+            ),
         )
 
 
@@ -575,18 +592,25 @@ async def enforce_update(
     if not agent:
         raise HTTPException(
             status_code=403,
-            detail=f"Agent '{agent_id}' is not registered and cannot update memories.",
+            detail=coded_detail(
+                AUTH_AGENT_NOT_REGISTERED, f"Agent '{agent_id}' is not registered and cannot update memories."
+            ),
         )
     trust = agent.get("trust_level", 0)
     if trust == 0:
         raise HTTPException(
             status_code=403,
-            detail=f"access policy: agent '{agent_id}' is restricted from updates.",
+            detail=coded_detail(
+                AUTH_AGENT_TRUST_TOO_LOW, f"access policy: agent '{agent_id}' is restricted from updates."
+            ),
         )
     if trust < 3 and agent_id != memory_owner_agent_id:
         raise HTTPException(
             status_code=403,
-            detail=f"access policy: agent '{agent_id}' may only update its own memories.",
+            detail=coded_detail(
+                AUTH_AGENT_TRUST_TOO_LOW,
+                f"access policy: agent '{agent_id}' may only update its own memories.",
+            ),
         )
 
 

--- a/core-api/src/core_api/services/caller_identity.py
+++ b/core-api/src/core_api/services/caller_identity.py
@@ -23,6 +23,11 @@ from fastapi import HTTPException
 from core_api.agent_ids import DEFAULT_AGENT_ID, AgentIdentity
 from core_api.auth import AuthContext
 from core_api.config import settings as app_settings
+from core_api.errors import (
+    AUTH_AGENT_NOT_REGISTERED,
+    AUTH_AGENT_TRUST_TOO_LOW,
+    coded_detail,
+)
 from core_api.services.agent_service import broker_owned_agent_id
 from core_api.services.trust_service import parse_trust_error, require_trust
 
@@ -96,8 +101,14 @@ async def resolve_caller_and_gate(
     if not_found:
         raise HTTPException(
             status_code=403,
-            detail=f"Agent '{caller_agent_id}' is not registered in tenant '{tenant_id}'.",
+            detail=coded_detail(
+                AUTH_AGENT_NOT_REGISTERED,
+                f"Agent '{caller_agent_id}' is not registered in tenant '{tenant_id}'.",
+            ),
         )
     if terr:
-        raise HTTPException(status_code=403, detail=parse_trust_error(terr))
+        raise HTTPException(
+            status_code=403,
+            detail=coded_detail(AUTH_AGENT_TRUST_TOO_LOW, parse_trust_error(terr)),
+        )
     return caller_agent_id

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -82,6 +82,10 @@ from core_api.constants import (
     SIMILARITY_BLEND,
     SQL_SCORING_PARAM_KEYS,
 )
+from core_api.errors import (
+    AUTH_FLEET_SCOPE_FORBIDDEN,
+    coded_detail,
+)
 from core_api.schemas import (
     BulkItemResult,
     BulkMemoryCreate,
@@ -3563,7 +3567,10 @@ async def update_memory(
         if not allowed:
             raise HTTPException(
                 status_code=403,
-                detail=f"Agent '{agent_id}' cannot modify memory in fleet '{mem.get('fleet_id')}'.",
+                detail=coded_detail(
+                    AUTH_FLEET_SCOPE_FORBIDDEN,
+                    f"Agent '{agent_id}' cannot modify memory in fleet '{mem.get('fleet_id')}'.",
+                ),
             )
 
     fields_set = data.model_fields_set

--- a/tests/test_c32_auth_failure_classes.py
+++ b/tests/test_c32_auth_failure_classes.py
@@ -1,0 +1,154 @@
+"""C32 / API-05 — every auth refusal names its own reason.
+
+``code_for_status`` maps every 403 to ``FORBIDDEN`` and every 401 to
+``UNAUTHORIZED``, so the distinct reasons a request can be refused at the auth
+boundary all arrived at the caller as one word. ``errors.py`` records what that
+cost: an agent refused a write with a tenant key concluded that tenant keys
+cannot write — false — and stopped trying. A wrong general rule learned from a
+specific refusal is worse than no answer, because the agent stops asking.
+
+#950 introduced ``coded_detail`` and converted 16 sites. This closes the
+remaining 33, so all 49 refusals carry a code that names the reason.
+
+The wire contract is unchanged. ``app.http_exception_handler`` flattens a
+``coded_detail`` dict back to ``{"detail": <message>, "error": {"code", ...}}``,
+so ``detail`` stays the same string it was; the code is additive.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+from core_api import errors
+
+pytestmark = pytest.mark.unit
+
+SRC = pathlib.Path("core-api/src")
+
+
+def _auth_raises():
+    """Every ``raise HTTPException(401|403)`` in core-api, with its detail node."""
+    out = []
+    for path in sorted(SRC.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - not our files to fix
+            continue
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call)):
+                continue
+            func = node.exc.func
+            if (
+                getattr(func, "id", None) or getattr(func, "attr", None)
+            ) != "HTTPException":
+                continue
+            kw = {k.arg: k.value for k in node.exc.keywords}
+            if getattr(kw.get("status_code"), "value", None) not in (401, 403):
+                continue
+            out.append((path, node.lineno, kw.get("detail")))
+    return out
+
+
+def _is_coded(detail) -> bool:
+    if not isinstance(detail, ast.Call):
+        return False
+    f = detail.func
+    return (getattr(f, "id", None) or getattr(f, "attr", None)) == "coded_detail"
+
+
+def test_every_auth_refusal_carries_a_code():
+    """The ratchet. A new bare-string 401/403 fails here rather than shipping a
+    refusal the caller cannot act on."""
+    bare = [
+        f"{p.relative_to(SRC)}:{line}"
+        for p, line, detail in _auth_raises()
+        if not _is_coded(detail)
+    ]
+    assert bare == [], "auth refusals without an error code:\n  " + "\n  ".join(bare)
+
+
+def test_the_census_is_not_vacuous():
+    """A guard that passes because it found nothing is not a guard."""
+    assert len(_auth_raises()) >= 45
+
+
+# ── the codes themselves ──────────────────────────────────────────────────
+
+
+def test_auth_codes_are_unique():
+    """Two constants sharing a value would make the code ambiguous at exactly
+    the moment a caller is trying to branch on it."""
+    codes = {n: v for n, v in vars(errors).items() if n.startswith("AUTH_")}
+    seen: dict[str, str] = {}
+    dupes = []
+    for name, value in sorted(codes.items()):
+        if value in seen:
+            dupes.append((value, seen[value], name))
+        seen[value] = name
+    assert dupes == []
+
+
+def test_auth_codes_are_upper_snake():
+    for name, value in vars(errors).items():
+        if not name.startswith("AUTH_"):
+            continue
+        assert value == value.upper(), name
+        assert " " not in value, name
+
+
+def test_no_auth_code_collides_with_a_status_derived_code():
+    """A code equal to ``FORBIDDEN`` or ``UNAUTHORIZED`` would be
+    indistinguishable from the generic fallback it exists to replace."""
+    generic = set(errors.STATUS_TO_CODE.values())
+    auth = {v for n, v in vars(errors).items() if n.startswith("AUTH_")}
+    assert auth & generic == set()
+
+
+# ── the four inherited values ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "const,value",
+    [
+        ("AUTH_TENANT_MISMATCH", "TENANT_MISMATCH"),
+        ("AUTH_UNAUTHENTICATED", "UNAUTHENTICATED"),
+        ("AUTH_SKILLS_FACTORY_DISABLED", "SKILLS_FACTORY_DISABLED"),
+        ("AUTH_SKILLS_INBOX_FORBIDDEN", "SKILLS_INBOX_FORBIDDEN"),
+    ],
+)
+def test_inherited_codes_keep_their_shipped_spelling(const, value):
+    """These four values are inherited, not chosen.
+
+    ``skills_inbox`` and ``stm`` already shipped the token welded to the front
+    of the prose — ``"TENANT_MISMATCH — this credential is not scoped…"`` — with
+    a comment at the site saying clients branch on the prefix, not the message.
+    Moving it into ``error.code`` has to keep the string byte-for-byte; a
+    tidier spelling here is a silent breaking change for every caller already
+    parsing the prefix.
+    """
+    assert getattr(errors, const) == value
+
+
+def test_the_prose_prefix_still_matches_the_code_it_became():
+    """Belt and braces on the above: the message these sites raise still opens
+    with the same token, so a client reading either surface agrees."""
+    src = (SRC / "core_api/routes/skills_inbox.py").read_text()
+    assert f'"{errors.AUTH_TENANT_MISMATCH} —' in src
+    assert f'"{errors.AUTH_UNAUTHENTICATED} —' in src
+
+
+# ── the shape a caller receives ───────────────────────────────────────────
+
+
+def test_coded_detail_is_flattened_by_the_handler_contract():
+    """``detail`` must survive as the plain string clients already read; the
+    code rides alongside in ``error``. This is what keeps C32 additive."""
+    detail = errors.coded_detail(errors.AUTH_AGENT_TRUST_TOO_LOW, "nope", required=2)
+    assert detail["code"] == "AGENT_TRUST_TOO_LOW"
+    assert detail["message"] == "nope"
+    assert detail["details"] == {"required": 2}
+
+    body = {"detail": detail["message"], **errors.make_error_payload(**detail)}
+    assert body["detail"] == "nope"
+    assert body["error"]["code"] == "AGENT_TRUST_TOO_LOW"

--- a/tests/test_org_role_plumb.py
+++ b/tests/test_org_role_plumb.py
@@ -18,10 +18,11 @@ Pins:
 """
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from core_api import auth as auth_mod
+from core_api.app import http_exception_handler as _http_exception_handler
 from core_api.routes import skills_inbox as si
 from tests._legacy_contracts import LEGACY_API_KEY_FIELD
 
@@ -140,6 +141,13 @@ def inbox_app(monkeypatch):
 
     app = FastAPI()
     app.include_router(si.router, prefix="/api/v1")
+    # C32 — register the app's real HTTPException handler. Without it a bare
+    # ``FastAPI()`` serialises ``HTTPException.detail`` verbatim, so a
+    # ``coded_detail`` dict reaches the assertion as a dict and the test is
+    # checking a shape NO CLIENT EVER RECEIVES. The production app flattens it
+    # back to the message string and puts the code in ``error.code``; with the
+    # handler wired here these tests assert the contract callers actually see.
+    app.add_exception_handler(HTTPException, _http_exception_handler)
     return app
 
 

--- a/tests/test_skills_inbox_routes.py
+++ b/tests/test_skills_inbox_routes.py
@@ -22,10 +22,11 @@ skill-write validator are patched at the module seam; no DB.
 """
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from core_api import errors
+from core_api.app import http_exception_handler as _http_exception_handler
 from core_api.auth import AuthContext, get_auth_context
 from core_api.routes import skills_inbox as si
 from core_api.services.forge.sentinel_scan import ScanResult
@@ -261,6 +262,13 @@ def make_client(
 ) -> AsyncClient:
     app = FastAPI()
     app.include_router(si.router, prefix="/api/v1")
+    # C32 — register the app's real HTTPException handler. Without it a bare
+    # ``FastAPI()`` serialises ``HTTPException.detail`` verbatim, so a
+    # ``coded_detail`` dict reaches the assertion as a dict and the test is
+    # checking a shape NO CLIENT EVER RECEIVES. The production app flattens it
+    # back to the message string and puts the code in ``error.code``; with the
+    # handler wired here these tests assert the contract callers actually see.
+    app.add_exception_handler(HTTPException, _http_exception_handler)
     auth = AuthContext(
         tenant_id=tenant_id,
         org_role=org_role,
@@ -533,7 +541,12 @@ async def test_actions_refuse_a_non_writing_credential(
     # top-level ``error`` key — is not installed and the dict stays under
     # ``detail``. Clients read ``error.code``; this is the harness's shape, and
     # the reason every other coded-error assertion in the suite differs.
-    assert r.json()["detail"]["code"] == code, f"{action}: {r.text}"
+    # C32 — the code lives in ``error.code``, not inside ``detail``. This used
+    # to read ``detail["code"]`` because the bare test app had no
+    # ``HTTPException`` handler and so leaked the raw ``coded_detail`` dict;
+    # with the real handler registered above, ``detail`` is the flat message
+    # string a client actually receives and the code sits alongside it.
+    assert r.json()["error"]["code"] == code, f"{action}: {r.text}"
     # Status alone would pass against a gate placed after the write.
     assert storage.upserts == [], f"{action} mutated the doc despite the refusal"
 

--- a/tests/test_stm_admin_tenant.py
+++ b/tests/test_stm_admin_tenant.py
@@ -28,9 +28,10 @@ are patched at the module boundary. No DB.
 from __future__ import annotations
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 
+from core_api.app import http_exception_handler as _http_exception_handler
 from core_api.auth import AuthContext, get_auth_context
 from core_api.routes import stm
 
@@ -126,6 +127,13 @@ def make_client(
 ) -> AsyncClient:
     app = FastAPI()
     app.include_router(stm.router, prefix="/api/v1")
+    # C32 — register the app's real HTTPException handler. Without it a bare
+    # ``FastAPI()`` serialises ``HTTPException.detail`` verbatim, so a
+    # ``coded_detail`` dict reaches the assertion as a dict and the test is
+    # checking a shape NO CLIENT EVER RECEIVES. The production app flattens it
+    # back to the message string and puts the code in ``error.code``; with the
+    # handler wired here these tests assert the contract callers actually see.
+    app.add_exception_handler(HTTPException, _http_exception_handler)
     auth = AuthContext(tenant_id=tenant_id, is_admin=is_admin)
 
     async def _auth_dep():


### PR DESCRIPTION
`code_for_status` maps every 403 to `FORBIDDEN` and every 401 to
`UNAUTHORIZED`, so the distinct reasons a request can be refused at the
auth boundary all reached the caller as one word. `errors.py` records
what that cost: an agent refused a write with a tenant key concluded that
tenant keys cannot write — false — and stopped trying. A wrong general
rule learned from a specific refusal is worse than no answer, because the
agent stops asking.

#950 introduced `coded_detail` and converted 16 sites. This closes the
remaining **33**, so all **49** refusals in core-api carry a code.

## Scope

The register says "~56 remaining of 69" and I could not reproduce those
numbers. Parsing the AST for `raise HTTPException(401|403)` finds **49**
sites, 16 already coded. The 69 likely counted a wider surface —
`auth.py` refuses at the dependency level and the MCP surface refuses
without raising. I would rather ship the number I can derive and show the
census than inherit one I can't; the test in this PR is what keeps it
honest from here.

## Eight new codes

`AGENT_NOT_REGISTERED`, `AGENT_TRUST_TOO_LOW`, `TARGET_AGENT_RESTRICTED`,
`FLEET_SCOPE_FORBIDDEN`, `FEATURE_DISABLED` — each earns its place by the
same test: it leaves the caller a different next move. "Register this
agent" and "raise this agent's trust_level" are both FORBIDDEN and are
not the same instruction.

Four values are **inherited, not chosen**: `UNAUTHENTICATED`,
`SKILLS_FACTORY_DISABLED`, `SKILLS_INBOX_FORBIDDEN`, and the existing
`TENANT_MISMATCH`. `skills_inbox` and `stm` already shipped these tokens
welded to the front of the prose —

```python
detail="TENANT_MISMATCH — this credential is not scoped to the requested tenant."
# Clients branch on the ``TENANT_MISMATCH`` prefix, not on the prose.
```

— with that comment at the site. That is a live contract, so moving it
into `error.code` keeps the string byte-for-byte; a tidier spelling would
be a silent breaking change for every caller already parsing the prefix.
These sites are the best argument for the whole change: the code was
already load-bearing, just carried somewhere clients had to string-parse.

## The wire contract does not change

`app.http_exception_handler` flattens a `coded_detail` dict back to
`{"detail": <message>, "error": {...}}`, so `detail` stays the exact
string it was and the code is purely additive.

## A test-harness bug this surfaced

Three test files build a bare `FastAPI()` with no exception handler, so
`HTTPException.detail` serialised verbatim and they were asserting a
shape **no client ever receives**. Two of them read `detail.startswith(...)`
(the string) and one read `detail["code"]` (the dict) — mutually
inconsistent, and both wrong against production. They now register the
real `http_exception_handler`, which makes them assert the contract
callers actually see; the `detail["code"]` assertion moved to
`error.code` accordingly.

## Guard

`test_every_auth_refusal_carries_a_code` re-runs the AST census and fails
on any new bare-string 401/403, with a non-vacuity check beside it so a
guard that passes by finding nothing can't go unnoticed.

Full suite **31 failures, identical to main's 31** — none new. `ruff`
clean; `mypy` unchanged at 164.

