### PR TITLE
feat(search): freshness_reference — As-Of Recall for backfilled corpora

### DIFF
--- a/capture_baselines.py
+++ b/capture_baselines.py
@@ -45,7 +45,14 @@ async def _capture() -> list[dict]:
 
     tools = await mcp_server.mcp.list_tools()
     tools_list = [
-        t.model_dump(mode="json") if hasattr(t, "model_dump") else dict(t.__dict__) for t in tools
+        # ``by_alias=True`` matches what ``test_v1_baseline_matches_live_registry``
+        # compares against — the SDK's wire names (``inputSchema``), not the
+        # model's Python field names, which became snake_case in mcp 2.x. Without
+        # it this script writes a fixture the test rejects on 74 renamed lines.
+        t.model_dump(mode="json", by_alias=True)
+        if hasattr(t, "model_dump")
+        else dict(t.__dict__)
+        for t in tools
     ]
     # The tests sort by name before comparing, because spec modules are
     # auto-loaded in `pkgutil.iter_modules` order; store it sorted so the file

--- a/common/constants.py
+++ b/common/constants.py
@@ -696,6 +696,27 @@ SEARCH_KNOBS: dict[str, SearchKnob] = {
     # ann_pool_size forced to 0 and the shadow call with the configured size).
     # Inert when ann_pool_size is 0.
     "ann_pool_shadow": SearchKnob(int, (0, 1)),
+    # Reference clock for freshness and the temporal window when the request
+    # carries ``valid_at`` (the as-of time of the question). 0 = ``now()`` —
+    # byte-identical to today. 1 = age is measured from ``valid_at``, and the
+    # row's anchor is ``coalesce(ts_valid_start, created_at)`` instead of
+    # ``greatest(created_at, ts_valid_start)``. Inert without ``valid_at`` on
+    # the request; ``valid_at`` without the knob keeps today's behaviour, so
+    # only the conjunction retargets the clock and no existing caller moves.
+    #
+    # Per TENANT on purpose, not per agent or per request: whether
+    # ``ts_valid_start`` means "when the event happened" (a backfilled history,
+    # a benchmark whose questions carry an as-of date) or "start of a validity
+    # window" (a price effective from a date) is a property of the tenant's
+    # data, and only the former wants freshness anchored to it. The
+    # ``greatest()`` in the default anchor is exactly the guard that protects
+    # the latter — a validity-window row must never rank as older than its
+    # ingest — which is why this is a switch and not a new default.
+    #
+    # Storage reads it (sql=True). The recall-usage decay is deliberately NOT
+    # retargeted: "recently recalled" is a system-time fact, not an event-time
+    # one, and stays on ``now()`` under either setting.
+    "freshness_reference": SearchKnob(int, (0, 1), sql=True),
 }
 
 # The wire contract, derived. Core-api's two search-path builders project

--- a/core-api/openapi.broker.json
+++ b/core-api/openapi.broker.json
@@ -1705,6 +1705,7 @@
                 "type": "null"
               }
             ],
+            "description": "As-of time for the question (ISO 8601). Rows whose ts_valid_start is after this date are excluded and rows whose ts_valid_end is before it are down-weighted; relative dates in the query ('last month') are resolved against it. When the tenant's search.default_profile sets freshness_reference=1, freshness and the temporal window are ALSO measured from this time against each row's event time (ts_valid_start, else created_at) instead of from now() — the setting for backfilled corpora where ingest time carries no signal. Naive values are read as UTC.",
             "title": "Valid At"
           }
         },

--- a/core-api/src/core_api/constants.py
+++ b/core-api/src/core_api/constants.py
@@ -335,6 +335,16 @@ ANN_POOL_SIZE = 0
 # log the comparison (see ExecuteScoredSearch). Enable per-tenant together with
 # ann_pool_size via default_search_profile; inert while ann_pool_size is 0.
 ANN_POOL_SHADOW = 0
