### PR TITLE
fix(client-typescript): recall() silently drops caller extras that write() and search() forward

### DIFF
--- a/clients/typescript/src/index.test.ts
+++ b/clients/typescript/src/index.test.ts
@@ -133,6 +133,24 @@ test("recall ignores the key the server never sends", async () => {
   assert.deepEqual(result.supportingMemories, []);
 });
 
+test("recall posts caller extras into the request body", async () => {
+  let captured: Record<string, unknown> = {};
+  const client = makeClient((_url, init) => {
+    captured = JSON.parse(init.body as string);
+    return jsonResponse(200, liveRecallBody([]));
+  });
+  await client.recall("q", { topK: 7 });
+  assert.equal(captured.top_k, 7);
+  const probe = "x-extra-probe";
+  try {
+    await client.recall("q", { [probe]: "v" });
+  } catch {
+    // response parsing is validated by the other recall tests; here we only
+    // check that the extra key reached the request body
+  }
+  assert.equal(captured[probe], "v");
+});
+
 test("health hits /health", async () => {
   const client = makeClient((url) => {
     assert.equal(new URL(url).pathname, "/api/v1/health");

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -71,6 +71,11 @@ export interface SearchOptions {
   [extra: string]: unknown;
 }
 
+export interface RecallOptions {
+  topK?: number;
+  [extra: string]: unknown;
+}
+
 function toMemory(d: Record<string, any>): Memory {
   return {
     id: d.id ?? null,
@@ -142,8 +147,10 @@ export class Caura {
   }
 
   /** Search + LLM-synthesized context brief. POST /api/v1/recall */
-  async recall(query: string, options: { topK?: number } = {}): Promise<RecallResult> {
-    const body = { tenant_id: this.tenantId, query, top_k: options.topK ?? 5 };
+  async recall(query: string, options: RecallOptions = {}): Promise<RecallResult> {
+    const { topK = 5, ...extra } = options;
+    const body: Record<string, unknown> = { tenant_id: this.tenantId, query, top_k: topK };
+    Object.assign(body, extra);
     const data = await this.request("POST", "/api/v1/recall", body);
     // Wire key is `memories`; the server aliases the identical list under
     // `items` too, for consumers written against /search's shape.


### PR DESCRIPTION
Closes #1405

## What

\ecall()\ accepted only \{ topK }\ and silently dropped every other key the caller passed — no type error, no runtime error, just a request body missing the field.

- Added \RecallOptions\ with the same \[extra: string]: unknown\ index signature as \WriteOptions\ and \SearchOptions\, exported alongside them.
- \ecall()\ now destructures \	opK\ and \Object.assign\s the rest into the body, matching its siblings exactly.
- Purely additive: existing \ecall(q, { topK })\ calls keep working.

## Tests

- New test using the existing injected-\etch\ pattern: asserts a caller-supplied extra key reaches the request body, and \	opK: 7\ maps to \	op_k: 7\.
- \
pm test\: 15/15 pass, 0 fail.

Did **not** touch the \supportingMemories\ / \items\-alias read (H-01) per the issue. Skipped the optional Python-side passthrough test — happy to add it on request.