### PR TITLE
perf(storage): stop shipping the embedding + tsvector on every scored-search row

### DIFF
--- a/core-storage-api/src/core_storage_api/routers/memories.py
+++ b/core-storage-api/src/core_storage_api/routers/memories.py
@@ -222,7 +222,20 @@ async def scored_search(request: Request) -> list[dict]:
                 history_query=bool(body.get("history_query", False)),
             )
         for r in results:
-            row = orm_to_dict(r.Memory, MEMORY_FIELDS)
+            # MEMORY_LIST_FIELDS, not MEMORY_FIELDS (audit oss-0814-m-39): this
+            # is the hottest read path — every recall crosses it, overfetched to
+            # ``top_k * 2`` rows — and neither of the two large columns survives
+            # the trip. ``orm_to_dict`` would ``tolist()`` the 1024-dim pgvector
+            # into ~20 KB of JSON floats per row (plus the tsvector text) for
+            # core-api to parse and drop: both consumers — ExecuteScoredSearch's
+            # row mapping and the legacy ``_dict_to_memory_out`` — read every
+            # field EXCEPT these two, and both read tolerantly, so the old shape
+            # cost CPU and wire on every search while its removal was silent.
+            # ``has_embedding`` below stays the authoritative presence signal;
+            # a caller that needs a row's actual vector fetches it by id
+            # (GET /memories/{id} keeps MEMORY_FIELDS — consumer.py's
+            # contradiction deferral reads the vector there, never from here).
+            row = orm_to_dict(r.Memory, MEMORY_LIST_FIELDS)
             row["score"] = float(r.score) if r.score is not None else 0.0
             row["similarity"] = float(r.similarity) if r.similarity is not None else 0.0
             row["vec_sim"] = float(r.vec_sim) if r.vec_sim is not None else 0.0

--- a/core-storage-api/src/core_storage_api/schemas.py
+++ b/core-storage-api/src/core_storage_api/schemas.py
@@ -97,11 +97,13 @@ MEMORY_FIELDS: list[str] = [
     "scope",
 ]
 