+# Reference clock for freshness when the request carries ``valid_at`` (see
+# ``common.constants.SEARCH_KNOBS["freshness_reference"]`` for the full
+# contract). 0 = now(); 1 = the request's ``valid_at``, with the row anchored to
+# ``coalesce(ts_valid_start, created_at)``. Off by default; enable per tenant via
+# ``default_search_profile.freshness_reference`` for corpora whose
+# ``ts_valid_start`` is EVENT time — a backfilled history, a benchmark whose
+# questions ask "as of" a date. Without it a corpus ingested in one sitting has
+# every row the same age, so the time signal is uniform noise and "last month"
+# resolves against the ingest date rather than the question's.
+FRESHNESS_REFERENCE = 0
 FRESHNESS_DECAY_DAYS = 90
 FRESHNESS_FLOOR = 0.7
 ENTITY_BOOST_FACTOR = 1.3

--- a/core-api/src/core_api/mcp_server.py
+++ b/core-api/src/core_api/mcp_server.py
@@ -1031,7 +1031,12 @@ async def caura_recall(
     ] = DEFAULT_SEARCH_TOP_K,
     valid_at: Annotated[
         str | None,
-        Field(description="As-of ISO 8601 date: filter to rows valid at that time."),
+        Field(
+            description=(
+                "As-of ISO 8601 date: filter to rows valid then; relative dates "
+                "resolve against it. Tenant freshness_reference=1 anchors freshness too."
+            )
+        ),
     ] = None,
     min_similarity: Annotated[
         float | None,

--- a/core-api/src/core_api/schemas.py
+++ b/core-api/src/core_api/schemas.py
@@ -864,7 +864,20 @@ class SearchRequest(BaseModel):
             "superseded rows directly."
         ),
     )
