### PR TITLE
feat(client-typescript): add getDocument() (#1404)

### DIFF
--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -46,10 +46,22 @@ const mc = new Caura("standalone", { tenantId: "default", baseUrl: "http://local
 | `write(content, opts?)` | `POST /api/v1/memories` | `Memory` |
 | `search(query, opts?)` | `POST /api/v1/search` | `Memory[]` |
 | `recall(query, opts?)` | `POST /api/v1/recall` | `RecallResult` |
+| `getDocument(docId, opts)` | `GET /api/v1/documents/{docId}` | `object` |
 | `health()` | `GET /api/v1/health` | `object` |
 
 Failures throw `AuthError` (401/403), `NotFoundError` (404), or
 `CauraApiError`. Every result also exposes the full API payload on `.raw`.
+
+### Fetching a document
+
+`getDocument()` returns the full `DocOut` envelope — the stored record is
+nested under the `"data"` key, not returned directly. `collection` is a
+required option, and a missing document raises `NotFoundError`:
+
+```ts
+const doc = await mc.getDocument("doc-123", { collection: "interviews" });
+const record = doc.data; // the stored record lives under "data"
+```
 
 ### Unknown fields on writes are rejected
 

--- a/clients/typescript/src/index.test.ts
+++ b/clients/typescript/src/index.test.ts
@@ -141,6 +141,54 @@ test("health hits /health", async () => {
   assert.equal((await client.health()).status, "ok");
 });
 
+test("getDocument fetches document by id with collection and tenant query params", async () => {
+  const client = makeClient((url, init) => {
+    const parsed = new URL(url);
+    assert.equal(parsed.pathname, "/api/v1/documents/doc-1");
+    assert.equal(parsed.searchParams.get("tenant_id"), "t1");
+    assert.equal(parsed.searchParams.get("collection"), "interviews");
+    assert.equal(init.method, "GET");
+    assert.equal((init.headers as Record<string, string>)["X-API-Key"], "mc_test");
+    return jsonResponse(200, { id: "doc-1", data: { title: "Doc Title" } });
+  });
+
+  const doc = await client.getDocument("doc-1", { collection: "interviews" });
+  assert.equal(doc.id, "doc-1");
+  assert.deepEqual(doc.data, { title: "Doc Title" });
+});
+
+test("getDocument encodes special characters in docId preventing path and query injection", async () => {
+  const client = makeClient((url) => {
+    const parsed = new URL(url);
+    assert.equal(parsed.pathname, "/api/v1/documents/path%2Fwith%2Fslash%3Fand%3Dquery");
+    assert.equal(parsed.searchParams.get("tenant_id"), "t1");
+    assert.equal(parsed.searchParams.get("collection"), "interviews");
+    assert.equal(parsed.searchParams.has("and"), false);
+    return jsonResponse(200, { id: "path/with/slash?and=query", data: {} });
+  });
+
+  await client.getDocument("path/with/slash?and=query", { collection: "interviews" });
+});
+
+test("getDocument allows overriding tenantId", async () => {
+  const client = makeClient((url) => {
+    const parsed = new URL(url);
+    assert.equal(parsed.searchParams.get("tenant_id"), "override-tenant");
+    assert.equal(parsed.searchParams.get("collection"), "interviews");
+    return jsonResponse(200, { id: "doc-1", data: {} });
+  });
+
+  await client.getDocument("doc-1", { collection: "interviews", tenantId: "override-tenant" });
+});
+
+test("getDocument maps 404 to NotFoundError", async () => {
+  const client = makeClient(() => jsonResponse(404, { detail: "document not found" }));
+  await assert.rejects(
+    client.getDocument("missing-id", { collection: "interviews" }),
+    NotFoundError
+  );
+});
+
 test("403 maps to AuthError and parses the error envelope", async () => {
   const client = makeClient(() => jsonResponse(403, { error: { message: "cross-fleet", details: { x: 1 } } }));
   await assert.rejects(client.write("x"), (err: unknown) => {

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -71,6 +71,11 @@ export interface SearchOptions {
   [extra: string]: unknown;
 }
 
+export interface GetDocumentOptions {
+  collection: string;
+  tenantId?: string;
+}
+
 function toMemory(d: Record<string, any>): Memory {
   return {
     id: d.id ?? null,
@@ -162,6 +167,20 @@ export class Caura {
         : [],
       raw: data,
     };
+  }
+
+  /** Fetch one structured document. GET /api/v1/documents/{docId} */
+  async getDocument(
+    docId: string,
+    options: GetDocumentOptions,
+  ): Promise<Record<string, unknown>> {
+    const encoded = encodeURIComponent(docId);
+    const tenant = options.tenantId || this.tenantId;
+    const params = new URLSearchParams({
+      tenant_id: tenant,
+      collection: options.collection,
+    });
+    return this.request("GET", `/api/v1/documents/${encoded}?${params.toString()}`);
   }
 
   /** Liveness probe. GET /api/v1/health */


### PR DESCRIPTION
﻿<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

Adds `getDocument()` to the TypeScript client (`@caura/client`), bringing parity with the Python client's `get_document()` method (GET `/api/v1/documents/{docId}`).

Key implementation details:
- Added `GetDocumentOptions` interface (`{ collection: string; tenantId?: string }`).
- Safely percent-encodes the path segment via `encodeURIComponent(docId)` to prevent path traversal and query string injection hazards.
- Passes query parameters (`tenant_id` and `collection`) and defaults `tenant_id` to client instance's `this.tenantId`.
- Added comprehensive unit tests in `clients/typescript/src/index.test.ts` asserting:
  - Happy path URL construction, HTTP method `GET`, and returned data.
  - Path encoding of special characters (`/` and `?`).
  - Overriding `tenantId`.
  - 404 response mapping to `NotFoundError`.
- Updated `clients/typescript/README.md` API table and added a `### Fetching a document` documentation section.

## Related Issue

Closes #1404

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

Ran the TypeScript client build and test suite:
```bash
cd clients/typescript
npm run build
npm test
```
All 18 tests passed (0 failures).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass (N/A - TypeScript client changes only)
- [ ] `mypy` passes (N/A)
- [ ] `pytest` passes locally (N/A)
- [x] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (handled by release-please)

## Additional Notes

Mirrors Python client (`clients/python/src/caura_client/client.py:119`) contract without introducing external dependencies.
