### PR TITLE
fix(llm): fall back json_schema -> json_object when the endpoint reje…

### DIFF
--- a/common/llm/providers/openai.py
+++ b/common/llm/providers/openai.py
@@ -259,7 +259,25 @@ class OpenAILLMProvider:
             # judge. Temperature is a no-op in reasoning mode anyway, so
             # drop it rather than fail the call.
             create_kwargs.pop("temperature", None)
-        response = await self._client.chat.completions.create(**create_kwargs)
+        try:
+            response = await self._client.chat.completions.create(**create_kwargs)
+        except openai.BadRequestError:
+            # Some OpenAI-compatible endpoints (notably Polza's DeepSeek route)
+            # reject ``response_format={"type": "json_schema"}`` with HTTP 400
+            # ("This response_format type is unavailable now" / "does not
+            # support 'json_schema' response format") instead of ignoring the
+            # kwarg. Retry once with shape-less ``json_object``; the prompt
+            # still specifies the shape and the caller's Pydantic parse is the
+            # real guardrail. Providers that support json_schema are unaffected.
+            if response_format.get("type") != "json_schema":
+                raise
+            logger.warning(
+                "Provider rejected json_schema response_format for model %s; "
+                "retrying with json_object",
+                self._model,
+            )
+            create_kwargs["response_format"] = {"type": "json_object"}
+            response = await self._client.chat.completions.create(**create_kwargs)
         llm_ms = int((time.perf_counter() - t0) * 1000)
         tokens_in, tokens_out, tokens_reasoning = _usage_tokens(response)
         logger.info(


### PR DESCRIPTION
…cts it

Some OpenAI-compatible endpoints reject response_format={"type":"json_schema"} with HTTP 400 instead of ignoring the kwarg (observed on Polza's DeepSeek route: "This response_format type is unavailable now" / "does not support 'json_schema' response format. Supported formats: json_object.").

entity_extraction passes response_schema=ExtractedGraph.model_json_schema(), so every extraction failed and fell back to fake extraction on such endpoints.

Retry once with shape-less json_object; the prompt still specifies the shape and the caller's Pydantic parse remains the guardrail. Providers that support json_schema are unaffected.

<!-- Thanks for the contribution! Please fill in this template so we can review quickly. -->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. `Closes #123`. Delete if N/A. -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Other:

## How Has This Been Tested?

<!-- Describe the tests you ran. Include commands if possible. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added tests that cover my changes (or explained why none are needed)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] `pytest` passes locally
- [ ] I have updated relevant documentation (README, docs, etc.)
- [ ] I have updated `CHANGELOG.md` under the `Unreleased` section (if user-facing)

## Additional Notes

<!-- Anything reviewers should know — tradeoffs, follow-up work, open questions. -->