-    valid_at: datetime | None = None
+    valid_at: datetime | None = Field(
+        default=None,
+        description=(
+            "As-of time for the question (ISO 8601). Rows whose ts_valid_start is "
+            "after this date are excluded and rows whose ts_valid_end is before it "
+            "are down-weighted; relative dates in the query ('last month') are "
+            "resolved against it. When the tenant's search.default_profile sets "
+            "freshness_reference=1, freshness and the temporal window are ALSO "
+            "measured from this time against each row's event time "
+            "(ts_valid_start, else created_at) instead of from now() — the "
+            "setting for backfilled corpora where ingest time carries no signal. "
+            "Naive values are read as UTC."
+        ),
+    )
     top_k: int = Field(
         default=DEFAULT_SEARCH_TOP_K,
         ge=1,

--- a/core-api/src/core_api/services/memory_service.py
+++ b/core-api/src/core_api/services/memory_service.py
@@ -61,6 +61,7 @@ from core_api.constants import (
     EMBEDDING_CACHE_TTL,
     FRESHNESS_DECAY_DAYS,
     FRESHNESS_FLOOR,
+    FRESHNESS_REFERENCE,
     FTS_BOOST_MAX_TOKENS,
     FTS_BOOST_SPECIFICITY_RATIO,
     FTS_RANK_SCALE,
@@ -4066,6 +4067,7 @@ def resolve_search_params(
         "score_formula": resolved.get("score_formula", SCORE_FORMULA),
         "ann_pool_size": resolved.get("ann_pool_size", ANN_POOL_SIZE),
         "ann_pool_shadow": resolved.get("ann_pool_shadow", ANN_POOL_SHADOW),
+        "freshness_reference": resolved.get("freshness_reference", FRESHNESS_REFERENCE),
     }
 
 

--- a/core-storage-api/src/core_storage_api/services/postgres_service.py
+++ b/core-storage-api/src/core_storage_api/services/postgres_service.py
@@ -24,6 +24,7 @@ from uuid import UUID
 from sqlalchemy import (
     ColumnElement,
     Date,
+    DateTime,
     String,
     Table,
     and_,
@@ -2532,6 +2533,15 @@ class PostgresService:
         memory_boost_factor = memory_boost_factor or {}
         sp = search_params
 
+        # ``valid_at`` is compared with timestamptz columns in multiple parts
+        # of this query. Normalize it once so every bind observes the public
+        # contract that a naive value means UTC.
+        if valid_at is not None and valid_at.tzinfo is None:
+            valid_at = valid_at.replace(tzinfo=UTC)
+        valid_at_ts: ColumnElement[Any] | None = (
+            literal(valid_at, type_=DateTime(timezone=True)) if valid_at is not None else None
+        )
+
         _fts_weight = sp["fts_weight"]
         _freshness_floor = sp["freshness_floor"]
         _freshness_decay_days = sp["freshness_decay_days"]
@@ -2555,6 +2565,19 @@ class PostgresService:
         # extensions so an on-prem box that predates iterative scans keeps
         # byte-identical behaviour.
         _ann_pool_size = int(sp.get("ann_pool_size", 0) or 0)
+        # Reference clock for freshness and temporal_boost. 0 = now() (default);
+        # 1 = the request's ``valid_at`` when one was sent. The knob alone changes
+        # nothing (no valid_at → now()) and valid_at alone changes nothing new
+        # (knob off → now()); only the conjunction retargets the clock, so no
+        # caller that exists today moves.
+        _freshness_reference = int(sp.get("freshness_reference", 0) or 0)
+        ref_ts: ColumnElement[Any]
+        anchor_to_valid_at = False
+        if _freshness_reference == 1 and valid_at_ts is not None:
+            anchor_to_valid_at = True
+            ref_ts = valid_at_ts
+        else:
+            ref_ts = func.now()
         use_ann_pool = _ann_pool_size > 0 and await _ann_pool_available()
         if use_ann_pool and _candidate_pool_size > 0:
             # The two pool selectors are mutually exclusive by design —
@@ -2956,11 +2979,22 @@ class PostgresService:
             else_=ing.c.fts_score,
         ).label("similarity")
 
-        anchor = func.greatest(
-            ing.c.created_at,
-            func.coalesce(ing.c.ts_valid_start, ing.c.created_at),
-        )
-        age_days = func.extract("epoch", func.now() - anchor) / 86400.0
+        anchor: ColumnElement[Any]
+        if anchor_to_valid_at:
+            # Event-time anchor: a backfilled row is as old as the event it
+            # records, not as old as its ingest. Only reachable when the tenant
+            # opted in AND the request said as-of when — see the knob's contract
+            # in ``common.constants``.
+            anchor = func.coalesce(ing.c.ts_valid_start, ing.c.created_at)
+        else:
+            # ``greatest`` is the guard for tenants whose ts_valid_start is a
+            # validity-window start rather than event time: such a row must
+            # never rank as older than its ingest.
+            anchor = func.greatest(
+                ing.c.created_at,
+                func.coalesce(ing.c.ts_valid_start, ing.c.created_at),
+            )
+        age_days = func.extract("epoch", ref_ts - anchor) / 86400.0
 
         type_decay = case(
             *[(ing.c.memory_type == mt, float(days)) for mt, days in TYPE_DECAY_DAYS.items()],
@@ -2971,7 +3005,10 @@ class PostgresService:
             (
                 and_(
                     ing.c.ts_valid_end.is_not(None),
-                    ing.c.ts_valid_end < func.now(),
+                    # Against the reference clock, not the wall clock: a row
+                    # whose validity ended AFTER the question's as-of time was
+                    # still current when the question was asked.
+                    ing.c.ts_valid_end < ref_ts,
                 ),
                 _freshness_floor,
             ),
@@ -3013,9 +3050,14 @@ class PostgresService:
         )
 
         if temporal_window is not None:
-            cutoff = func.now() - temporal_window
+            # "Last month" is a window ending at the reference clock. Under the
+            # default that is now() against created_at, unchanged; anchored to
+            # valid_at it is the question's as-of time against the row's event
+            # time, so a corpus ingested in one sitting still has a "last month".
+            cutoff = ref_ts - temporal_window
+            window_ts = anchor if anchor_to_valid_at else ing.c.created_at
             temporal_boost = case(
-                (ing.c.created_at >= cutoff, 1.3),
+                (window_ts >= cutoff, 1.3),
                 else_=1.0,
             ).label("temporal_boost")
         else:
@@ -3090,14 +3132,14 @@ class PostgresService:
         # relative to valid_at are down-weighted instead of excluded.
         # Pairs with the removal of the `ts_valid_end >= valid_at` WHERE
         # clause above — one bad enrichment date no longer blanks a memory.
-        if valid_at is not None:
+        if valid_at_ts is not None:
             from core_storage_api.config import settings as _storage_settings_cf
 
             currency_factor = case(
                 (
                     and_(
                         ing.c.ts_valid_end.is_not(None),
-                        ing.c.ts_valid_end < valid_at,
+                        ing.c.ts_valid_end < valid_at_ts,
                     ),
                     _storage_settings_cf.expired_currency_factor,
                 ),

--- a/plugin/tools.json
+++ b/plugin/tools.json
@@ -747,7 +747,7 @@
       },
       {
         "default": null,
-        "description": "As-of ISO 8601 date: filter to rows valid at that time.",
+        "description": "As-of ISO 8601 date: filter to rows valid then; relative dates resolve against it. Tenant freshness_reference=1 anchors freshness too.",
         "name": "valid_at",
         "required": false,
         "type": "str | None"

--- a/static/docs/integration-guide.md
+++ b/static/docs/integration-guide.md
@@ -172,7 +172,7 @@ Once configured, the MCP client handles tool discovery. Agents can use Caura too
 | Works with | Any MCP client | OpenClaw agents only |
 | Tools | 12 (write, recall, manage, list, doc, entity_get, tune, insights, evolve, stats, keystones, keystones_set) | 11 (all except `keystones_set`) |
 | RDF triples | Not exposed (contradiction detection via semantic similarity only) | Yes — `subject_entity_id`, `predicate`, `object_value` on write |
-| Temporal filter | Not exposed | Yes — `valid_at` on search |
+| Temporal filter | Yes — `valid_at` on `caura_recall` | Yes — `valid_at` on search |
 | Visibility | Passed per-call (`scope_agent` / `scope_team` / `scope_org`) | Passed per-call (`scope_agent` / `scope_team` / `scope_org`) |
 | Multi-fleet search | Yes — `fleet_ids` parameter | Yes — `fleet_ids` parameter |
 | Fleet ID | Passed per-call (optional) | Auto-stamped from gateway env |
@@ -381,7 +381,7 @@ BEFORE starting any task:
   model's working)
 - Include fleet_id to scope to this fleet, omit for tenant-wide search
 - Filter by status="active" to skip deleted/archived memories
-- Use valid_at for point-in-time queries (OpenClaw plugin and REST API only)
+- Use `valid_at` for point-in-time queries (REST `/search`, MCP `caura_recall`, and the OpenClaw plugin all accept it)
 
 AFTER completing work:
 - Store findings with caura_write — just provide content
@@ -664,7 +664,8 @@ Togglable per tenant via `lifecycle_automation_enabled` setting.
 ### Temporal validity
 
 - `ts_valid_start` / `ts_valid_end` — auto-extracted from content by LLM, or set explicitly
-- Search with `valid_at` to return only memories valid at a point in time
+- Search with `valid_at` to return only memories valid at a point in time; relative dates in the query ("last month") resolve against it
+- For backfilled corpora whose `ts_valid_start` is the time the event happened, set `search.default_profile.freshness_reference` to `1` in tenant settings — freshness and the temporal window are then measured from `valid_at` against event time instead of from now against ingest time. Off by default; inert on requests without `valid_at`
 - Memories without temporal bounds are always considered valid
 
 ### Batch Write

--- a/tests/fixtures/tools_list_baseline_v1.json
+++ b/tests/fixtures/tools_list_baseline_v1.json
@@ -853,7 +853,7 @@
             }
           ],
           "default": null,
-          "description": "As-of ISO 8601 date: filter to rows valid at that time.",
+          "description": "As-of ISO 8601 date: filter to rows valid then; relative dates resolve against it. Tenant freshness_reference=1 anchors freshness too.",
           "title": "Valid At"
         },
         "min_similarity": {

--- a/tests/test_freshness_reference.py
+++ b/tests/test_freshness_reference.py
@@ -1,0 +1,212 @@
+"""``freshness_reference`` — freshness and the temporal window measured from
+``valid_at`` instead of ``now()`` — end-to-end against Postgres.
+
+The scenario is a backfilled corpus: every row is CREATED in the same sitting
+but carries the time its event happened in ``ts_valid_start``. Under the
+default anchor, ``greatest(created_at, ts_valid_start)`` resolves to the ingest
+time for all of them, so freshness is a constant and "last month" is a window
+ending at the ingest date. The knob retargets both to the request's ``valid_at``.
+
+Invariants pinned here:
+
+* knob OFF + valid_at   ⇒ freshness is flat across the backfilled rows (the
+  behaviour being made optional — recorded so the fix is visible as a delta);
+* knob ON  + valid_at   ⇒ the row whose event is nearer the as-of time ranks
+  first, on freshness alone (identical embedding, weight, lexical score);
+* knob ON  + NO valid_at ⇒ ids AND scores identical to knob OFF — the switch
+  is inert without an as-of time, so no caller that exists today moves;
+* knob ON  + temporal_window ⇒ the window ends at valid_at, not now();
+* a NAIVE valid_at is read as UTC rather than 500ing on the timestamptz bind.
+
+Two rows, same embedding vector, same weight, a query that matches neither
+lexically — so ``base_score`` is identical and any ordering comes from the
+factor under test. Requires a database like the rest of this tree.
+"""
+
+import contextlib
+import hashlib
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+import core_storage_api.services.postgres_service as ps
+from common.embedding import fake_embedding
+from core_api.clients.storage_client import get_storage_client
+
+_SP = {
+    "fts_weight": 0.3,
+    "freshness_floor": 0.7,
+    "freshness_decay_days": 90,
+    "recall_boost_cap": 1.1,
+    "recall_decay_window_days": 14,
+    "similarity_blend": 0.85,
+    "fts_rank_scale": 6.0,
+}
+
+# The as-of time of the question. Well in the past relative to any test run,
+# so ``created_at`` (now) is always LATER than both event times below — the
+# exact shape that makes the default ``greatest`` anchor collapse to ingest.
+AS_OF = datetime(2024, 3, 15, 12, 0, tzinfo=UTC)
+RECENT_EVENT = AS_OF - timedelta(
+    days=20
+)  # inside a 60-day window, well inside 90-day decay
+OLD_EVENT = AS_OF - timedelta(days=400)  # past the decay → floor
+
+# One vector for both rows: the probe is this same text, so vec_sim ties.
+_SHARED = fake_embedding("shared vector so only time can separate the rows")
+# Matches nothing in either row → fts_score 0 for both.
+_NEUTRAL_QUERY = "zzznomatchzzz"
+
+
+async def _insert(tenant_id: str, content: str, *, event_at: datetime):
+    sc = get_storage_client()
+    return await sc.create_memory(
+        {
+            "tenant_id": tenant_id,
+            "fleet_id": None,
+            "agent_id": "test-agent",
+            "memory_type": "fact",
+            "content": content,
+            "weight": 0.5,
+            "embedding": _SHARED,
+            "content_hash": hashlib.sha256(
+                f"{tenant_id}:{content}".encode()
+            ).hexdigest(),
+            "status": "active",
+            "visibility": "scope_team",
+            "ts_valid_start": event_at.isoformat(),
+        }
+    )
+
+
+async def _search(tenant_id: str, *, freshness_reference: int, valid_at=None, **kw):
+    sp = dict(_SP)
+    sp["freshness_reference"] = freshness_reference
+    rows = await ps.PostgresService().memory_scored_search(
+        tenant_id=tenant_id,
+        embedding=_SHARED,
+        query=_NEUTRAL_QUERY,
+        search_params=sp,
+        top_k=10,
+        valid_at=valid_at,
+        **kw,
+    )
+    return {str(r.Memory.id): float(r.score) for r in rows}, [
+        str(r.Memory.id) for r in rows
+    ]
+
+
+@pytest.fixture
+async def backfilled(tenant_id):
+    recent = await _insert(
+        tenant_id, "the irrigation valve was replaced", event_at=RECENT_EVENT
+    )
+    old = await _insert(
+        tenant_id, "the irrigation schedule was first drafted", event_at=OLD_EVENT
+    )
+    return tenant_id, str(recent["id"]), str(old["id"])
+
+
+async def test_default_anchor_is_flat_on_a_backfilled_corpus(backfilled):
+    """Knob off: both rows were ingested now, so both are 'fresh' — a tie."""
+    tenant, recent, old = backfilled
+    scores, _ = await _search(tenant, freshness_reference=0, valid_at=AS_OF)
+    assert set(scores) == {recent, old}
+    assert scores[recent] == pytest.approx(scores[old]), (
+        "with freshness anchored to ingest time a backfilled corpus cannot be told apart by age"
+    )
+
+
+async def test_valid_at_anchor_ranks_the_nearer_event_first(backfilled):
+    """Knob on: 20 days before the as-of time beats 400 days before it."""
+    tenant, recent, old = backfilled
+    scores, order = await _search(tenant, freshness_reference=1, valid_at=AS_OF)
+    assert set(scores) == {recent, old}
+    assert order[0] == recent
+    assert scores[recent] > scores[old]
+    # Floor is 0.7 and the recent row is at ~20/90 of the decay: the ratio must
+    # be a real gap, not a rounding artefact.
+    assert scores[recent] / scores[old] > 1.15
+
+
+async def test_knob_is_inert_without_valid_at(backfilled):
+    """The switch alone must not move anyone: identical ids and scores."""
+    tenant, _, _ = backfilled
+    off_scores, off_order = await _search(tenant, freshness_reference=0)
+    on_scores, on_order = await _search(tenant, freshness_reference=1)
+    assert on_order == off_order
+    assert on_scores == pytest.approx(off_scores)
+
+
+async def test_temporal_window_ends_at_valid_at(backfilled):
+    """A 60-day window: under the knob only the 20-day-old event is inside it."""
+    tenant, recent, old = backfilled
+    window = timedelta(days=60)
+
+    off_scores, _ = await _search(
+        tenant, freshness_reference=0, valid_at=AS_OF, temporal_window=window
+    )
+    # Default: window ends now(), both rows were CREATED now → both inside → tie.
+    assert off_scores[recent] == pytest.approx(off_scores[old])
+
+    on_scores, on_order = await _search(
+        tenant, freshness_reference=1, valid_at=AS_OF, temporal_window=window
+    )
+    assert on_order[0] == recent
+    # Freshness already favours the recent row; the window adds the 1.3x on top,
+    # so the gap widens compared to the no-window case.
+    no_window_scores, _ = await _search(tenant, freshness_reference=1, valid_at=AS_OF)
+    assert (on_scores[recent] / on_scores[old]) > (
+        no_window_scores[recent] / no_window_scores[old]
+    )
+
+
+async def test_naive_valid_at_is_read_as_utc(backfilled):
+    """A naive datetime must bind to timestamptz, not 500 — and mean UTC."""
+    tenant, recent, old = backfilled
+    aware, aware_order = await _search(tenant, freshness_reference=1, valid_at=AS_OF)
+    naive, naive_order = await _search(
+        tenant, freshness_reference=1, valid_at=AS_OF.replace(tzinfo=None)
+    )
+    assert naive_order == aware_order == [recent, old]
+    assert naive == pytest.approx(aware)
+
+
+async def test_naive_valid_at_is_normalized_for_every_timestamp_bind(monkeypatch):
+    """The currency-factor bind must share the freshness clock's UTC coercion."""
+    captured = []
+
+    class _Stop(Exception):
+        pass
+
+    class _Session:
+        async def execute(self, stmt, *args, **kwargs):
+            captured.append(stmt)
+            raise _Stop
+
+    @contextlib.asynccontextmanager
+    async def _fake_session():
+        yield _Session()
+
+    monkeypatch.setattr(ps, "get_read_session", _fake_session)
+
+    with contextlib.suppress(_Stop):
+        await ps.PostgresService().memory_scored_search(
+            tenant_id="t",
+            embedding=_SHARED,
+            query=_NEUTRAL_QUERY,
+            # Keep the new freshness clock off: any datetime bind in this
+            # statement comes from the pre-existing currency-factor path.
+            search_params={**_SP, "freshness_reference": 0},
+            valid_at=AS_OF.replace(tzinfo=None),
+        )
+
+    assert captured, "no statement reached session.execute"
+    params = captured[0].compile(dialect=postgresql.dialect()).params.values()
+    datetime_params = [value for value in params if isinstance(value, datetime)]
+    assert datetime_params
+    assert all(
+        value == AS_OF and value.utcoffset() == timedelta(0)
+        for value in datetime_params
+    )

--- a/tests/test_search_default_profile.py
+++ b/tests/test_search_default_profile.py
@@ -136,6 +136,38 @@ async def test_precedence_empty_tenant_default_is_neutral():
     assert params["min_similarity"] == MIN_SEARCH_SIMILARITY
 
 
+async def test_freshness_reference_defaults_to_now_and_crosses_the_wire():
+    """Off by default (0 = now()), and present in the SQL projection so storage
+    can read it — a knob that is ``sql=True`` but missing from the resolved
+    params would silently never reach the scoring query."""
+    from common.constants import SQL_SCORING_PARAM_KEYS
+
+    params = await _resolve(tenant_config=None, agent_profile=None)
+    assert params["freshness_reference"] == 0
+    assert "freshness_reference" in SQL_SCORING_PARAM_KEYS
+
+
+async def test_freshness_reference_is_a_tenant_default():
+    tc = ResolvedConfig({"search": {"default_profile": {"freshness_reference": 1}}})
+    params = await _resolve(tenant_config=tc, agent_profile=None)
+    assert params["freshness_reference"] == 1
+
+
+def test_validate_default_profile_bounds_freshness_reference():
+    _validate_default_search_profile(
+        {"search": {"default_profile": {"freshness_reference": 1}}}
+    )
+    with pytest.raises(ValueError, match="in \\[0, 1\\]"):
+        _validate_default_search_profile(
+            {"search": {"default_profile": {"freshness_reference": 2}}}
+        )
+    # bool is an int subclass; the validator must not let ``True`` through as 1.
+    with pytest.raises(ValueError, match="must be int"):
+        _validate_default_search_profile(
+            {"search": {"default_profile": {"freshness_reference": True}}}
+        )
+
+
 async def test_keyword_strategy_keeps_the_global_semantic_floor():
     step = ResolveSearchProfile()
     ctx = PipelineContext(
@@ -292,12 +324,16 @@ def test_caura_tune_signature_matches_the_knob_table():
 
 def test_the_ab_knobs_are_not_agent_tunable():
     """``fts_rank_scale`` / ``candidate_pool_size`` / ``score_formula`` /
-    ``ann_pool_size`` / ``ann_pool_shadow`` stay off the agent ingress.
+    ``ann_pool_size`` / ``ann_pool_shadow`` / ``freshness_reference`` stay off
+    the agent ingress.
 
-    They are the A/B and rollout knobs — held at their global defaults until
-    the offline comparison validates them, and flipped per TENANT via
-    ``default_profile``, not per agent. The 9-of-14 split is deliberate; this
-    records which five and why, so a future reader does not "fix" the omission.
+    They are the A/B, rollout and data-shape knobs — held at their global
+    defaults until the offline comparison validates them, and flipped per
+    TENANT via ``default_profile``, not per agent. ``freshness_reference`` is
+    tenant-level for a different reason: whether ``ts_valid_start`` is event
+    time or a validity-window start is a property of the tenant's data, not of
+    any one agent. The 9-of-15 split is deliberate; this records which six and
+    why, so a future reader does not "fix" the omission.
     """
     from common.constants import SEARCH_KNOBS
     from core_api.schemas import SearchProfileUpdate
@@ -308,6 +344,7 @@ def test_the_ab_knobs_are_not_agent_tunable():
         "score_formula",
         "ann_pool_size",
         "ann_pool_shadow",
+        "freshness_reference",
     }
 
 


### PR DESCRIPTION
**Pitch page (one-pager for the team):** https://claude.ai/code/artifact/c0f6ea56-c07a-4123-a344-9fb387a255f0

## What

A per-tenant knob, `search.default_profile.freshness_reference` (`int` in `[0, 1]`, default `0`). When a tenant sets it to `1` **and** a request carries `valid_at`, freshness and the temporal window are measured from `valid_at` against each row's event time — `coalesce(ts_valid_start, created_at)` — instead of from `now()` against `greatest(created_at, ts_valid_start)`.

| Knob | Request | Clock / anchor | Effect |
|---|---|---|---|
| `0` (default) | any | `now()` / `greatest(created_at, ts_valid_start)` | byte-identical |
| `1` | no `valid_at` | same | byte-identical |
| `1` | `valid_at` present | `valid_at` / `coalesce(ts_valid_start, created_at)`; `ts_valid_end` and the window compared to `valid_at` | retargets |

Only the conjunction moves the clock.

## Why

A corpus ingested in one sitting — a customer's imported history, a transcript backfill, a benchmark — has every row the same age under the default anchor, because `greatest()` picks `created_at` whenever the event predates its ingest. Freshness becomes a constant and "last month" is a window ending on the import date. With `valid_at` set, the existing filter keeps the right rows and then freshness floors all of them: the filter and the ranker argue.

`valid_at` already did two of the three things a `reference_time` field would do — future-row filter and expiry penalty (`postgres_service.py`), relative-date resolution (`extract_temporal_hint.py:35`). This closes the third without a second temporal parameter.

## Why a knob, not a default

Whether `ts_valid_start` means *event time* or *start of a validity window* ("price effective from…") is a property of the tenant's data. The `greatest()` in the default anchor is exactly the guard the latter relies on — such a row must never rank as older than its ingest — so this is a switch that preserves it, not a new default. Tenant-level (not agent-tunable) for the same reason, alongside `score_formula` and `ann_pool_size`. The recall-usage decay stays on `now()`: "recently recalled" is a system-time fact.

## Safety

- Default off → the scoring SQL is the same expression tree (`ref_ts` resolves to `func.now()`).
- Knob on without `valid_at` → identical ids **and** scores (pinned by test).
- Zero production callers send `valid_at` today (enterprise, plugin, clients, rail).
- Skew-safe in both directions: storage reads `sp.get("freshness_reference", 0)`; an older storage ignores the key, an older core-api never sends it.
- Naive `valid_at` is read as UTC rather than failing the `timestamptz` bind.
- No DB migration — the knob lives in the existing `organization_settings` JSONB; the settings model is untouched.

## Plumbing

Rides the table-driven knob machinery end to end: `SEARCH_KNOBS` (`sql=True`), `_validate_default_search_profile`, `validate_search_profile`, `SQL_SCORING_PARAM_KEYS`, `resolve_search_params`. `PUT /settings` validates it; the diagnostic's `search_params` echoes the resolved value.

## Tests

`tests/test_freshness_reference.py` (against Postgres) pins: default is flat on a backfilled corpus; knob ranks the nearer event first on freshness alone (same vector, same weight, no lexical match); knob inert without `valid_at`; temporal window ends at `valid_at`; naive == aware. Knob-table drift tests extended. Locally: 91 root + 15 storage-api scored-search tests green; MCP/plugin spec tests 117/117.

## Second commit — docs and generated specs

- `integration-guide.md`: two lines still claimed MCP lacks `valid_at`; `caura_recall` has had it since C31/D2. Fixed — closes **oss-0902-l-64**.
- `caura_recall`'s `valid_at` description states the full contract in 24 tokens; tools/list lands at **5,312** against the 5,320 ceiling (main is at 5,287). Ceiling not raised.
- `plugin/tools.json` and `tests/fixtures/tools_list_baseline_v1.json` regenerated — one line each.
- `capture_baselines.py`: `model_dump(by_alias=True)`. #682 taught the live-match test to compare wire names but left this script dumping Python field names, so the README's regeneration recipe produced a fixture the test rejects on 74 lines. One argument realigns them.

Noted, not changed: `test_mcp_token_budget.py` and `test_plugin_source_manifest.py` call `Path.read_text()` with no encoding and fail on a cp1255 Windows locale; `PYTHONUTF8=1` reproduces CI.

## Harness side

Both benchmark harnesses had been dropping the `query_timestamp` their runners supplied. They now send it as `valid_at` (harness-only, no server dependency — measurable against production today) and can set this knob on the benchmark tenant. Suggested run order: `CAURA_VALID_AT=1` first, then the knob after deploy, so the two halves are attributed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