-# Same as MEMORY_FIELDS minus the two large columns (a 1536-dim ``embedding``
-# vector + the ``search_vector`` tsvector). Use for list/bundle endpoints whose
-# core-api consumers don't read the vector (admin list, contradiction rows):
-# serialising the full vector ships ~hundreds of KB per row over the internal
-# network only for ``_memory_to_out`` to discard it.
+# Same as MEMORY_FIELDS minus the two large columns (the 1024-dim ``embedding``
+# vector + the ``search_vector`` tsvector). Use for multi-row endpoints whose
+# core-api consumers don't read the vector (scored-search, admin list,
+# contradiction rows): serialising the full vector ships ~20 KB of JSON floats
+# per row over the internal network only for the consumer to discard it.
+# ``has_embedding`` (a projected boolean, where a route provides it) is the
+# presence signal; the vector itself is fetched by id when actually needed.
 MEMORY_LIST_FIELDS: list[str] = [f for f in MEMORY_FIELDS if f not in ("embedding", "search_vector")]
 
 ENTITY_FIELDS: list[str] = [

--- a/core-storage-api/tests/test_scored_search_row_serialization.py
+++ b/core-storage-api/tests/test_scored_search_row_serialization.py
@@ -1,0 +1,242 @@
+"""Scored-search response rows must not carry the two large columns nothing reads.
+
+Audit oss-0814-m-39. ``POST /memories/scored-search`` is the hottest read
+path — every recall crosses it, overfetched to ``top_k * 2`` rows — and it
+serialized each row with the full ``MEMORY_FIELDS``, which includes the
+1024-dim ``embedding`` pgvector (~20 KB once ``tolist()``-ed into JSON
+floats) and the ``search_vector`` tsvector text. Neither consumer reads
+either field: ``ExecuteScoredSearch`` splats them into a namespace no
+downstream step touches, and the legacy ``_dict_to_memory_out`` reads a
+fixed field list without them. ``MEMORY_LIST_FIELDS`` exists for exactly
+this shape of endpoint; these tests pin that scored-search uses it.
+
+The flip side is pinned too: the consumers' actual read-set must stay
+present, so this file fails on an over-pruned field list just as it fails
+on the two heavy columns coming back.
+
+No database: the service method is stubbed and the request goes through the
+real route (auth middleware, body validation, row serialization) via
+ASGITransport, the same app surface ``test_storage_auth.py`` exercises.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from common.constants import VECTOR_DIM
+from core_storage_api.app import create_app
+from core_storage_api.config import settings
+from core_storage_api.routers import memories as memories_router
+from core_storage_api.schemas import MEMORY_FIELDS, MEMORY_LIST_FIELDS
+
+pytestmark = pytest.mark.unit
+
+_PREFIX = "/api/v1/storage"
+
+# The scoring knobs the route hard-requires (SQL_SCORING_REQUIRED_KEYS);
+# values are arbitrary in-range floats — the service call is stubbed.
+_SEARCH_PARAMS = {
+    "fts_weight": 0.3,
+    "freshness_floor": 0.5,
+    "freshness_decay_days": 30,
+    "recall_boost_cap": 1.5,
+    "recall_decay_window_days": 30,
+    "similarity_blend": 0.7,
+}
+
+_BODY = {
+    "tenant_id": "t-row-serialization",
+    "embedding": [0.0] * VECTOR_DIM,
+    "query": "what does the row carry",
+    "top_k": 5,
+    "search_params": _SEARCH_PARAMS,
+}
+
+# Every Memory field core-api actually reads off a scored-search row —
+# the union of ``ExecuteScoredSearch``'s namespace consumers
+# (``_memory_to_out`` via LoadAndSerialize, RerankResults, the D12
+# diagnostic in PostFilterResults) and the legacy path's
+# ``_dict_to_memory_out``. If trimming the serialized field list ever
+# cuts into THIS set, the missing field degrades silently on the
+# consumer side (every reader is a tolerant ``getattr``/``.get``), so
+# this assertion is the loud version.
+_CONSUMER_READ_FIELDS = {
+    "id",
+    "tenant_id",
+    "fleet_id",
+    "agent_id",
+    "agent_display_name",
+    "memory_type",
+    "title",
+    "content",
+    "weight",
+    "source_uri",
+    "run_id",
+    "metadata_",
+    "created_at",
+    "expires_at",
+    "subject_entity_id",
+    "predicate",
+    "object_value",
+    "ts_valid_start",
+    "ts_valid_end",
+    "status",
+    "visibility",
+    "recall_count",
+    "last_recalled_at",
+    "supersedes_id",
+}
+
+# What the route itself attaches beside the Memory columns.
+_ROUTE_ADDED_KEYS = {
+    "score",
+    "similarity",
+    "vec_sim",
+    "fts_match",
+    "has_embedding",
+    "status_penalty",
+    "fts_score",
+    "freshness",
+    "entity_boost",
+    "recall_boost",
+    "temporal_boost",
+    "entity_links",
+}
+
+
+def _fake_memory() -> SimpleNamespace:
+    """An ORM-shaped row with EVERY ``MEMORY_FIELDS`` attribute populated.
+
+    ``embedding`` and ``search_vector`` are deliberately non-None: the test
+    must catch them being *serialized*, not merely observe that a NULL
+    column serializes to null.
+    """
+    now = datetime.now(UTC)
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        tenant_id=_BODY["tenant_id"],
+        fleet_id="f1",
+        agent_id="agent-a",
+        agent_display_name="Agent A",
+        memory_type="fact",
+        content="the row under test",
+        embedding=[0.001] * VECTOR_DIM,
+        weight=0.5,
+        source_uri="test://row",
+        run_id="run-1",
+        metadata_={"k": "v"},
+        created_at=now,
+        title="row title",
+        content_hash="abc123",
+        embedded_content_hash="abc123",
+        client_request_id=None,
+        expires_at=None,
+        deleted_at=None,
+        search_vector="'row':2 'test':1 'under':3",
+        subject_entity_id=None,
+        predicate=None,
+        object_value=None,
+        ts_valid_start=now,
+        ts_valid_end=None,
+        status="active",
+        visibility="scope_team",
+        recall_count=3,
+        last_recalled_at=now,
+        last_dedup_checked_at=None,
+        supersedes_id=None,
+        confidence=0.9,
+        is_inferred=False,
+        scope={},
+    )
+
+
+async def _post_scored_search(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    async def _stub(**kwargs) -> list[SimpleNamespace]:
+        return [
+            SimpleNamespace(
+                Memory=_fake_memory(),
+                score=1.2,
+                similarity=0.9,
+                vec_sim=0.9,
+                fts_match=True,
+                has_embedding=True,
+                status_penalty=1.0,
+                fts_score=0.4,
+                freshness=0.8,
+                entity_boost=1.0,
+                recall_boost=1.1,
+                temporal_boost=1.0,
+                entity_links=[{"entity_id": str(uuid.uuid4()), "role": "subject"}],
+            )
+        ]
+
+    monkeypatch.setattr(memories_router._svc, "memory_scored_search", _stub)
+
+    app = create_app()
+    headers = {"X-Storage-Secret": settings.core_storage_shared_secret.get_secret_value()}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(f"{_PREFIX}/memories/scored-search", json=_BODY, headers=headers)
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()
+    assert len(rows) == 1
+    return rows
+
+
+async def test_rows_do_not_carry_embedding_or_search_vector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The waste itself: neither heavy column may reach the wire.
+
+    Pre-fix this failed with both keys present — a 1024-float JSON array and
+    the tsvector text serialized per row, per request, for consumers that
+    drop them on arrival.
+    """
+    (row,) = await _post_scored_search(monkeypatch)
+
+    assert "embedding" not in row, (
+        "scored-search serialized the full embedding vector; no consumer reads it "
+        "(has_embedding is the presence signal, and vector-needing callers use GET /memories/{id})"
+    )
+    assert "search_vector" not in row, (
+        "scored-search serialized the FTS tsvector; no consumer reads it "
+        "(fts_match/fts_score are the lexical signals)"
+    )
+
+
+async def test_consumers_still_get_every_field_they_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard rail for the trim: the consumer read-set stays intact.
+
+    Every reader on the core-api side is a tolerant ``getattr``/``.get``, so
+    losing a field there is a silent degradation (e.g. every result reporting
+    ``status=None`` would un-gate the status penalty display). This is the
+    assertion that fails loudly instead.
+    """
+    (row,) = await _post_scored_search(monkeypatch)
+
+    missing = _CONSUMER_READ_FIELDS - set(row)
+    assert not missing, f"scored-search rows lost consumer-read fields: {sorted(missing)}"
+
+    # And the full contract, exactly: the serialized Memory columns are
+    # MEMORY_LIST_FIELDS (already pinned by the repo as "MEMORY_FIELDS minus
+    # the two large columns") plus what the route attaches.
+    assert set(row) == set(MEMORY_LIST_FIELDS) | _ROUTE_ADDED_KEYS
+
+
+def test_single_get_field_list_still_carries_the_vector() -> None:
+    """The trim is scoped to scored-search, not to the field catalogue.
+
+    ``consumer.py``'s contradiction deferral reads ``memory.get("embedding")``
+    from the single-get response, so ``MEMORY_FIELDS`` (GET /memories/{id},
+    load-by-ids, find-successors) must keep both columns.
+    """
+    assert "embedding" in MEMORY_FIELDS
+    assert "search_vector" in MEMORY_FIELDS
+    assert "embedding" not in MEMORY_LIST_FIELDS
+    assert "search_vector" not in MEMORY_LIST_FIELDS


### PR DESCRIPTION
## Evidence (audit oss-0814-m-39)

`POST /memories/scored-search` serialized every result row with the full `MEMORY_FIELDS`:

- `core-storage-api/src/core_storage_api/routers/memories.py:225` — `orm_to_dict(r.Memory, MEMORY_FIELDS)`; the list includes `embedding` (`schemas.py:65`) and `search_vector` (`schemas.py:81`).
- `core-storage-api/src/core_storage_api/schemas.py:24-25` — `_serialise_value` `tolist()`s the 1024-dim pgvector into a JSON float array per row.
- Upstream, the SQL selects the full `Memory` entity (`postgres_service.py:3225-3248`, `select(Memory, ...)`), so both columns are hydrated for every outer-join row before the router drops into serialization.
- Downstream, core-api receives them (`clients/storage_client.py:1057`), splats them into a namespace (`pipeline/steps/search/execute_scored_search.py:191-212`) — and nothing ever reads them.

**Measured** (fake ORM rows through `orm_to_dict` + `json.dumps`, 20-row batch = default `top_k=10` × `SEARCH_OVERFETCH_FACTOR=2`):

| | payload | serialize CPU |
|---|---|---|
| `MEMORY_FIELDS` (before) | 443.6 KB | 4.85 ms |
| `MEMORY_LIST_FIELDS` (after) | 24.2 KB | 0.16 ms |

419 KB wire (18.3×) and 31× serialize CPU saved per search request, plus the mirror-image JSON parse in core-api.

## Consumer audit

The route has exactly one client, `storage_client.scored_search`, with two call sites; every field either consumer reads survives:

- Pipeline (`execute_scored_search.py` → `rerank_results` / `post_filter_results` / `log_recall_event` / `track_recalls` / `load_and_serialize` → `_memory_to_out`): reads id/status/content/memory_type/supersedes_id/title + score factors + entity_links — never `.embedding` / `.search_vector`. All reads are tolerant `getattr`/`.get`.
- Legacy (`memory_service._search_memories_legacy` → `_dict_to_memory_out`): fixed field list, neither field.
- `has_embedding` (the projected boolean, CAURA-594) remains the authoritative presence signal for async-embed callers; `consumer.py`'s contradiction deferral reads the actual vector from single-get (`GET /memories/{id}`), which keeps `MEMORY_FIELDS`.
- Checked worker/scripts/dedup/backfill: no other reader of scored-search rows; `test_ph5b_insights_storage` / `test_provider_protocols` embedding assertions target other endpoints (`insights_discover_sample`, sqlite backend `get`).

## Fix

One-line mechanical change plus rationale comments: scored-search rows serialize with `MEMORY_LIST_FIELDS` — the constant the repo already defines as "MEMORY_FIELDS minus the two large columns" and already uses for the admin list, ingest preview, and contradiction bundles. Also corrected the stale `MEMORY_LIST_FIELDS` doc comment (said 1536-dim; migration 012 made it 1024) and named scored-search among its consumers.

**Deliberately out of scope:** the SQL-side `select(Memory, ...)` still transfers both columns DB→storage in binary (~4 KB/row, fanned out per entity link by the outerjoin). Deferring those columns touches the exact statement open PR #1460 (HNSW plan PR3) and audit row oss-0814-m-40 are reshaping, so this PR stays on the serialization layer; a `defer()` follow-up can land after those.

## Tests

`core-storage-api/tests/test_scored_search_row_serialization.py` (no DB — stubbed service, real route through auth middleware via ASGITransport, same surface as `test_storage_auth.py`):

- `test_rows_do_not_carry_embedding_or_search_vector` — **fails pre-fix** (verified via `git stash`: both keys present in the response row), passes post-fix.
- `test_consumers_still_get_every_field_they_read` — pins the consumer read-set (24 Memory fields) ⊆ row keys, and the exact response contract (`MEMORY_LIST_FIELDS` ∪ route-added keys).
- `test_single_get_field_list_still_carries_the_vector` — the trim is scoped to scored-search; `MEMORY_FIELDS` keeps both columns for get-by-id/load-by-ids/find-successors.

## Gates (worktree root, `EMBEDDING_PROVIDER=fake`)

- New tests + `test_fts_score_single_render` + `test_ann_pool_statement` + `test_storage_auth`: **41 passed**.
- Consumer-side batch (`test_rerank_results`, `test_entity_lookup_short_circuit`, `test_c27_strict_fleet_scoping`, `test_storage_client_routing`, `test_c10_storage_slot_dedup`, `test_a63_candidate_gate_wiring`, `test_a49_candidate_pool`, `test_a50_score_formula`, `test_a70_fanout_wireup`): **88 passed**.
- DB-backed: `core-storage-api/tests/test_integration.py` + `test_history_query_demotion_lift`: **75 passed**. Root `test_integration_search` / `test_api_memories` / `test_scored_search_materialized_plan` / `test_ann_pool_behavior`: 61 passed, 10 failed — the **identical 10 fail on pristine origin/main** (local-Postgres env: title-FTS trigger + HNSW/pgvector state), zero deltas from this change.
- `ruff check` clean, `ruff format --check` clean, `mypy src/` (core-storage-api): no issues in 88 files. core-api untouched.

Audit tracker: oss-0814-m-39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
